### PR TITLE
Allow `undefined` to be passed to optional params

### DIFF
--- a/src/typing/flow_js.ml
+++ b/src/typing/flow_js.ml
@@ -4238,29 +4238,19 @@ and multiflow_partial cx trace ?strict = function
   *)
   | (_,[]) -> []
 
-  | ([],(OptionalT t)::touts) -> (OptionalT t)::touts
-
-  | ([RestT tin],(OptionalT tout)::touts) ->
-    rec_flow cx trace (tin, tout);
-    multiflow_partial cx trace ?strict ([RestT tin],touts)
-
-  | ((OptionalT tin)::tins,[RestT tout]) ->
-    rec_flow cx trace (tin,tout);
-    multiflow_partial cx trace ?strict (tins,[RestT tout])
-
   | ([RestT tin],[RestT tout]) ->
     rec_flow cx trace (tin,tout);
     []
 
-  | (tins,[RestT tout]) ->
-    tins |> List.iter (fun tin ->
-      rec_flow cx trace (tin,tout);
-    );
-    [RestT tout]
+  | ([RestT tin],tout::touts) ->
+    rec_flow cx trace (tin,tout);
+    multiflow_partial cx trace ?strict ([RestT tin], touts)
 
-  | (tin::tins,(OptionalT tout)::touts) ->
-    rec_flow cx trace (tin,(OptionalT tout));
-    multiflow_partial cx trace ?strict (tins,touts)
+  | (tin::tins,[RestT tout]) ->
+    rec_flow cx trace (tin,tout);
+    multiflow_partial cx trace ?strict (tins, [RestT tout])
+
+  | ([],[RestT _]) -> []
 
   | ([],ts) ->
     (match strict with

--- a/src/typing/flow_js.ml
+++ b/src/typing/flow_js.ml
@@ -4248,6 +4248,9 @@ and multiflow_partial cx trace ?strict = function
     rec_flow cx trace (tin,tout);
     multiflow_partial cx trace ?strict (tins,[RestT tout])
 
+  | ((VoidT _)::tins,(OptionalT _)::touts) ->
+    multiflow_partial cx trace ?strict (tins,touts)
+
   | ((OptionalT tin)::tins,(OptionalT tout)::touts)
   | (tin::tins,(OptionalT tout)::touts) ->
     rec_flow cx trace (tin,tout);

--- a/src/typing/flow_js.ml
+++ b/src/typing/flow_js.ml
@@ -4248,14 +4248,6 @@ and multiflow_partial cx trace ?strict = function
     rec_flow cx trace (tin,tout);
     multiflow_partial cx trace ?strict (tins,[RestT tout])
 
-  | ((VoidT _)::tins,(OptionalT _)::touts) ->
-    multiflow_partial cx trace ?strict (tins,touts)
-
-  | ((OptionalT tin)::tins,(OptionalT tout)::touts)
-  | (tin::tins,(OptionalT tout)::touts) ->
-    rec_flow cx trace (tin,tout);
-    multiflow_partial cx trace ?strict (tins,touts)
-
   | ([RestT tin],[RestT tout]) ->
     rec_flow cx trace (tin,tout);
     []
@@ -4265,6 +4257,10 @@ and multiflow_partial cx trace ?strict = function
       rec_flow cx trace (tin,tout);
     );
     [RestT tout]
+
+  | (tin::tins,(OptionalT tout)::touts) ->
+    rec_flow cx trace (tin,(OptionalT tout));
+    multiflow_partial cx trace ?strict (tins,touts)
 
   | ([],ts) ->
     (match strict with

--- a/tests/optional/optional_param3.js
+++ b/tests/optional/optional_param3.js
@@ -1,0 +1,7 @@
+function foo(x?: number) {}
+foo(undefined); // ok
+
+function bar(x = "bar"): string {
+  return x;
+}
+bar(undefined); // ok


### PR DESCRIPTION
There is already a flow for `VoidT ~> OptionalT`, but in the case of
function parameters, `multiflow` actually unwraps the `OptionalT`, so by
the argument flows into the parameter, flow isn't able to detect this
case.

I fixed this by adding a redundant case to `multiflow` instead of a
larger overhaul that would use the existing flow.

Note that functions with default argument values use the same mechanism
as optional parameters. The included test ensures that the default
expression type still flows correctly.

Fixes #437