### PR TITLE
Improve error message clarity in a few places

### DIFF
--- a/tests/cycle/cycle.exp
+++ b/tests/cycle/cycle.exp
@@ -1,5 +1,5 @@
 
 B.js:5:18,18: identifier B
-Unknown global name
+Could not resolve name
 
 Found 1 error

--- a/tests/destructuring/destructuring.exp
+++ b/tests/destructuring/destructuring.exp
@@ -22,7 +22,7 @@ This type is incompatible with
   destructuring.js:1:15,20: string
 
 destructuring.js:15:9,9: identifier z
-Unknown global name
+Could not resolve name
 
 destructuring.js:18:14,14: number
 This type is incompatible with

--- a/tests/error_messages/error_messages.exp
+++ b/tests/error_messages/error_messages.exp
@@ -1,6 +1,6 @@
 
 errors.js:1:12,17: identifier define
-Unknown global name
+Could not resolve name
 
 errors.js:3:1,9: function call
 Callable signature not found in

--- a/tests/es6modules/es6modules.exp
+++ b/tests/es6modules/es6modules.exp
@@ -47,10 +47,6 @@ CommonJS_Named.js:9:24,24: number
 This type is incompatible with
   es6modules.js:4:28,33: string
 
-CommonJS_Named.js:10:24,24: number
-This type is incompatible with
-  es6modules.js:4:28,33: string
-
 ES6_ExportAllFrom_Source1.js:6:12,23: number
 This type is incompatible with
   es6modules.js:4:28,33: string
@@ -147,86 +143,110 @@ ProvidesModuleA.js:6:24,25: number
 This type is incompatible with
   es6modules.js:4:28,33: string
 
-es6modules.js:21:22,24: C
-Required module not found
-
-es6modules.js:24:22,26: ./D
-Required module not found
-
-es6modules.js:30:9,19: import { doesntExist }
+es6modules.js:11:8,15: "default" export of "A"
 Property not found in
-  es6modules.js:30:9,19: import { doesntExist }
+  es6modules.js:11:22,24: exports of "A"
 
-es6modules.js:42:14,39: number
+es6modules.js:22:22,24: C
+Required module not found
+
+es6modules.js:25:22,26: ./D
+Required module not found
+
+es6modules.js:31:9,19: "doesntExist" export of "CommonJS_Clobbering_Lit"
+Property not found in
+  es6modules.js:31:27,51: exports of "CommonJS_Clobbering_Lit"
+
+es6modules.js:43:14,39: number
 This type is incompatible with
   es6modules.js:4:28,33: string
 
-es6modules.js:43:14,38: property doesntExist
+es6modules.js:44:14,38: property doesntExist
 Property not found in
   CommonJS_Clobbering_Lit.js:6:18,12:1: object literal
 
-es6modules.js:48:1,32: property default
+es6modules.js:49:1,32: property default
 Property not found in
   CommonJS_Clobbering_Lit.js:6:18,12:1: object literal
 
-es6modules.js:50:14,50: number
+es6modules.js:51:14,50: number
 This type is incompatible with
   es6modules.js:4:28,33: string
 
-es6modules.js:62:1,33: property doesntExist
+es6modules.js:57:9,19: "doesntExist" export of "CommonJS_Clobbering_Class"
+Property not found in
+  es6modules.js:57:27,53: exports of "CommonJS_Clobbering_Class"
+
+es6modules.js:65:1,33: property doesntExist
 Property not found in
   CommonJS_Clobbering_Class.js:16:18,21: Test
 
-es6modules.js:66:14,48: number
+es6modules.js:69:14,48: number
 This type is incompatible with
   es6modules.js:4:28,33: string
 
-es6modules.js:69:1,24: constructor call
+es6modules.js:72:1,24: constructor call
 Constructor cannot be called on
-  es6modules.js:68:13,30: import * as CJS_Clobb_Class_NS
+  es6modules.js:71:37,63: exports of "CommonJS_Clobbering_Class"
 
-es6modules.js:76:14,59: number
+es6modules.js:79:14,59: number
 This type is incompatible with
   es6modules.js:4:28,33: string
 
-es6modules.js:82:9,19: import { doesntExist }
+es6modules.js:85:9,19: "doesntExist" export of "CommonJS_Named"
 Property not found in
-  CommonJS_Named.js: exports
+  es6modules.js:85:27,42: exports of "CommonJS_Named"
 
-es6modules.js:95:14,34: property doesntExist
+es6modules.js:98:14,34: property doesntExist
 Property not found in
