### PR TITLE
Implement PropTypes.oneOfType

### DIFF
--- a/src/typing/type_inference_js.ml
+++ b/src/typing/type_inference_js.ml
@@ -3552,9 +3552,17 @@ and mk_proptype cx = Ast.Expression.(function
           (_, {Ast.Identifier.name = "oneOfType"; _ });
          _
       };
-      arguments = es;
+      arguments = [Expression (_, Array { Array.elements })]
     } ->
-      AnyT.at vloc (* TODO *)
+      let rec proptype_elements ts es = match es with
+        | Some (Expression e) :: tl ->
+            proptype_elements (mk_proptype cx e :: ts) tl
+        | [] -> Some ts
+        | _ -> None in
+      let reason = mk_reason "oneOf" vloc in
+      (match proptype_elements [] elements with
+        | Some ts -> UnionT (reason, ts)
+        | None -> AnyT.at vloc)
 
   | vloc, Call { Call.
       callee = _, Member { Member.

--- a/src/typing/type_inference_js.ml
+++ b/src/typing/type_inference_js.ml
@@ -3519,9 +3519,7 @@ and mk_proptype cx = Ast.Expression.(function
           (_, {Ast.Identifier.name = "oneOf"; _ });
          _
       };
-      arguments = [Expression (_, Array { Array.
-        elements = es
-      })];
+      arguments = [Expression (_, Array { Array.elements })]
     } ->
       let rec string_literals lits es = match (es) with
         | Some (Expression (loc, Literal { Ast.Literal.
@@ -3530,21 +3528,11 @@ and mk_proptype cx = Ast.Expression.(function
             string_literals (lit :: lits) tl
         | [] -> Some lits
         | _  -> None in
-      (match string_literals [] es with
+      (match string_literals [] elements with
         | Some lits ->
             let reason = mk_reason "oneOf" vloc in
             mk_enum_type cx reason lits
         | None -> AnyT.at vloc)
-
-  | vloc, Call { Call.
-      callee = _, Member { Member.
-         property = Member.PropertyIdentifier
-          (_, {Ast.Identifier.name = "oneOf"; _ });
-         _
-      };
-      arguments = es;
-    } ->
-      AnyT.at vloc (* TODO *)
 
   | vloc, Call { Call.
       callee = _, Member { Member.

--- a/tests/react/proptype_oneOfType.js
+++ b/tests/react/proptype_oneOfType.js
@@ -1,0 +1,23 @@
+/* @flow */
+
+var React = require('react');
+var Example = React.createClass({
+  propTypes: {
+    prop: React.PropTypes.oneOfType([
+      React.PropTypes.string,
+      React.PropTypes.number
+    ]).isRequired
+  },
+  render() {
+    if (typeof this.props.prop === "string") {
+      return <div>{this.props.prop}</div>
+    } else {
+      return <div>{this.props.prop.toFixed(2)}</div>
+    }
+  }
+});
+
+var ok_number = <Example prop={42} />;
+var ok_string = <Example prop="bar" />;
+
+var fail_bool = <Example prop={true} />

--- a/tests/react/react.exp
+++ b/tests/react/react.exp
@@ -35,4 +35,8 @@ proptype_oneOf.js:11:28,32: string literal bar
 Property not found in
   proptype_oneOf.js:6:14,43: oneOf
 
-Found 9 errors
+proptype_oneOfType.js:23:32,35: boolean
+This type is incompatible with
+  proptype_oneOfType.js:6:11,9:6: oneOf
+
+Found 10 errors


### PR DESCRIPTION
Each expression in the array becomes a type in a union. It's possible (likely even) that we will produce a union containing an AnyT, but I don't believe that will be a problem. If the array is empty, we will create an "empty union" which should not admit any value. If the array contains a spread, we fall back to AnyT.