### PR TITLE
add node util module

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -476,7 +476,7 @@ declare module "util" {
   declare function log(string: string): void;
   declare function inspect(object: any, options?: {
     showHidden?: boolean;
-    depth?: number;
+    depth?: ?number;
     colors?: boolean;
     customInspect?: boolean;
   }): string;


### PR DESCRIPTION
This is based off of the documentation at http://nodejs.org/docs/v0.11.14/api/util.html.
Deprecated APIs mentioned there have been left out for now.
