### PR TITLE
Add ES2015 String method includes

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -170,7 +170,7 @@ declare class String {
     charCodeAt(index: number): number;
     concat(...strings: Array<string>): string;
     contains(substr: string): boolean;
-    includes(searchString: string | RegExp, position?: number): boolean;
+    includes(searchString: string, position?: number): boolean;
     indexOf(searchString: string, position?: number): number;
     lastIndexOf(searchString: string, position?: number): number;
     localeCompare(that: string): number;

--- a/lib/core.js
+++ b/lib/core.js
@@ -170,6 +170,7 @@ declare class String {
     charCodeAt(index: number): number;
     concat(...strings: Array<string>): string;
     contains(substr: string): boolean;
+    includes(searchString: string | RegExp, position?: number): boolean;
     indexOf(searchString: string, position?: number): number;
     lastIndexOf(searchString: string, position?: number): number;
     localeCompare(that: string): number;


### PR DESCRIPTION
Per the specification at http://www.ecma-international.org/ecma-262/6.0/#sec-string.prototype.includes

I'm not certain whether the first argument should accept a RegExp. The specification says: 

> "Throwing an exception if the first argument is a RegExp is specified in order to allow future editions to define extensions that allow such argument values."

So using a RegExp won't work today, but allowing that argument type is forward-compatible, so I've included it.