### PR TITLE
Uncomment React.createElement(name: string) declarations

### DIFF
--- a/lib/react.js
+++ b/lib/react.js
@@ -92,7 +92,7 @@ declare module react {
 
     declare function createClass(spec: any): ReactClass<any,any,any>; // compiler magic
 
-//    declare function createElement(name: string, props?: any, children?: any): any;
+    declare function createElement(name: string, props?: any, children?: any): any;
     declare function createElement<A,P,S>(name: ReactClass<A,P,S>, props: A & $Shape<P>, children?: any): ReactElement<A,P,S>;
 
     declare function createFactory(name: string): (props?: any, children?: any) => any;
@@ -126,7 +126,7 @@ declare module React {
 
     declare function createClass(spec: any): ReactClass<any,any,any>; // compiler magic
 
-//    declare function createElement(name: string, props?: any, children?: any): any;
+    declare function createElement(name: string, props?: any, children?: any): any;
     declare function createElement<A,P,S>(name: ReactClass<A,P,S>, props: A & $Shape<P>, children?: any): ReactElement<A,P,S>;
 
     declare function createFactory(name: string): (props?: any, children?: any) => any;


### PR DESCRIPTION
I wasn't able to find why `React.createElement(name: string)` was commented out (it's like that from [the first commit](https://github.com/facebook/flow/blob/0b64272ee2af3f1666946553ba40190f073607d0/lib/react.js#L55)), but it's still a perfectly valid use-case, e.g.:
```JavaScript
var tag = typeof props.rows === 'number' ? 'textarea' : 'input';
return React.createElement(tag, ...);
```
IIRC, React even had a warning advising to use React.createElement() instead of React.DOM.* factories.