### PR TITLE
Implement more PropTypes

### DIFF
--- a/src/typing/flow_js.ml
+++ b/src/typing/flow_js.ml
@@ -1549,11 +1549,9 @@ let rec flow cx (l,u) trace =
          unaliased), propertywise subtyping is sound *)
       let lit =
         let desc = (desc_of_reason reason1) in
-        let is_prefix a b =
-          let a_len = String.length a in
-          let b_len = String.length b in
-          let rec loop i = i = b_len || a.[i] = b.[i] && loop (i + 1) in
-          a_len >= b_len && loop 0 in
+        let is_prefix a b = String.(
+          let n = length b in
+          length a >= n && sub a 0 n = b) in
         desc = "object literal" || is_prefix desc "props of React element" in
       iter_props_ cx flds2
         (fun s -> fun t2 ->

--- a/src/typing/flow_js.ml
+++ b/src/typing/flow_js.ml
@@ -1547,7 +1547,14 @@ let rec flow cx (l,u) trace =
       ->
       (* if inflowing type is literal (thus guaranteed to be
          unaliased), propertywise subtyping is sound *)
-      let lit = (desc_of_reason reason1) = "object literal" in
+      let lit =
+        let desc = (desc_of_reason reason1) in
+        let is_prefix a b =
+          let a_len = String.length a in
+          let b_len = String.length b in
+          let rec loop i = i = b_len || a.[i] = b.[i] && loop (i + 1) in
+          a_len >= b_len && loop 0 in
+        desc = "object literal" || is_prefix desc "props of React element" in
       iter_props_ cx flds2
         (fun s -> fun t2 ->
           if (not(has_prop cx flds1 s))

--- a/src/typing/type_inference_js.ml
+++ b/src/typing/type_inference_js.ml
@@ -519,17 +519,7 @@ let rec convert cx map = Ast.Type.(function
 
       | "Function" | "function" ->
         let reason = mk_reason "function type" loc in
-        FunT (
-          reason,
-          AnyT.at loc,
-          AnyT.at loc,
-          {
-            this_t = AnyT.at loc;
-            params_tlist = [RestT (AnyT.at loc)];
-            params_names = None;
-            return_t = AnyT.at loc;
-            closure_t = 0
-          })
+        mk_any_function reason loc
 
       | "Object" ->
         let reason = mk_reason "any object type" loc in
@@ -719,6 +709,19 @@ and mk_enum_type cx reason keys =
     SMap.add key AnyT.t map
   ) SMap.empty keys in
   EnumT (reason, Flow_js.mk_object_with_map_proto cx reason map (MixedT reason))
+
+and mk_any_function reason loc =
+  FunT (
+    reason,
+    AnyT.at loc,
+    AnyT.at loc,
+    {
+      this_t = AnyT.at loc;
+      params_tlist = [RestT (AnyT.at loc)];
+      params_names = None;
+      return_t = AnyT.at loc;
+      closure_t = 0
+    })
 
 (************)
 (* Visitors *)
@@ -3032,7 +3035,7 @@ and mk_proptype cx = Ast.Expression.(function
         (_, {Ast.Identifier.name = "func"; _ });
       _
     } ->
-      AnyT.at vloc (* TODO *)
+      mk_any_function (mk_reason "func" vloc) vloc
 
   | vloc, Member { Member.
       property = Member.PropertyIdentifier

--- a/src/typing/type_inference_js.ml
+++ b/src/typing/type_inference_js.ml
@@ -3087,7 +3087,18 @@ and mk_proptype cx = Ast.Expression.(function
       };
       arguments = [Expression e];
     } ->
-      AnyT.at vloc (* TODO *)
+      let flags = {
+        sealed = false;
+        exact = true
+      } in
+      let dict = {
+        dict_name = None;
+        key = AnyT.t;
+        value = mk_proptype cx e
+      } in
+      let pmap = Flow_js.mk_propmap cx SMap.empty in
+      let proto = MixedT (reason_of_string "Object") in
+      ObjT (mk_reason "objectOf" vloc, Flow_js.mk_objecttype ~flags dict pmap proto)
 
   | vloc, Call { Call.
       callee = _, Member { Member.

--- a/src/typing/type_inference_js.ml
+++ b/src/typing/type_inference_js.ml
@@ -3042,7 +3042,7 @@ and mk_proptype cx = Ast.Expression.(function
         (_, {Ast.Identifier.name = "object"; _ });
       _
     } ->
-      AnyT.at vloc (* TODO *)
+      AnyObjT (mk_reason "object" vloc)
 
   | vloc, Member { Member.
       property = Member.PropertyIdentifier

--- a/tests/new_react/new_react.exp
+++ b/tests/new_react/new_react.exp
@@ -47,10 +47,6 @@ new_react.js:4:12,33: string
 This type is incompatible with
   new_react.js:18:15,20: number
 
-new_react.js:4:12,33: string
-This type is incompatible with
-  new_react.js:26:23,23: number
-
 new_react.js:6:12,33: number
 This type is incompatible with
   new_react.js:17:18,23: string
@@ -135,4 +131,4 @@ This type is incompatible with
 Too few arguments (expected default/rest parameters in function)
   classes.js:3:7,9: Foo
 
-Found 34 errors
+Found 33 errors

--- a/tests/react/proptype_arrayOf.js
+++ b/tests/react/proptype_arrayOf.js
@@ -1,0 +1,14 @@
+/* @flow */
+
+var React = require('react');
+var Example = React.createClass({
+  propTypes: {
+    arr: React.PropTypes.arrayOf(React.PropTypes.number).isRequired
+  },
+});
+
+var ok_empty = <Example arr={[]} />
+var ok_numbers = <Example arr={[1, 2]} />
+
+var fail_not_array = <Example arr={2} />
+var fail_mistyped_elems = <Example arr={[1, "foo"]} />

--- a/tests/react/proptype_func.js
+++ b/tests/react/proptype_func.js
@@ -1,0 +1,14 @@
+/* @flow */
+
+var React = require('react');
+var Example = React.createClass({
+  propTypes: {
+    func: React.PropTypes.func.isRequired
+  },
+});
+
+var ok_void = <Example func={() => {}} />;
+var ok_args = <Example func={(x) => {}} />;
+var ok_retval = <Example func={() => 1} />
+
+var fail_mistyped = <Example func={2} />

--- a/tests/react/proptype_object.js
+++ b/tests/react/proptype_object.js
@@ -1,0 +1,13 @@
+/* @flow */
+
+var React = require('react');
+var Example = React.createClass({
+  propTypes: {
+    object: React.PropTypes.object.isRequired
+  },
+});
+
+var ok_empty = <Example object={{}} />;
+var ok_props = <Example object={{foo: "bar"}} />;
+
+var fail_mistyped = <Example object={2} />

--- a/tests/react/proptype_objectOf.js
+++ b/tests/react/proptype_objectOf.js
@@ -1,0 +1,14 @@
+/* @flow */
+
+var React = require('react');
+var Example = React.createClass({
+  propTypes: {
+    obj: React.PropTypes.objectOf(React.PropTypes.number).isRequired
+  },
+});
+
+var ok_empty = <Example obj={{}} />
+var ok_numbers = <Example obj={{foo: 1, bar: 2}} />
+
+var fail_not_object = <Example obj={2} />
+var fail_mistyped_props = <Example obj={{foo: "foo"}} />

--- a/tests/react/react.exp
+++ b/tests/react/react.exp
@@ -7,14 +7,6 @@ jsx_spread.js:10:19,20: number
 This type is incompatible with
   jsx_spread.js:6:10,31: string
 
-proptype_arrayOf.js:6:10,56: arrayOf
-This type is incompatible with
-  proptype_arrayOf.js:13:36,36: number
-
-proptype_arrayOf.js:6:34,55: number
-This type is incompatible with
-  proptype_arrayOf.js:14:45,49: string
-
 proptype_arrayOf.js:13:36,36: number
 This type is incompatible with
   proptype_arrayOf.js:6:10,56: arrayOf
@@ -23,17 +15,9 @@ proptype_arrayOf.js:14:45,49: string
 This type is incompatible with
   proptype_arrayOf.js:6:34,55: number
 
-proptype_func.js:6:11,30: func
-This type is incompatible with
-  proptype_func.js:14:36,36: number
-
 proptype_func.js:14:36,36: number
 This type is incompatible with
   proptype_func.js:6:11,30: func
-
-proptype_object.js:6:13,34: object
-This type is incompatible with
-  proptype_object.js:13:38,38: number
 
 proptype_object.js:13:38,38: number
 This type is incompatible with
@@ -43,4 +27,4 @@ proptype_oneOf.js:11:28,32: string literal bar
 Property not found in
   proptype_oneOf.js:6:14,43: oneOf
 
-Found 11 errors
+Found 7 errors

--- a/tests/react/react.exp
+++ b/tests/react/react.exp
@@ -7,6 +7,22 @@ jsx_spread.js:10:19,20: number
 This type is incompatible with
   jsx_spread.js:6:10,31: string
 
+proptype_arrayOf.js:6:10,56: arrayOf
+This type is incompatible with
+  proptype_arrayOf.js:13:36,36: number
+
+proptype_arrayOf.js:6:34,55: number
+This type is incompatible with
+  proptype_arrayOf.js:14:45,49: string
+
+proptype_arrayOf.js:13:36,36: number
+This type is incompatible with
+  proptype_arrayOf.js:6:10,56: arrayOf
+
+proptype_arrayOf.js:14:45,49: string
+This type is incompatible with
+  proptype_arrayOf.js:6:34,55: number
+
 proptype_func.js:6:11,30: func
 This type is incompatible with
   proptype_func.js:14:36,36: number
@@ -27,4 +43,4 @@ proptype_oneOf.js:11:28,32: string literal bar
 Property not found in
   proptype_oneOf.js:6:14,43: oneOf
 
-Found 7 errors
+Found 11 errors

--- a/tests/react/react.exp
+++ b/tests/react/react.exp
@@ -23,8 +23,16 @@ proptype_object.js:13:38,38: number
 This type is incompatible with
   proptype_object.js:6:13,34: object
 
+proptype_objectOf.js:13:37,37: number
+This type is incompatible with
+  proptype_objectOf.js:6:10,57: objectOf
+
+proptype_objectOf.js:14:47,51: string
+This type is incompatible with
+  proptype_objectOf.js:6:35,56: number
+
 proptype_oneOf.js:11:28,32: string literal bar
 Property not found in
   proptype_oneOf.js:6:14,43: oneOf
 
-Found 7 errors
+Found 9 errors

--- a/tests/react/react.exp
+++ b/tests/react/react.exp
@@ -7,8 +7,16 @@ jsx_spread.js:10:19,20: number
 This type is incompatible with
   jsx_spread.js:6:10,31: string
 
+proptype_func.js:6:11,30: func
+This type is incompatible with
+  proptype_func.js:14:36,36: number
+
+proptype_func.js:14:36,36: number
+This type is incompatible with
+  proptype_func.js:6:11,30: func
+
 proptype_oneOf.js:11:28,32: string literal bar
 Property not found in
   proptype_oneOf.js:6:14,43: oneOf
 
-Found 3 errors
+Found 5 errors

--- a/tests/react/react.exp
+++ b/tests/react/react.exp
@@ -15,8 +15,16 @@ proptype_func.js:14:36,36: number
 This type is incompatible with
   proptype_func.js:6:11,30: func
 
+proptype_object.js:6:13,34: object
+This type is incompatible with
+  proptype_object.js:13:38,38: number
+
+proptype_object.js:13:38,38: number
+This type is incompatible with
+  proptype_object.js:6:13,34: object
+
 proptype_oneOf.js:11:28,32: string literal bar
 Property not found in
   proptype_oneOf.js:6:14,43: oneOf
 
-Found 5 errors
+Found 7 errors


### PR DESCRIPTION
Implemented `func`, `object`, and `objectOf`. Added tests for the existing `arrayOf` proptype. "Fixed" issue flowing React props to generated proptypes (see  ba95d17).