### PR TITLE
Fix type of websocket event

### DIFF
--- a/lib/bom.js
+++ b/lib/bom.js
@@ -106,7 +106,7 @@ declare class WebSocket extends EventTarget {
     bufferedAmount: number;
     onopen: (ev: Event) => any;
     extensions: string;
-    onmessage: (ev: Event) => any;
+    onmessage: (ev: MessageEvent) => any;
     onclose: (ev: Event) => any;
     onerror: (ev: Event) => any;
     binaryType: string;

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -85,6 +85,17 @@ declare class Event {
     BUBBLING_PHASE: number;
 }
 
+// used for websockets, for example. See:
+// http://www.w3.org/TR/2011/WD-websockets-20110419/
+// and
+// http://www.w3.org/TR/2008/WD-html5-20080610/comms.html
+declare class MessageEvent {
+    data: string;
+    origin: string;
+    lastEventId: string;
+    source: Document;
+}
+
 // TODO: *Event
 
 declare class Node extends EventTarget {


### PR DESCRIPTION
You usually work with websockets like this:

``` js
var ws = new WebSocket();
ws.onmessage = function(event) {
    console.log(event.data);
}
```

Previously flow would error that `event.data` property is not defined.
