### PR TITLE
Fix incorrect ID on typeof docs page

### DIFF
--- a/docs/01-typeof.md
+++ b/docs/01-typeof.md
@@ -1,5 +1,5 @@
 ---
-id: arrays
+id: typeof
 title: Typeof
 layout: docs
 permalink: /docs/typeof.html


### PR DESCRIPTION
The typeof page on the docs had the wrong ID, which was causing the wrong link in the nav bar to be highlighted when you were on that page.
