### PR TITLE
Clarify standard promise API

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -358,22 +358,23 @@ declare class Promise<R> {
       onReject?: (error: any) => Promise<U> | U
     ): Promise<U>;
 
-    done<U>(
-      onFulfill?: (value: R) => void,
-      onReject?: (error: any) => void
-    ): void;
-
     catch<U>(
       onReject?: (error: any) => ?Promise<U> | U
     ): Promise<U>;
 
     static resolve<T>(object?: Promise<T> | T): Promise<T>;
     static reject<T>(error?: any): Promise<T>;
-
-    // Non-standard APIs
-    static cast<T>(object?: T): Promise<T>;
     static all<T>(promises: Array<Promise<T>>): Promise<Array<T>>;
     static race<T>(promises: Array<Promise<T>>): Promise<T>;
+
+    // Non-standard APIs common in some libraries
+    
+    done<U>(
+      onFulfill?: (value: R) => void,
+      onReject?: (error: any) => void
+    ): void;
+
+    static cast<T>(object?: T): Promise<T>;
 }
 
 // we use this signature when typing await expressions


### PR DESCRIPTION
Promise type includes some non-standard API, which is ok, but some of the standard API is marked as non-standard, and some of the non-standard API is marked as standard. This moves things around a little to clarify what is and is not standardized API.