-  CommonJS_Named.js: exports
+  es6modules.js:95:28,43: exports of "CommonJS_Named"
 
-es6modules.js:111:14,32: number
+es6modules.js:102:14,33: property default
+Property not found in
+  es6modules.js:100:31,46: exports of "CommonJS_Named"
+
+es6modules.js:109:9,19: "doesntExist" export of "ES6_Default_AnonFunction1"
+Property not found in
+  es6modules.js:109:27,53: exports of "ES6_Default_AnonFunction1"
+
+es6modules.js:113:14,32: number
 This type is incompatible with
   es6modules.js:4:28,33: string
 
-es6modules.js:115:14,33: number
+es6modules.js:117:14,33: number
 This type is incompatible with
   es6modules.js:4:28,33: string
 
-es6modules.js:151:14,27: number
+es6modules.js:133:8,18: "default" export of "ES6_Named1"
+Property not found in
+  es6modules.js:133:25,36: exports of "ES6_Named1"
+
+es6modules.js:155:14,27: number
 This type is incompatible with
   es6modules.js:4:28,33: string
 
-es6modules.js:155:14,49: number
+es6modules.js:159:14,49: number
 This type is incompatible with
   es6modules.js:4:28,33: string
 
-es6modules.js:189:14,32: number
+es6modules.js:191:1,48: property doesntExist
+Property not found in
+  ES6_Default_AnonFunction2.js: exports
+
+es6modules.js:195:14,32: number
 This type is incompatible with
   es6modules.js:4:28,33: string
 
-es6modules.js:193:14,33: number
+es6modules.js:199:14,33: number
 This type is incompatible with
   es6modules.js:4:28,33: string
 
-es6modules.js:226:14,28: number
+es6modules.js:232:14,28: number
 This type is incompatible with
   es6modules.js:4:28,33: string
 
-es6modules.js:230:14,50: number
+es6modules.js:236:14,50: number
 This type is incompatible with
   es6modules.js:4:28,33: string
 
-Found 58 errors
+Found 63 errors

--- a/tests/es6modules/es6modules.js
+++ b/tests/es6modules/es6modules.js
@@ -8,12 +8,13 @@ function takesAString(str: string): void {}
 // ===================== //
 
 // @providesModule
-import DefaultA from "A";
+import DefaultA from "A"; // Error: There is no default export
+import * as DefaultA from "A";
 takesANumber(DefaultA.numberValue1);
 takesAString(DefaultA.numberValue1); // Error: number ~> string
 
 // File path
-import DefaultB from "./B";
+import * as DefaultB from "./B";
 takesANumber(DefaultB.numberValue);
 takesAString(DefaultB.numberValue); // Error: number ~> string
 
@@ -40,7 +41,7 @@ takesAString(numVal1); // Error: number ~> string
 import CJS_Clobb_Lit from "CommonJS_Clobbering_Lit";
 takesANumber(CJS_Clobb_Lit.numberValue3);
 takesAString(CJS_Clobb_Lit.numberValue3); // Error: number ~> string
-takesANumber(CJS_Clobb_Lit.doesntExist); // Error doesntExist isn't a property
+takesANumber(CJS_Clobb_Lit.doesntExist); // Error: doesntExist isn't a property
 
 import * as CJS_Clobb_Lit_NS from "CommonJS_Clobbering_Lit";
 takesANumber(CJS_Clobb_Lit_NS.numberValue4);
@@ -53,13 +54,15 @@ takesAString(CJS_Clobb_Lit_NS.default.numberValue5); // Error: number ~> string
 // == CommonJS Clobbering Class Exports -> ES6 == //
 // ============================================== //
 
+import {doesntExist} from "CommonJS_Clobbering_Class"; // Error: Not an exported binding
+
 import {staticNumber1} from "CommonJS_Clobbering_Class";
 takesANumber(staticNumber1());
 takesAString(staticNumber1()); // Error: number ~> string
 
 import CJS_Clobb_Class from "CommonJS_Clobbering_Class";
 new CJS_Clobb_Class();
-new CJS_Clobb_Class().doesntExist; // Class has no `doesntExist` property
+new CJS_Clobb_Class().doesntExist; // Error: Class has no `doesntExist` property
 takesANumber(CJS_Clobb_Class.staticNumber2());
 takesAString(CJS_Clobb_Class.staticNumber2()); // Error: number ~> string
 takesANumber(new CJS_Clobb_Class().instNumber1());
@@ -89,22 +92,21 @@ import {numberValue3 as numVal3} from "CommonJS_Named";
 takesANumber(numVal3);
 takesAString(numVal3); // Error: number ~> string
 
