### PR TITLE
Refine switch cases

### DIFF
--- a/tests/refinements/refinements.exp
+++ b/tests/refinements/refinements.exp
@@ -119,6 +119,22 @@ refinements.js:50:13,17: boolean
 This type is incompatible with
   refinements.js:54:11,16: number
 
+switch.js:3:29,34: number
+This type is incompatible with
+  switch.js:3:38,43: string
+
+switch.js:27:14,20: access of computed property/element
+Computed property/element cannot be accessed on
+  switch.js:23:30,35: number
+
+switch.js:37:14,20: access of computed property/element
+Computed property/element cannot be accessed on
+  switch.js:33:30,35: number
+
+switch.js:43:22,27: string
+This type is incompatible with
+  switch.js:51:15,20: number
+
 typeof.js:5:5,8: access of computed property/element
 Computed property/element cannot be accessed on
   typeof.js:3:17,20: boolean
@@ -191,4 +207,4 @@ void.js:75:7,9: undefined
 This type is incompatible with
   void.js:75:36,45: number
 
-Found 48 errors
+Found 52 errors

--- a/tests/refinements/switch.js
+++ b/tests/refinements/switch.js
@@ -1,0 +1,55 @@
+/* @flow */
+
+function foo(text: string | number): string {
+  switch (typeof text) {
+　　case 'string':
+　　　return text;
+    case 'number':
+      return text; // error, should return string
+　　default:
+　　　return 'wat';
+　}
+}
+
+function bar(text: string | number): string {
+  switch (typeof text) {
+    case 'string':
+      return text[0];
+  　default:
+      return (text++) + '';
+　}
+}
+
+function baz1(text: string | number): string {
+  switch (typeof text) {
+    case 'number':
+    case 'string':
+      return text[0]; // error, [0] on number
+  　default:
+      return 'wat';
+　}
+}
+
+function baz2(text: string | number): string {
+  switch (typeof text) {
+    case 'string':
+    case 'number':
+      return text[0];
+  　default:
+      return 'wat';
+　}
+}
+
+function corge(text: string | number | Array<string>): string {
+  switch (typeof text) {
+    case 'object':
+      return text[0];
+    case 'string':
+    case 'number':
+      // using ++ since it isn't valid on arrays or strings.
+      // should only error for string since Array was filtered out.
+      return (text++) + '';
+  　default:
+      return 'wat';
+　}
+}

--- a/tests/refinements/switch.js
+++ b/tests/refinements/switch.js
@@ -34,7 +34,7 @@ function baz2(text: string | number): string {
   switch (typeof text) {
     case 'string':
     case 'number':
-      return text[0];
+      return text[0]; // error, [0] on number
   　default:
       return 'wat';
 　}


### PR DESCRIPTION
Refines switch statements as if they were `===` binary expressions with the discriminant on the LHS and the case expression on the RHS.

This is similar to the handling for if/else if/else, except complicated by fallthroughs. `fallthrough_ctx` is a clone of the `ctx` from before the switch, which has been refined by the //not// of all of the case statements seen so far. `last_ctx` is similar, but it assumes the previous cases can all be true -- except that each time a `break` or `return` happens, `last_ctx` gets emptied out. merging `fallthrough_ctx` with `last_ctx` gives you `case_ctx`, which is correct for just that case statement.

For example:

```
function x(foo: string | number | boolean) {
  switch (typeof foo) {
  case 'string':
    // fallthrough_ctx: string | number | boolean
    // case_ctx: (string | number | boolean) & string => string
  case 'number':
    // last_ctx: string
    // fallthrough_ctx: (string | number | boolean) & !string => number | boolean
    // case_ctx: ((number | boolean) & number) | string => number | string
    return foo;
  case 'boolean':
    // last_ctx: {}
    // fallthrough_ctx: (number | boolean) & !number => boolean
    // case_ctx: boolean & boolean => boolean
    return foo ? 'foo' : 'bar';
}
```

Test Plan: unit tests