### PR TITLE
Allow '*-/' to mark the end of a block comment inside a flow-comment

### DIFF
--- a/src/parser/parse_error.ml
+++ b/src/parser/parse_error.ml
@@ -10,6 +10,7 @@
 
 type t =
   | UnexpectedToken of string
+  | UnexpectedTokenWithSuggestion of string * string
   | UnexpectedNumber
   | UnexpectedString
   | UnexpectedIdentifier
@@ -66,6 +67,10 @@ module PP =
   struct
     let error = function
       | UnexpectedToken token->  "Unexpected token "^token
+      | UnexpectedTokenWithSuggestion (token, suggestion) ->  
+          Printf.sprintf "Unexpected token `%s`. Did you mean `%s`?"
+            token
+            suggestion
       | UnexpectedNumber ->  "Unexpected number"
       | UnexpectedString ->  "Unexpected string"
       | UnexpectedIdentifier ->  "Unexpected identifier"

--- a/src/parser/test/hardcoded_tests.js
+++ b/src/parser/test/hardcoded_tests.js
@@ -1970,17 +1970,59 @@ module.exports = {
           'name': 'T',
         }
       ]
-    }
+    },
+    '/*::type F = /* inner escaped comment *-/ number;*/': {
+      'body': [
+        {
+          'type': 'TypeAlias',
+          'id.name': 'F',
+          'typeParameters': null,
+          'right': {
+            'type': 'NumberTypeAnnotation',
+          },
+        }
+      ],
+      'comments': [
+        {
+          'type': 'Block',
+          'value': ' inner escaped comment '
+        }
+      ]
+    },
+    '/*flow-include type F = /* inner escaped comment *-/ number;*/': {
+      'body': [
+        {
+          'type': 'TypeAlias',
+          'id.name': 'F',
+          'typeParameters': null,
+          'right': {
+            'type': 'NumberTypeAnnotation',
+          },
+        }
+      ],
+      'comments': [
+        {
+          'type': 'Block',
+          'value': ' inner escaped comment '
+        }
+      ]
+    },
+    'var a/*: /* inner escaped comment *-/ number*/;': {
+      'body': [
+        {'type': 'VariableDeclaration'}
+      ],
+      'comments': [
+        {
+          'type': 'Block',
+          'value': ' inner escaped comment '
+        }
+      ]
+    },
   },
   'Invalid Type Annotations In Comments': {
     '/*: */': {
       'errors': {
         '0.message': 'Unexpected token /*:',
-      }
-    },
-    '/*:: /* */': {
-      'errors': {
-        '0.message': 'Unexpected token /*',
       }
     },
     '/*:: /*: */': {
@@ -2012,7 +2054,12 @@ module.exports = {
       'errors': {
         '0.message': 'Unexpected end of input',
       }
-    }
+    },
+    '/*:: type PowerGlove = /* bad means good */ soBad; */': {
+      'errors': {
+        '0.message': 'Unexpected token `*/`. Did you mean `*-/`?'
+      }
+    },
   },
   'Trailing commas': {
     'Math.max(a, b, c,)': {},
@@ -2300,4 +2347,13 @@ module.exports = {
       }]
     },
   },
+  'Comments': {
+    // Regression test: "/*" should be allowed inside block comments
+    '/* /* */': {
+      'comments': [{
+        type: 'Block',
+        value: ' /* ',
+      }]
+    },
+  }
 };


### PR DESCRIPTION
Currently Babel doesn't have a good option for commentizing something like:

```javascript
type F = /* test */ number
```

(at the moment it naively/invalidly transforms it to `/*::type F = // test number */` -- not accounting for single-line block comments)

So an idea that I suggested (and @hzoo implemented) is one that allows Babel to convert a legit block comment's end-token to `*-/` -- which fixes the resulting raw JS source. However, we still want Flow to be able to understand this when parsing the flow-comment, so I've special-cased it in the Flow lexer here when we're inside a `/*::` flow-comment.

See here: https://github.com/babel-plugins/babel-plugin-flow-comments/pull/6#issuecomment-122709012 (and then https://github.com/babel-plugins/babel-plugin-flow-comments/pull/13 for the actual PR)