-import CJS_Named from "CommonJS_Named";
+import * as CJS_Named from "CommonJS_Named";
 takesANumber(CJS_Named.numberValue1);
 takesAString(CJS_Named.numberValue1); // Error: number ~> string
-takesANumber(CJS_Named.doesntExist); // Error doesntExist isn't a property
+takesANumber(CJS_Named.doesntExist); // Error: doesntExist isn't a property
 
 import * as CJS_Named_NS from "CommonJS_Named";
 takesANumber(CJS_Named_NS.numberValue4);
-takesANumber(CJS_Named_NS.default.numberValue4);
-CJS_Named_NS.default.default; // Not an error -- just a weird consequence of CJS compatibility
-takesANumber(CJS_Named_NS.default.default.numberValue4);
+takesANumber(CJS_Named_NS.default.numberValue4); // Error: CommonJS_Named has no default export
 takesAString(CJS_Named_NS.numberValue4); // Error: number ~> string
-takesAString(CJS_Named_NS.default.numberValue5); // Error: number ~> string
 
 //////////////////////////////
 // == ES6 Default -> ES6 == //
 //////////////////////////////
+
+import {doesntExist} from "ES6_Default_AnonFunction1"; // Error: Not an exported binding
 
 import ES6_Def_AnonFunc1 from "ES6_Default_AnonFunction1";
 takesANumber(ES6_Def_AnonFunc1());
@@ -127,6 +129,8 @@ takesAString(ES6_Def_NamedFunc1()); // Error: number ~> string
 ////////////////////////////
 // == ES6 Named -> ES6 == //
 ////////////////////////////
+
+import doesntExist from "ES6_Named1"; // Error: Not an exported binding
 
 import {specifierNumber1} from "ES6_Named1";
 takesANumber(specifierNumber1);
@@ -183,6 +187,8 @@ takesAString(numberValue5); // Error: number ~> string
 ///////////////////////////////////
 // == ES6 Default -> CommonJS == //
 ///////////////////////////////////
+
+require('ES6_Default_AnonFunction2').doesntExist; // Error: 'doesntExist' isn't an export
 
 var ES6_Def_AnonFunc2 = require("ES6_Default_AnonFunction2").default;
 takesANumber(ES6_Def_AnonFunc2());

--- a/tests/import_type/import_type.exp
+++ b/tests/import_type/import_type.exp
@@ -1,6 +1,6 @@
 
 named_imports.js:15:21,23: identifier Bar
-Unknown global name
+Could not resolve name
 
 namespace_imports.js:19:2,4: number
 This type is incompatible with
@@ -11,9 +11,9 @@ This type is incompatible with
   namespace_imports.js:20:7,11: Bar
 
 namespace_imports.js:21:1,1: identifier A
-Unknown global name
+Could not resolve name
 
 namespace_imports.js:25:3,3: identifier B
-Unknown global name
+Could not resolve name
 
 Found 5 errors

--- a/tests/requireLazy/requireLazy.exp
+++ b/tests/requireLazy/requireLazy.exp
@@ -16,10 +16,10 @@ This type is incompatible with
   requireLazy.js:14:13,18: string
 
 requireLazy.js:17:20,20: identifier A
-Unknown global name
+Could not resolve name
 
 requireLazy.js:18:20,20: identifier B
-Unknown global name
+Could not resolve name
 
 requireLazy.js:20:1,13: 
 The first arg to requireLazy() must be a literal array of string literals!

--- a/tests/type_only_vars/type_only_vars.exp
+++ b/tests/type_only_vars/type_only_vars.exp
@@ -51,15 +51,15 @@ This binding is shadowing
 which is a different sort of binding
 
 import_type.js:11:9,9: identifier A
-Unknown global name
+Could not resolve name
 
 import_type.js:12:9,11: identifier Foo
-Unknown global name
+Could not resolve name
 
 import_type.js:13:9,11: identifier Baz
-Unknown global name
+Could not resolve name
 
 type_alias.js:8:9,11: identifier Foo
-Unknown global name
+Could not resolve name
 
 Found 15 errors


### PR DESCRIPTION
This improves error message clarity for ES6 module imports and also general property/global variables when the name being looked up is not found.

Rather than "unknown global variable", now we say "Could not resolve name: %s".
Rather than "Required module not found", now we say "Required module not found: %s".

ES6 module errors are also more fine-grained now (rather than just using a summary of the import string syntax as the reason for pretty much everything).

See updated tests for example output