### PR TITLE
Typo fix in 02-existing.md

### DIFF
--- a/docs/02-existing.md
+++ b/docs/02-existing.md
@@ -11,7 +11,7 @@ next: third-party.html
 
 Making existing code typecheck with Flow is not for the faint of heart - and often it may not be worth the effort in the short term. If your project just depends on a library, check out our [guide](third-party.html) on using Flow with external dependencies. Flow supports *interface files* so you can use libraries in a typed way without having to run Flow on them at all.
 
-Why is typechecking existing code so hard? Libraries not written with types in mind often contain complex, highly dynamic code that confuses analyses such as Flow. The code may also have been written in a style that Flow deliberately chooses not to support in order to give the programmer more help. Some typical examples are:
+Why is typechecking existing code so hard? Libraries not written with types in mind often contain complex, highly dynamic code that confuses analysers such as Flow. The code may also have been written in a style that Flow deliberately chooses not to support in order to give the programmer more help. Some typical examples are:
 
 * Operations on primitive values: While JavaScript allows operations such as `true + 3`, Flow considers it a type error. This is by design, and is done to provide the programmer with more safety. While that's easily avoided for new code, it can be a lot of effort to eliminate such patterns from existing code.
 * Nullability: Flow protects you against accessing properties on `null` by tracking null or undefined values throughout the program. In large existing codebases though this can require inserting some extra null checks in places where a value appears null but isn't at runtime.


### PR DESCRIPTION
"... confuses analyses such as Flow." -> "... confuses analysers such as Flow."
