### PR TITLE
Make interface-defined modules work with CommonJS/ES6Module interop

### DIFF
--- a/src/typing/type_inference_js.ml
+++ b/src/typing/type_inference_js.ml
@@ -1920,7 +1920,7 @@ and statement cx = Ast.Statement.(
           let map = SMap.map (fun {specific=export;_} -> export) !block in
           Flow_js.mk_object_with_map_proto cx reason map (MixedT reason)
     in
-    Flow_js.unify cx exports t
+    Flow_js.unify cx (CJSExportDefaultT(reason, exports)) t
   | (loc, ExportDeclaration {
       ExportDeclaration.default;
       ExportDeclaration.declaration;

--- a/tests/react/import_react.js
+++ b/tests/react/import_react.js
@@ -1,0 +1,7 @@
+/* @flow */
+
+import react from "react";
+import {Component} from "react";
+
+var a: Component = new react.Component();
+var b: number = new react.Component(); // Error: ReactComponent ~> number

--- a/tests/react/react.exp
+++ b/tests/react/react.exp
@@ -3,6 +3,10 @@ ArityError.react.js:6:37,46: any
 Number of type arguments differs from
   [LIB] react.js:97:62,78: any
 
+import_react.js:7:21,35: ReactComponent
+This type is incompatible with
+  import_react.js:7:8,13: number
+
 jsx_spread.js:10:19,20: number
 This type is incompatible with
   jsx_spread.js:6:10,31: string
@@ -39,4 +43,4 @@ proptype_oneOfType.js:23:32,35: boolean
 This type is incompatible with
   proptype_oneOfType.js:6:11,9:6: oneOfType
 
-Found 10 errors
+Found 11 errors


### PR DESCRIPTION
With a normal CommonJS module, when the exports object is assigned we mark it as a CommonJS default export. This lets the flow system understand that it needs to be mapped properly to an ES6 ModuleNamespace object when imported from an ES6 module.

Declared modules, however, weren't treating their exports in this way as well. This fixes the issue by marking declared module exports as CJSDefault.

More tangibly, this PR fixes this issue: https://github.com/facebook/flow/issues/400