### PR TITLE
Update echo PATH command

### DIFF
--- a/docs/00-getting-started.md
+++ b/docs/00-getting-started.md
@@ -24,7 +24,7 @@ This creates a directory called `flow` containing the executable binary (also ca
 
 ```bash
 $> cd flow
-$> echo "PATH=\"\$PATH:$(pwd)/\"" >> ~/.bashrc && source ~/.bashrc
+$> echo -e "\nPATH=\"\$PATH:$(pwd)/\"" >> ~/.bashrc && source ~/.bashrc
 ```
 ### Brew on OSX
 


### PR DESCRIPTION
when last line of .bashrc file is a comment, follow command add path end of comment, so it becomes a comment.

```bash
$> echo "PATH=\"\$PATH:$(pwd)/\"" >> ~/.bashrc && source ~/.bashrc
```

for avoid this situation I add a break line before path

```bash
$> echo -e "\nPATH=\"\$PATH:$(pwd)/\"" >> ~/.bashrc && source ~/.bashrc
```