### PR TITLE
Match string variables with literal information in oneOf proptype

### DIFF
--- a/src/typing/type_inference_js.ml
+++ b/src/typing/type_inference_js.ml
@@ -3115,6 +3115,11 @@ and mk_proptype cx = Ast.Expression.(function
             value = Ast.Literal.String lit; _
           })) :: tl ->
             string_literals (lit :: lits) tl
+        | Some (Expression (loc, Identifier (_, { Ast.Identifier.name; _ }))) :: tl ->
+            (match (Env_js.get_var cx name (mk_reason "identifier" loc)) with
+              | StrT (_, Some lit) ->
+                  string_literals (lit :: lits) tl
+              | _ -> None)
         | [] -> Some lits
         | _  -> None in
       (match string_literals [] es with

--- a/tests/react/proptype_oneOf.js
+++ b/tests/react/proptype_oneOf.js
@@ -1,11 +1,17 @@
 /* @flow */
 
+var foo = "foo";
+var bar = "bar";
+
 var React = require('react');
 var Example = React.createClass({
   propTypes: {
-    literal: React.PropTypes.oneOf(["foo"]).isRequired
+    literal: React.PropTypes.oneOf(["foo"]).isRequired,
+    string: React.PropTypes.oneOf([foo]).isRequired
   },
 });
 
-var ex1 = <Example literal="foo" />;
-var ex2 = <Example literal="bar" />;
+var ok = <Example literal={foo} string={foo} />;
+
+var fail_wrong_literal = <Example literal={bar} string={foo} />;
+var fail_wrong_string = <Example literal={foo} string={bar} />;

--- a/tests/react/react.exp
+++ b/tests/react/react.exp
@@ -31,8 +31,12 @@ proptype_objectOf.js:14:47,51: string
 This type is incompatible with
   proptype_objectOf.js:6:35,56: number
 
-proptype_oneOf.js:11:28,32: string literal bar
+proptype_oneOf.js:16:44,46: string literal bar
 Property not found in
-  proptype_oneOf.js:6:14,43: oneOf
+  proptype_oneOf.js:9:14,43: oneOf
 
-Found 9 errors
+proptype_oneOf.js:17:56,58: string literal bar
+Property not found in
+  proptype_oneOf.js:10:13,40: oneOf
+
+Found 10 errors


### PR DESCRIPTION
This could be way off-base, but it seems like we'll often have literal information with a StrT. This makes oneOf a lot more powerful/useful.