### PR TITLE
Revise DOM API

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -54,249 +54,619 @@ declare class FileList {
 
 /* DOM */
 
-declare class DOMError {
-    name: string;
+/**
+ * Definitions taken from https://dom.spec.whatwg.org/ and http://www.w3.org/TR/WebIDL
+ */
+
+type DOMString = string;
+type DOMTimeStamp = number;
+
+// Defined in http://www.w3.org/TR/dom/#domexception but will be moved to WebIDL
+declare class DOMException {
+    static INDEX_SIZE_ERR: number; // = 1;
+    static DOMSTRING_SIZE_ERR: number; // = 2; // historical
+    static HIERARCHY_REQUEST_ERR: number; // = 3;
+    static WRONG_DOCUMENT_ERR: number; // = 4;
+    static INVALID_CHARACTER_ERR: number; // = 5;
+    static NO_DATA_ALLOWED_ERR: number; // = 6; // historical
+    static NO_MODIFICATION_ALLOWED_ERR: number; // = 7;
+    static NOT_FOUND_ERR: number; // = 8;
+    static NOT_SUPPORTED_ERR: number; // = 9;
+    static INUSE_ATTRIBUTE_ERR: number; // = 10; // historical
+    static INVALID_STATE_ERR: number; // = 11;
+    static SYNTAX_ERR: number; // = 12;
+    static INVALID_MODIFICATION_ERR: number; // = 13;
+    static NAMESPACE_ERR: number; // = 14;
+    static INVALID_ACCESS_ERR: number; // = 15;
+    static VALIDATION_ERR: number; // = 16; // historical
+    static TYPE_MISMATCH_ERR: number; // = 17; // historical; use JavaScript's TypeError instead
+    static SECURITY_ERR: number; // = 18;
+    static NETWORK_ERR: number; // = 19;
+    static ABORT_ERR: number; // = 20;
+    static URL_MISMATCH_ERR: number; // = 21;
+    static QUOTA_EXCEEDED_ERR: number; // = 22;
+    static TIMEOUT_ERR: number; // = 23;
+    static INVALID_NODE_TYPE_ERR: number; // = 24;
+    static DATA_CLONE_ERR: number; // = 25;
+    code: number;
+}
+
+
+// 3.2 Event
+
+type EventInit = {
+    bubbles: boolean /*=false*/;
+    cancelable: boolean /*=false*/;
+};
+
+declare class Event {
+    constructor(type: DOMString, eventInitDict?: EventInit): void;
+
+    type: DOMString;
+    target: ?EventTarget;
+    currentTarget: ?EventTarget;
+
+    // Phase constants
+    static NONE: number; // = 0
+    static CAPTURE_PHASE: number; // = 1
+    static AT_TARGET: number; // = 2
+    static BUBBLING_PHASE: number; // = 3
+    currentPhase: number;
+
+    stopPropagation(): void;
+    stopImmediatePropagation(): void;
+
+    bubbles: boolean;
+    cancelable: boolean;
+    preventDefault(): void;
+    defaultPrevented: boolean;
+
+    isTrusted: boolean;
+    timeStamp: DOMTimeStamp;
+
+    initEvent(type: DOMString, bubbles: boolean, cancelable: boolean): Event;
+
+    // IE
+    srcElement: Element;
+    cancelBubble: boolean;
+}
+
+// 3.3 CustomEvent
+
+type CustomEventInit = {
+    detail: any /*=null*/;
+    bubbles: boolean /*=false*/;
+    cancelable: boolean /*=false*/;
+};
+
+declare class CustomEvent extends Event {
+    constructor(type: DOMString, eventInitDict?: CustomEventInit): void;
+
+    detail: any;
+    initCustomEvent(type: DOMString, bubbles: boolean, cancelable: boolean): CustomEvent;
+}
+
+// 3.6 EventTarget
+
+type callback = (evt: Event) => void;
+
+declare class EventListener {
+  handleEvent(event: Event): void;
 }
 
 declare class EventTarget {
-    removeEventListener(type: string, listener: (evt: any) => void, useCapture?: boolean): void;
-    addEventListener(type: string, listener: (evt: any) => void, useCapture?: boolean): void;
+    removeEventListener(
+        type: string,
+        callback: ?callback | ?EventListener,
+        capture?: boolean
+    ): void;
+    addEventListener(
+        type: string,
+        callback: ?callback | ?EventListener,
+        capture?: boolean
+    ): void;
     dispatchEvent(evt: Event): boolean;
 }
 
-declare class Event {
-    timeStamp: number;
-    defaultPrevented: boolean;
-    isTrusted: boolean;
-    currentTarget: EventTarget;
-    cancelBubble: boolean;
-    target: EventTarget;
-    eventPhase: number;
-    cancelable: boolean;
-    type: string;
-    srcElement: Element;
-    bubbles: boolean;
-    initEvent(eventTypeArg: string, canBubbleArg: boolean, cancelableArg: boolean): void;
-    stopPropagation(): void;
-    stopImmediatePropagation(): void;
-    preventDefault(): void;
-    CAPTURING_PHASE: number;
-    AT_TARGET: number;
-    BUBBLING_PHASE: number;
+
+// 4.2.6 Collections: Elements
+
+declare class Elements extends Array {
+    query(relativeSelectors: DOMString): ?Element;
+    queryAll(relativeSelectors: DOMString): Elements;
 }
 
-// TODO: *Event
+// 4.2.7 Old-style collections: NodeList and HTMLCollection
 
-declare class Node extends EventTarget {
-    nodeType: number;
-    previousSibling: Node;
-    localName: string;
-    namespaceURI: string;
-    textContent: string;
-    parentNode: Node;
-    nextSibling: Node;
-    nodeValue: string;
-    lastChild: Node;
-    childNodes: NodeList;
-    nodeName: string;
-    ownerDocument: Document;
-    attributes: NamedNodeMap;
-    firstChild: Node;
-    prefix: string;
-    removeChild(oldChild: Node): Node;
-    appendChild(newChild: Node): Node;
-    isSupported(feature: string, version: string): boolean;
-    isEqualNode(arg: Node): boolean;
-    lookupPrefix(namespaceURI: string): string;
-    isDefaultNamespace(namespaceURI: string): boolean;
-    compareDocumentPosition(other: Node): number;
-    normalize(): void;
-    isSameNode(other: Node): boolean;
-    hasAttributes(): boolean;
-    lookupNamespaceURI(prefix: string): string;
-    cloneNode(deep?: boolean): Node;
-    hasChildNodes(): boolean;
-    replaceChild(newChild: Node, oldChild: Node): Node;
-    insertBefore(newChild: Node, refChild?: Node): Node;
-    static ENTITY_REFERENCE_NODE: number;
-    static ATTRIBUTE_NODE: number;
-    static DOCUMENT_FRAGMENT_NODE: number;
-    static TEXT_NODE: number;
-    static ELEMENT_NODE: number;
-    static COMMENT_NODE: number;
-    static DOCUMENT_POSITION_DISCONNECTED: number;
-    static DOCUMENT_POSITION_CONTAINED_BY: number;
-    static DOCUMENT_POSITION_CONTAINS: number;
-    static DOCUMENT_TYPE_NODE: number;
-    static DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC: number;
-    static DOCUMENT_NODE: number;
-    static ENTITY_NODE: number;
-    static PROCESSING_INSTRUCTION_NODE: number;
-    static CDATA_SECTION_NODE: number;
-    static NOTATION_NODE: number;
-    static DOCUMENT_POSITION_FOLLOWING: number;
-    static DOCUMENT_POSITION_PRECEDING: number;
-}
-
-declare class NodeList {
+declare class NodeList<T> {
+    [index: number]: ?T;
+    item(index: number): ?T;
     length: number;
-    item(index: number): Node;
-    [index: number]: Node;
-}
-
-declare class NamedNodeMap {
-    length: number;
-    removeNamedItemNS(namespaceURI: string, localName: string): Attr;
-    item(index: number): Attr;
-    [index: number]: Attr;
-    removeNamedItem(name: string): Attr;
-    getNamedItem(name: string): Attr;
-    setNamedItem(arg: Attr): Attr;
-    getNamedItemNS(namespaceURI: string, localName: string): Attr;
-    setNamedItemNS(arg: Attr): Attr;
-}
-
-declare class Attr extends Node {
-    isId: boolean;
-    specified: boolean;
-    ownerElement: Element;
-    value: string;
-    name: string;
+    // TODO: iterable<T>
 }
 
 declare class HTMLCollection {
+    [index: number]: ?Element;
+    // TODO: Multiple indexers
+    // [name: string]: ?Element;
+    item(index: number): ?Element;
+    namedItem(name: string): ?Element;
     length: number;
-    item(nameOrIndex?: any, optionalIndex?: any): Element;
-    namedItem(name: string): Element;
-    [index: number]: Element;
 }
 
-declare class Document extends Node {
-    documentElement: HTMLElement;
+// 4.3.1 Interface MutationObserver
+
+declare class MutationObserver {
+    constructor(callback: MutationCallback): void;
+    observe(target: Node, options: MutationObserverInit): void;
+    disconnect(): void;
+    takeRecords(): Array<MutationRecord>;
+}
+
+type MutationCallback = (mutations: Array<MutationRecord>, observer: MutationObserver) => void;
+
+type MutationObserverInit = {
+    childList: boolean; // = false
+    attributes: boolean;
+    characterData: boolean;
+    subtree: boolean; // = false
+    attributeOldValue: boolean;
+    characterDataOldValue: boolean;
+    attributeFilter: Array<DOMString>;
+};
+
+// 4.3.3 Interface MutationRecord
+
+declare class MutationRecord {
+    type: DOMString;
+    target: Node;
+    addedNodes: NodeList<Node>;
+    removedNodes: NodeList<Node>;
+    previousSibling: ?Node;
+    nextSibling: ?Node;
+    attributeName: ?DOMString;
+    attributeNamespace: ?DOMString;
+    oldValue: ?DOMString;
+}
+
+// 4.4 Interface Node
+
+declare class Node extends EventTarget {
+    static ELEMENT_NODE: number; // = 1
+    static ATTRIBUTE_NODE: number; // = 2 // historical
+    static TEXT_NODE: number; // = 3
+    static CDATA_SECTION_NODE: number; // = 4 // historical
+    static ENTITY_REFERENCE_NODE: number; // = 5 // historical
+    static ENTITY_NODE: number; // = 6 // historical
+    static PROCESSING_INSTRUCTION_NODE: number; // = 7
+    static COMMENT_NODE: number; // = 8
+    static DOCUMENT_NODE: number; // = 9
+    static DOCUMENT_TYPE_NODE: number; // = 10
+    static DOCUMENT_FRAGMENT_NODE: number; // = 11
+    static NOTATION_NODE: number; // = 12 // historical
+    nodeType: number;
+    nodeName: DOMString;
+
+    baseURI: ?DOMString;
+
+    ownerDocument: ?Document;
+    parentNode: ?Node;
+    parentElement: ?Element;
+    hasChildNodes(): boolean;
+    childNodes: NodeList<Node>;
+    firstChild: ?Node;
+    lastChild: ?Node;
+    previousSibling: ?Node;
+    nextSibling: ?Node;
+
+    nodeValue: ?DOMString;
+    textContent: ?DOMString;
+    normalize(): void;
+
+    cloneNode(deep?: boolean): Node;
+    isEqualNode(node: ?Node): boolean;
+
+    static DOCUMENT_POSITION_DISCONNECTED: number; // = 0x01;
+    static DOCUMENT_POSITION_PRECEDING: number; // = 0x02;
+    static DOCUMENT_POSITION_FOLLOWING: number; // = 0x04;
+    static DOCUMENT_POSITION_CONTAINS: number; // = 0x08;
+    static DOCUMENT_POSITION_CONTAINED_BY: number; // = 0x10;
+    static DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC: number; // = 0x20;
+    compareDocumentPosition(other: Node): number;
+    contains(other: ?Node): boolean;
+
+    lookupPrefix(namespace: ?DOMString): ?DOMString;
+    lookupNamespaceURI(prefix: ?DOMString): ?DOMString;
+    isDefaultNamespace(namespace: ?DOMString): boolean;
+
+    insertBefore(node: Node, child: ?Node): Node;
+    appendChild(node: Node): Node;
+    replaceChild(node: Node, child: Node): Node;
+    removeChild(node: Node): Node;
+}
+
+// 4.5 Interface Document
+
+type Nodish = Node | DOMString;
+
+declare class Document {
     implementation: DOMImplementation;
-    scripts: HTMLCollection;
-    title: string;
-    embeds: HTMLCollection;
-    forms: HTMLCollection;
-    inputEncoding: string;
-    links: HTMLCollection;
-    URL: string;
-    head: HTMLElement;
-    cookie: string;
-    documentMode: number;
-    characterSet: string;
-    anchors: HTMLCollection;
-    readyState: string;
-    referrer: string;
-    doctype: DocumentType;
-    applets: HTMLCollection;
-    body: HTMLElement;
-    domain: string;
-    media: string;
-    images: HTMLCollection;
-    lastModified: string;
-    getElementById(elementId: string): HTMLElement;
-    adoptNode(source: Node): Node;
-    createCDATASection(data: string): Text;
-    write(...content: Array<string>): void;
-    createElement(tagName: string): HTMLElement;
-    writeln(...content: Array<string>): void;
-    getElementsByTagNameNS(namespaceURI: string, localName: string): NodeList;
-    createElementNS(namespaceURI: string, qualifiedName: string): Element;
-    open(url?: string, name?: string, features?: string, replace?: boolean): any;
-    createAttributeNS(namespaceURI: string, qualifiedName: string): Attr;
-    close(): void;
-    getElementsByClassName(classNames: string): NodeList;
-    importNode(importedNode: Node, deep: boolean): Node;
-    createComment(data: string): Comment;
-    getElementsByTagName(name: string): NodeList;
-    createDocumentFragment(): Node;
-    getElementsByName(elementName: string): NodeList;
-    createAttribute(name: string): Attr;
-    createTextNode(data: string): Text;
-    xmlEncoding: string;
-    xmlStandalone: boolean;
-    xmlVersion: string;
+    URL: DOMString;
+    documentURI: DOMString;
+    origin: DOMString;
+    compatMode: DOMString;
+    characterSet: DOMString;
+    inputEncoding: DOMString; // legacy alias of .characterSet
+    contentType: DOMString;
 
-    // extension
-    location: Location;
-    querySelectorAll(selectors: string): NodeList;
-    querySelector(selectors: string): Element;
-    createEvent(eventInterface: string): Event;
+    doctype: ?DocumentType;
+    documentElement: ?Element;
+    getElementsByTagName(localName: DOMString): HTMLCollection;
+    getElementsByTagNameNS(namespace: ?DOMString, localName: DOMString): HTMLCollection;
+    getElementsByClassName(classNames: DOMString): HTMLCollection;
+
+    createElement(localName: DOMString): Element;
+    createElementNS(namespace: ?DOMString, qualifiedName: DOMString): Element;
+    createDocumentFragment(): DocumentFragment;
+    createTextNode(data: DOMString): Text;
+    createComment(data: DOMString): Comment;
+    createProcessingInstruction(target: DOMString, data: DOMString): ProcessingInstruction;
+
+    importNode(node: Node, deep?: boolean /* =false */): Node;
+    adoptNode(node: Node): Node;
+
+    createAttribute(localName: DOMString): Attr;
+    createAttributeNS(namespace: ?DOMString, name: DOMString): Attr;
+
+    createEvent(iface: DOMString): Event;
+
     createRange(): Range;
-    elementFromPoint(x: number, y: number): Element;
-    defaultView: any;
-    compatMode: string;
-    activeElement: Element;
-    hidden: boolean;
+
+    // NODEFilter.SHOW_ALL = 0xFFFFFFF
+    createNodeIterator(
+        root: Node,
+        whatToShow?: number, /* =0xFFFFFFF */
+        filter?: ?NodeFilter
+    ): NodeIterator;
+    createTreeWalker(
+        root: Node,
+        whatToShow?: number, /* =0xFFFFFFF */
+        filter?: ?NodeFilter
+    ): TreeWalker;
+
+    // from interface NonElementParentNode
+    getElementById(elementId: DOMString): ?Element;
+
+    // from interface ParentNode
+    children: HTMLCollection;
+    firstElementChild: ?Element;
+    lastElementChild: ?Element;
+    childElementCount: number;
+
+    prepend(...nodes: Nodish[]): void;
+    append(...nodes: Nodish[]): void;
+
+    query(relativeSelectors: DOMString): ?Element;
+    queryAll(relativeSelectors: DOMString): Elements;
+    querySelector(selectors: DOMString): ?Element;
+    querySelectorAll(selectors: DOMString): NodeList<Element>;
 }
 
-declare class Range { // extension
-    startOffset: number;
-    collapsed: boolean;
-    endOffset: number;
-    startContainer: Node;
-    endContainer: Node;
-    commonAncestorContainer: Node;
-    setStart(refNode: Node, offset: number): void;
-    setEndBefore(refNode: Node): void;
-    setStartBefore(refNode: Node): void;
-    selectNode(refNode: Node): void;
-    detach(): void;
-    getBoundingClientRect(): ClientRect;
-    toString(): string;
-    compareBoundaryPoints(how: number, sourceRange: Range): number;
-    insertNode(newNode: Node): void;
-    collapse(toStart: boolean): void;
-    selectNodeContents(refNode: Node): void;
-    cloneContents(): Node;
-    setEnd(refNode: Node, offset: number): void;
-    cloneRange(): Range;
-    getClientRects(): ClientRectList;
-    surroundContents(newParent: Node): void;
-    deleteContents(): void;
-    setStartAfter(refNode: Node): void;
-    extractContents(): Node;
-    setEndAfter(refNode: Node): void;
-    createContextualFragment(fragment: string): Node;
-    END_TO_END: number;
-    START_TO_START: number;
-    START_TO_END: number;
-    END_TO_START: number;
+declare class XMLDocument extends Document {}
+
+// 4.5.1 Interface DOMImplementation
+
+declare class DOMImplementation {
+  createDocumentType(
+      qualifiedName: DOMString,
+      publicId: DOMString,
+      systemId: DOMString
+  ): DocumentType;
+  createDocument(
+      namespace: ?DOMString,
+      qualifiedName: ?DOMString,
+      doctype?: ?DocumentType
+  ): XMLDocument;
+  createHTMLDocument(title?: DOMString): Document;
+
+  hasFeature(): boolean; // useless; always returns true
 }
 
-declare var document: Document;
+// 4.6 Interface DocumentFragment
 
-// TODO: HTMLDocument
+declare class DocumentFragment extends Node {
+    // from interface NonElementParentNode
+    getElementById(elementId: DOMString): ?Element;
+    //
+    // from interface ParentNode
+    children: HTMLCollection;
+    firstElementChild: ?Element;
+    lastElementChild: ?Element;
+    childElementCount: number;
+
+    prepend(...nodes: Nodish[]): void;
+    append(...nodes: Nodish[]): void;
+
+    query(relativeSelectors: DOMString): ?Element;
+    queryAll(relativeSelectors: DOMString): Elements;
+    querySelector(selectors: DOMString): ?Element;
+    querySelectorAll(selectors: DOMString): NodeList<Element>;
+}
+
+// 4.7 Interface DocumentType
+
+declare class DocumentType extends Node {
+    name: DOMString;
+    publicId: DOMString;
+    systemId: DOMString;
+
+    // from interface ChildNode
+    before(...nodes: Nodish[]): void;
+    after(...nodes: Nodish[]): void;
+    replace(...nodes: Nodish[]): void;
+    remove(): void;
+}
+
+// 4.8 Interface Element
 
 declare class Element extends Node {
-    scrollTop: number;
-    clientLeft: number;
-    scrollLeft: number;
-    tagName: string;
-    clientWidth: number;
-    scrollWidth: number;
-    clientHeight: number;
-    clientTop: number;
-    scrollHeight: number;
-    getAttribute(name?: string): string;
-    getElementsByTagNameNS(namespaceURI: string, localName: string): NodeList;
-    hasAttributeNS(namespaceURI: string, localName: string): boolean;
-    getAttributeNS(namespaceURI: string, localName: string): string;
-    getAttributeNodeNS(namespaceURI: string, localName: string): Attr;
-    setAttributeNodeNS(newAttr: Attr): Attr;
-    hasAttribute(name: string): boolean;
-    removeAttribute(name?: string): void;
-    setAttributeNS(namespaceURI: string, qualifiedName: string, value: string): void;
-    getAttributeNode(name: string): Attr;
-    getElementsByTagName(name: string): NodeList;
-    setAttributeNode(newAttr: Attr): Attr;
-    removeAttributeNode(oldAttr: Attr): Attr;
-    setAttribute(name?: string, value?: string): void;
-    removeAttributeNS(namespaceURI: string, localName: string): void;
-    querySelector(selector: string): Element;
-    querySelectorAll(selector: string): NodeList;
+    namespaceURI: ?DOMString;
+    prefix: ?DOMString;
+    localName: DOMString;
+    tagName: DOMString;
+
+    id: DOMString;
+    className: DOMString;
+    classList: DOMTokenList;
+
+    hasAttributes(): boolean;
+    attributes: NamedNodeMap;
+    getAttribute(name: DOMString): ?DOMString;
+    getAttributeNS(namespace: ?DOMString, localName: DOMString): ?DOMString;
+    setAttribute(name: DOMString, value: DOMString): void;
+    setAttributeNS(namespace: ?DOMString, name: DOMString, value: DOMString): void;
+    removeAttribute(name: DOMString): void;
+    removeAttributeNS(namespace: ?DOMString, localName: DOMString): void;
+    hasAttribute(name: DOMString): boolean;
+    hasAttributeNS(namespace: ?DOMString, localName: DOMString): boolean;
+
+    getAttributeNode(name: DOMString): ?Attr;
+    getAttributeNodeNS(namespace: ?DOMString, localName: DOMString): ?Attr;
+    setAttributeNode(attr: Attr): ?Attr;
+    setAttributeNodeNS(attr: Attr): ?Attr;
+    removeAttributeNode(attr: Attr): Attr;
+
+    closest(selectors: DOMString): ?Element;
+    matches(selectors: DOMString): boolean;
+
+    getElementsByTagName(localName: DOMString): HTMLCollection;
+    getElementsByTagNameNS(namespace: ?DOMString, localName: DOMString): HTMLCollection;
+    getElementsByClassName(classNames: DOMString): HTMLCollection;
+
+    // from interface ParentNode
+    children: HTMLCollection;
+    firstElementChild: ?Element;
+    lastElementChild: ?Element;
+    childElementCount: number;
+
+    prepend(...nodes: Nodish[]): void;
+    append(...nodes: Nodish[]): void;
+
+    query(relativeSelectors: DOMString): ?Element;
+    queryAll(relativeSelectors: DOMString): Elements;
+    querySelector(selectors: DOMString): ?Element;
+    querySelectorAll(selectors: DOMString): NodeList<Element>;
+
+    // from interface NonDocumentTypeChildNode
+    previousElementSibling: ?Element;
+    nextElementSibling: ?Element;
+
+
+    // from interface ChildNode
+    before(...nodes: Nodish[]): void;
+    after(...nodes: Nodish[]): void;
+    replace(...nodes: Nodish[]): void;
+    remove(): void;
 }
+
+// 4.8.1 Interface NamedNodeMap
+
+declare class NamedNodeMap {
+    length: number;
+    [index: number]: ?Attr;
+    item(index: number): ?Attr;
+    // TODO: Multiple indexers
+    // [name: DOMString]: ?Attr;
+    getNamedItem(name: DOMString): ?Attr;
+    getNamedItemNS(namespace: ?DOMString, localName: DOMString): ?Attr;
+    setNamedItem(attr: Attr): ?Attr;
+    setNamedItemNS(attr: Attr): ?Attr;
+    removeNamedItem(name: DOMString): Attr;
+    removeNamedItemNS(namespace: ?DOMString, localName: DOMString): Attr;
+}
+
+// 4.8.2 Interface Attr
+
+declare class Attr {
+    namespaceURI: ?DOMString;
+    prefix: ?DOMString;
+    localName: DOMString;
+    name: DOMString;
+    value: DOMString;
+    nodeValue: DOMString; // legacy alias of .value
+    textContent: DOMString; // legacy alias of .value
+
+    ownerElement: ?Element;
+    specified: boolean; // useless; always returns true
+}
+
+// 4.9 Interface CharacterData
+
+declare class CharacterData extends Node {
+    data: DOMString;
+    length: number;
+    substringData(offset: number, count: number): DOMString;
+    appendData(data: DOMString): void;
+    insertData(offset: number, data: DOMString): void;
+    deleteData(offset: number, count: number): void;
+    replaceData(offset: number, count: number, data: DOMString): void;
+
+    // from interface NonDocumentTypeChildNode
+    previousElementSibling: ?Element;
+    nextElementSibling: ?Element;
+
+    // from interface ChildNode
+    before(...nodes: Nodish[]): void;
+    after(...nodes: Nodish[]): void;
+    replace(...nodes: Nodish[]): void;
+    remove(): void;
+}
+
+// 4.10 Interface Text
+
+declare class Text extends CharacterData {
+    constructor(data?: DOMString /*=""*/): void;
+    splitText(offset: number): Text;
+    wholeText: DOMString;
+}
+
+// 4.11 Interface ProcessingInstruction
+
+declare class ProcessingInstruction extends CharacterData {
+    target: DOMString;
+}
+
+// 4.12 Interface Comment
+
+declare class Comment extends CharacterData {
+    constructor(data?: DOMString /*=""*/): void;
+}
+
+// 5.2 Interface Range
+
+declare class Range {
+    startContainer: Node;
+    startOffset: number;
+    endContainer: Node;
+    endOffset: number;
+    collapsed: boolean;
+    commonAncestorContainer: Node;
+
+    setStart(node: Node, offset: number): void;
+    setEnd(node: Node, offset: number): void;
+    setStartBefore(node: Node): void;
+    setStartAfter(node: Node): void;
+    setEndBefore(node: Node): void;
+    setEndAfter(node: Node): void;
+    collapse(toStart?: boolean /*=false*/): void;
+    selectNode(node: Node): void;
+    selectNodeContents(node: Node): void;
+
+    static START_TO_START: number; // = 0
+    static START_TO_END: number; // = 1
+    static END_TO_START: number; // = 2
+    static END_TO_START: number; // = 3
+    compareBoundaryPoints(how: number, sourceRange: Range): number;
+
+    deleteContents(): void;
+    extractContents(): DocumentFragment;
+    cloneContents(): DocumentFragment;
+    inserNode(node: Node): void;
+    surroundContents(newParent: Node): void;
+
+    cloneRange(): Range;
+    detach(): void;
+    isPointInRange(node: Node, offset: number): boolean;
+    comparePoint(node: Node, offset: number): number;
+
+    intersectsNode(node: Node): boolean;
+
+    toString(): string;
+}
+
+// 6.1 Interface NodeIterator
+
+declare class NodeIterator {
+    root: Node;
+    referenceNode: Node;
+    pointerBeforeReferenceNode: boolean;
+    whatToShow: number;
+    filter: ?NodeFilter;
+
+    nextNode(): ?Node;
+    previousNode(): ?Node;
+
+    detach(): void;
+}
+
+// 6.2 Interface TreeWalker
+
+declare class TreeWalker {
+    root: Node;
+    whatToShow: number;
+    filter: ?NodeFilter;
+    currentNode: Node;
+
+    parenNode(): ?Node;
+    firstChild(): ?Node;
+    lastChild(): ?Node;
+    previousSibling(): ?Node;
+    nextSibling(): ?Node;
+    previousNode(): ?Node;
+    nextNode(): ?Node;
+}
+
+// 6.3 Interface NodeFilter
+
+declare class NodeFilter {
+    // Constants for acceptNode()
+    static FILTER_ACCEPT: number; // = 1;
+    static FILTER_REJECT: number; // = 2;
+    static FILTER_SKIP: number; // = 3;
+
+    // Constants for whatToShow
+    static SHOW_ALL: number; // = 0xFFFFFFFF;
+    static SHOW_ELEMENT: number; // = 0x1;
+    static SHOW_ATTRIBUTE: number; // = 0x2; // historical
+    static SHOW_TEXT: number; // = 0x4;
+    static SHOW_CDATA_SECTION: number; // = 0x8; // historical
+    static SHOW_ENTITY_REFERENCE: number; // = 0x10; // historical
+    static SHOW_ENTITY: number; // = 0x20; // historical
+    static SHOW_PROCESSING_INSTRUCTION: number; // = 0x40;
+    static SHOW_COMMENT: number; // = 0x80;
+    static SHOW_DOCUMENT: number; // = 0x100;
+    static SHOW_DOCUMENT_TYPE: number; // = 0x200;
+    static SHOW_DOCUMENT_FRAGMENT: number; // = 0x400;
+    static SHOW_NOTATION: number; // = 0x800; // historical
+
+    acceptNode(node: Node): number;
+}
+
+// 7.1 Interface DOMTokenList
+
+declare class DOMTokenList {
+    length: number;
+    [index: number]: ?DOMString;
+    item(index: number): ?DOMString;
+    contains(token: DOMString): boolean;
+    add(...tokens: DOMString[]): void;
+    remove(...tokens: DOMString[]): void;
+    toggle(token: DOMString, force?: boolean): boolean;
+    toString(): string;
+    // TODO: iterable<DOMString>;
+}
+
+// 7.2 Interface DOMSettableTokenList
+
+declare class DOMSettableTokenList extends DOMTokenList {
+    value: DOMString;
+}
+
+/* Browser globals */
+
+declare var document:  Document;
+
+/* HTML */
 
 declare class HTMLElement extends Element {
     id: string;
@@ -329,13 +699,6 @@ declare class HTMLCanvasElement extends HTMLElement {
     getContext(contextId: string, ...args: any): ?RenderingContext;
     toDataURL(type?: string, ...args: any): string;
     toBlob(callback: (v: File) => void, type?: string, ...args: any): void;
-}
-
-declare class HTMLCollection {
-    [name: number]: Element;
-    length: number;
-    item(nameOrIndex?: any, optionalIndex?: any): Element;
-    namedItem(name: string): Element;
 }
 
 declare class HTMLFormElement extends HTMLElement {
@@ -462,41 +825,3 @@ declare class ClientRectList { // extension
 }
 
 // TODO: HTML*Element
-
-declare class DOMImplementation {
-    createDocumentType(qualifiedName: string, publicId: string, systemId: string): DocumentType;
-    createDocument(namespaceURI: string, qualifiedName: string, doctype: DocumentType): Document;
-    hasFeature(feature: string, version?: string): boolean;
-
-    // non-standard
-    createHTMLDocument(title: string): Document;
-}
-
-declare class DocumentType extends Node {
-    name: string;
-    notations: NamedNodeMap;
-    systemId: string;
-    internalSubset: string;
-    entities: NamedNodeMap;
-    publicId: string;
-}
-
-declare class CharacterData extends Node {
-    length: number;
-    data: string;
-    deleteData(offset: number, count: number): void;
-    replaceData(offset: number, count: number, arg: string): void;
-    appendData(arg: string): void;
-    insertData(offset: number, arg: string): void;
-    substringData(offset: number, count: number): string;
-}
-
-declare class Text extends CharacterData {
-    wholeText: string;
-    splitText(offset: number): Text;
-    replaceWholeText(content: string): Text;
-}
-
-declare class Comment extends CharacterData {
-    text: string;
-}


### PR DESCRIPTION
I tried to clean up the DOM API, by mostly following  https://dom.spec.whatwg.org/. This version does **not** include 

- Browser specific properties (except some for `Event`)
- Properties / interface from older versions of the spec ( < DOM Level 4) which have been changed / removed

Ideally we could somehow create separate declarations for this and put everything together. If people can choose which standard lib declarations to use, would it make sense to create something like `dom.js` (latest) and `dom3.js`? Thoughts?

Next step would be to go through https://html.spec.whatwg.org and do the same for HTML.

---

I originally wanted to programmatically convert IDL interface declarations to flow class declarations, but I haven't found a parser yet that can understand the latest version of WebIDL. But I think this would still be worth pursuing at some point. 