### PR TITLE
Add type definitions for HTMLCanvasElement.

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -315,6 +315,22 @@ declare class HTMLElement extends Element {
     onreadystatechange: (ev: any) => any;
 }
 
+declare class CanvasRenderingContext2D {}
+
+declare class WebGLRenderingContext {}
+
+// http://www.w3.org/TR/html5/scripting-1.html#renderingcontext
+type RenderingContext = CanvasRenderingContext2D | WebGLRenderingContext;
+
+// http://www.w3.org/TR/html5/scripting-1.html#htmlcanvaselement
+declare class HTMLCanvasElement extends HTMLElement {
+    width: number;
+    height: number;
+    getContext(contextId: string, ...args: any): ?RenderingContext;
+    toDataURL(type?: string, ...args: any): string;
+    toBlob(callback: (v: File) => void, type?: string, ...args: any): void;
+}
+
 declare class HTMLImageElement extends HTMLElement {
     alt: string;
     src: string;


### PR DESCRIPTION
This adds only the definitions of `HTMLCanvasElement`. To real usecases, we need to add definitions of `CanvasRenderingContext2D`.
#61
