### PR TITLE
Include information about third party tools

### DIFF
--- a/docs/02-running.md
+++ b/docs/02-running.md
@@ -9,7 +9,7 @@ next: troubleshooting.html
 
 Since types are not part of the JavaScript specification, we need to strip them out before sending the file to the user. There are two ways to do so:
 
-* You can use the JSX transform tool (part of the React tools) to translate your files to plain JavaScript
+* You can use the JSX transform tool (part of the React tools), or a  [third party transform tool](https://github.com/facebook/flow/wiki/3rd-party-tools#transformers), to translate your files to plain JavaScript.
 * For quick prototyping, you can run the transforms directly in the browser
 
 ## Using the offline transform tool


### PR DESCRIPTION
Other tools (like Babel) are available and can solve problems devs have with the react-tools transform. I wanted to make devs aware of them, and one way to do this is via the wiki. If such a list should instead be included into the site, that's fine for me as well.