### PR TITLE
Stop claims of file re-checks by server for ignored files.

### DIFF
--- a/src/server/server.ml
+++ b/src/server/server.ml
@@ -491,11 +491,6 @@ struct
       end;
       let options = OptionParser.get_flow_options () in
 
-      let n = SSet.cardinal diff_js in
-      prerr_endlinef "recheck %d files:" n;
-      let _ = SSet.fold (fun f i ->
-        prerr_endlinef "%d/%d: %s" i n f; i + 1) diff_js 1 in
-
       let server_env = Types_js.recheck genv env diff_js options in
       SearchService_js.update_from_master updates;
       server_env

--- a/src/typing/types_js.ml
+++ b/src/typing/types_js.ml
@@ -547,6 +547,14 @@ let recheck genv env modified opts =
   let config = FlowConfig.get root in
   let modified = SSet.filter (Files_js.wanted config) modified in
 
+  let n = SSet.cardinal modified in
+    if n > 0
+    then prerr_endlinef "recheck %d files:" n;
+
+  let _ = SSet.fold (fun f i ->
+    if n > 0
+    then prerr_endlinef "%d/%d: %s" i n f; i + 1) modified 1 in
+
   (* clear errors for modified files and master *)
   clear_errors (Flow_js.master_cx.file :: SSet.elements modified);
 
@@ -602,7 +610,9 @@ let recheck genv env modified opts =
       let unmod_deps = deps unmodified_parsed inferred_set removed_modules in
 
       let n = SSet.cardinal unmod_deps in
-      prerr_endlinef "remerge %d dependent files:" n;
+        if n > 0
+        then prerr_endlinef "remerge %d dependent files:" n;
+      
       let _ = SSet.fold (fun f i ->
         prerr_endlinef "%d/%d: %s" i n f; i + 1) unmod_deps 1 in
 


### PR DESCRIPTION
While running the server with `flow server`, it would report re-checks for files that match expressions in the [ignore] section of .flowconfig. This change should prevent that from occurring.