### PR TITLE
Clarify assignment_lhs

### DIFF
--- a/src/typing/type_inference_js.ml
+++ b/src/typing/type_inference_js.ml
@@ -3279,8 +3279,11 @@ and assignment_lhs cx = Ast.Pattern.(function
   | loc, Identifier i ->
       expression cx (loc, Ast.Expression.Identifier i)
 
-  | loc, Expression e ->
-      expression cx e
+  | _, Expression ((_, Ast.Expression.Member _) as m) ->
+      expression cx m
+
+  (* parser will error before we get here *)
+  | _ -> assert false
 )
 
 and assignment cx loc = Ast.Expression.(function


### PR DESCRIPTION
Maybe this is obvious to others, but I was confused that it seemed flow
would allow arbitrary expressions as the LHS of an assignment.

I was confused by this code when I went to add a check for mutating
operations to const-declared variables. Eventually I realized that the
parser prevents arbitrary expressions from reaching this code path, but
this code would have saved me some time.