### PR TITLE
Expand 'child_process' options and functions

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -62,53 +62,76 @@ declare module "buffer" {
   declare var INSPECT_MAX_BYTES: number;
 }
 
-type child_process$execFileOpts = {
-  cwd: string;
-  env: Object;
-  encoding: string;
-  timeout: number;
-  maxBuffer: number;
-  killSignal: string;
+type child_process$execOpts = {
+  cwd?: string;
+  env?: Object;
+  encoding?: string;
+  shell?: string;
+  timeout?: number;
+  maxBuffer?: number;
+  killSignal?: string;
+  uid?: number;
+  gid?: number;
 };
 
-type child_process$execOpts = {
-  cwd: ?string;
-  env: ?Object;
-  encoding: ?string;
-  timeout: ?number;
-  maxBuffer: ?number;
-  killSignal: ?string;
+type child_process$execCallback = (error: ?Error, stdout: Buffer, stderr: Buffer) => void;
+
+type child_process$execSyncOpts = {
+  cwd?: string;
+  input?: string | Buffer;
+  stdio?: Array<any>;
+  env?: Object;
+  uid?: number;
+  gid?: number;
+  timeout?: number;
+  killSignal?: string;
+  maxBuffer?: number;
+  encoding?: string;
 };
+
+type child_process$execFileOpts = {
+  cwd?: string;
+  env?: Object;
+  encoding?: string;
+  timeout?: number;
+  maxBuffer?: number;
+  killSignal?: string;
+  uid?: number;
+  gid?: number;
+};
+
+type child_process$execFileCallback = (error: ?Error, stdout: Buffer, stderr: Buffer) => void;
 
 type child_process$forkOpts = {
-  cwd: string;
-  encoding: string;
-  env: Object;
-  execArgv: Array<string>;
-  execPath: string;
-  silent: boolean;
+  cwd?: string;
+  env?: Object;
+  execPath?: string;
+  execArgv?: Array<string>;
+  silent?: boolean;
+  uid?: number;
+  gid?: number;
 };
 
 type child_process$Handle = any; // TODO
 
 type child_process$spawnOpts = {
-  cwd: string;
-  detached: boolean;
-  env: Object;
-  gid: number;
-  stdio: string|Array<any>;
-  uid: number;
-}
+  cwd?: string;
+  env?: Object;
+  stdio?: string | Array<any>;
+  detached?: boolean;
+  uid?: number;
+  gid?: number;
+};
 
 type child_process$spawnRet = {
   pid: number;
   output: Array<any>;
-  stdout: any;
-  stderr: any;
+  stdout: Buffer | string;
+  stderr: Buffer | string;
   status: number;
   signal: string;
   error: Error;
-}
+};
 
 declare class child_process$ChildProcess extends events$EventEmitter {
   stdin: stream$Writable;
@@ -125,43 +148,44 @@ declare class child_process$ChildProcess extends events$EventEmitter {
 declare module "child_process" {
   declare function exec(
     command: string,
-    options?: Object, // TODO: child_process$execOpts,
-    callback: (error: ?Error, stdout: Buffer, stderr: Buffer) => void
+    optionsOrCallback?: child_process$execOpts | child_process$execCallback,
+    callback?: child_process$execCallback
   ): child_process$ChildProcess;
 
   declare function execSync(
     command: string,
-    options?: Object // TODO: child_process$execOpts,
-  ): any;
+    options?: child_process$execSyncOpts
+  ): Buffer | string;
 
   declare function execFile(
     file: string,
-    args?: Array<string>,
-    options: child_process$execFileOpts,
-    callback: (error: ?Error, stdout: Buffer, stderr: Buffer) => void
+    argsOrOptionsOrCallback?:
+      Array<string> | child_process$execFileOpts | child_process$execFileCallback,
+    optionsOrCallback?: child_process$execFileOpts | child_process$execFileCallback,
+    callback?: child_process$execFileCallback
   ): child_process$ChildProcess;
 
   declare function execFileSync(
     command: string,
-    args?: Array<string>,
+    argsOrOptions?: Array<string> | child_process$execFileOpts,
     options?: child_process$execFileOpts
-  ): any;
+  ): Buffer | string;
 
   declare function fork(
     modulePath: string,
-    args?: Array<string>,
+    argsOrOptions?: Array<string> | child_process$forkOpts,
     options?: child_process$forkOpts
   ): child_process$ChildProcess;
 
   declare function spawn(
     command: string,
-    args?: Array<string>,
+    argsOrOptions?: Array<string> | child_process$spawnOpts,
     options?: child_process$spawnOpts
   ): child_process$ChildProcess;
 
   declare function spawnSync(
     command: string,
-    args?: Array<string>,
+    argsOrOptions?: Array<string> | child_process$spawnOpts,
     options?: child_process$spawnOpts
   ): child_process$spawnRet;
 }

--- a/tests/node_tests/child_process/exec.js
+++ b/tests/node_tests/child_process/exec.js
@@ -1,0 +1,16 @@
+/* @flow */
+
+var exec = require('child_process').exec;
+
+// callback only.
+exec('ls', function(error, stdout, stderr) {
+  console.info(stdout);
+});
+
+// options only.
+exec('ls', {timeout: 250});
+
+// options + callback.
+exec('ls', {maxBuffer: 100}, function(error, stdout, stderr) {
+  console.info(stdout);
+});

--- a/tests/node_tests/child_process/execFile.js
+++ b/tests/node_tests/child_process/execFile.js
@@ -1,0 +1,27 @@
+/* @flow */
+
+var execFile = require('child_process').execFile;
+
+// args only.
+execFile('ls', ['-lh']);
+
+// callback only.
+execFile('ls', function(error, stdout, stderr) {
+  console.info(stdout);
+});
+
+// options only.
+execFile('wc', {timeout: 250});
+
+// args + callback.
+execFile('ls', ['-l'], function(error, stdout, stderr) {
+  console.info(stdout);
+});
+
+// args + options.
+execFile('ls', ['-l'], {timeout: 250});
+
+// Put it all together.
+execFile('ls', ['-l'], {timeout: 250}, function(error, stdout, stderr) {
+  console.info(stdout);
+});

--- a/tests/node_tests/child_process/spawn.js
+++ b/tests/node_tests/child_process/spawn.js
@@ -1,8 +1,15 @@
 /* @flow */
 
 var child_process = require('child_process');
+
 var ls = child_process.spawn('ls');
 var wc = child_process.spawn('wc', ['-l']);
+
+// args + options.
+child_process.spawn('echo', ['-n', '"Testing..."'], {env: {TEST: 'foo'}});
+
+// options only.
+child_process.spawn('echo', {env: {FOO: 2}});
 
 ls.stdout.on('data', function(data) {
   wc.stdin.write(data);


### PR DESCRIPTION
Fill in and refine params for functions in Node's `child_process`.

* Let all keys in the options arguments to functions in 'child_process' be optional.
* Add `uid` and `gid` options to each of the options arguments.
* Use more exact `Buffer | string` for stderr and stdout instead of `any`.
* Handle variable number of arguments for each function like is allowed in `execFile`[0], for example:

      child_process.execFile(file[, args][, options][, callback])

[0]
https://nodejs.org/api/child_process.html#child_process_child_process_execfile_file_args_options_callback