### PR TITLE
Resubmit #113 this fixes #155

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -11,8 +11,8 @@
 
 declare class Blob {
     constructor(blobParts?: Array<any>, options?: {
-        type: string;
-        endings: string;
+        type?: string;
+        endings?: string;
     }): void;
     type: string;
     size: number;


### PR DESCRIPTION
According to https://developer.mozilla.org/en-US/docs/Web/API/Blob.Blob type and endings are optional arguments.
(http://dev.w3.org/2006/webapi/FileAPI/#dfn-BlobPropertyBag also says type is optional, but has no endings argument at all)