### PR TITLE
Password, key, iv can be buffer

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -273,20 +273,20 @@ type crypto$Verify = {
 declare module "crypto" {
   declare var DEFAULT_ENCODING: string;
 
-  declare function createCipher(algorithm: string, password: string): crypto$Cipher;
+  declare function createCipher(algorithm: string, password: string | Buffer): crypto$Cipher;
   declare function createCipheriv(
     algorithm: string,
-    key: string,
-    iv: string
+    key: string | Buffer,
+    iv: string | Buffer
   ): crypto$Cipher;
   declare function createCredentials(
     details?: crypto$createCredentialsDetails
   ): crypto$Credentials
-  declare function createDecipher(algorithm: string, password: string): crypto$Decipher;
+  declare function createDecipher(algorithm: string, password: string | Buffer): crypto$Decipher;
   declare function createDecipheriv(
     algorithm: string,
-    key: string,
-    iv: string
+    key: string | Buffer,
+    iv: string | Buffer
   ): crypto$Decipher;
   declare function createDiffieHellman(prime_length: number): crypto$DiffieHellman;
   declare function createDiffieHellman(prime: number, encoding?: string): crypto$DiffieHellman;


### PR DESCRIPTION
[From node.js documentation](https://nodejs.org/api/crypto.html#crypto_crypto_createcipher_algorithm_password):

> password is used to derive key and IV, which must be a 'binary' encoded string or a buffer.

And similarly to createDecipher and the variants with IV.

Note: the same error will probably be seen through all node.crypto, I just needed to fix this one.