### PR TITLE
Match returns null with no matches

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -196,7 +196,7 @@ declare class String {
     indexOf(searchString: string, position?: number): number;
     lastIndexOf(searchString: string, position?: number): number;
     localeCompare(that: string): number;
-    match(regexp: string | RegExp): Array<string>;
+    match(regexp: string | RegExp): ?Array<string>;
     startsWith(searchString: string, position?: number): boolean;
     endsWith(searchString: string, position?: number): boolean;
     repeat(count: number): string;

--- a/tests/overload/overload.exp
+++ b/tests/overload/overload.exp
@@ -7,6 +7,18 @@ overload.js:1:9,14: number
 
 overload.js:1:18,28: call of method `match`
 Error:
+overload.js:1:18,31: access of computed property/element
+Computed property/element cannot be accessed on possibly null value
+overload.js:1:18,28: null
+
+overload.js:1:18,28: call of method `match`
+Error:
+overload.js:1:18,31: access of computed property/element
+Computed property/element cannot be accessed on possibly undefined value
+overload.js:1:18,28: undefined
+
+overload.js:1:18,28: call of method `match`
+Error:
 overload.js:1:27,27: number
 This type is incompatible with
 [LIB] core.js:199:19,33: union type
@@ -16,6 +28,18 @@ Error:
 overload.js:2:18,39: string
 This type is incompatible with
 overload.js:2:9,14: number
+
+overload.js:2:18,36: call of method `match`
+Error:
+overload.js:2:18,39: access of computed property/element
+Computed property/element cannot be accessed on possibly null value
+overload.js:2:18,36: null
+
+overload.js:2:18,36: call of method `match`
+Error:
+overload.js:2:18,39: access of computed property/element
+Computed property/element cannot be accessed on possibly undefined value
+overload.js:2:18,36: undefined
 
 overload.js:4:18,36: call of method `split`
 Error:
@@ -27,4 +51,4 @@ test2.js:7:2,16: string
 This type is incompatible with
 test2.js:7:19,24: number
 
-Found 5 errors
+Found 9 errors


### PR DESCRIPTION
"foobar".match(/Foo/) returns null.

See [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/match)

> Returns
>
> array
> 
> An Array containing the matched results or null if there were no matches.