### PR TITLE
fixed variable 'buffer' is void

### DIFF
--- a/flow-types.el
+++ b/flow-types.el
@@ -52,7 +52,8 @@
   "fill types"
   (interactive)
   (let ((file (buffer-file-name))
-        (region (string-of-region)))
+        (region (string-of-region))
+        (buffer (current-buffer)))
     (switch-to-buffer-other-window "*Shell Command Output*")
     (shell-command
      (format "%s suggest %s%s"


### PR DESCRIPTION
A varibale 'buffer' is void at call fill-types, so assign current-buffer.
