### PR TITLE
add node.js fs module declaration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ _build
 .DS_STORE
 docs/_site/
 bin
+*.diff

--- a/lib/node.js
+++ b/lib/node.js
@@ -1,12 +1,12 @@
 /**
- * Copyright (c) 2014, Facebook, Inc.
- * All rights reserved.
- *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the "flow" directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
- *
- */
+* Copyright (c) 2014, Facebook, Inc.
+* All rights reserved.
+*
+* This source code is licensed under the BSD-style license found in the
+* LICENSE file in the "flow" directory of this source tree. An additional grant
+* of patent rights can be found in the PATENTS file in the same directory.
+*
+*/
 
 declare class Buffer {
   constructor(value: Array<number> | number | string, encoding?: string): void;
@@ -115,7 +115,12 @@ type child_process$ChildProcess = {
 declare module "child_process" {
   declare function exec(
     command: string,
-    options?: Object, // TODO: child_process$execOpts,
+    callback: (error: ?Error, stdout: Buffer, stderr: Buffer) => void
+  ): child_process$ChildProcess;
+
+  declare function exec(
+    command: string,
+    options: Object, // TODO: child_process$execOpts,
     callback: (error: ?Error, stdout: Buffer, stderr: Buffer) => void
   ): child_process$ChildProcess;
 
@@ -414,8 +419,185 @@ declare module "events" {
   declare class EventEmitter extends events$EventEmitter {}
 }
 
+declare class ErrnoException extends Error {
+  errno?: any;
+  code?: string;
+  path?: string;
+  syscall?: string;
+}
+
+declare class ReadableStream extends events$EventEmitter {
+  readable: boolean;
+  read(size?: number): any;
+  setEncoding(encoding: string): void;
+  pause(): void;
+  resume(): void;
+  pipe(destination: any, options?: { end?: boolean; }): any;
+  //unpipe<T>(destination?: T): void;
+  //pipe<T extends WritableStream>(destination: T, options?: { end?: boolean; }): T;
+  //unpipe<T extends WritableStream>(destination?: T): void;
+  unshift(chunk: string): void;
+  unshift(chunk: Buffer): void;
+  wrap(oldStream: ReadableStream): ReadableStream;
+}
+
+declare class WritableStream extends events$EventEmitter {
+  writable: boolean;
+  write(buffer: Buffer, cb?: Function): boolean;
+  write(str: string, cb?: Function): boolean;
+  write(str: string, encoding?: string, cb?: Function): boolean;
+  end(): void;
+  end(buffer: Buffer, cb?: Function): void;
+  end(str: string, cb?: Function): void;
+  end(str: string, encoding?: string, cb?: Function): void;
+}
+
+
 declare module "fs" {
-  // TODO
+
+  declare class FSWatcher extends events$EventEmitter {
+    close(): void;
+  }
+
+  declare class ReadStream extends ReadableStream {
+    close(): void;
+  }
+  declare class WriteStream extends WritableStream {
+    close(): void;
+  }
+
+  declare class Stats {
+    isFile(): boolean;
+    isDirectory(): boolean;
+    isBlockDevice(): boolean;
+    isCharacterDevice(): boolean;
+    isSymbolicLink(): boolean;
+    isFIFO(): boolean;
+    isSocket(): boolean;
+    dev: number;
+    ino: number;
+    mode: number;
+    nlink: number;
+    uid: number;
+    gid: number;
+    rdev: number;
+    size: number;
+    blksize: number;
+    blocks: number;
+    atime: Date;
+    mtime: Date;
+    ctime: Date;
+  }
+
+  declare function rename(oldPath: string, newPath: string, callback?: (err?: ErrnoException) => void): void;
+  declare function renameSync(oldPath: string, newPath: string): void;
+  declare function truncate(path: string, callback?: (err?: ErrnoException) => void): void;
+  declare function truncate(path: string, len: number, callback?: (err?: ErrnoException) => void): void;
+  declare function truncateSync(path: string, len?: number): void;
+  declare function ftruncate(fd: number, callback?: (err?: ErrnoException) => void): void;
+  declare function ftruncate(fd: number, len: number, callback?: (err?: ErrnoException) => void): void;
+  declare function ftruncateSync(fd: number, len?: number): void;
+  declare function chown(path: string, uid: number, gid: number, callback?: (err?: ErrnoException) => void): void;
+  declare function chownSync(path: string, uid: number, gid: number): void;
+  declare function fchown(fd: number, uid: number, gid: number, callback?: (err?: ErrnoException) => void): void;
+  declare function fchownSync(fd: number, uid: number, gid: number): void;
+  declare function lchown(path: string, uid: number, gid: number, callback?: (err?: ErrnoException) => void): void;
+  declare function lchownSync(path: string, uid: number, gid: number): void;
+  declare function chmod(path: string, mode: number, callback?: (err?: ErrnoException) => void): void;
+  declare function chmod(path: string, mode: string, callback?: (err?: ErrnoException) => void): void;
+  declare function chmodSync(path: string, mode: number): void;
+  declare function chmodSync(path: string, mode: string): void;
+  declare function fchmod(fd: number, mode: number, callback?: (err?: ErrnoException) => void): void;
+  declare function fchmod(fd: number, mode: string, callback?: (err?: ErrnoException) => void): void;
+  declare function fchmodSync(fd: number, mode: number): void;
+  declare function fchmodSync(fd: number, mode: string): void;
+  declare function lchmod(path: string, mode: number, callback?: (err?: ErrnoException) => void): void;
+  declare function lchmod(path: string, mode: string, callback?: (err?: ErrnoException) => void): void;
+  declare function lchmodSync(path: string, mode: number): void;
+  declare function lchmodSync(path: string, mode: string): void;
+  declare function stat(path: string, callback?: (err: ErrnoException, stats: Stats) => any): void;
+  declare function lstat(path: string, callback?: (err: ErrnoException, stats: Stats) => any): void;
+  declare function fstat(fd: number, callback?: (err: ErrnoException, stats: Stats) => any): void;
+  declare function statSync(path: string): Stats;
+  declare function lstatSync(path: string): Stats;
+  declare function fstatSync(fd: number): Stats;
+  declare function link(srcpath: string, dstpath: string, callback?: (err?: ErrnoException) => void): void;
+  declare function linkSync(srcpath: string, dstpath: string): void;
+  declare function symlink(srcpath: string, dstpath: string, type?: string, callback?: (err?: ErrnoException) => void): void;
+  declare function symlinkSync(srcpath: string, dstpath: string, type?: string): void;
+  declare function readlink(path: string, callback?: (err: ErrnoException, linkString: string) => any): void;
+  declare function readlinkSync(path: string): string;
+  declare function realpath(path: string, callback?: (err: ErrnoException, resolvedPath: string) => any): void;
+  declare function realpath(path: string, cache: {[path: string]: string}, callback: (err: ErrnoException, resolvedPath: string) =>any): void;
+  declare function realpathSync(path: string, cache?: {[path: string]: string}): string;
+  declare function unlink(path: string, callback?: (err?: ErrnoException) => void): void;
+  declare function unlinkSync(path: string): void;
+  declare function rmdir(path: string, callback?: (err?: ErrnoException) => void): void;
+  declare function rmdirSync(path: string): void;
+  declare function mkdir(path: string, callback?: (err?: ErrnoException) => void): void;
+  declare function mkdir(path: string, mode: number, callback?: (err?: ErrnoException) => void): void;
+  declare function mkdir(path: string, mode: string, callback?: (err?: ErrnoException) => void): void;
+  declare function mkdirSync(path: string, mode?: number): void;
+  declare function mkdirSync(path: string, mode?: string): void;
+  declare function readdir(path: string, callback?: (err: ErrnoException, files: string[]) => void): void;
+  declare function readdirSync(path: string): string[];
+  declare function close(fd: number, callback?: (err?: ErrnoException) => void): void;
+  declare function closeSync(fd: number): void;
+  declare function open(path: string, flags: string, callback?: (err: ErrnoException, fd: number) => any): void;
+  declare function open(path: string, flags: string, mode: number, callback?: (err: ErrnoException, fd: number) => any): void;
+  declare function open(path: string, flags: string, mode: string, callback?: (err: ErrnoException, fd: number) => any): void;
+  declare function openSync (path: string, flags: string, mode?: number): number;
+  declare function openSync (path: string, flags: string, mode?: string): number;
+  declare function utimes(path: string, atime: number | Date, mtime: number | Date, callback?: (err?: ErrnoException) => void): void;
+  declare function utimesSync(path: string, atime: number | Date, mtime: number | Date): void;
+  declare function futimes(fd: number, atime: number | Date, mtime: number | Date, callback?: (err?: ErrnoException) => void): void;
+  declare function futimesSync(fd: number, atime: number | Date, mtime: number | Date): void;
+  declare function fsync(fd: number, callback?: (err?: ErrnoException) => void): void;
+  declare function fsyncSync(fd: number): void;
+  declare function write(fd: number, buffer: Buffer, offset: number, length: number, position: number, callback?: (err: ErrnoException, written: number, buffer: Buffer) => void): void;
+  declare function writeSync(fd: number, buffer: Buffer, offset: number, length: number, position: number): number;
+  declare function read(fd: number, buffer: Buffer, offset: number, length: number, position: number, callback?: (err: ErrnoException, bytesRead: number, buffer: Buffer) => void): void;
+  declare function readSync(fd: number, buffer: Buffer, offset: number, length: number, position: number): number;
+  declare function readFile(filename: string, encoding: string, callback: (err: ErrnoException, data: string | Buffer) => void): void;
+  declare function readFile(filename: string, options: { encoding: string; flag?: string; }, callback: (err: ErrnoException, data: string | Buffer) => void): void;
+  declare function readFileSync(filename: string, encoding?: string): string;
+  declare function readFileSync(filename: string, options?: { encoding?: string; flag?: string; }): Buffer | string;
+  declare function writeFile(filename: string, data: any, callback?: (err: ErrnoException) => void): void;
+  declare function writeFile(filename: string, data: any, options: { encoding?: string; mode?: number; flag?: string; }, callback?: (err: ErrnoException) => void): void;
+  declare function writeFile(filename: string, data: any, options: { encoding?: string; mode?: string; flag?: string; }, callback?: (err: ErrnoException) => void): void;
+  declare function writeFileSync(filename: string, data: any, options?: { encoding?: string; mode?: number; flag?: string; }): void;
+  declare function writeFileSync(filename: string, data: any, options?: { encoding?: string; mode?: string; flag?: string; }): void;
+  declare function appendFile(filename: string, data: any, options: { encoding?: string; mode?: number; flag?: string; }, callback?: (err: ErrnoException) => void): void;
+  declare function appendFile(filename: string, data: any, options: { encoding?: string; mode?: string; flag?: string; }, callback?: (err: ErrnoException) => void): void;
+  declare function appendFile(filename: string, data: any, callback?: (err: ErrnoException) => void): void;
+  declare function appendFileSync(filename: string, data: any, options?: { encoding?: string; mode?: number; flag?: string; }): void;
+  declare function appendFileSync(filename: string, data: any, options?: { encoding?: string; mode?: string; flag?: string; }): void;
+  declare function watchFile(filename: string, listener: (curr: Stats, prev: Stats) => void): void;
+  declare function watchFile(filename: string, options: { persistent?: boolean; interval?: number; }, listener: (curr: Stats, prev: Stats) => void): void;
+  declare function unwatchFile(filename: string, listener?: (curr: Stats, prev: Stats) => void): void;
+  declare function watch(filename: string, listener?: (event: string, filename: string) => any): FSWatcher;
+  declare function watch(filename: string, options: { persistent?: boolean; }, listener?: (event: string, filename: string) => any): FSWatcher;
+  declare function exists(path: string, callback?: (exists: boolean) => void): void;
+  declare function existsSync(path: string): boolean;
+  declare function createReadStream(path: string, options?: {
+    flags?: string;
+    encoding?: string;
+    fd?: string;
+    mode?: number;
+    bufferSize?: number;
+  }): ReadStream;
+  declare function createReadStream(path: string, options?: {
+    flags?: string;
+    encoding?: string;
+    fd?: string;
+    mode?: string;
+    bufferSize?: number;
+  }): ReadStream;
+  declare function createWriteStream(path: string, options?: {
+    flags?: string;
+    encoding?: string;
+    string?: string;
+  }): WriteStream;
 }
 
 declare module "http" {


### PR DESCRIPTION
This is converted declaration from https://github.com/borisyankov/DefinitelyTyped/blob/master/node/node.d.ts
1). Currently there is a makefile command `make test`, but other tests could be run only manually (like `node_tests`, `auxiliary_tests` and tests for declarations). Should we consider to add new makefile target? Also, is it possible to connect `flow` repository with CI server like travic-ci / codeship? 
2). There is no tests for `lib/*.js`, so I ran it across existing codebase, though this is only part of node API and I'm pretty sure somebody have written their own declarations for node core modules. Is it possible to overwrite system declaration? How we can ensure that all contributed declaration is valid? For example, after updating from 0.1.1 to 0.1.2 I've got this error:

```
/gulp-flowtype/index.js:24:3,61:4: function call
Too few arguments (expected default/rest parameters in function)
  /private/var/folders/tp/ffwbqwn51dd1zgb9pb8j4g7w0000gn/T/flow_potomushto/flowlib_825dbe6/lib/node.js:116:24,120:31: function type

/gulp-flowtype/index.js:24:17,61:3: function
This type is incompatible with
  /private/var/folders/tp/ffwbqwn51dd1zgb9pb8j4g7w0000gn/T/flow_potomushto/flowlib_825dbe6/lib/node.js:118:15,20: object type
```

That's because the signature of `child_process.exec` was:

```
declare function exec(
    command: string,
    options?: Object, // TODO: child_process$execOpts,
    callback: (error: ?Error, stdout: Buffer, stderr: Buffer) => void
  ): child_process$ChildProcess;
```

but it didn't work with `exec(command, callback)` because `flow` can't manage Maybe types this way. I've fixed it, but the general problem is here. 

Maybe somehow we could run `flow` across `node` simple tests? https://github.com/joyent/node/blob/master/test/simple/test-fs-append-file-sync.js

3). Does it make sense at all to convert and debug other modules manually or better to wait for https://github.com/facebook/flow/issues/72? 

Flow is great, we would like to use it for both server and client side, but it requires to contribute system declarations or at least overriding declaration to be independent (or `--no-lib` option https://github.com/facebook/flow/issues/114). 
