### PR TITLE
Export default class

### DIFF
--- a/src/parser/flow_parser_js.ml
+++ b/src/parser/flow_parser_js.ml
@@ -493,7 +493,7 @@ module Translate = struct
     ret
   )
 
-  and class_declaration (loc, c) = Statement.Class.(
+  and class_declaration (loc, c) = Class.(
     (* esprima/estree hasn't come around to the idea that class decls can have
      * optional ids :( *)
     let (node_type, node_value) = (
@@ -523,25 +523,25 @@ module Translate = struct
     ret
   )
 
-  and class_implements (loc, implements) = Statement.Class.Implements.(
+  and class_implements (loc, implements) = Class.Implements.(
     let ret = node "ClassImplements" loc in
     Js.Unsafe.set ret "id" (identifier implements.id);
     Js.Unsafe.set ret "typeParameters" (option type_parameter_instantiation implements.typeParameters);
     ret
   )
 
-  and class_body (loc, body) = Statement.Class.Body.(
+  and class_body (loc, body) = Class.Body.(
     let ret = node "ClassBody" loc in
     Js.Unsafe.set ret "body" (array class_element body.body);
     ret
   )
 
-  and class_element = Statement.Class.Body.(function
+  and class_element = Class.Body.(function
     | Method m -> class_method m
     | Property p -> class_property p)
 
   and class_method (loc, method_) =
-    let { Statement.Class.Method.key; value; kind; static; } = method_ in
+    let { Class.Method.key; value; kind; static; } = method_ in
     Expression.Object.Property.(
       let ret = node "MethodDefinition" loc in
       let key, computed = (match key with
@@ -559,7 +559,7 @@ module Translate = struct
       ret
     )
 
-  and class_property (loc, prop) = Statement.Class.Property.(
+  and class_property (loc, prop) = Class.Property.(
     let ret = node "ClassProperty" loc in
     let key, computed = (match prop.key with
     | Expression.Object.Property.Literal lit -> literal lit, false

--- a/src/parser/parser_flow.ml
+++ b/src/parser/parser_flow.ml
@@ -3000,7 +3000,7 @@ end = struct
       let loc = match typeParameters with
       | None -> fst id
       | Some (loc, _) -> Loc.btwn (fst id) loc in
-      let implement = loc, Ast.Statement.Class.Implements.({
+      let implement = loc, Ast.Class.Implements.({
         id;
         typeParameters;
       }) in
@@ -3028,7 +3028,7 @@ end = struct
         let body = elements env [] in
         let end_loc = Peek.loc env in
         Expect.token env T_RCURLY;
-        Loc.btwn start_loc end_loc, Ast.Statement.Class.Body.({
+        Loc.btwn start_loc end_loc, Ast.Class.Body.({
           body;
         })
 
@@ -3038,7 +3038,7 @@ end = struct
       let get env start_loc static =
         let key, (end_loc, _ as value) =
           _method env Ast.Expression.Object.Property.Get in
-        Ast.Statement.Class.(Body.Method (Loc.btwn start_loc end_loc, Method.({
+        Ast.Class.(Body.Method (Loc.btwn start_loc end_loc, Method.({
           key;
           value;
           kind = Ast.Expression.Object.Property.Get;
@@ -3048,7 +3048,7 @@ end = struct
       in let set env start_loc static =
         let key, (end_loc, _ as value) =
           _method env Ast.Expression.Object.Property.Set in
-        Ast.Statement.Class.(Body.Method (Loc.btwn start_loc end_loc, Method.({
+        Ast.Class.(Body.Method (Loc.btwn start_loc end_loc, Method.({
           key;
           value;
           kind = Ast.Expression.Object.Property.Set;
@@ -3063,7 +3063,7 @@ end = struct
           let end_loc = Peek.loc env in
           Expect.token env T_SEMICOLON;
           let loc = Loc.btwn start_loc end_loc in
-          Ast.Statement.Class.(Body.Property (loc, Property.({
+          Ast.Class.(Body.Property (loc, Property.({
             key;
             typeAnnotation;
             static;
@@ -3091,7 +3091,7 @@ end = struct
             returnType;
             typeParameters;
           }) in
-          Ast.Statement.Class.(Body.Method (Loc.btwn start_loc end_loc, Method.({
+          Ast.Class.(Body.Method (Loc.btwn start_loc end_loc, Method.({
             key;
             value;
             kind = Ast.Expression.Object.Property.Init;

--- a/src/parser/spider_monkey_ast.ml
+++ b/src/parser/spider_monkey_ast.ml
@@ -396,49 +396,6 @@ and Statement : sig
       body: Statement.t;
     }
   end
-  module Class : sig
-    module Method : sig
-      type t = Loc.t * t'
-      and t' = {
-        kind: Expression.Object.Property.kind;
-        key: Expression.Object.Property.key;
-        value: Loc.t * Expression.Function.t;
-        static: bool;
-      }
-    end
-    module Property : sig
-      type t = Loc.t * t'
-      and t' = {
-        key: Expression.Object.Property.key;
-        typeAnnotation: Type.annotation;
-        static: bool;
-      }
-    end
-    module Implements : sig
-      type t = Loc.t * t'
-      and t' = {
-        id: Identifier.t;
-        typeParameters: Type.ParameterInstantiation.t option;
-      }
-    end
-    module Body : sig
-      type element =
-        | Method of Method.t
-        | Property of Property.t
-      type t = Loc.t * t'
-      and t' = {
-        body: element list;
-      }
-    end
-    type t = {
-      id: Identifier.t option;
-      body: Body.t;
-      superClass: Expression.t option;
-      typeParameters: Type.ParameterDeclaration.t option;
-      superTypeParameters: Type.ParameterInstantiation.t option;
-      implements: Implements.t list;
-    }
-  end
   module Interface : sig
     module Extends : sig
       type t = Loc.t * t'
@@ -807,16 +764,6 @@ and Expression : sig
       body: Expression.t;
     }
   end
-  module Class : sig
-    type t = {
-      id: Identifier.t option;
-      body: Statement.Class.Body.t;
-      superClass: Expression.t option;
-      typeParameters: Type.ParameterDeclaration.t option;
-      superTypeParameters: Type.ParameterInstantiation.t option;
-      implements: Statement.Class.Implements.t list;
-    }
-  end
   module TypeCast : sig
     type t = {
       expression: Expression.t;
@@ -850,7 +797,7 @@ and Expression : sig
     | TemplateLiteral of TemplateLiteral.t
     | TaggedTemplate of TaggedTemplate.t
     | JSXElement of JSX.element
-    | Class of Expression.Class.t
+    | Class of Class.t
     | TypeCast of TypeCast.t
 end = Expression
 
@@ -1010,5 +957,49 @@ and Comment : sig
     | Block of string
     | Line of string
 end = Comment
+
+and Class : sig
+  module Method : sig
+    type t = Loc.t * t'
+    and t' = {
+      kind: Expression.Object.Property.kind;
+      key: Expression.Object.Property.key;
+      value: Loc.t * Expression.Function.t;
+      static: bool;
+    }
+  end
+  module Property : sig
+    type t = Loc.t * t'
+    and t' = {
+      key: Expression.Object.Property.key;
+      typeAnnotation: Type.annotation;
+      static: bool;
+    }
+  end
+  module Implements : sig
+    type t = Loc.t * t'
+    and t' = {
+      id: Identifier.t;
+      typeParameters: Type.ParameterInstantiation.t option;
+    }
+  end
+  module Body : sig
+    type element =
+      | Method of Method.t
+      | Property of Property.t
+    type t = Loc.t * t'
+    and t' = {
+      body: element list;
+    }
+  end
+  type t = {
+    id: Identifier.t option;
+    body: Class.Body.t;
+    superClass: Expression.t option;
+    typeParameters: Type.ParameterDeclaration.t option;
+    superTypeParameters: Type.ParameterInstantiation.t option;
+    implements: Class.Implements.t list;
+  }
+end = Class
 
 type program = Loc.t * Statement.t list * Comment.t list

--- a/src/server/searchService_js.ml
+++ b/src/server/searchService_js.ml
@@ -86,7 +86,7 @@ let update fn ast =
           let fuzzy_defs = add_fuzzy_term f_name Function fuzzy_defs in
           fuzzy_defs, trie_defs
       | Ast.Statement.ClassDeclaration
-         { Ast.Statement.Class.id = Some f_name; _ }
+         { Ast.Class.id = Some f_name; _ }
       | Ast.Statement.DeclareClass
          { Ast.Statement.Interface.id = f_name; _ } ->
           let fuzzy_defs = add_fuzzy_term f_name Class fuzzy_defs in

--- a/src/typing/comments_js.ml
+++ b/src/typing/comments_js.ml
@@ -318,9 +318,9 @@ and meta_statement cmap = Ast.Statement.(function
   | loc, Expression { Expression.expression = e } ->
       meta_expression cmap e
 
-  | loc, ClassDeclaration { Class.body; _ } ->
-      let _, { Class.Body.body = elements; _ } = body in
-      concat_fold Class.(fun cmap -> function
+  | loc, ClassDeclaration { Ast.Class.body; _ } ->
+      let _, { Ast.Class.Body.body = elements; _ } = body in
+      concat_fold Ast.Class.(fun cmap -> function
         | Body.Method (loc, {
             Method.key = Ast.Expression.Object.Property.Identifier (_,
               { Ast.Identifier.name; _ });

--- a/src/typing/type_inference_js.ml
+++ b/src/typing/type_inference_js.ml
@@ -174,8 +174,8 @@ let nameify_default_export_decl decl = Ast.Statement.(
       }))
 
   | loc, ClassDeclaration(class_decl) ->
-    if class_decl.Class.id <> None then decl else
-      loc, ClassDeclaration(Class.({
+    if class_decl.Ast.Class.id <> None then decl else
+      loc, ClassDeclaration(Ast.Class.({
         class_decl with
           id = Some(Ast.Identifier.(loc, {
             name = internal_name "*default*";
@@ -1015,7 +1015,7 @@ and statement_decl cx = Ast.Statement.(
   | (loc, VariableDeclaration decl) ->
       variable_declaration cx loc decl
 
-  | (loc, ClassDeclaration { Class.id; _ }) -> (
+  | (loc, ClassDeclaration { Ast.Class.id; _ }) -> (
       match id with
       | Some(id) ->
         let _, { Ast.Identifier.name; _ } = id in
@@ -1849,7 +1849,7 @@ and statement cx = Ast.Statement.(
   | (loc, VariableDeclaration decl) ->
       variables cx loc decl
 
-  | (loc, ClassDeclaration { Class.id; body; superClass;
+  | (loc, ClassDeclaration { Ast.Class.id; body; superClass;
       typeParameters; superTypeParameters; implements }) ->
       if implements <> [] then
         let msg = "implements not supported" in
@@ -2006,14 +2006,14 @@ and statement cx = Ast.Statement.(
         | loc, FunctionDeclaration({FunctionDeclaration.id=Some(_, id); _;}) ->
           let name = id.Ast.Identifier.name in
           [(spf "function %s() {}" name, loc, name)]
-        | loc, ClassDeclaration({Class.id=None; _;}) ->
+        | loc, ClassDeclaration({Ast.Class.id=None; _;}) ->
           if default then
             [("class {}", loc, internal_name "*default*")]
           else failwith (
             "Parser Error: Immediate exports of nameless classes can " ^
             "only exist for default exports"
           )
-        | loc, ClassDeclaration({Class.id=Some(_, id); _;}) ->
+        | loc, ClassDeclaration({Ast.Class.id=Some(_, id); _;}) ->
           let name = id.Ast.Identifier.name in
           [(spf "class %s() {}" name, loc, name)]
         | _, VariableDeclaration({VariableDeclaration.declarations; _; }) ->
@@ -3073,7 +3073,7 @@ and expression_ cx loc e = Ast.Expression.(match e with
   | JSXElement e ->
       jsx cx e
 
-  | Class { Class.id; body; superClass;
+  | Class { Ast.Class.id; body; superClass;
       typeParameters; superTypeParameters; implements } ->
       if implements <> [] then
         let msg = "implements not supported" in
@@ -4382,7 +4382,7 @@ and body_loc = Ast.Statement.FunctionDeclaration.(function
 )
 
 (* Makes signatures for fields and methods in a class. *)
-and mk_signature cx reason_c c_type_params_map body = Ast.Statement.Class.(
+and mk_signature cx reason_c c_type_params_map body = Ast.Class.(
   let _, { Body.body = elements } = body in
 
   (* In case there is no constructor, we create one. *)
@@ -4502,7 +4502,7 @@ and mk_signature cx reason_c c_type_params_map body = Ast.Statement.Class.(
 )
 
 (* Processes the bodies of instance and static methods. *)
-and mk_class_elements cx instance_info static_info body = Ast.Statement.Class.(
+and mk_class_elements cx instance_info static_info body = Ast.Class.(
   let _, { Body.body = elements } = body in
   List.iter (function
 

--- a/src/typing/type_inference_js.ml
+++ b/src/typing/type_inference_js.ml
@@ -3073,12 +3073,26 @@ and expression_ cx loc e = Ast.Expression.(match e with
   | JSXElement e ->
       jsx cx e
 
+  | Class { Class.id; body; superClass;
+      typeParameters; superTypeParameters; implements } ->
+      if implements <> [] then
+        let msg = "implements not supported" in
+        Flow_js.add_error cx [mk_reason "" loc, msg]
+      else ();
+      let (nloc, name) = (
+        match id with
+        | Some(nloc, { Ast.Identifier.name; _ }) -> nloc, name
+        | None -> loc, "<<anonymous class>>"
+      ) in
+      let reason = mk_reason name nloc in
+      let extends = superClass, superTypeParameters in
+      mk_class cx reason typeParameters extends body
+
   (* TODO *)
   | Yield _
   | Comprehension _
   | Generator _
-  | Let _
-  | Class _ ->
+  | Let _ ->
     Flow_js.add_error cx [mk_reason "" loc, "not (sup)ported"];
     UndefT.at loc
 )

--- a/tests/es6modules/ES6_Default_AnonClass1.js
+++ b/tests/es6modules/ES6_Default_AnonClass1.js
@@ -4,4 +4,4 @@
  */
 
 // TODO: Support anonymous class declarations
-//export default class { givesANum(): number { return 42; }};
+export default class { givesANum(): number { return 42; }};

--- a/tests/es6modules/ES6_Default_AnonClass1.js
+++ b/tests/es6modules/ES6_Default_AnonClass1.js
@@ -3,5 +3,4 @@
  * @flow
  */
 
-// TODO: Support anonymous class declarations
 export default class { givesANum(): number { return 42; }};

--- a/tests/es6modules/ES6_Default_AnonClass2.js
+++ b/tests/es6modules/ES6_Default_AnonClass2.js
@@ -4,4 +4,4 @@
  */
 
 // TODO: Support anonymous class declarations
-//export default class { givesANum(): number { return 42; }};
+export default class { givesANum(): number { return 42; }};

--- a/tests/es6modules/ES6_Default_AnonClass2.js
+++ b/tests/es6modules/ES6_Default_AnonClass2.js
@@ -3,5 +3,4 @@
  * @flow
  */
 
-// TODO: Support anonymous class declarations
 export default class { givesANum(): number { return 42; }};

--- a/tests/es6modules/ES6_Default_NamedClass1.js
+++ b/tests/es6modules/ES6_Default_NamedClass1.js
@@ -3,5 +3,4 @@
  * @flow
  */
 
-// TODO: Support named class declarations in an export
 export default class Foo { givesANum(): number { return 42; }};

--- a/tests/es6modules/ES6_Default_NamedClass1.js
+++ b/tests/es6modules/ES6_Default_NamedClass1.js
@@ -4,4 +4,4 @@
  */
 
 // TODO: Support named class declarations in an export
-//export default class Foo { givesANum(): number { return 42; }};
+export default class Foo { givesANum(): number { return 42; }};

--- a/tests/es6modules/ES6_Default_NamedClass2.js
+++ b/tests/es6modules/ES6_Default_NamedClass2.js
@@ -1,0 +1,6 @@
+/**
+ * @providesModule ES6_Default_NamedClass2
+ * @flow
+ */
+
+export default class Foo { givesANum(): number { return 42; }};

--- a/tests/es6modules/es6modules.exp
+++ b/tests/es6modules/es6modules.exp
@@ -233,71 +233,71 @@ es6modules.js:117:14,33: number
 This type is incompatible with
 es6modules.js:4:28,33: string
 
-es6modules.js:122:14,49: call of method givesANum
+es6modules.js:121:14,49: call of method givesANum
 Error:
-es6modules.js:122:14,49: number
+es6modules.js:121:14,49: number
 This type is incompatible with
 es6modules.js:4:28,33: string
 
-es6modules.js:127:14,50: call of method givesANum
+es6modules.js:125:14,50: call of method givesANum
 Error:
-es6modules.js:127:14,50: number
+es6modules.js:125:14,50: number
 This type is incompatible with
 es6modules.js:4:28,33: string
 
-es6modules.js:133:8,18: "default" export of "ES6_Named1"
+es6modules.js:131:8,18: "default" export of "ES6_Named1"
 Property not found in
-es6modules.js:133:25,36: exports of "ES6_Named1"
+es6modules.js:131:25,36: exports of "ES6_Named1"
 
-es6modules.js:155:14,27: function call
+es6modules.js:153:14,27: function call
 Error:
-es6modules.js:155:14,27: number
+es6modules.js:153:14,27: number
 This type is incompatible with
 es6modules.js:4:28,33: string
 
-es6modules.js:159:14,49: call of method givesANumber
+es6modules.js:157:14,49: call of method givesANumber
 Error:
-es6modules.js:159:14,49: number
+es6modules.js:157:14,49: number
 This type is incompatible with
 es6modules.js:4:28,33: string
 
-es6modules.js:191:1,48: property doesntExist
+es6modules.js:189:1,48: property doesntExist
 Property not found in
 ES6_Default_AnonFunction2.js: exports
 
-es6modules.js:195:14,32: function call
+es6modules.js:193:14,32: function call
 Error:
-es6modules.js:195:14,32: number
+es6modules.js:193:14,32: number
 This type is incompatible with
 es6modules.js:4:28,33: string
 
-es6modules.js:199:14,33: function call
+es6modules.js:197:14,33: function call
 Error:
-es6modules.js:199:14,33: number
+es6modules.js:197:14,33: number
 This type is incompatible with
 es6modules.js:4:28,33: string
 
-es6modules.js:204:14,49: call of method givesANum
+es6modules.js:201:14,49: call of method givesANum
 Error:
-es6modules.js:204:14,49: number
+es6modules.js:201:14,49: number
 This type is incompatible with
 es6modules.js:4:28,33: string
 
-es6modules.js:209:14,50: call of method givesANum
+es6modules.js:205:14,50: call of method givesANum
 Error:
-es6modules.js:209:14,50: number
+es6modules.js:205:14,50: number
 This type is incompatible with
 es6modules.js:4:28,33: string
 
-es6modules.js:232:14,28: function call
+es6modules.js:228:14,28: function call
 Error:
-es6modules.js:232:14,28: number
+es6modules.js:228:14,28: number
 This type is incompatible with
 es6modules.js:4:28,33: string
 
-es6modules.js:236:14,50: call of method givesANumber
+es6modules.js:232:14,50: call of method givesANumber
 Error:
-es6modules.js:236:14,50: number
+es6modules.js:232:14,50: number
 This type is incompatible with
 es6modules.js:4:28,33: string
 

--- a/tests/es6modules/es6modules.exp
+++ b/tests/es6modules/es6modules.exp
@@ -233,6 +233,18 @@ es6modules.js:117:14,33: number
 This type is incompatible with
 es6modules.js:4:28,33: string
 
+es6modules.js:122:14,49: call of method givesANum
+Error:
+es6modules.js:122:14,49: number
+This type is incompatible with
+es6modules.js:4:28,33: string
+
+es6modules.js:127:14,50: call of method givesANum
+Error:
+es6modules.js:127:14,50: number
+This type is incompatible with
+es6modules.js:4:28,33: string
+
 es6modules.js:133:8,18: "default" export of "ES6_Named1"
 Property not found in
 es6modules.js:133:25,36: exports of "ES6_Named1"
@@ -265,6 +277,18 @@ es6modules.js:199:14,33: number
 This type is incompatible with
 es6modules.js:4:28,33: string
 
+es6modules.js:204:14,49: call of method givesANum
+Error:
+es6modules.js:204:14,49: number
+This type is incompatible with
+es6modules.js:4:28,33: string
+
+es6modules.js:209:14,50: call of method givesANum
+Error:
+es6modules.js:209:14,50: number
+This type is incompatible with
+es6modules.js:4:28,33: string
+
 es6modules.js:232:14,28: function call
 Error:
 es6modules.js:232:14,28: number
@@ -277,4 +301,4 @@ es6modules.js:236:14,50: number
 This type is incompatible with
 es6modules.js:4:28,33: string
 
-Found 63 errors
+Found 67 errors

--- a/tests/es6modules/es6modules.js
+++ b/tests/es6modules/es6modules.js
@@ -116,12 +116,10 @@ import ES6_Def_NamedFunc1 from "ES6_Default_NamedFunction1";
 takesANumber(ES6_Def_NamedFunc1());
 takesAString(ES6_Def_NamedFunc1()); // Error: number ~> string
 
-// TODO: Support anonymous class declarations
 import ES6_Def_AnonClass1 from "ES6_Default_AnonClass1";
 takesANumber(new ES6_Def_AnonClass1().givesANum());
 takesAString(new ES6_Def_AnonClass1().givesANum()); // Error: number ~> string
 
-// TODO: Support named class declarations in an export
 import ES6_Def_NamedClass1 from "ES6_Default_NamedClass1";
 takesANumber(new ES6_Def_NamedClass1().givesANum());
 takesAString(new ES6_Def_NamedClass1().givesANum()); // Error: number ~> string
@@ -198,12 +196,10 @@ var ES6_Def_NamedFunc2 = require("ES6_Default_NamedFunction2").default;
 takesANumber(ES6_Def_NamedFunc2());
 takesAString(ES6_Def_NamedFunc2()); // Error: number ~> string
 
-// TODO: Support anonymous class declarations
 var ES6_Def_AnonClass2 = require("ES6_Default_AnonClass2").default;
 takesANumber(new ES6_Def_AnonClass2().givesANum());
 takesAString(new ES6_Def_AnonClass2().givesANum()); // Error: number ~> string
 
-// TODO: Support named class declarations in an export
 var ES6_Def_NamedClass2 = require("ES6_Default_NamedClass2").default;
 takesANumber(new ES6_Def_NamedClass2().givesANum());
 takesAString(new ES6_Def_NamedClass2().givesANum());

--- a/tests/es6modules/es6modules.js
+++ b/tests/es6modules/es6modules.js
@@ -117,14 +117,14 @@ takesANumber(ES6_Def_NamedFunc1());
 takesAString(ES6_Def_NamedFunc1()); // Error: number ~> string
 
 // TODO: Support anonymous class declarations
-//import ES6_Def_AnonClass1 from "ES6_Default_AnonClass1";
-//takesANumber(new ES6_Def_AnonClass1().givesANum());
-//takesAString(new ES6_Def_AnonClass1().givesANum()); // Error: number ~> string
+import ES6_Def_AnonClass1 from "ES6_Default_AnonClass1";
+takesANumber(new ES6_Def_AnonClass1().givesANum());
+takesAString(new ES6_Def_AnonClass1().givesANum()); // Error: number ~> string
 
 // TODO: Support named class declarations in an export
-//import ES6_Def_NamedClass1 from "ES6_Default_NamedClass1";
-//takesANumber(new ES6_Def_NamedClass1().givesANum());
-//takesAString(new ES6_Def_NamedClass1().givesANum());
+import ES6_Def_NamedClass1 from "ES6_Default_NamedClass1";
+takesANumber(new ES6_Def_NamedClass1().givesANum());
+takesAString(new ES6_Def_NamedClass1().givesANum()); // Error: number ~> string
 
 ////////////////////////////
 // == ES6 Named -> ES6 == //
@@ -199,14 +199,14 @@ takesANumber(ES6_Def_NamedFunc2());
 takesAString(ES6_Def_NamedFunc2()); // Error: number ~> string
 
 // TODO: Support anonymous class declarations
-// var ES6_Def_AnonClass2 = require("ES6_Default_AnonClass2").default;
-//takesANumber(new ES6_Def_AnonClass2().givesANum());
-//takesAString(new ES6_Def_AnonClass2().givesANum()); // Error: number ~> string
+var ES6_Def_AnonClass2 = require("ES6_Default_AnonClass2").default;
+takesANumber(new ES6_Def_AnonClass2().givesANum());
+takesAString(new ES6_Def_AnonClass2().givesANum()); // Error: number ~> string
 
 // TODO: Support named class declarations in an export
-// var ES6_Def_NamedClass2 = require("ES6_Default_NamedClass2");
-//takesANumber(new ES6_Def_NamedClass2().givesANum());
-//takesAString(new ES6_Def_NamedClass2().givesANum());
+var ES6_Def_NamedClass2 = require("ES6_Default_NamedClass2").default;
+takesANumber(new ES6_Def_NamedClass2().givesANum());
+takesAString(new ES6_Def_NamedClass2().givesANum());
 
 /////////////////////////////////
 // == ES6 Named -> CommonJS == //


### PR DESCRIPTION
This change implements the class expression case for the type inferencer, which is very similar to the existing code to handle class declarations. I refactored the AST to enable more sharing of this code. See individual commits for details.

Notably, I didn't touch the `dts` subdirectory, because I am not sure what it is for.