### PR TITLE
Date constructor definition (fixed tests)

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -207,6 +207,11 @@ declare class RegExp {
 }
 
 declare class Date {
+    // new Date();
+    // new Date(timestamp);
+    // new Date(dateString);
+    // new Date(year, month[, day[, hour[, minute[, second[, millisecond]]]]]);
+    constructor(value?: number | string, month?: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
     toDateString(): string;
     toTimeString(): string;
     toLocaleString(): string;

--- a/lib/core.js
+++ b/lib/core.js
@@ -211,6 +211,8 @@ declare class Date {
     // new Date(timestamp);
     // new Date(dateString);
     // new Date(year, month[, day[, hour[, minute[, second[, millisecond]]]]]);
+    // TODO: This should specify an overloaded constructor once they're
+    // supported, instead of a union type for the first argument.
     constructor(value?: number | string, month?: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
     toDateString(): string;
     toTimeString(): string;

--- a/src/parser/package.json
+++ b/src/parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flow-parser",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "JavaScript parser written in OCaml. Produces SpiderMonkey AST",
   "author": {
     "name": "Gabe Levi",

--- a/tests/async/async.exp
+++ b/tests/async/async.exp
@@ -1,8 +1,8 @@
 
 async.js: inconsistent use of library definitions
-[LIB] core.js:343:1,370:1: Promise
+[LIB] core.js:348:1,375:1: Promise
 This type is incompatible with
-[LIB] core.js:373:31,44: union type
+[LIB] core.js:378:31,44: union type
 
 async.js:12:30,33: boolean
 This type is incompatible with
@@ -14,7 +14,7 @@ async.js:12:30,33: boolean
 
 async.js:46:22,25: undefined
 This type is incompatible with
-[LIB] core.js:343:1,370:1: Promise
+[LIB] core.js:348:1,375:1: Promise
 
 async2.js:10:11,21: await
 Error:
@@ -24,11 +24,11 @@ async2.js:12:10,15: string
 
 async2.js:29:21,24: undefined
 This type is incompatible with
-[LIB] core.js:343:1,370:1: Promise
+[LIB] core.js:348:1,375:1: Promise
 
 async2.js:43:28,31: undefined
 This type is incompatible with
-[LIB] core.js:343:1,370:1: Promise
+[LIB] core.js:348:1,375:1: Promise
 
 async2.js:48:3,17: undefined
 This type is incompatible with
@@ -42,13 +42,13 @@ async3.js:23:11,21: await
 Error:
 async3.js:27:10,15: number
 This type is incompatible with
-[LIB] core.js:343:1,370:1: Promise
+[LIB] core.js:348:1,375:1: Promise
 
 async3.js:23:11,21: await
 Error:
 async3.js:31:10,15: string
 This type is incompatible with
-[LIB] core.js:343:1,370:1: Promise
+[LIB] core.js:348:1,375:1: Promise
 
 await_not_in_async.js:5:9,9: Unexpected number
 

--- a/tests/async/async.exp
+++ b/tests/async/async.exp
@@ -1,8 +1,8 @@
 
 async.js: inconsistent use of library definitions
-[LIB] core.js:348:1,375:1: Promise
+[LIB] core.js:350:1,377:1: Promise
 This type is incompatible with
-[LIB] core.js:378:31,44: union type
+[LIB] core.js:380:31,44: union type
 
 async.js:12:30,33: boolean
 This type is incompatible with
@@ -14,7 +14,7 @@ async.js:12:30,33: boolean
 
 async.js:46:22,25: undefined
 This type is incompatible with
-[LIB] core.js:348:1,375:1: Promise
+[LIB] core.js:350:1,377:1: Promise
 
 async2.js:10:11,21: await
 Error:
@@ -24,11 +24,11 @@ async2.js:12:10,15: string
 
 async2.js:29:21,24: undefined
 This type is incompatible with
-[LIB] core.js:348:1,375:1: Promise
+[LIB] core.js:350:1,377:1: Promise
 
 async2.js:43:28,31: undefined
 This type is incompatible with
-[LIB] core.js:348:1,375:1: Promise
+[LIB] core.js:350:1,377:1: Promise
 
 async2.js:48:3,17: undefined
 This type is incompatible with
@@ -42,13 +42,13 @@ async3.js:23:11,21: await
 Error:
 async3.js:27:10,15: number
 This type is incompatible with
-[LIB] core.js:348:1,375:1: Promise
+[LIB] core.js:350:1,377:1: Promise
 
 async3.js:23:11,21: await
 Error:
 async3.js:31:10,15: string
 This type is incompatible with
-[LIB] core.js:348:1,375:1: Promise
+[LIB] core.js:350:1,377:1: Promise
 
 await_not_in_async.js:5:9,9: Unexpected number
 

--- a/tests/date/date.exp
+++ b/tests/date/date.exp
@@ -5,4 +5,46 @@ date.js:2:16,26: number
 This type is incompatible with
 date.js:2:7,12: string
 
-Found 1 error
+date.js:18:1,12: constructor call
+Error:
+date.js:18:10,11: object literal
+This type is incompatible with
+[LIB] core.js:214:25,39: union type
+
+date.js:19:1,19: constructor call
+Error:
+date.js:19:16,18: string
+This type is incompatible with
+[LIB] core.js:214:50,55: number
+
+date.js:20:1,23: constructor call
+Error:
+date.js:20:19,22: string
+This type is incompatible with
+[LIB] core.js:214:64,69: number
+
+date.js:21:1,27: constructor call
+Error:
+date.js:21:23,26: string
+This type is incompatible with
+[LIB] core.js:214:79,84: number
+
+date.js:22:1,31: constructor call
+Error:
+date.js:22:27,30: string
+This type is incompatible with
+[LIB] core.js:214:96,101: number
+
+date.js:23:1,35: constructor call
+Error:
+date.js:23:31,34: string
+This type is incompatible with
+[LIB] core.js:214:113,118: number
+
+date.js:24:1,40: constructor call
+Error:
+date.js:24:35,39: string
+This type is incompatible with
+[LIB] core.js:214:135,140: number
+
+Found 8 errors

--- a/tests/date/date.exp
+++ b/tests/date/date.exp
@@ -9,42 +9,42 @@ date.js:18:1,12: constructor call
 Error:
 date.js:18:10,11: object literal
 This type is incompatible with
-[LIB] core.js:214:25,39: union type
+[LIB] core.js:216:25,39: union type
 
 date.js:19:1,19: constructor call
 Error:
 date.js:19:16,18: string
 This type is incompatible with
-[LIB] core.js:214:50,55: number
+[LIB] core.js:216:50,55: number
 
 date.js:20:1,23: constructor call
 Error:
 date.js:20:19,22: string
 This type is incompatible with
-[LIB] core.js:214:64,69: number
+[LIB] core.js:216:64,69: number
 
 date.js:21:1,27: constructor call
 Error:
 date.js:21:23,26: string
 This type is incompatible with
-[LIB] core.js:214:79,84: number
+[LIB] core.js:216:79,84: number
 
 date.js:22:1,31: constructor call
 Error:
 date.js:22:27,30: string
 This type is incompatible with
-[LIB] core.js:214:96,101: number
+[LIB] core.js:216:96,101: number
 
 date.js:23:1,35: constructor call
 Error:
 date.js:23:31,34: string
 This type is incompatible with
-[LIB] core.js:214:113,118: number
+[LIB] core.js:216:113,118: number
 
 date.js:24:1,40: constructor call
 Error:
 date.js:24:35,39: string
 This type is incompatible with
-[LIB] core.js:214:135,140: number
+[LIB] core.js:216:135,140: number
 
 Found 8 errors

--- a/tests/date/date.js
+++ b/tests/date/date.js
@@ -2,3 +2,27 @@ var d = new Date(0);
 var x:string = d.getTime();
 
 var y:number = d;
+
+// valid constructors
+new Date();
+new Date(1234567890);
+new Date('2015/06/18');
+new Date(2015, 6);
+new Date(2015, 6, 18);
+new Date(2015, 6, 18, 11);
+new Date(2015, 6, 18, 11, 55);
+new Date(2015, 6, 18, 11, 55, 42);
+new Date(2015, 6, 18, 11, 55, 42, 999);
+
+// invalid constructors
+new Date({});
+new Date(2015, '6');
+new Date(2015, 6, '18');
+new Date(2015, 6, 18, '11');
+new Date(2015, 6, 18, 11, '55');
+new Date(2015, 6, 18, 11, 55, '42');
+new Date(2015, 6, 18, 11, 55, 42, '999');
+
+// invalid constructors that we incorrectly consider valid
+new Date('2015', 6);
+new Date(2015, 6, 18, 11, 55, 42, 999, 'hahaha');

--- a/tests/forof/forof.exp
+++ b/tests/forof/forof.exp
@@ -13,11 +13,11 @@ This type is incompatible with
 
 forof.js:32:12,17: number
 This type is incompatible with
-[LIB] core.js:306:28,33: tuple type
+[LIB] core.js:311:28,33: tuple type
 
 forof.js:39:12,17: number
 This type is incompatible with
-[LIB] core.js:306:28,33: tuple type
+[LIB] core.js:311:28,33: tuple type
 
 forof.js:43:28,33: string
 This type is incompatible with

--- a/tests/forof/forof.exp
+++ b/tests/forof/forof.exp
@@ -13,11 +13,11 @@ This type is incompatible with
 
 forof.js:32:12,17: number
 This type is incompatible with
-[LIB] core.js:311:28,33: tuple type
+[LIB] core.js:313:28,33: tuple type
 
 forof.js:39:12,17: number
 This type is incompatible with
-[LIB] core.js:311:28,33: tuple type
+[LIB] core.js:313:28,33: tuple type
 
 forof.js:43:28,33: string
 This type is incompatible with

--- a/tests/include/include.exp
+++ b/tests/include/include.exp
@@ -13,7 +13,7 @@ This type is incompatible with
 Error:
 ../lib/libtest.js:3:7,12: number
 This type is incompatible with
-[LIB] core.js:266:11,16: string
+[LIB] core.js:268:11,16: string
 
 ../lib/libtest.js:4:16,30: function call
 Error:

--- a/tests/include/include.exp
+++ b/tests/include/include.exp
@@ -13,7 +13,7 @@ This type is incompatible with
 Error:
 ../lib/libtest.js:3:7,12: number
 This type is incompatible with
-[LIB] core.js:261:11,16: string
+[LIB] core.js:266:11,16: string
 
 ../lib/libtest.js:4:16,30: function call
 Error:

--- a/tests/iterable/iterable.exp
+++ b/tests/iterable/iterable.exp
@@ -17,7 +17,7 @@ caching_bug.js:21:62,67: string
 
 map.js:13:55,60: string
 This type is incompatible with
-[LIB] core.js:311:28,33: tuple type
+[LIB] core.js:313:28,33: tuple type
 
 set.js:13:28,33: string
 This type is incompatible with

--- a/tests/iterable/iterable.exp
+++ b/tests/iterable/iterable.exp
@@ -17,7 +17,7 @@ caching_bug.js:21:62,67: string
 
 map.js:13:55,60: string
 This type is incompatible with
-[LIB] core.js:306:28,33: tuple type
+[LIB] core.js:311:28,33: tuple type
 
 set.js:13:28,33: string
 This type is incompatible with

--- a/tests/lib/lib.exp
+++ b/tests/lib/lib.exp
@@ -13,7 +13,7 @@ libtest.js:3:16,35: property name
 Error:
 libtest.js:3:7,12: number
 This type is incompatible with
-[LIB] core.js:266:11,16: string
+[LIB] core.js:268:11,16: string
 
 libtest.js:4:16,30: function call
 Error:

--- a/tests/lib/lib.exp
+++ b/tests/lib/lib.exp
@@ -13,7 +13,7 @@ libtest.js:3:16,35: property name
 Error:
 libtest.js:3:7,12: number
 This type is incompatible with
-[LIB] core.js:261:11,16: string
+[LIB] core.js:266:11,16: string
 
 libtest.js:4:16,30: function call
 Error:

--- a/tests/object_api/object_api.exp
+++ b/tests/object_api/object_api.exp
@@ -81,7 +81,7 @@ object_prototype.js:122:25,33: property valueOf
 Error:
 object_prototype.js:122:16,21: number
 This type is incompatible with
-[LIB] core.js:215:5,21: function type
+[LIB] core.js:220:5,21: function type
 
 object_prototype.js:126:16,21: number
 This type is incompatible with
@@ -91,13 +91,13 @@ object_prototype.js:150:32,47: property toLocaleString
 Error:
 object_prototype.js:150:23,28: number
 This type is incompatible with
-[LIB] core.js:212:5,28: function type
+[LIB] core.js:217:5,28: function type
 
 object_prototype.js:151:39,54: property toLocaleString
 Error:
 object_prototype.js:151:30,35: number
 This type is incompatible with
-[LIB] core.js:212:23,28: string
+[LIB] core.js:217:23,28: string
 
 object_prototype.js:155:23,28: number
 This type is incompatible with

--- a/tests/object_api/object_api.exp
+++ b/tests/object_api/object_api.exp
@@ -81,7 +81,7 @@ object_prototype.js:122:25,33: property valueOf
 Error:
 object_prototype.js:122:16,21: number
 This type is incompatible with
-[LIB] core.js:220:5,21: function type
+[LIB] core.js:222:5,21: function type
 
 object_prototype.js:126:16,21: number
 This type is incompatible with
@@ -91,13 +91,13 @@ object_prototype.js:150:32,47: property toLocaleString
 Error:
 object_prototype.js:150:23,28: number
 This type is incompatible with
-[LIB] core.js:217:5,28: function type
+[LIB] core.js:219:5,28: function type
 
 object_prototype.js:151:39,54: property toLocaleString
 Error:
 object_prototype.js:151:30,35: number
 This type is incompatible with
-[LIB] core.js:217:23,28: string
+[LIB] core.js:219:23,28: string
 
 object_prototype.js:155:23,28: number
 This type is incompatible with

--- a/tests/promises/promises.exp
+++ b/tests/promises/promises.exp
@@ -3,78 +3,78 @@ promise.js:10:1,17:2: call of method then
 Error:
 promise.js:11:11,11: number
 This type is incompatible with
-[LIB] core.js:350:25,38: union type
+[LIB] core.js:352:25,38: union type
 
 promise.js:21:11,23:4: constructor call
 Error:
 promise.js:22:13,13: number
 This type is incompatible with
-[LIB] core.js:350:25,38: union type
+[LIB] core.js:352:25,38: union type
 
 promise.js:32:13,34:6: constructor call
 Error:
 promise.js:33:15,15: number
 This type is incompatible with
-[LIB] core.js:350:25,38: union type
+[LIB] core.js:352:25,38: union type
 
 promise.js:42:1,55:2: call of method then
 Error:
 promise.js:44:13,14: number
 This type is incompatible with
-[LIB] core.js:350:25,38: union type
+[LIB] core.js:352:25,38: union type
 
 promise.js:106:1,109:2: call of method then
 Error:
 promise.js:106:17,17: number
 This type is incompatible with
-[LIB] core.js:368:32,45: union type
+[LIB] core.js:370:32,45: union type
 
 promise.js:112:17,34: call of method resolve
 Error:
 promise.js:112:33,33: number
 This type is incompatible with
-[LIB] core.js:368:32,45: union type
+[LIB] core.js:370:32,45: union type
 
 promise.js:118:33,50: call of method resolve
 Error:
 promise.js:118:49,49: number
 This type is incompatible with
-[LIB] core.js:368:32,45: union type
+[LIB] core.js:370:32,45: union type
 
 promise.js:148:1,153:4: call of method then
 Error:
 promise.js:149:32,37: string
 This type is incompatible with
-[LIB] core.js:355:33,46: union type
+[LIB] core.js:357:33,46: union type
 
 promise.js:157:32,54: call of method resolve
 Error:
 promise.js:157:48,53: string
 This type is incompatible with
-[LIB] core.js:368:32,45: union type
+[LIB] core.js:370:32,45: union type
 
 promise.js:165:48,70: call of method resolve
 Error:
 promise.js:165:64,69: string
 This type is incompatible with
-[LIB] core.js:368:32,45: union type
+[LIB] core.js:370:32,45: union type
 
 promise.js:188:1,193:4: call of method then
 Error:
 promise.js:189:33,38: string
 This type is incompatible with
-[LIB] core.js:365:34,48: union type
+[LIB] core.js:367:34,48: union type
 
 promise.js:197:33,55: call of method resolve
 Error:
 promise.js:197:49,54: string
 This type is incompatible with
-[LIB] core.js:368:32,45: union type
+[LIB] core.js:370:32,45: union type
 
 promise.js:205:49,71: call of method resolve
 Error:
 promise.js:205:65,70: string
 This type is incompatible with
-[LIB] core.js:368:32,45: union type
+[LIB] core.js:370:32,45: union type
 
 Found 13 errors

--- a/tests/promises/promises.exp
+++ b/tests/promises/promises.exp
@@ -3,78 +3,78 @@ promise.js:10:1,17:2: call of method then
 Error:
 promise.js:11:11,11: number
 This type is incompatible with
-[LIB] core.js:345:25,38: union type
+[LIB] core.js:350:25,38: union type
 
 promise.js:21:11,23:4: constructor call
 Error:
 promise.js:22:13,13: number
 This type is incompatible with
-[LIB] core.js:345:25,38: union type
+[LIB] core.js:350:25,38: union type
 
 promise.js:32:13,34:6: constructor call
 Error:
 promise.js:33:15,15: number
 This type is incompatible with
-[LIB] core.js:345:25,38: union type
+[LIB] core.js:350:25,38: union type
 
 promise.js:42:1,55:2: call of method then
 Error:
 promise.js:44:13,14: number
 This type is incompatible with
-[LIB] core.js:345:25,38: union type
+[LIB] core.js:350:25,38: union type
 
 promise.js:106:1,109:2: call of method then
 Error:
 promise.js:106:17,17: number
 This type is incompatible with
-[LIB] core.js:363:32,45: union type
+[LIB] core.js:368:32,45: union type
 
 promise.js:112:17,34: call of method resolve
 Error:
 promise.js:112:33,33: number
 This type is incompatible with
-[LIB] core.js:363:32,45: union type
+[LIB] core.js:368:32,45: union type
 
 promise.js:118:33,50: call of method resolve
 Error:
 promise.js:118:49,49: number
 This type is incompatible with
-[LIB] core.js:363:32,45: union type
+[LIB] core.js:368:32,45: union type
 
 promise.js:148:1,153:4: call of method then
 Error:
 promise.js:149:32,37: string
 This type is incompatible with
-[LIB] core.js:350:33,46: union type
+[LIB] core.js:355:33,46: union type
 
 promise.js:157:32,54: call of method resolve
 Error:
 promise.js:157:48,53: string
 This type is incompatible with
-[LIB] core.js:363:32,45: union type
+[LIB] core.js:368:32,45: union type
 
 promise.js:165:48,70: call of method resolve
 Error:
 promise.js:165:64,69: string
 This type is incompatible with
-[LIB] core.js:363:32,45: union type
+[LIB] core.js:368:32,45: union type
 
 promise.js:188:1,193:4: call of method then
 Error:
 promise.js:189:33,38: string
 This type is incompatible with
-[LIB] core.js:360:34,48: union type
+[LIB] core.js:365:34,48: union type
 
 promise.js:197:33,55: call of method resolve
 Error:
 promise.js:197:49,54: string
 This type is incompatible with
-[LIB] core.js:363:32,45: union type
+[LIB] core.js:368:32,45: union type
 
 promise.js:205:49,71: call of method resolve
 Error:
 promise.js:205:65,70: string
 This type is incompatible with
-[LIB] core.js:363:32,45: union type
+[LIB] core.js:368:32,45: union type
 
 Found 13 errors

--- a/tests/union/union.exp
+++ b/tests/union/union.exp
@@ -3,7 +3,7 @@ issue-198.js:1:9,10:6: call of method then
 Error:
 issue-198.js:5:16,28: string
 This type is incompatible with
-[LIB] core.js:350:33,46: union type
+[LIB] core.js:355:33,46: union type
 
 issue-324.js:3:7,9: Bar
 This type is incompatible with

--- a/tests/union/union.exp
+++ b/tests/union/union.exp
@@ -3,7 +3,7 @@ issue-198.js:1:9,10:6: call of method then
 Error:
 issue-198.js:5:16,28: string
 This type is incompatible with
-[LIB] core.js:355:33,46: union type
+[LIB] core.js:357:33,46: union type
 
 issue-324.js:3:7,9: Bar
 This type is incompatible with


### PR DESCRIPTION
Pull request #537, now with fixed tests (changed line numbers in core.js).

Partially solves #188

Includes updated test case.

It looks like overloaded constructors are not supported, so this doesn't detect all invalid constructor calls (see examples in the test case).
