### PR TITLE
Fix error handling for nested unions and intersections

### DIFF
--- a/src/typing/type_inference_js.ml
+++ b/src/typing/type_inference_js.ml
@@ -576,12 +576,6 @@ let rec convert cx map = Ast.Type.(function
 
   | loc, Union ts ->
       let ts = List.map (convert cx map) ts in
-      (* "Flatten" out any unions in this union, like
-       * var a: number | (string | bool) *)
-      let ts = List.map (function
-        | UnionT (r, ts) -> ts
-        | t -> [t]) ts in
-      let ts = List.flatten ts in
       UnionT (mk_reason "union type" loc, ts)
 
   | loc, Intersection ts ->

--- a/tests/namespace/namespace.exp
+++ b/tests/namespace/namespace.exp
@@ -11,7 +11,7 @@ namespace.js:11:28,29: string
 This type is incompatible with
 namespace.js:11:7,12: number
 
-namespace.js:15:16,17: string
+namespace.js:15:14,19: array literal
 This type is incompatible with
 namespace.js:13:12,30: union type
 

--- a/tests/promises/promises.exp
+++ b/tests/promises/promises.exp
@@ -7,13 +7,13 @@ This type is incompatible with
 
 promise.js:21:11,23:4: constructor call
 Error:
-promise.js:22:13,13: number
+[LIB] core.js:350:1,377:1: Promise
 This type is incompatible with
 [LIB] core.js:352:25,38: union type
 
 promise.js:32:13,34:6: constructor call
 Error:
-promise.js:33:15,15: number
+[LIB] core.js:350:1,377:1: Promise
 This type is incompatible with
 [LIB] core.js:352:25,38: union type
 
@@ -31,13 +31,13 @@ This type is incompatible with
 
 promise.js:112:17,34: call of method resolve
 Error:
-promise.js:112:33,33: number
+[LIB] core.js:350:1,377:1: Promise
 This type is incompatible with
 [LIB] core.js:370:32,45: union type
 
 promise.js:118:33,50: call of method resolve
 Error:
-promise.js:118:49,49: number
+[LIB] core.js:350:1,377:1: Promise
 This type is incompatible with
 [LIB] core.js:370:32,45: union type
 
@@ -49,13 +49,13 @@ This type is incompatible with
 
 promise.js:157:32,54: call of method resolve
 Error:
-promise.js:157:48,53: string
+[LIB] core.js:350:1,377:1: Promise
 This type is incompatible with
-[LIB] core.js:370:32,45: union type
+[LIB] core.js:357:33,46: union type
 
 promise.js:165:48,70: call of method resolve
 Error:
-promise.js:165:64,69: string
+[LIB] core.js:350:1,377:1: Promise
 This type is incompatible with
 [LIB] core.js:370:32,45: union type
 
@@ -67,13 +67,13 @@ This type is incompatible with
 
 promise.js:197:33,55: call of method resolve
 Error:
-promise.js:197:49,54: string
+[LIB] core.js:350:1,377:1: Promise
 This type is incompatible with
-[LIB] core.js:370:32,45: union type
+[LIB] core.js:367:34,48: union type
 
 promise.js:205:49,71: call of method resolve
 Error:
-promise.js:205:65,70: string
+[LIB] core.js:350:1,377:1: Promise
 This type is incompatible with
 [LIB] core.js:370:32,45: union type
 

--- a/tests/union/union.js
+++ b/tests/union/union.js
@@ -20,10 +20,10 @@ function corge(b) {
     new F().foo(x);
 }
 
-var ok: ('foo' | 'bar') | 'baz' = 'baz';
+var nested1: ('foo' | 'bar') | 'baz' = 'baz';
 
 type FooBar = 'foo' | 'bar';
 type Baz = 'baz';
 type FooBarBaz = FooBar | Baz;
 
-var bad: FooBarBaz = 'baz';
+var nested2: FooBarBaz = 'baz';

--- a/tests/union/union.js
+++ b/tests/union/union.js
@@ -19,3 +19,11 @@ function corge(b) {
     var x = b ? "" : 0;
     new F().foo(x);
 }
+
+var ok: ('foo' | 'bar') | 'baz' = 'baz';
+
+type FooBar = 'foo' | 'bar';
+type Baz = 'baz';
+type FooBarBaz = FooBar | Baz;
+
+var bad: FooBarBaz = 'baz';


### PR DESCRIPTION
Union and intersection errors are handled using a speculative match
process, where an error on one side of the match raises an exception,
which is caught by the speculative match code, which then tries the
other side of the match.

If, however, there are nested speculative matches in a given flow, the
innermost one would raise an error too early. This can happen if a type
alias is a union containing union types.

To fix, instead of using a boolean to track whether to log the error or
raise, we use an integer representing the "depth" of the speculative
match.

Before, there was some code to "flatten" unions of unions during the
convertion of annotations to types, but this doesn't work for the case
where the unions are themselves type aliases.

Unfortunately, this change affects error messages around union types,
and in my opinion, the new messages are worse and less helpful than they
used to be. Any ideas how to make this change without making error
messages worse?

Fixes #582