### PR TITLE
Allow type alias declaration in module.

### DIFF
--- a/src/parser/parser_flow.ml
+++ b/src/parser/parser_flow.ml
@@ -1621,6 +1621,25 @@ end = struct
             extends;
           })) in
 
+      (* This is more or less identical to `type_alias` *)
+      let declare_type_alias env start_loc =
+	Expect.token env T_TYPE;
+	Eat.push_lex_mode env TYPE_LEX;
+	let id = Parse.identifier env in
+	let typeParameters = Type.type_parameter_declaration env in
+	Expect.token env T_ASSIGN;
+	let right = Type._type env in
+	let end_loc = match Peek.semicolon_loc env with
+	  | None -> fst right
+	  | Some end_loc -> end_loc in
+	Eat.semicolon env;
+	Eat.pop_lex_mode env;
+        Loc.btwn start_loc end_loc, Statement.(TypeAlias TypeAlias.({
+          id;
+          typeParameters;
+          right;
+        })) in
+
       let declare_function env start_loc =
         Expect.token env T_FUNCTION;
         let id = Parse.identifier env in
@@ -1693,6 +1712,7 @@ end = struct
         Expect.token env T_DECLARE;
         (* eventually, just emit a wrapper AST node *)
         (match Peek.token env with
+	| T_TYPE -> declare_type_alias env start_loc
         | T_CLASS -> declare_class env start_loc
         | T_FUNCTION -> declare_function env start_loc
         | T_VAR -> declare_var env start_loc

--- a/src/parser/spider_monkey_ast.ml
+++ b/src/parser/spider_monkey_ast.ml
@@ -546,6 +546,7 @@ and Statement : sig
     | DeclareVariable of DeclareVariable.t
     | DeclareFunction of DeclareFunction.t
     | DeclareClass of Interface.t
+    | DeclareTypeAlias of TypeAlias.t
     | DeclareModule of DeclareModule.t
     | ExportDeclaration of ExportDeclaration.t
     | ImportDeclaration of ImportDeclaration.t

--- a/src/typing/type_inference_js.ml
+++ b/src/typing/type_inference_js.ml
@@ -867,7 +867,7 @@ and statement_decl cx = Ast.Statement.(
   | (loc, With _) ->
       (* TODO disallow or push vars into env? *)
       ()
-
+  | (loc, DeclareTypeAlias { TypeAlias.id; typeParameters; right})
   | (loc, TypeAlias { TypeAlias.id; typeParameters; right; } ) ->
       let _, { Ast.Identifier.name; _ } = id in
       let r = mk_reason (spf "type %s" name) loc in
@@ -1249,7 +1249,7 @@ and statement cx = Ast.Statement.(
   | (loc, With _) ->
       (* TODO or disallow? *)
       ()
-
+  | (loc, DeclareTypeAlias { TypeAlias.id; typeParameters; right})
   | (loc, TypeAlias { TypeAlias.id; typeParameters; right; } ) ->
       let _, { Ast.Identifier.name; _ } = id in
       let r = mk_reason (spf "type %s" name) loc in


### PR DESCRIPTION
This pull request add type alias declaration in module. (exactly the same thing as type alias outside a module definition)