### PR TITLE
adding missing dependency

### DIFF
--- a/examples/flux-chat/package.json
+++ b/examples/flux-chat/package.json
@@ -7,7 +7,8 @@
   "dependencies": {
     "flux": "^2.0.0",
     "object-assign": "^1.0.0",
-    "react": "^0.12.0"
+    "react": "^0.12.0",
+    "events": "^1.0.2"
   },
   "devDependencies": {
     "browserify": "^6.2.0",


### PR DESCRIPTION
this actually works w/o this is because browserify has events as a dependency.
