### PR TITLE
Update dom.js: change NodeList to NodeList<HTMLElement>

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -97,7 +97,7 @@ declare class Node extends EventTarget {
     nextSibling: Node;
     nodeValue: string;
     lastChild: Node;
-    childNodes: NodeList;
+    childNodes: NodeList<Node>;
     nodeName: string;
     ownerDocument: Document;
     attributes: NamedNodeMap;
@@ -138,10 +138,10 @@ declare class Node extends EventTarget {
     static DOCUMENT_POSITION_PRECEDING: number;
 }
 
-declare class NodeList {
+declare class NodeList<T> {
     length: number;
-    item(index: number): Node;
-    [index: number]: Node;
+    item(index: number): T;
+    [index: number]: T;
 }
 
 declare class NamedNodeMap {
@@ -201,17 +201,17 @@ declare class Document extends Node {
     write(...content: Array<string>): void;
     createElement(tagName: string): HTMLElement;
     writeln(...content: Array<string>): void;
-    getElementsByTagNameNS(namespaceURI: string, localName: string): NodeList;
+    getElementsByTagNameNS(namespaceURI: string, localName: string): HTMLCollection;
     createElementNS(namespaceURI: string, qualifiedName: string): Element;
     open(url?: string, name?: string, features?: string, replace?: boolean): any;
     createAttributeNS(namespaceURI: string, qualifiedName: string): Attr;
     close(): void;
-    getElementsByClassName(classNames: string): NodeList;
+    getElementsByClassName(classNames: string): HTMLCollection;
     importNode(importedNode: Node, deep: boolean): Node;
     createComment(data: string): Comment;
-    getElementsByTagName(name: string): NodeList;
+    getElementsByTagName(name: string): HTMLCollection;
     createDocumentFragment(): Node;
-    getElementsByName(elementName: string): NodeList;
+    getElementsByName(elementName: string): HTMLCollection;
     createAttribute(name: string): Attr;
     createTextNode(data: string): Text;
     xmlEncoding: string;
@@ -220,14 +220,14 @@ declare class Document extends Node {
 
     // extension
     location: Location;
-    querySelectorAll(selectors: string): NodeList;
-    querySelector(selectors: string): Element;
+    querySelectorAll(selectors: string): NodeList<HTMLElement>;
+    querySelector(selectors: string): HTMLElement;
     createEvent(eventInterface: string): Event;
     createRange(): Range;
-    elementFromPoint(x: number, y: number): Element;
+    elementFromPoint(x: number, y: number): HTMLElement;
     defaultView: any;
     compatMode: string;
-    activeElement: Element;
+    activeElement: HTMLElement;
     hidden: boolean;
 }
 
@@ -280,7 +280,7 @@ declare class Element extends Node {
     clientTop: number;
     scrollHeight: number;
     getAttribute(name?: string): string;
-    getElementsByTagNameNS(namespaceURI: string, localName: string): NodeList;
+    getElementsByTagNameNS(namespaceURI: string, localName: string): NodeList<HTMLElement>;
     hasAttributeNS(namespaceURI: string, localName: string): boolean;
     getAttributeNS(namespaceURI: string, localName: string): string;
     getAttributeNodeNS(namespaceURI: string, localName: string): Attr;
@@ -289,13 +289,13 @@ declare class Element extends Node {
     removeAttribute(name?: string): void;
     setAttributeNS(namespaceURI: string, qualifiedName: string, value: string): void;
     getAttributeNode(name: string): Attr;
-    getElementsByTagName(name: string): NodeList;
+    getElementsByTagName(name: string): HTMLCollection;
     setAttributeNode(newAttr: Attr): Attr;
     removeAttributeNode(oldAttr: Attr): Attr;
     setAttribute(name?: string, value?: string): void;
     removeAttributeNS(namespaceURI: string, localName: string): void;
-    querySelector(selector: string): Element;
-    querySelectorAll(selector: string): NodeList;
+    querySelector(selector: string): HTMLElement;
+    querySelectorAll(selector: string): NodeList<HTMLElement>;
 }
 
 declare class HTMLElement extends Element {


### PR DESCRIPTION
There is a problem with code like this: 

``` javascript
document.querySelectorAll('.selector')[0].style.display = 'block';
```

because `querySelectorAll` returns `NodeList` of `Element`, not `Node` https://developer.mozilla.org/en-US/docs/Web/API/element. 

I've changed `NodeList` to `NodeList<T>` and signatures of some relevant functions:

```
querySelector(selector: string): HTMLElement;
querySelectorAll(selector: string): NodeList<HTMLElement>;
```

though HTMLElement is no exactly correct (it could be any of derived classes of `Element` such as `SVGElement`, for example) I don't know better solution. 
Also, there is inconsistency with `HTMLCollection` which is collection of `Element` and will produce error with code sample.
