### PR TITLE
Warn on unsupported class members

### DIFF
--- a/src/typing/type_inference_js.ml
+++ b/src/typing/type_inference_js.ml
@@ -4422,8 +4422,38 @@ and mk_signature cx reason_c c_type_params_map body = Ast.Statement.Class.(
           SMap.add name t fields,
           methods
 
-    (* skip unexpected members *)
-    | _ -> sfields, smethods, fields, methods
+    (* get/set *)
+    | Body.Method (loc, {
+       Method.kind = Ast.Expression.Object.Property.Get
+                   | Ast.Expression.Object.Property.Set
+      }) ->
+        let msg = "get/set properties not yet supported" in
+        Flow_js.add_error cx [mk_reason "" loc, msg];
+        sfields, smethods, fields, methods
+
+    (* literal LHS *)
+    | Body.Method (loc, {
+        Method.key = Ast.Expression.Object.Property.Literal _;
+        Method.kind = Ast.Expression.Object.Property.Init;
+      })
+    | Body.Property (loc, {
+        Property.key = Ast.Expression.Object.Property.Literal _;
+      }) ->
+        let msg = "literal properties not yet supported" in
+        Flow_js.add_error cx [mk_reason "" loc, msg];
+        sfields, smethods, fields, methods
+
+    (* computed LHS *)
+    | Body.Method (loc, {
+        Method.key = Ast.Expression.Object.Property.Computed _;
+        Method.kind = Ast.Expression.Object.Property.Init;
+      })
+    | Body.Property (loc, {
+        Property.key = Ast.Expression.Object.Property.Computed _;
+      }) ->
+        let msg = "computed property keys not supported" in
+        Flow_js.add_error cx [mk_reason "" loc, msg];
+        sfields, smethods, fields, methods
 
   ) (SMap.empty, SMap.empty, SMap.empty, default_methods) elements
 )


### PR DESCRIPTION
Before this change, flow would silently ignore these properties and
instead users would see "Property not found" errors when they went to
use the desired properties.

I intentionally didn't include a fallthrough case, because the compiler
will warn if this pattern ever becomes inexhaustive in the future.
However, that's currently just a warning. Can we make it an error?

Also, because of the way the AST is defined, some of these cases are
actually syntax errors, like computed- and literal-key method bodies. I
would be happy to also make the changes to the AST to restrict the
representation to exclude impossible cases, if that seems important.

See #444