### PR TITLE
Interfaces are only allowed to appear as type annotations

### DIFF
--- a/src/typing/type_inference_js.ml
+++ b/src/typing/type_inference_js.ml
@@ -1026,11 +1026,14 @@ and statement_decl cx = Ast.Statement.(
     )
 
   | (loc, DeclareClass { Interface.id; _ })
-  | (loc, InterfaceDeclaration { Interface.id; _ }) ->
+  | (loc, InterfaceDeclaration { Interface.id; _ }) as stmt ->
+      let is_interface = match stmt with
+      | (_, InterfaceDeclaration _) -> true
+      | _ -> false in
       let _, { Ast.Identifier.name; _ } = id in
       let r = mk_reason (spf "class %s" name) loc in
       let tvar = Flow_js.mk_tvar cx r in
-      Env_js.init_env cx name (create_env_entry tvar tvar (Some loc))
+      Env_js.init_env cx name (create_env_entry ~for_type:is_interface tvar tvar (Some loc))
   | (loc, DeclareModule { DeclareModule.id; _ }) ->
       let name = match id with
       | DeclareModule.Identifier (_, id) -> id.Ast.Identifier.name
@@ -1878,10 +1881,9 @@ and statement cx = Ast.Statement.(
       body = (_, { Ast.Type.Object.properties; indexers; callProperties });
       extends;
     }) as stmt ->
-    let structural = match stmt with
+    let is_interface = match stmt with
     | (_, InterfaceDeclaration _) -> true
     | _ -> false in
-
     let _, { Ast.Identifier.name = iname; _ } = id in
     let reason = mk_reason iname loc in
     let typeparams, map = mk_type_param_declarations cx typeParameters in
@@ -1956,9 +1958,9 @@ and statement cx = Ast.Statement.(
         mmap
     in
     let i = mk_interface cx reason typeparams map
-      (sfmap, smmap, fmap, mmap) extends structural in
+      (sfmap, smmap, fmap, mmap) extends is_interface in
     Hashtbl.replace cx.type_table loc i;
-    Env_js.set_var cx iname i reason
+    Env_js.set_var ~for_type:is_interface cx iname i reason
 
   | (loc, DeclareModule { DeclareModule.id; body; }) ->
     let name = match id with

--- a/tests/interface/interface.exp
+++ b/tests/interface/interface.exp
@@ -3,4 +3,7 @@ interface.js:1:22,27: number
 This type is incompatible with
 interface.js:3:8,13: string
 
-Found 1 error
+interface.js:7:13,13: identifier I
+Could not resolve name
+
+Found 2 errors

--- a/tests/interface/interface.js
+++ b/tests/interface/interface.js
@@ -1,3 +1,7 @@
 declare class C { x: number; }
 
 var x: string = new C().x;
+
+interface I { x: number; }
+
+var i = new I(); // error


### PR DESCRIPTION
Before this change, flow treated interfaces declarations the same as
class declarations, with the exception of structural subtyping. Another
important distinction is that interfaces can only appears as a type
annotation, and are not a real binding at runtime.