### PR TITLE
disable colors when TERM=dumb

### DIFF
--- a/src/common/errors_js.ml
+++ b/src/common/errors_js.ml
@@ -47,7 +47,7 @@ let print_reason_color ~(first:bool) ((p, s): Pos.t * string) = Pos.(
   ] in
 
   if not first then Printf.printf "  " else Printf.printf "\n";
-  if Unix.isatty Unix.stdout
+  if Unix.isatty Unix.stdout && Sys.getenv "TERM" <> "dumb"
   then
     C.print to_print
   else


### PR DESCRIPTION
Fixes #220

I didn't add a command line flag since hack uses `--color` for a very different meaning, and `--no-color` would be confusing if we ever add hack's `--color`.