### PR TITLE
Correcting removeAllListeners

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -431,7 +431,7 @@ declare class events$EventEmitter {
   listeners(event: string): Array<Function>;
   on(event: string, listener: (data: any) => void): events$EventEmitter;
   once(event: string, listener: Function): events$EventEmitter;
-  removeAllListeners(events?: Array<string>): events$EventEmitter;
+  removeAllListeners(event?: string): events$EventEmitter;
   removeListener(event: string, listener: Function): events$EventEmitter;
   setMaxListeners(n: number): void;
 }


### PR DESCRIPTION
removeAllListeners gets one event, not array of events

See

https://github.com/joyent/node/blob/ef4344311e19a4f73c031508252b21712b22fe8a/lib/events.js#L258-L297