### PR TITLE
Make querystring.stringify params optional, rather than using maybe types.

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -701,8 +701,8 @@ declare module "punycode" {
 declare module "querystring" {
   declare function stringify(
     obj: Object,
-    separator: ?string,
-    equal: ?string,
+    separator?: string,
+    equal?: string,
     options?: {
       encodeURIComponent?: (str: string) => string;
     }


### PR DESCRIPTION
From [the Query String docs](https://nodejs.org/api/querystring.html#querystring_querystring_stringify_obj_sep_eq_options):
> Serialize an object to a query string. Optionally override the default separator ('&') and assignment ('=') characters.

Test file:

```javascript
#!/usr/bin/env node
/* @flow */
import querystring from 'querystring';
var output = querystring.stringify({ 'key': 'value' });
console.log(output);
```

`flow` without this PR:  `call of method stringify Too few arguments (expected default/rest parameters in function) Found 1 error`

`flow` with this PR: `No errors!`