### PR TITLE
Add missing stream/child_process declarations

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -100,10 +100,10 @@ type child_process$spawnOpts = {
   uid: number;
 }
 
-type child_process$ChildProcess = {
-  stdin: stream$Stream;
-  stdout: stream$Stream;
-  stderr: stream$Stream;
+declare class child_process$ChildProcess extends events$EventEmitter {
+  stdin: stream$Writable;
+  stdout: stream$Readable;
+  stderr: stream$Readable;
   pid: number;
   connected: boolean;
 
@@ -524,16 +524,26 @@ declare module "readline" {
 }
 
 declare class stream$Stream extends events$EventEmitter {
-  pipe(dest: any, options: any): void;
+  pipe(dest: any, options?: any): void;
 }
 
 declare class stream$Readable extends stream$Stream {
   setEncoding(): void;
+  isPaused(): boolean;
+  pause(): void;
+  read(size?: number): ?(string | Buffer);
+  resume(): void;
+  unpipe(dest: any): void;
+  unshift(chunk: any): void;
+  wrap(oldReadable: any): stream$Readable;
 }
 
 declare class stream$Writable extends stream$Stream {
   close(): void;
+  end(): void;
   finish(): void;
+  setDefaultEncoding(): void;
+  write(): void;
 }
 
 declare module "stream" {

--- a/tests/node_tests/child_process/spawn.js
+++ b/tests/node_tests/child_process/spawn.js
@@ -1,0 +1,23 @@
+/* @flow */
+
+var child_process = require('child_process');
+var ls = child_process.spawn('ls');
+var wc = child_process.spawn('wc', ['-l']);
+
+ls.stdout.on('data', function(data) {
+  wc.stdin.write(data);
+});
+
+ls.stderr.on('data', function(data) {
+  console.warn(data);
+});
+
+ls.on('close', function(code) {
+  if (code !== 0) {
+    console.warn('`ls` exited with code %s', code);
+  }
+  wc.stdin.end();
+});
+
+wc.stdout.pipe(process.stdout);
+wc.stderr.pipe(process.stderr);


### PR DESCRIPTION
Adds/updates declarations for lib/node.js `Readable` and `Writable` stream classes and `child_process` type. The added test is based on the nodejs.org documentation examples.

Resolve #129.