### PR TITLE
Add methods and variables exported by the zlib module built in to node.

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -753,6 +753,28 @@ declare class stream$Writable extends stream$Stream {
   ): boolean;
 }
 
+declare class stream$Duplex extends stream$Stream {
+  setEncoding(): void;
+  isPaused(): boolean;
+  pause(): void;
+  read(size?: number): ?(string | Buffer);
+  resume(): void;
+  unpipe(dest?: any): void;
+  unshift(chunk: any): void;
+  wrap(oldReadable: any): stream$Readable;
+  end(
+    chunk?: string | Buffer,
+    encodingOrCallback?: string | (data: any) => void,
+    callback?: (data: any) => void
+  ): void;
+  setDefaultEncoding(encoding: string): boolean;
+  write(
+    chunk?: string | Buffer,
+    encodingOrCallback?: string | (data: any) => void,
+    callback?: (data: any) => void
+  ): boolean;
+}
+
 declare module "stream" {
   declare class Stream extends stream$Stream {}
 }
@@ -887,7 +909,7 @@ declare module "zlib" {
     Z_BUF_ERROR: number,
     Z_VERSION_ERROR: number
   };
-  declare class Zlib {
+  declare class Zlib extends stream$Duplex {
     // TODO
   }
   declare class Deflate extends Zlib {}

--- a/lib/node.js
+++ b/lib/node.js
@@ -844,15 +844,26 @@ declare module "vm" {
   // TODO
 }
 
-type zlib$ZlibOptions = {
-  flush: ?number;
-  chunkSize: ?number;
-  windowBits: ?number;
-  level: ?number;
-  memLevel: ?number;
-  strategy: ?number;
-  dictionary: ?Buffer;
+type zlib$options = {
+  flush?: number;
+  chunkSize?: number;
+  windowBits?: number;
+  level?: number;
+  memLevel?: number;
+  strategy?: number;
+  dictionary?: Buffer;
 };
+
+type zlib$asyncFn = (
+  buffer: string | Buffer,
+  options?: zlib$options
+) => void;
+
+type zlib$syncFn = (
+  buffer: string | Buffer,
+  options?: zlib$options,
+  callback?: ((error: ?Error, result: any) => void)
+) => void;
 
 declare module "zlib" {
   declare var Z_NO_FLUSH: number;
@@ -919,27 +930,27 @@ declare module "zlib" {
   declare class DeflateRaw extends Zlib {}
   declare class InflateRaw extends Zlib {}
   declare class Unzip extends Zlib {}
-  declare function createDeflate(options?: zlib$ZlibOptions): Deflate;
-  declare function createInflate(options?: zlib$ZlibOptions): Inflate;
-  declare function createDeflateRaw(options?: zlib$ZlibOptions): DeflateRaw;
-  declare function createInflateRaw(options?: zlib$ZlibOptions): InflateRaw;
-  declare function createGzip(options?: zlib$ZlibOptions): Gzip;
-  declare function createGunzip(options?: zlib$ZlibOptions): Gunzip;
-  declare function createUnzip(options?: zlib$ZlibOptions): Unzip;
-  declare function deflate(buffer: string | Buffer, options: zlib$ZlibOptions, callback?: ((error: ?Error, ...args: Array<any>) => void)): void;
-  declare function deflateSync(buffer: string | Buffer, options: zlib$ZlibOptions): void;
-  declare function gzip(buffer: string | Buffer, options: zlib$ZlibOptions, callback?: ((error: ?Error, ...args: Array<any>) => void)): void;
-  declare function gzipSync(buffer: string | Buffer, options: zlib$ZlibOptions): void;
-  declare function deflateRaw(buffer: string | Buffer, options: zlib$ZlibOptions, callback?: ((error: ?Error, ...args: Array<any>) => void)): void;
-  declare function deflateRawSync(buffer: string | Buffer, options: zlib$ZlibOptions): void;
-  declare function unzip(buffer: string | Buffer, options: zlib$ZlibOptions, callback?: ((error: ?Error, ...args: Array<any>) => void)): void;
-  declare function unzipSync(buffer: string | Buffer, options: zlib$ZlibOptions): void;
-  declare function inflate(buffer: string | Buffer, options: zlib$ZlibOptions, callback?: ((error: ?Error, ...args: Array<any>) => void)): void;
-  declare function inflateSync(buffer: string | Buffer, options: zlib$ZlibOptions): void;
-  declare function gunzip(buffer: string | Buffer, options: zlib$ZlibOptions, callback?: ((error: ?Error, ...args: Array<any>) => void)): void;
-  declare function gunzipSync(buffer: string | Buffer, options: zlib$ZlibOptions): void;
-  declare function inflateRaw(buffer: string | Buffer, options: zlib$ZlibOptions, callback?: ((error: ?Error, ...args: Array<any>) => void)): void;
-  declare function inflateRawSync(buffer: string | Buffer, options: zlib$ZlibOptions): void;
+  declare function createDeflate(options?: zlib$options): Deflate;
+  declare function createInflate(options?: zlib$options): Inflate;
+  declare function createDeflateRaw(options?: zlib$options): DeflateRaw;
+  declare function createInflateRaw(options?: zlib$options): InflateRaw;
+  declare function createGzip(options?: zlib$options): Gzip;
+  declare function createGunzip(options?: zlib$options): Gunzip;
+  declare function createUnzip(options?: zlib$options): Unzip;
+  declare var deflate: zlib$asyncFn;
+  declare var deflateSync: zlib$syncFn;
+  declare var gzip: zlib$asyncFn;
+  declare var gzipSync: zlib$syncFn;
+  declare var deflateRaw: zlib$asyncFn;
+  declare var deflateRawSync: zlib$syncFn;
+  declare var unzip: zlib$asyncFn;
+  declare var unzipSync: zlib$syncFn;
+  declare var inflate: zlib$asyncFn;
+  declare var inflateSync: zlib$syncFn;
+  declare var gunzip: zlib$asyncFn;
+  declare var gunzipSync: zlib$syncFn;
+  declare var inflateRaw: zlib$asyncFn;
+  declare var inflateRawSync: zlib$syncFn;
 }
 
 declare module "assert" {

--- a/lib/node.js
+++ b/lib/node.js
@@ -867,15 +867,15 @@ declare module "zlib" {
   declare var Z_MIN_MEMLEVEL: number;
   declare var Z_MIN_WINDOWBITS: number;
   declare var codes: {
-    Z_OK: any,
-    Z_STREAM_END: any,
-    Z_NEED_DICT: any,
-    Z_ERRNO: any,
-    Z_STREAM_ERROR: any,
-    Z_DATA_ERROR: any,
-    Z_MEM_ERROR: any,
-    Z_BUF_ERROR: any,
-    Z_VERSION_ERROR: any
+    Z_OK: number,
+    Z_STREAM_END: number,
+    Z_NEED_DICT: number,
+    Z_ERRNO: number,
+    Z_STREAM_ERROR: number,
+    Z_DATA_ERROR: number,
+    Z_MEM_ERROR: number,
+    Z_BUF_ERROR: number,
+    Z_VERSION_ERROR: number
   };
   declare class Zlib {
     // TODO
@@ -887,27 +887,27 @@ declare module "zlib" {
   declare class DeflateRaw extends Zlib {}
   declare class InflateRaw extends Zlib {}
   declare class Unzip extends Zlib {}
-  declare function createDeflate(o?: any): Deflate;
-  declare function createInflate(o?: any): Inflate;
-  declare function createDeflateRaw(o?: any): DeflateRaw;
-  declare function createInflateRaw(o?: any): InflateRaw;
-  declare function createGzip(o?: any): Gzip;
-  declare function createGunzip(o?: any): Gunzip;
-  declare function createUnzip(o?: any): Unzip;
-  declare function deflate(buffer: string | Buffer, opts: any, callback?: ((...args: Array<any>) => void)): void;
-  declare function deflateSync(buffer: string | Buffer, opts: any): void;
-  declare function gzip(buffer: string | Buffer, opts: any, callback?: ((...args: Array<any>) => void)): void;
-  declare function gzipSync(buffer: string | Buffer, opts: any): void;
-  declare function deflateRaw(buffer: string | Buffer, opts: any, callback?: ((...args: Array<any>) => void)): void;
-  declare function deflateRawSync(buffer: string | Buffer, opts: any): void;
-  declare function unzip(buffer: string | Buffer, opts: any, callback?: ((...args: Array<any>) => void)): void;
-  declare function unzipSync(buffer: string | Buffer, opts: any): void;
-  declare function inflate(buffer: string | Buffer, opts: any, callback?: ((...args: Array<any>) => void)): void;
-  declare function inflateSync(buffer: string | Buffer, opts: any): void;
-  declare function gunzip(buffer: string | Buffer, opts: any, callback?: ((...args: Array<any>) => void)): void;
-  declare function gunzipSync(buffer: string | Buffer, opts: any): void;
-  declare function inflateRaw(buffer: string | Buffer, opts: any, callback?: ((...args: Array<any>) => void)): void;
-  declare function inflateRawSync(buffer: string | Buffer, opts: any): void;
+  declare function createDeflate(options?: any): Deflate;
+  declare function createInflate(options?: any): Inflate;
+  declare function createDeflateRaw(options?: any): DeflateRaw;
+  declare function createInflateRaw(options?: any): InflateRaw;
+  declare function createGzip(options?: any): Gzip;
+  declare function createGunzip(options?: any): Gunzip;
+  declare function createUnzip(options?: any): Unzip;
+  declare function deflate(buffer: string | Buffer, options: any, callback?: ((...args: Array<any>) => void)): void;
+  declare function deflateSync(buffer: string | Buffer, options: any): void;
+  declare function gzip(buffer: string | Buffer, options: any, callback?: ((...args: Array<any>) => void)): void;
+  declare function gzipSync(buffer: string | Buffer, options: any): void;
+  declare function deflateRaw(buffer: string | Buffer, options: any, callback?: ((...args: Array<any>) => void)): void;
+  declare function deflateRawSync(buffer: string | Buffer, options: any): void;
+  declare function unzip(buffer: string | Buffer, options: any, callback?: ((...args: Array<any>) => void)): void;
+  declare function unzipSync(buffer: string | Buffer, options: any): void;
+  declare function inflate(buffer: string | Buffer, options: any, callback?: ((...args: Array<any>) => void)): void;
+  declare function inflateSync(buffer: string | Buffer, options: any): void;
+  declare function gunzip(buffer: string | Buffer, options: any, callback?: ((...args: Array<any>) => void)): void;
+  declare function gunzipSync(buffer: string | Buffer, options: any): void;
+  declare function inflateRaw(buffer: string | Buffer, options: any, callback?: ((...args: Array<any>) => void)): void;
+  declare function inflateRawSync(buffer: string | Buffer, options: any): void;
 }
 
 declare module "assert" {

--- a/lib/node.js
+++ b/lib/node.js
@@ -823,34 +823,49 @@ declare module "vm" {
 }
 
 declare module "zlib" {
-  declare var Z_BLOCK: any;
-  declare var Z_BUF_ERROR: any;
-  declare var Z_DATA_ERROR: any;
-  declare var Z_DEFAULT_CHUNK: any;
-  declare var Z_DEFAULT_COMPRESSION: any;
-  declare var Z_DEFAULT_LEVEL: any;
-  declare var Z_DEFAULT_MEMLEVEL: any;
-  declare var Z_DEFAULT_WINDOWBITS: any;
-  declare var Z_ERRNO: any;
-  declare var Z_FINISH: any;
-  declare var Z_FULL_FLUSH: any;
-  declare var Z_MAX_CHUNK: any;
-  declare var Z_MAX_LEVEL: any;
-  declare var Z_MAX_MEMLEVEL: any;
-  declare var Z_MAX_WINDOWBITS: any;
-  declare var Z_MEM_ERROR: any;
-  declare var Z_MIN_CHUNK: any;
-  declare var Z_MIN_LEVEL: any;
-  declare var Z_MIN_MEMLEVEL: any;
-  declare var Z_MIN_WINDOWBITS: any;
-  declare var Z_NEED_DICT: any;
-  declare var Z_NO_FLUSH: any;
-  declare var Z_OK: any;
-  declare var Z_PARTIAL_FLUSH: any;
-  declare var Z_STREAM_END: any;
-  declare var Z_STREAM_ERROR: any;
-  declare var Z_SYNC_FLUSH: any;
-  declare var Z_VERSION_ERROR: any;
+  declare var Z_NO_FLUSH: number;
+  declare var Z_PARTIAL_FLUSH: number;
+  declare var Z_SYNC_FLUSH: number;
+  declare var Z_FULL_FLUSH: number;
+  declare var Z_FINISH: number;
+  declare var Z_BLOCK: number;
+  declare var Z_TREES: number;
+  declare var Z_OK: number;
+  declare var Z_STREAM_END: number;
+  declare var Z_NEED_DICT: number;
+  declare var Z_ERRNO: number;
+  declare var Z_STREAM_ERROR: number;
+  declare var Z_DATA_ERROR: number;
+  declare var Z_MEM_ERROR: number;
+  declare var Z_BUF_ERROR: number;
+  declare var Z_VERSION_ERROR: number;
+  declare var Z_NO_COMPRESSION: number;
+  declare var Z_BEST_SPEED: number;
+  declare var Z_BEST_COMPRESSION: number;
+  declare var Z_DEFAULT_COMPRESSION: number;
+  declare var Z_FILTERED: number;
+  declare var Z_HUFFMAN_ONLY: number;
+  declare var Z_RLE: number;
+  declare var Z_FIXED: number;
+  declare var Z_DEFAULT_STRATEGY: number;
+  declare var Z_BINARY: number;
+  declare var Z_TEXT: number;
+  declare var Z_ASCII: number;
+  declare var Z_UNKNOWN: number;
+  declare var Z_DEFLATED: number;
+  declare var Z_NULL: number;
+  declare var Z_DEFAULT_CHUNK: number;
+  declare var Z_DEFAULT_LEVEL: number;
+  declare var Z_DEFAULT_MEMLEVEL: number;
+  declare var Z_DEFAULT_WINDOWBITS: number;
+  declare var Z_MAX_CHUNK: number;
+  declare var Z_MAX_LEVEL: number;
+  declare var Z_MAX_MEMLEVEL: number;
+  declare var Z_MAX_WINDOWBITS: number;
+  declare var Z_MIN_CHUNK: number;
+  declare var Z_MIN_LEVEL: number;
+  declare var Z_MIN_MEMLEVEL: number;
+  declare var Z_MIN_WINDOWBITS: number;
   declare var codes: {
     Z_OK: any,
     Z_STREAM_END: any,

--- a/lib/node.js
+++ b/lib/node.js
@@ -854,12 +854,12 @@ type zlib$options = {
   dictionary?: Buffer;
 };
 
-type zlib$asyncFn = (
+type zlib$syncFn = (
   buffer: string | Buffer,
   options?: zlib$options
-) => void;
+) => Buffer;
 
-type zlib$syncFn = (
+type zlib$asyncFn = (
   buffer: string | Buffer,
   options?: zlib$options,
   callback?: ((error: ?Error, result: any) => void)

--- a/lib/node.js
+++ b/lib/node.js
@@ -822,6 +822,16 @@ declare module "vm" {
   // TODO
 }
 
+type zlib$ZlibOptions = {
+  flush: ?number;
+  chunkSize: ?number;
+  windowBits: ?number;
+  level: ?number;
+  memLevel: ?number;
+  strategy: ?number;
+  dictionary: ?Buffer;
+};
+
 declare module "zlib" {
   declare var Z_NO_FLUSH: number;
   declare var Z_PARTIAL_FLUSH: number;
@@ -887,27 +897,27 @@ declare module "zlib" {
   declare class DeflateRaw extends Zlib {}
   declare class InflateRaw extends Zlib {}
   declare class Unzip extends Zlib {}
-  declare function createDeflate(options?: any): Deflate;
-  declare function createInflate(options?: any): Inflate;
-  declare function createDeflateRaw(options?: any): DeflateRaw;
-  declare function createInflateRaw(options?: any): InflateRaw;
-  declare function createGzip(options?: any): Gzip;
-  declare function createGunzip(options?: any): Gunzip;
-  declare function createUnzip(options?: any): Unzip;
-  declare function deflate(buffer: string | Buffer, options: any, callback?: ((error: ?Error, ...args: Array<any>) => void)): void;
-  declare function deflateSync(buffer: string | Buffer, options: any): void;
-  declare function gzip(buffer: string | Buffer, options: any, callback?: ((error: ?Error, ...args: Array<any>) => void)): void;
-  declare function gzipSync(buffer: string | Buffer, options: any): void;
-  declare function deflateRaw(buffer: string | Buffer, options: any, callback?: ((error: ?Error, ...args: Array<any>) => void)): void;
-  declare function deflateRawSync(buffer: string | Buffer, options: any): void;
-  declare function unzip(buffer: string | Buffer, options: any, callback?: ((error: ?Error, ...args: Array<any>) => void)): void;
-  declare function unzipSync(buffer: string | Buffer, options: any): void;
-  declare function inflate(buffer: string | Buffer, options: any, callback?: ((error: ?Error, ...args: Array<any>) => void)): void;
-  declare function inflateSync(buffer: string | Buffer, options: any): void;
-  declare function gunzip(buffer: string | Buffer, options: any, callback?: ((error: ?Error, ...args: Array<any>) => void)): void;
-  declare function gunzipSync(buffer: string | Buffer, options: any): void;
-  declare function inflateRaw(buffer: string | Buffer, options: any, callback?: ((error: ?Error, ...args: Array<any>) => void)): void;
-  declare function inflateRawSync(buffer: string | Buffer, options: any): void;
+  declare function createDeflate(options?: zlib$ZlibOptions): Deflate;
+  declare function createInflate(options?: zlib$ZlibOptions): Inflate;
+  declare function createDeflateRaw(options?: zlib$ZlibOptions): DeflateRaw;
+  declare function createInflateRaw(options?: zlib$ZlibOptions): InflateRaw;
+  declare function createGzip(options?: zlib$ZlibOptions): Gzip;
+  declare function createGunzip(options?: zlib$ZlibOptions): Gunzip;
+  declare function createUnzip(options?: zlib$ZlibOptions): Unzip;
+  declare function deflate(buffer: string | Buffer, options: zlib$ZlibOptions, callback?: ((error: ?Error, ...args: Array<any>) => void)): void;
+  declare function deflateSync(buffer: string | Buffer, options: zlib$ZlibOptions): void;
+  declare function gzip(buffer: string | Buffer, options: zlib$ZlibOptions, callback?: ((error: ?Error, ...args: Array<any>) => void)): void;
+  declare function gzipSync(buffer: string | Buffer, options: zlib$ZlibOptions): void;
+  declare function deflateRaw(buffer: string | Buffer, options: zlib$ZlibOptions, callback?: ((error: ?Error, ...args: Array<any>) => void)): void;
+  declare function deflateRawSync(buffer: string | Buffer, options: zlib$ZlibOptions): void;
+  declare function unzip(buffer: string | Buffer, options: zlib$ZlibOptions, callback?: ((error: ?Error, ...args: Array<any>) => void)): void;
+  declare function unzipSync(buffer: string | Buffer, options: zlib$ZlibOptions): void;
+  declare function inflate(buffer: string | Buffer, options: zlib$ZlibOptions, callback?: ((error: ?Error, ...args: Array<any>) => void)): void;
+  declare function inflateSync(buffer: string | Buffer, options: zlib$ZlibOptions): void;
+  declare function gunzip(buffer: string | Buffer, options: zlib$ZlibOptions, callback?: ((error: ?Error, ...args: Array<any>) => void)): void;
+  declare function gunzipSync(buffer: string | Buffer, options: zlib$ZlibOptions): void;
+  declare function inflateRaw(buffer: string | Buffer, options: zlib$ZlibOptions, callback?: ((error: ?Error, ...args: Array<any>) => void)): void;
+  declare function inflateRawSync(buffer: string | Buffer, options: zlib$ZlibOptions): void;
 }
 
 declare module "assert" {

--- a/lib/node.js
+++ b/lib/node.js
@@ -823,7 +823,83 @@ declare module "vm" {
 }
 
 declare module "zlib" {
-  // TODO
+  declare var DEFLATE: any;
+  declare var DEFLATERAW: any;
+  declare var GUNZIP: any;
+  declare var GZIP: any;
+  declare var INFLATE: any;
+  declare var INFLATERAW: any;
+  declare var UNZIP: any;
+  declare var Z_BLOCK: any;
+  declare var Z_BUF_ERROR: any;
+  declare var Z_DATA_ERROR: any;
+  declare var Z_DEFAULT_CHUNK: any;
+  declare var Z_DEFAULT_COMPRESSION: any;
+  declare var Z_DEFAULT_LEVEL: any;
+  declare var Z_DEFAULT_MEMLEVEL: any;
+  declare var Z_DEFAULT_WINDOWBITS: any;
+  declare var Z_ERRNO: any;
+  declare var Z_FINISH: any;
+  declare var Z_FULL_FLUSH: any;
+  declare var Z_MAX_CHUNK: any;
+  declare var Z_MAX_LEVEL: any;
+  declare var Z_MAX_MEMLEVEL: any;
+  declare var Z_MAX_WINDOWBITS: any;
+  declare var Z_MEM_ERROR: any;
+  declare var Z_MIN_CHUNK: any;
+  declare var Z_MIN_LEVEL: any;
+  declare var Z_MIN_MEMLEVEL: any;
+  declare var Z_MIN_WINDOWBITS: any;
+  declare var Z_NEED_DICT: any;
+  declare var Z_NO_FLUSH: any;
+  declare var Z_OK: any;
+  declare var Z_PARTIAL_FLUSH: any;
+  declare var Z_STREAM_END: any;
+  declare var Z_STREAM_ERROR: any;
+  declare var Z_SYNC_FLUSH: any;
+  declare var Z_VERSION_ERROR: any;
+  declare var codes: {
+    Z_OK: any,
+    Z_STREAM_END: any,
+    Z_NEED_DICT: any,
+    Z_ERRNO: any,
+    Z_STREAM_ERROR: any,
+    Z_DATA_ERROR: any,
+    Z_MEM_ERROR: any,
+    Z_BUF_ERROR: any,
+    Z_VERSION_ERROR: any
+  };
+  declare class Zlib {
+    // TODO
+  }
+  declare class Deflate extends Zlib {}
+  declare class Inflate extends Zlib {}
+  declare class Gzip extends Zlib {}
+  declare class Gunzip extends Zlib {}
+  declare class DeflateRaw extends Zlib {}
+  declare class InflateRaw extends Zlib {}
+  declare class Unzip extends Zlib {}
+  declare function createDeflate(o?: any): Deflate;
+  declare function createInflate(o?: any): Inflate;
+  declare function createDeflateRaw(o?: any): DeflateRaw;
+  declare function createInflateRaw(o?: any): InflateRaw;
+  declare function createGzip(o?: any): Gzip;
+  declare function createGunzip(o?: any): Gunzip;
+  declare function createUnzip(o?: any): Unzip;
+  declare function deflate(buffer: string | Buffer, opts: any, callback?: ((...args: Array<any>) => void)): void;
+  declare function deflateSync(buffer: string | Buffer, opts: any): void;
+  declare function gzip(buffer: string | Buffer, opts: any, callback?: ((...args: Array<any>) => void)): void;
+  declare function gzipSync(buffer: string | Buffer, opts: any): void;
+  declare function deflateRaw(buffer: string | Buffer, opts: any, callback?: ((...args: Array<any>) => void)): void;
+  declare function deflateRawSync(buffer: string | Buffer, opts: any): void;
+  declare function unzip(buffer: string | Buffer, opts: any, callback?: ((...args: Array<any>) => void)): void;
+  declare function unzipSync(buffer: string | Buffer, opts: any): void;
+  declare function inflate(buffer: string | Buffer, opts: any, callback?: ((...args: Array<any>) => void)): void;
+  declare function inflateSync(buffer: string | Buffer, opts: any): void;
+  declare function gunzip(buffer: string | Buffer, opts: any, callback?: ((...args: Array<any>) => void)): void;
+  declare function gunzipSync(buffer: string | Buffer, opts: any): void;
+  declare function inflateRaw(buffer: string | Buffer, opts: any, callback?: ((...args: Array<any>) => void)): void;
+  declare function inflateRawSync(buffer: string | Buffer, opts: any): void;
 }
 
 declare module "assert" {

--- a/lib/node.js
+++ b/lib/node.js
@@ -823,13 +823,6 @@ declare module "vm" {
 }
 
 declare module "zlib" {
-  declare var DEFLATE: any;
-  declare var DEFLATERAW: any;
-  declare var GUNZIP: any;
-  declare var GZIP: any;
-  declare var INFLATE: any;
-  declare var INFLATERAW: any;
-  declare var UNZIP: any;
   declare var Z_BLOCK: any;
   declare var Z_BUF_ERROR: any;
   declare var Z_DATA_ERROR: any;

--- a/lib/node.js
+++ b/lib/node.js
@@ -894,19 +894,19 @@ declare module "zlib" {
   declare function createGzip(options?: any): Gzip;
   declare function createGunzip(options?: any): Gunzip;
   declare function createUnzip(options?: any): Unzip;
-  declare function deflate(buffer: string | Buffer, options: any, callback?: ((...args: Array<any>) => void)): void;
+  declare function deflate(buffer: string | Buffer, options: any, callback?: ((error: ?Error, ...args: Array<any>) => void)): void;
   declare function deflateSync(buffer: string | Buffer, options: any): void;
-  declare function gzip(buffer: string | Buffer, options: any, callback?: ((...args: Array<any>) => void)): void;
+  declare function gzip(buffer: string | Buffer, options: any, callback?: ((error: ?Error, ...args: Array<any>) => void)): void;
   declare function gzipSync(buffer: string | Buffer, options: any): void;
-  declare function deflateRaw(buffer: string | Buffer, options: any, callback?: ((...args: Array<any>) => void)): void;
+  declare function deflateRaw(buffer: string | Buffer, options: any, callback?: ((error: ?Error, ...args: Array<any>) => void)): void;
   declare function deflateRawSync(buffer: string | Buffer, options: any): void;
-  declare function unzip(buffer: string | Buffer, options: any, callback?: ((...args: Array<any>) => void)): void;
+  declare function unzip(buffer: string | Buffer, options: any, callback?: ((error: ?Error, ...args: Array<any>) => void)): void;
   declare function unzipSync(buffer: string | Buffer, options: any): void;
-  declare function inflate(buffer: string | Buffer, options: any, callback?: ((...args: Array<any>) => void)): void;
+  declare function inflate(buffer: string | Buffer, options: any, callback?: ((error: ?Error, ...args: Array<any>) => void)): void;
   declare function inflateSync(buffer: string | Buffer, options: any): void;
-  declare function gunzip(buffer: string | Buffer, options: any, callback?: ((...args: Array<any>) => void)): void;
+  declare function gunzip(buffer: string | Buffer, options: any, callback?: ((error: ?Error, ...args: Array<any>) => void)): void;
   declare function gunzipSync(buffer: string | Buffer, options: any): void;
-  declare function inflateRaw(buffer: string | Buffer, options: any, callback?: ((...args: Array<any>) => void)): void;
+  declare function inflateRaw(buffer: string | Buffer, options: any, callback?: ((error: ?Error, ...args: Array<any>) => void)): void;
   declare function inflateRawSync(buffer: string | Buffer, options: any): void;
 }
 


### PR DESCRIPTION
Test file:
```javascript
#!/usr/bin/env node
/* @flow */
var zlib = require('zlib');
console.log(zlib.createGunzip());
```

`flow` without this PR: `index.js:4:13,31: call of method createGunzip Could not resolve name Found 1 error`

`flow` with this PR: `No errors!`