### PR TITLE
Move methods and attributes to appropriate parent classes, and add declarations to describe the CSSOM to provide stronger typing for `HTMLElement.style` attribute.

### DIFF
--- a/lib/cssom.js
+++ b/lib/cssom.js
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) 2014, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the "flow" directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+declare class CSSStyleSheet {
+  cssRules: CSSRuleList;
+  ownerRule: ?CSSRule;
+  deleteRule(index: number): void;
+  insertRule(rule: string, index: number): void;
+}
+
+declare class CSSRule {
+  cssText: string;
+  parentRule: ?CSSRule;
+  parentStyleSheet: ?CSSStyleSheet;
+  type: number;
+  static STYLE_RULE: number;
+  static MEDIA_RULE: number;
+  static FONT_FACE_RULE: number;
+  static PAGE_RULE: number;
+  static IMPORT_RULE: number;
+  static CHARSET_RULE: number;
+  static UNKNOWN_RULE: number;
+  static KEYFRAMES_RULE: number;
+  static KEYFRAME_RULE: number;
+  static NAMESPACE_RULE: number;
+  static COUNTER_STYLE_RULE: number;
+  static SUPPORTS_RULE: number;
+  static DOCUMENT_RULE: number;
+  static FONT_FEATURE_VALUES_RULE: number;
+  static VIEWPORT_RULE: number;
+  static REGION_STYLE_RULE: number;
+}
+
+declare class CSSRuleList {
+  length: number;
+  item(index: number): ?CSSRule;
+}
+
+declare class CSSStyleDeclaration {
+  cssText: string;
+  length: number;
+  parentRule: CSSRule;
+  cssFloat: string;
+  item(index: number): string;
+  getPropertyValue(property:string): string;
+  getPropertyPriority(property: string): string;
+  setProperty(property: string, value: ?string, priority: ?string): void;
+  setPropertyValue(property: string, value: string): void;
+  setPropertyPriority(property: string, priority: string): void;
+  removeProperty(property: string): string;
+}

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -294,6 +294,15 @@ declare var document: Document;
 
 // TODO: HTMLDocument
 
+declare class DOMTokenList {
+  length: number;
+  item(index: number): string;
+  contains(token: string): boolean;
+  add(token: string): void;
+  remove(token: string): void;
+  toggle(token: string): boolean;
+}
+
 declare class Element extends Node {
     scrollTop: number;
     clientLeft: number;
@@ -304,6 +313,15 @@ declare class Element extends Node {
     clientHeight: number;
     clientTop: number;
     scrollHeight: number;
+    innerHTML: string;
+    outerHTML: string;
+    childElementCount: number;
+    nextElementSibling: Element;
+    previousElementSibling: Element;
+    firstElementChild: ?Element;
+    lastElementChild: ?Element;
+    classList: DOMTokenList;
+
     getAttribute(name?: string): string;
     getElementsByTagNameNS(namespaceURI: string, localName: string): NodeList<HTMLElement>;
     hasAttributeNS(namespaceURI: string, localName: string): boolean;
@@ -321,19 +339,31 @@ declare class Element extends Node {
     removeAttributeNS(namespaceURI: string, localName: string): void;
     querySelector(selector: string): HTMLElement;
     querySelectorAll(selector: string): NodeList<HTMLElement>;
+    insertAdjacentHTML(position: string, text: string): void;
 }
 
 declare class HTMLElement extends Element {
     id: string;
     title: string;
     lang: string;
+    translate: boolean;
     dir: string;
     className: string;
+    accessKey: string;
+    accessKeyLabel: string;
+    dataset: {[key:string]: string};
+    contentEditable: string;
+    isContentEditable: boolean;
+    hidden: boolean;
+    tabIndex: number;
+    spellcheck: boolean;
+    getBoundingClientRect(): ClientRect;
+    blur(): void;
+    click(): void;
+    focus(): void;
 
     // extension
-    getBoundingClientRect(): ClientRect;
-    style: any;
-    innerHTML: string;
+    style: CSSStyleDeclaration;
     scrollIntoView(top?: boolean): void;
     onerror: (ev: any) => void;
     onload: (ev: any) => void;
@@ -437,7 +467,6 @@ declare class HTMLInputElement extends HTMLElement {
 }
 
 declare class HTMLAnchorElement extends HTMLElement {
-    accessKey: string;
     charset: string;
     coords: string;
     download: string;
@@ -461,10 +490,6 @@ declare class HTMLAnchorElement extends HTMLElement {
     text: string;
     type: string;
     username: string;
-
-    // Note: these should be on base class HTMLElement.
-    blur(): void;
-    click(): void;
 }
 
 declare class HTMLScriptElement extends HTMLElement {


### PR DESCRIPTION
This pull brings flow's definition of `HTMLElement` into line with the W3C HTML5 Recommendation and introduces most of the classes described by the CSS Object Model.