### PR TITLE
Fix missing word in site index

### DIFF
--- a/index.md
+++ b/index.md
@@ -64,4 +64,4 @@ We first introduced Flow at the <a href="https://www.facebook.com/atscale2014">@
 
 Start with our <a href="/docs/getting-started.html">Getting Started</a> guide to download and try Flow yourself. Flow is open-source, so you can also start with the code on the <a href="https://github.com/facebook/flow">GitHub repo</a>.
 
-Flow is still evolving: it is already used within Facebook, and we want to continue develop it in the open. We hope it will be useful for other JavaScript projects, so please try it out, join the community and give us feedback!
+Flow is still evolving: it is already used within Facebook, and we want to continue to develop it in the open. We hope it will be useful for other JavaScript projects, so please try it out, join the community and give us feedback!


### PR DESCRIPTION
"continue develop it" -> "continue to develop it"
