### PR TITLE
Show errors when failed to read definitions file

### DIFF
--- a/src/typing/init_js.ml
+++ b/src/typing/init_js.ml
@@ -30,8 +30,9 @@ let parse_lib () =
   |> List.map (fun lib_file ->
     try (
       let lib_content = cat lib_file in
-      match fst (Parsing_service_js.do_parse lib_content lib_file) with
-      | Some ast -> lib_file, ast
+      match (Parsing_service_js.do_parse ~keep_errors:true lib_content lib_file) with
+      | Some ast, _ -> lib_file, ast
+      | _, Some err -> Errors.print_error_summary true (Errors.to_list err); assert false
       | _ -> assert false
     )
     with _ ->


### PR DESCRIPTION
When I make a typo in a huge declarations file, I get common error `Can't read library definitions file %s, exiting`. 
Is there any special reason not to show the exact errors while parsing definitions files? Since `--no-flowlib` is now available (and many thanks to merge) the question becomes relevant. 
