### PR TITLE
Update travis config to use containers

### DIFF
--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -9,12 +9,9 @@ setup_linux () {
   *) echo Unknown $OCAML_VERSION,$OPAM_VERSION; exit 1 ;;
   esac
 
-  echo "yes" | sudo add-apt-repository ppa:$ppa
-  sudo apt-get update -qq
-  sudo apt-get install -qq ocaml ocaml-native-compilers camlp4-extra opam libelf-dev
   export OPAMYES=1
   # We could in theory tell opam to init with a particular version of ocaml,
-  # but this is much slower than using the ppa
+  # but this is much slower than using the ppa & apt
   opam init -a -y
   # TODO: Install js_of_ocaml and test the parser
   # opam install ${OPAM_DEPENDS}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: c
 script: bash -ex .travis-ci.sh
+sudo: false
 
 os:
 - linux
@@ -17,3 +18,14 @@ matrix:
       env: OCAML_VERSION=4.02.1 OPAM_VERSION=1.1.0
     - os: osx
       env: OCAML_VERSION=4.01.0 OPAM_VERSION=1.1.0
+
+addons:
+  apt:
+    sources:
+    - avsm
+    packages:
+    - ocaml
+    - ocaml-native-compilers
+    - camlp4-extra
+    - opam
+    - libelf-dev


### PR DESCRIPTION
This is pretty easy, just need to do apt-install-y things using the config
rather than manually.

The OSX build doesn't seem to use containers yet, but the Linux one does. The OSX build also seems to ignore the apt addon, which is good :)

Fixes #626