### PR TITLE
Add types for execSync, execFileSync, spawnSync

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -100,6 +100,16 @@ type child_process$spawnOpts = {
   uid: number;
 }
 
+type child_process$spawnRet = {
+  pid: number;
+  output: Array<any>;
+  stdout: any;
+  stderr: any;
+  status: number;
+  signal: string;
+  error: Error;
+}
+
 type child_process$ChildProcess = {
   stdin: stream$Stream;
   stdout: stream$Stream;
@@ -119,12 +129,23 @@ declare module "child_process" {
     callback: (error: ?Error, stdout: Buffer, stderr: Buffer) => void
   ): child_process$ChildProcess;
 
+  declare function execSync(
+    command: string,
+    options?: Object // TODO: child_process$execOpts,
+  ): any;
+
   declare function execFile(
     file: string,
     args?: Array<string>,
     options: child_process$execFileOpts,
     callback: (error: ?Error, stdout: Buffer, stderr: Buffer) => void
   ): child_process$ChildProcess;
+
+  declare function execFileSync(
+    command: string,
+    args?: Array<string>,
+    options?: child_process$execFileOpts
+  ): any;
 
   declare function fork(
     modulePath: string,
@@ -137,6 +158,12 @@ declare module "child_process" {
     args?: Array<string>,
     options?: child_process$spawnOpts
   ): child_process$ChildProcess;
+
+  declare function spawnSync(
+    command: string,
+    args?: Array<string>,
+    options?: child_process$spawnOpts
+  ): child_process$spawnRet;
 }
 
 type cluster$Worker = {


### PR DESCRIPTION
The types added in this commit were designed based on the definitions of
the relevant functions [here](https://nodejs.org/api/child_process.html#child_process_synchronous_process_creation)

An attempt was made to follow the conventions found in lib/node.js, but
there wasn't a precedent for return objects hence the name spawnRet.