### PR TITLE
reduceRight's initialValue should be optional

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -157,7 +157,7 @@ declare class Array<T> {
     find(callbackfn: (value: T, index: number, array: Array<T>) => any, thisArg?: any): T;
     findIndex(callbackfn: (value: T, index: number, array: Array<T>) => any, thisArg?: any): number;
     reduce<U>(callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: Array<T>) => U, initialValue?: U): U;
-    reduceRight<U>(callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: Array<T>) => U, initialValue: U): U;
+    reduceRight<U>(callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: Array<T>) => U, initialValue?: U): U;
     length: number;
     static (...values:Array<any>): Array<any>;
     static isArray(obj: any): bool;


### PR DESCRIPTION
Small change to fix what I believe is a bug: the second parameter, `initialValue`, of `Array.prototype.reduceRight` should be optional, just like `reduce`.