### PR TITLE
Declare overloaded versions of fs.readFile and fs.readFileSync

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -573,10 +573,27 @@ declare module "fs" {
   ): number;
   declare function readFile(
     filename: string,
-    options?: Object | string,
-    callback?: (err: ?Error, data: Buffer) => void
+    callback: (err: ?Error, data: Buffer) => void
   ): void;
-  declare function readFileSync(filename: string, options?: Object | string): Buffer;
+  declare function readFile(
+    filename: string,
+    encoding: string,
+    callback: (err: ?Error, data: string) => void
+  ): void;
+  declare function readFile(
+    filename: string,
+    options: { encoding: string; flag?: string },
+    callback: (err: ?Error, data: string) => void
+  ): void;
+  declare function readFile(
+    filename: string,
+    options: { flag?: string },
+    callback: (err: ?Error, data: Buffer) => void
+  ): void;
+  declare function readFileSync(filename: string): Buffer;
+  declare function readFileSync(filename: string, encoding: string): string;
+  declare function readFileSync(filename: string, options: { encoding: string, flag?: string }): string;
+  declare function readFileSync(filename: string, options: { flag?: string }): Buffer;
   declare function writeFile(
     filename: string,
     data: Buffer | string,

--- a/tests/node_tests/fs/fs.js
+++ b/tests/node_tests/fs/fs.js
@@ -1,0 +1,29 @@
+var fs = require("fs");
+
+/* readFile */
+
+fs.readFile("file.exp", (_, data) => {
+  (data : Buffer);
+});
+
+fs.readFile("file.exp", "blah", (_, data) => {
+  (data : string);
+});
+
+fs.readFile("file.exp", { encoding: "blah" }, (_, data) => {
+  (data : string);
+});
+
+fs.readFile("file.exp", {}, (_, data) => {
+  (data : Buffer);
+});
+
+/* readFileSync */
+
+(fs.readFileSync("file.exp") : Buffer);
+
+(fs.readFileSync("file.exp", "blah") : string);
+
+(fs.readFileSync("file.exp", { encoding: "blah" }) : string);
+
+(fs.readFileSync("file.exp", {}) : Buffer);


### PR DESCRIPTION
If no options are provided, data is a Buffer.
If options are provided without an encoding set, data is a Buffer.
If options are provided and an encoding is specified, data is a string.

If the second parameter is a string, data is a Buffer. This is the "old"
API, so it's undocumented, but it is still supported and does the right
thing.