### PR TITLE
Publish flow-parser 0.4.0 and add make rule to npm publish

### DIFF
--- a/src/parser/Makefile
+++ b/src/parser/Makefile
@@ -23,3 +23,10 @@ tools: native_test_files
 native_test_files:
 	ocamlbuild tools/native_test_files.native
 	mv native_test_files.native tools/native_test_files
+
+npm-publish:
+	mv README.md README-backup.md
+	mv README-npm.md README.md
+	-npm publish
+	mv README.md README-npm.md
+	mv README-backup.md README.md

--- a/src/parser/package.json
+++ b/src/parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flow-parser",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "JavaScript parser written in OCaml. Produces SpiderMonkey AST",
   "author": {
     "name": "Gabe Levi",


### PR DESCRIPTION
As suggested on #387, use `make` to move around the `README`'s. This works
great :)