### PR TITLE
 Mention flow init when doesn't find .flowconfig

### DIFF
--- a/src/commands/commandUtils.ml
+++ b/src/commands/commandUtils.ml
@@ -173,7 +173,7 @@ let guess_root dir_or_file =
   match ClientArgs.guess_root ".flowconfig" (Path.mk_path dir) 50 with
   | Some root -> root
   | None -> Printf.fprintf stderr "Could not find a .flowconfig in %s or any \
-      of its parent directories\n%!" dir; exit 2
+      of its parent directories\nsee \"flow init --help\" for more info\n%!" dir; exit 2
 
 (* convert 1,1 based line/column to 1,0 for internal use *)
 let convert_input_pos (line, column) =


### PR DESCRIPTION
fixes #19.

I'm not sure what the policy is on multiline error messages, but this looked a little better on separate lines IMO.  I tested the change locally.

I'm also not sure if this extra message is needed once people become familiar with the tool (or look at the --help options).  I found out pretty quickly I needed to run `flow init`, so I'm guessing others will as well.  Feel free to ignore/close this pull request.  I figured it was a ticket I could close out quickly (when looking at the issues).
