### PR TITLE
Add declaration for Document.execCommand()

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -238,6 +238,7 @@ declare class Document extends Node {
     getElementsByName(elementName: string): HTMLCollection;
     createAttribute(name: string): Attr;
     createTextNode(data: string): Text;
+    execCommand(cmdID: string, showUI?: boolean, value?: any): boolean;
     xmlEncoding: string;
     xmlStandalone: boolean;
     xmlVersion: string;

--- a/tests/union/union.exp
+++ b/tests/union/union.exp
@@ -5,7 +5,7 @@ This type is incompatible with
 
 union.js:7:5,5: number
 This type is incompatible with
-  [LIB] dom.js:198:1,256:1: Document
+  [LIB] dom.js:198:1,257:1: Document
 
 union.js:9:7,7: C
 This type is incompatible with


### PR DESCRIPTION
Adds a declaration for the document's [`execCommand()`](https://developer.mozilla.org/en-US/docs/Web/API/document.execCommand), copied from the already-implemented IE-only textRange's `execCommand()`.