### PR TITLE
Add type signature for node "url", "querystring" and "path" modules

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -468,7 +468,25 @@ declare module "punycode" {
 }
 
 declare module "querystring" {
-  // TODO
+  declare function stringify(
+    obj: Object,
+    separator: ?string,
+    equal: ?string,
+    options?: {
+      encodeURIComponent?: (str: string) => string;
+    }
+  ): string;
+  declare function parse(
+    str: string,
+    separator: ?string,
+    equal: ?string,
+    options?: {
+      decodeURIComponent?: (str: string) => string;
+      maxKeys?: number;
+    }
+  ): any;
+  declare function escape(str: string): string;
+  declare function unescape(str: string, decodeSpaces?: boolean): string;
 }
 
 declare module "readline" {

--- a/lib/node.js
+++ b/lib/node.js
@@ -501,7 +501,38 @@ declare module "tls" {
 }
 
 declare module "url" {
-  // TODO
+  declare function parse(
+    urlStr: string,
+    parseQueryString: ?boolean,
+    slashesDenoteHost?: boolean
+  ): {
+    protocol: ?string;
+    slashes: ?boolean;
+    auth: ?string;
+    host: ?string;
+    port: ?string;
+    hostname: ?string;
+    hash: ?string;
+    search: ?string;
+    query: ?any; // null | string | Object
+    pathname: ?string;
+    path: ?string;
+    href: string;
+  };
+  declare function format(urlObj: {
+    href?: string;
+    protocol?: string;
+    slashes?: boolean;
+    auth?: string;
+    hostname?: string;
+    port?: string | number;
+    host?: string;
+    pathname?: string;
+    search?: string;
+    query?: Object;
+    hash?: string;
+  }): string;
+  declare function resolve(from: string, to: string): string;
 }
 
 declare module "util" {

--- a/lib/node.js
+++ b/lib/node.js
@@ -460,7 +460,32 @@ declare module "os" {
 }
 
 declare module "path" {
-  // TODO
+  declare function normalize(path: string): string;
+  declare function join(...parts: Array<string>): string;
+  declare function resolve(...parts: Array<string>): string;
+  declare function isAbsolute(path: string): boolean;
+  declare function relative(from: string, to: string): string;
+  declare function dirname(path: string): string;
+  declare function basename(path: string, ext?: string): string;
+  declare function extname(path: string): string;
+  declare var sep: string;
+  declare var delimiter: string;
+  declare function parse(pathString: string): {
+    root: string;
+    dir: string;
+    base: string;
+    ext: string;
+    name: string;
+  };
+  declare function format(pathObject: {
+    root?: string;
+    dir?: string;
+    base?: string;
+    ext?: string;
+    name?: string;
+  }): string;
+  declare var posix: any;
+  declare var win32: any;
 }
 
 declare module "punycode" {


### PR DESCRIPTION
_I'm just experimenting with Flow - so if this PR sucks, it's ok to just say so_

Things I'm not totally clear on:

* The `path` module exports `posix` and `win32` - they have the same interface as `path`. How do I express that? See https://github.com/joyent/node/blob/a995a6a/lib/path.js#L620-L626

* `querystring` has undocumented aliases for `stringify` and `parse` (`encode` and `decode` respectively). Should they be included?

* `url#parse` can return a `query` that can be `null | string | Object`, but I couldn't get that to work in any form.