### PR TITLE
Type check React.Components when the type of defaultProps is unspecified

### DIFF
--- a/lib/react.js
+++ b/lib/react.js
@@ -58,7 +58,7 @@ declare class ReactComponent<D, P, S> {
  * existential type (*). The * can be thought of as an "auto" instruction to the
  * typechecker, telling it to fill in the type from context.
  */
-type ReactClass<D, P, S> = _ReactClass<D, P, S, *>;
+type ReactClass<D, P, S> = _ReactClass<$ObjTest<{},D>, P, S, *>;
 type _ReactClass<D, P, S, C: ReactComponent<D, P, S>> = Class<C>;
 
 /**
@@ -66,7 +66,7 @@ type _ReactClass<D, P, S, C: ReactComponent<D, P, S>> = Class<C>;
  * literals, which desugar to React.createElement calls (see below).
  */
 declare class ReactElement<D, P, S> {
-    type: ReactClass<D, P, S>;
+    type: ReactClass<$ObjTest<{},D>, P, S>;
     props: P;
     key: ?string;
     ref: any;

--- a/src/typing/flow_js.ml
+++ b/src/typing/flow_js.ml
@@ -1616,6 +1616,11 @@ let rec __flow cx (l, u) trace =
       then rec_flow cx trace (l, u)
       else rec_flow cx trace (default, u)
 
+    | (ObjTestT(reason, default, u), _) ->
+      if object_like u
+      then rec_flow cx trace (l, u)
+      else rec_flow cx trace (l, default)
+
     (*****************************)
     (* upper and lower any types *)
     (*****************************)
@@ -3121,6 +3126,9 @@ and subst cx ?(force=true) (map: Type.t SMap.t) t =
 
   | ObjAssignT(reason, t1, t2, xs, resolve) ->
     ObjAssignT(reason, subst cx ~force map t1, subst cx ~force map t2, xs, resolve)
+
+  | ObjTestT(reason, t1, t2) ->
+    ObjTestT(reason, subst cx ~force map t1, subst cx ~force map t2)
 
   | _ -> assert false (** TODO **)
 

--- a/src/typing/type_inference_js.ml
+++ b/src/typing/type_inference_js.ml
@@ -632,7 +632,7 @@ let rec convert cx map = Ast.Type.(function
           RecordT (mk_reason "record type" loc, t)
         )
 
-      (* $Record<T> is the type of objects whose keys are those of T *)
+      (* $ObjTest<T> is the default if the given type is not an object *)
       | "$ObjTest" ->
         check_type_param_arity cx loc typeParameters 2 (fun () ->
           let t1 = typeParameters |> List.hd |> convert cx map in

--- a/src/typing/type_inference_js.ml
+++ b/src/typing/type_inference_js.ml
@@ -632,6 +632,14 @@ let rec convert cx map = Ast.Type.(function
           RecordT (mk_reason "record type" loc, t)
         )
 
+      (* $Record<T> is the type of objects whose keys are those of T *)
+      | "$ObjTest" ->
+        check_type_param_arity cx loc typeParameters 2 (fun () ->
+          let t1 = typeParameters |> List.hd |> convert cx map in
+          let t2 = typeParameters |> List.tl |> List.hd |> convert cx map in
+          ObjTestT (mk_reason "object test" loc, t1, t2)
+        )
+
       (* $Exports<'M'> is the type of the exports of module 'M' *)
       (** TODO: use `import typeof` instead when that lands **)
       | "$Exports" ->

--- a/tests/new_react/classes.js
+++ b/tests/new_react/classes.js
@@ -80,3 +80,9 @@ FooLegacy.defaultProps = 0; // TODO: should be error
 var foo_legacy: $jsx<number> = <FooLegacy/>;
 
 FooLegacy.bar();
+
+class NoDefaultProps extends React.Component {
+  props: { x: number };
+}
+
+var noDefaultProps = <NoDefaultProps /> // error

--- a/tests/new_react/new_react.exp
+++ b/tests/new_react/new_react.exp
@@ -65,6 +65,12 @@ classes.js:80:22,27: number
 This type is incompatible with
 [LIB] react.js:16:1,49:1: ReactComponent
 
+classes.js:88:22,39: React element: NoDefaultProps
+Error:
+classes.js:85:10,22: property x
+Property not found in
+classes.js:88:22,39: type parameter D of React element: NoDefaultProps
+
 new_react.js:3:9,27:2: state of React component
 This type is incompatible with
 new_react.js:17:18,23: string
@@ -203,4 +209,4 @@ state3.js:14:16,20: boolean
 This type is incompatible with
 state3.js:11:16,21: number
 
-Found 44 errors
+Found 45 errors


### PR DESCRIPTION
Using ObjTestT like this is a bit imprecise, but in the case of react
props, if the defaultProps isn't an object type, we have other problems.