### PR TITLE
Assign function literals to callable objects with subtyping rules

### DIFF
--- a/src/typing/flow_js.ml
+++ b/src/typing/flow_js.ml
@@ -1724,6 +1724,7 @@ let rec __flow cx (l,u) trace =
       let desc1 = (desc_of_reason reason1) in
       let lit =
         (desc1 = "object literal")
+        || (desc1 = "function")
         || (Str.string_match (Str.regexp ".*React") desc1 0)
       in
 

--- a/src/typing/flow_js.ml
+++ b/src/typing/flow_js.ml
@@ -1725,6 +1725,7 @@ let rec __flow cx (l,u) trace =
       let lit =
         (desc1 = "object literal")
         || (desc1 = "function")
+        || (desc1 = "arrow function")
         || (Str.string_match (Str.regexp ".*React") desc1 0)
       in
 

--- a/tests/call_properties/B.js
+++ b/tests/call_properties/B.js
@@ -10,6 +10,11 @@ var c: { (x: string): string } = function (x: number): string { return "hi"; };
 // ...or if the arity is wrong
 var d: { (): string } = function (x: number): string { return "hi"; };
 
+// ...but subtyping rules still apply
+var e: { (x: any): void } = function() { } // arity
+var f: { (): mixed } = function(): string { return "hi" } // return type
+var g: { (x: string): void } = function(x: mixed) { } // param type
+
 // A function can be an object
-var f : {} = function (x: number): string { return "hi"; };
-var g : Object = function (x: number): string { return "hi"; };
+var y : {} = function (x: number): string { return "hi"; };
+var z : Object = function (x: number): string { return "hi"; };

--- a/tests/call_properties/F.js
+++ b/tests/call_properties/F.js
@@ -1,0 +1,21 @@
+// You should be able to use an arrow function as an object with a call property
+
+var a: { (x: number): string } = (x) => x.toString()
+
+// ...and it should notice when the return type is wrong
+var b: { (x: number): number } = (x) => "hi"
+
+// ...or if the param type is wrong
+var c: { (x: string): string } = (x) => x.toFixed()
+
+// ...or if the arity is wrong
+var d: { (): string } = (x) => "hi"
+
+// ...but subtyping rules still apply
+var e: { (x: any): void } = () => { } // arity
+var f: { (): mixed } = () => "hi" // return type
+var g: { (x: Date): void } = (x) => { x * 2 } // param type (date < number)
+
+// A function can be an object
+var y : {} = (x) => "hi"
+var z : Object = (x) => "hi"

--- a/tests/call_properties/call_properties.exp
+++ b/tests/call_properties/call_properties.exp
@@ -61,4 +61,16 @@ E.js:2:9,28: property someProp
 Property not found in
 E.js:2:32,45: function
 
-Found 15 errors
+F.js:6:41,44: string
+This type is incompatible with
+F.js:6:23,28: number
+
+F.js:9:41,51: call of method toFixed
+Property not found in
+[LIB] core.js:166:1,192:1: String
+
+F.js:12:10,19: function type
+Too few arguments (expected default/rest parameters in function)
+F.js:12:25,35: arrow function
+
+Found 18 errors

--- a/tests/call_properties/call_properties.exp
+++ b/tests/call_properties/call_properties.exp
@@ -21,10 +21,6 @@ A.js:29:10,12: function call
 Callable signature not found in
 A.js:29:10,10: object literal
 
-B.js:5:23,28: number
-This type is incompatible with
-B.js:5:56,61: string
-
 B.js:5:56,61: string
 This type is incompatible with
 B.js:5:23,28: number
@@ -32,10 +28,6 @@ B.js:5:23,28: number
 B.js:8:14,19: string
 This type is incompatible with
 B.js:8:47,52: number
-
-B.js:8:47,52: number
-This type is incompatible with
-B.js:8:14,19: string
 
 B.js:11:10,19: function type
 Too few arguments (expected default/rest parameters in function)
@@ -69,4 +61,4 @@ E.js:2:9,28: property someProp
 Property not found in
 E.js:2:32,45: function
 
-Found 17 errors
+Found 15 errors


### PR DESCRIPTION
Flow allows this assignment by first converting the FunT into an ObjT
with a $call property. The resulting object has the reason string
"function" from the original function literal.

After this conversion, the newly minted ObjT can flow into the callable
object type.

Before this change, flow tried to unify the FunT-to-ObjT and callable
object type, but we can do better! Flow looks at the reason string to
determine if unification is necessary, but doesn't recognize the reason
"function" as identifying a literal inhabitant.

Now, this kind of reason-based reasoning is totally suspect, no doubt.
Fixing that sounds really hard! Someone else can do it!

h/t to @bhosmer for introducing me to the unreasonable reason reasoning. ;)