### PR TITLE
Add missing HTMLImageElement properties

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -430,11 +430,18 @@ declare class HTMLFormElement extends HTMLElement {
 
 declare class HTMLImageElement extends HTMLElement {
     alt: string;
-    src: string;
-    usemap: string;
-    ismap: boolean;
-    width: number;
+    complete: boolean; // readonly
+    crossOrigin: string;
+    currentSrc: string; // readonly
     height: number;
+    isMap: boolean;
+    naturalHeight: number; // readonly
+    naturalWidth: number; // readonly
+    sizes: string;
+    src: string;
+    srcset: string;
+    useMap: string;
+    width: number;
 }
 
 declare class Image extends HTMLImageElement {


### PR DESCRIPTION
Resolve #173 by adding missing HTMLImageElement properties including `complete`. This adds all properties defined at https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element.

This is my first PR, would appreciate feedback of anything I'm missing or doing wrong :-)