### PR TITLE
Removed hard-coded .length case

### DIFF
--- a/src/typing/flow_js.ml
+++ b/src/typing/flow_js.ml
@@ -1262,12 +1262,6 @@ let rec flow cx (l,u) trace =
     | (_,
        (GetT(_,"toLocaleString",_) | SetT(_,"toLocaleString",_))) -> ()
 
-    | ((ObjT _ | ArrT _), GetT(reason_op,"length",tout)) ->
-      unit_flow cx (NumT.why reason_op, tout)
-
-    | ((ObjT _ | ArrT _),
-       (SetT(_,"length",_) | MethodT(_,"length",_,_,_,_))) -> ()
-
     | ((ObjT _ | ArrT _), GetT(reason_op,"constructor",tout)) ->
       unit_flow cx (AnyT.why reason_op, tout)
 

--- a/tests/misc/F.js
+++ b/tests/misc/F.js
@@ -1,0 +1,2 @@
+function fn2(x) { return x.length * 4; }
+fn2({length: 'hi'}); 

--- a/tests/misc/G.js
+++ b/tests/misc/G.js
@@ -1,0 +1,3 @@
+var a = { length: "duck" };
+a.length = 123;
+a.length();

--- a/tests/misc/misc.exp
+++ b/tests/misc/misc.exp
@@ -11,4 +11,16 @@ E.js:8:6,10: boolean
 This type is incompatible with
   E.js:4:14,19: number
 
-Found 3 errors
+F.js:2:14,17: string
+This type is incompatible with
+  F.js:1:26,37: number
+
+G.js:2:12,14: number
+This type is incompatible with
+  G.js:1:19,24: string
+
+G.js:3:1,10: call of method length
+Function cannot be called on
+  G.js:1:19,24: string
+
+Found 6 errors


### PR DESCRIPTION
Enable type checker to correctly type non-standard length properties.
Fixes issue #131.