### PR TITLE
Stupid simple interfaces

### DIFF
--- a/src/parser/estree_translator.ml
+++ b/src/parser/estree_translator.ml
@@ -828,6 +828,7 @@ end with type t = Impl.t) = struct
     | Nullable t -> nullable_type loc t
     | Function fn -> function_type (loc, fn)
     | Object o -> object_type (loc, o)
+    | Class c -> class_type (loc, c)
     | Array t -> array_type loc t
     | Generic g -> generic_type (loc, g)
     | Union u -> union_type (loc, u)
@@ -908,6 +909,37 @@ end with type t = Impl.t) = struct
     node "ObjectTypeCallProperty" loc [|
       "value", function_type callProperty.value;
       "static", bool callProperty.static;
+    |]
+  )
+
+  and class_type (loc, c) = Type.Class.(
+    node "ClassTypeAnnotation" loc [|
+      "properties", array_of_list class_type_property c.properties;
+      "indexers", array_of_list class_type_indexer c.indexers;
+    |]
+  )
+
+  and class_type_property (loc, prop) = Type.Object.Property.(
+    let key = match prop.key with
+    | Expression.Object.Property.Literal lit -> literal lit
+    | Expression.Object.Property.Identifier id -> identifier id
+    | Expression.Object.Property.Computed _ ->
+      failwith "There should not be computed class type property keys"
+    in
+    node "ClassTypeProperty" loc [|
+      "key", key;
+      "value", _type prop.value;
+      "optional", bool prop.optional;
+      "static", bool prop.static;
+    |]
+  )
+
+  and class_type_indexer (loc, indexer) = Type.Object.Indexer.(
+    node "ClassTypeIndexer" loc [|
+      "id", identifier indexer.id;
+      "key", _type indexer.key;
+      "value", _type indexer.value;
+      "static", bool indexer.static;
     |]
   )
 

--- a/src/parser/estree_translator.ml
+++ b/src/parser/estree_translator.ml
@@ -914,32 +914,9 @@ end with type t = Impl.t) = struct
 
   and class_type (loc, c) = Type.Class.(
     node "ClassTypeAnnotation" loc [|
-      "properties", array_of_list class_type_property c.properties;
-      "indexers", array_of_list class_type_indexer c.indexers;
-    |]
-  )
-
-  and class_type_property (loc, prop) = Type.Object.Property.(
-    let key = match prop.key with
-    | Expression.Object.Property.Literal lit -> literal lit
-    | Expression.Object.Property.Identifier id -> identifier id
-    | Expression.Object.Property.Computed _ ->
-      failwith "There should not be computed class type property keys"
-    in
-    node "ClassTypeProperty" loc [|
-      "key", key;
-      "value", _type prop.value;
-      "optional", bool prop.optional;
-      "static", bool prop.static;
-    |]
-  )
-
-  and class_type_indexer (loc, indexer) = Type.Object.Indexer.(
-    node "ClassTypeIndexer" loc [|
-      "id", identifier indexer.id;
-      "key", _type indexer.key;
-      "value", _type indexer.value;
-      "static", bool indexer.static;
+      "id", option identifier c.id;
+      "typeParameters", option type_parameter_declaration c.typeParameters;
+      "body", object_type (loc, c.body);
     |]
   )
 

--- a/src/parser/lexer_flow.mll
+++ b/src/parser/lexer_flow.mll
@@ -518,6 +518,7 @@
       "number",  T_NUMBER_TYPE;
       "string",  T_STRING_TYPE;
       "void",    T_VOID_TYPE;
+      "class",   T_CLASS;
     ]
 }
 

--- a/src/parser/parse_error.ml
+++ b/src/parser/parse_error.ml
@@ -57,6 +57,7 @@ type t =
   | ParameterAfterRestParameter
   | AsyncGenerator
   | DeclareAsync
+  | CallableClass
 
 exception Error of (Loc.t * t) list
 
@@ -120,4 +121,5 @@ module PP =
           "Rest parameter must be final parameter of an argument list"
       | AsyncGenerator -> "A function may not be both async and a generator"
       | DeclareAsync -> "async is an implementation detail and isn't necessary for your declare function statement. It is sufficient for your declare function to just have a Promise return type."
+      | CallableClass -> "Class may not be called as a function"
   end

--- a/src/parser/parser_flow.ml
+++ b/src/parser/parser_flow.ml
@@ -2379,9 +2379,10 @@ end = struct
       Expect.token env T_CLASS;
       let obj_loc, c = Type._object ~allow_static:true env in
       let loc = Loc.btwn start_loc obj_loc (* Do I need to dig out the right bound? *) in
-      match c.Ast.Type.Object.callProperties with
-        | [] -> loc, Ast.Type.Object c
-        | _ -> error env (Error.CallableClass); loc, Ast.Type.Object c
+      let properties = c.Ast.Type.Object.properties in
+      let indexers = c.Ast.Type.Object.indexers in
+      if c.Ast.Type.Object.callProperties <> [] then error env (Error.CallableClass);
+      loc, Ast.Type.(Class Class.({ properties; indexers; }))
 
     let key = key ~allow_computed_key:false
   end

--- a/src/parser/parser_flow.ml
+++ b/src/parser/parser_flow.ml
@@ -2372,9 +2372,10 @@ end = struct
 
     let class_type env =
       let start_loc = Peek.loc env in
+      let name = Peek.value env in
       Expect.token env T_CLASS;
       let id, typeParameters = match Peek.token env with
-        | T_EXTENDS -> error env (Error.UnexpectedToken T_EXTENDS); None, None
+        | T_EXTENDS -> error env (Error.UnexpectedToken name); None, None
         | T_LESS_THAN (*TJP: I like the prospect of syntax `class<T: A> {...}` for interfaces. Instead match expectations :( *)
         | T_LCURLY -> None, None
         | _ ->

--- a/src/parser/spider_monkey_ast.ml
+++ b/src/parser/spider_monkey_ast.ml
@@ -98,8 +98,9 @@ and Type : sig
 
   module Class : sig
     type t = {
-      properties: Type.Object.Property.t list;
-      indexers: Type.Object.Indexer.t list;
+      id: Identifier.t option;
+      typeParameters: Type.ParameterDeclaration.t option;
+      body: Type.Object.t;
     }
   end
 

--- a/src/parser/spider_monkey_ast.ml
+++ b/src/parser/spider_monkey_ast.ml
@@ -96,6 +96,13 @@ and Type : sig
     }
   end
 
+  module Class : sig
+    type t = {
+      properties: Type.Object.Property.t list;
+      indexers: Type.Object.Indexer.t list;
+    }
+  end
+
   module Generic : sig
     module Identifier : sig
       type t =
@@ -146,6 +153,7 @@ and Type : sig
     | Nullable of t
     | Function of Function.t
     | Object of Object.t
+    | Class of Class.t
     | Array of t
     | Generic of Generic.t
     | Union of t list

--- a/src/typing/constraint_js.ml
+++ b/src/typing/constraint_js.ml
@@ -1038,10 +1038,6 @@ let rec reason_of_t = function
   | ArrT (reason,_,_)
       -> reason
 
-(*
- * TJP: This is a good bottleneck to find all things `ShiftT`.  Prefixes should
- * probably be refined ("instance" is to "class", as "?" is to "interface").
- *)
   | ShiftT (ClsT _ as t) ->
       prefix_reason "interface type: " (reason_of_t t)
   | ShiftT (InstanceT _ as t) ->
@@ -1499,6 +1495,9 @@ let rec type_printer override fallback enclosure cx t =
     (* The following types are not syntax-supported *)
     | ShiftT (InstanceT _ as t) ->
         spf "[class: %s]" (pp EnclosureNone cx t)
+
+    | ShiftT (ClsT _ as t) ->
+        spf "[interface: %s]" (pp EnclosureNone cx t)
 
     | TypeT (_, t) ->
         spf "[type: %s]" (pp EnclosureNone cx t)

--- a/src/typing/constraint_js.mli
+++ b/src/typing/constraint_js.mli
@@ -32,6 +32,7 @@ module Type :
 
       | FunT of reason * static * prototype * funtype
       | ObjT of reason * objtype
+      | ClsT of reason * clstype
       | ArrT of reason * t * t list
 
       | ClassT of t
@@ -179,6 +180,14 @@ module Type :
       methods_tmap: int;
       mixins: bool;
       structural: bool;
+    }
+    and clstype = {
+      ct_type_args: t SMap.t;
+      ct_arg_polarities: polarity SMap.t;
+      ct_fields_tmap: int;
+      ct_methods_tmap: int;
+      ct_sfields_tmap: int;
+      ct_smethods_tmap: int;
     }
     and exporttypes = {
       exports_tmap: int;

--- a/src/typing/constraint_js.mli
+++ b/src/typing/constraint_js.mli
@@ -35,7 +35,7 @@ module Type :
       | ClsT of reason * clstype
       | ArrT of reason * t * t list
 
-      | ClassT of t
+      | ShiftT of t
       | InstanceT of reason * static * super * insttype
 
       | OptionalT of t
@@ -181,13 +181,15 @@ module Type :
       mixins: bool;
       structural: bool;
     }
+    and prop_tmaps = {
+      fields: int;
+      methods: int;
+    }
     and clstype = {
       ct_type_args: t SMap.t;
       ct_arg_polarities: polarity SMap.t;
-      ct_fields_tmap: int;
-      ct_methods_tmap: int;
-      ct_sfields_tmap: int;
-      ct_smethods_tmap: int;
+      ct_props: prop_tmaps;
+      ct_statics: prop_tmaps option;
     }
     and exporttypes = {
       exports_tmap: int;

--- a/src/typing/flow_js.ml
+++ b/src/typing/flow_js.ml
@@ -2470,7 +2470,7 @@ let rec __flow cx (l, u) trace =
          _;
        }))
       ->
-      structural_subtype cx trace l (reason1, super, fields_tmap, methods_tmap)
+      structural_subtype cx trace l (super, fields_tmap, methods_tmap)
 
     (********************************************************)
     (* runtime types derive static types through annotation *)
@@ -5654,10 +5654,10 @@ end = struct
     | PolyT (type_params, sub_type) ->
         (* TODO: replace type parameters with stable/proper names? *)
         extract_members cx sub_type
-    | ClassT (InstanceT (_, static, _, _)) ->
+    | ShiftT (InstanceT (_, static, _, _)) ->
         let static_t = resolve_type cx static in
         extract_members cx static_t
-    | ClassT t ->
+    | ShiftT t ->
         (* TODO: Can this happen? *)
         extract_members cx t
     | IntersectionT (r, ts) ->

--- a/src/typing/flow_js.ml
+++ b/src/typing/flow_js.ml
@@ -2539,22 +2539,11 @@ let rec __flow cx (l, u) trace =
     (* "statics" can be read *)
     (*************************)
 
-    | ClsT (reason, {
-        ct_type_args;
-        ct_arg_polarities;
-        ct_statics = Some { fields; methods; }
-      }),
+    | ClsT (reason, ({ ct_statics = Some statics; _; } as ct)),
       GetT (_, "statics", t)
       ->
-      let c = ClsT (prefix_reason "statics of " reason, {
-        ct_type_args;
-        ct_arg_polarities;
-        ct_props = {
-          fields;
-          methods;
-        };
-        ct_statics = None;
-      }) in
+      let cls_statics = { ct with ct_props = statics; ct_statics = None; } in
+      let c = ClsT (prefix_reason "statics of " reason, cls_statics) in
       rec_flow cx trace (c, t)
 
     | ClsT (reason, { ct_statics = None; _; }),

--- a/src/typing/flow_js.ml
+++ b/src/typing/flow_js.ml
@@ -1481,7 +1481,7 @@ let rec __flow cx (l, u) trace =
     (* The sink component of an annotation constrains values flowing
        into the annotated site. *)
 
-    | _, AnnotT (sink_t, _)
+    | l, AnnotT (sink_t, _)
     | ShiftT(l), ShiftT(AnnotT (sink_t, _)) ->
       rec_flow cx trace (l, sink_t)
 

--- a/src/typing/flow_js.ml
+++ b/src/typing/flow_js.ml
@@ -1892,7 +1892,6 @@ let rec __flow cx (l, u) trace =
        because substitution of type parameters in def types does not affect
        their reasons, so we'd trivially lose precision. *)
 
-(*TJP: For specialization by AnnotT, the unification problem of `ShiftT ~> ShiftT` again*)
     | (TypeAppT(c,ts), MethodT _) ->
         let reason_op = reason_of_t u in
         let t = mk_typeapp_instance cx reason_op ~cache:true c ts in
@@ -2504,8 +2503,6 @@ let rec __flow cx (l, u) trace =
     (*********************************************************)
     (* class types derive instance types (with constructors) *)
     (*********************************************************)
-
-(*TJP: Consider TypeT,AnnotT and AnnotT,TypeT.  Is this where I need to constrain AnnotT?*)
 
     | ShiftT (this),
       ConstructorT (reason_op, args, t) ->

--- a/src/typing/type_inference_js.ml
+++ b/src/typing/type_inference_js.ml
@@ -875,12 +875,27 @@ let rec convert cx map = Ast.Type.(function
     ObjT (mk_reason "object type" loc,
       Flow_js.mk_objecttype ~flags dict pmap proto)
 
-  | loc, Class { Class.id; typeParameters; Object.body; } -> (* TJP: remove `Class.` prefix *)
-    let _, { Ast.Identifier.name; _ } = id in
-    let reason, typeparams, map, properties =
-      object_with_statics cx name loc typeParameters body in
-    ClsT (mk_reason "class type" loc,
-      mk_cls_t cx reason typeparams map properties)
+  | loc, Class ({ Class.id; typeParameters; body; } as c) -> (* TJP: remove `Class.` prefix *)
+    let class_loc, name = extract_class_type_name loc c in
+    let creason = mk_reason name loc in
+    let typeparams, map, (sfmap, smmap, fmap, mmap) =
+      object_with_statics cx creason name class_loc typeParameters body in
+    let ct_arg_polarities = map |> SMap.map (fun t -> match t with
+    | BoundT { polarity; _ } -> polarity
+    | _ -> assert_false (spf "Expected BoundT but found %s" (string_of_ctor t))) in
+
+    let cls_type = {
+      ct_type_args = map;
+      ct_arg_polarities;
+      ct_fields_tmap = Flow_js.mk_propmap cx fmap;
+      ct_methods_tmap = Flow_js.mk_propmap cx mmap;
+      ct_sfields_tmap = Flow_js.mk_propmap cx sfmap;
+      ct_smethods_tmap = Flow_js.mk_propmap cx smmap;
+    } in
+
+    if typeparams = []
+    then ClsT (creason, cls_type)
+    else PolyT (typeparams, ClsT (creason, cls_type))
     (*
      * TJP: Verify that nonsealeds get indexer compatibility checked in addition
      * to method/field compatibility.  What is the trigger?  Emulate it with
@@ -942,7 +957,7 @@ and mk_properties_map cx map loc properties = Ast.Type.Object.Property.(
   ) SMap.empty properties
 )
 
-and mk_indexer loc indexers = Ast.Type.Object.Indexer.(
+and mk_indexer cx map loc indexers = Ast.Type.Object.Indexer.(
   (* Seal an object type unless it specifies an indexer. *)
   match indexers with
   | [(_, { id = (_, { Ast.Identifier.name; _ }); key; value; _; })] ->
@@ -2104,18 +2119,19 @@ and statement cx = Ast.Statement.(
   | (loc, DeclareClass {
       Interface.id;
       typeParameters;
-      body = (_, { Ast.Type.Object.properties; indexers; callProperties });
+      body = _, ({ Ast.Type.Object.properties; indexers; callProperties } as body);
       extends;
     })
   | (loc, InterfaceDeclaration {
       Interface.id;
       typeParameters;
-      body = (_, { Ast.Type.Object.properties; indexers; callProperties });
+      body = _, ({ Ast.Type.Object.properties; indexers; callProperties } as body);
       extends;
     }) as stmt ->
     let _, { Ast.Identifier.name; _ } = id in
-    let reason, typeparams, map, properties =
-      object_with_statics cx name loc typeParameters body in
+    let reason = mk_reason name loc in
+    let typeparams, map, properties =
+      object_with_statics cx reason name loc typeParameters body in
     let
       is_interface = match stmt with
       | (_, InterfaceDeclaration _) -> true
@@ -2663,88 +2679,88 @@ and object_ cx props = Ast.Expression.Object.(
   !spread
 )
 
-and object_with_statics cx id_name loc typeParameters body =
-  let reason = mk_reason id_name loc in
+and object_with_statics cx reason id_name loc typeParameters =
+  Ast.Type.Object.(fun { properties; indexers; callProperties } ->
+    (* TODO excise the Promise/PromisePolyfill special-case ASAP *)
+    let typeparams, map =
+      if (id_name = "Promise" || id_name = "PromisePolyfill") &&
+        List.length (extract_type_param_declarations typeParameters) = 1
+      then mk_type_param_declarations cx typeParameters ~polarities:[Positive]
+      else mk_type_param_declarations cx typeParameters in
 
-  (* TODO excise the Promise/PromisePolyfill special-case ASAP *)
-  let typeparams, map =
-    if (id_name = "Promise" || id_name = "PromisePolyfill") &&
-      List.length (extract_type_param_declarations typeParameters) = 1
-    then mk_type_param_declarations cx typeParameters ~polarities:[Positive]
-    else mk_type_param_declarations cx typeParameters in
+    let sfmap, smmap, fmap, mmap = List.fold_left Ast.Type.Object.Property.(
+      fun (sfmap_, smmap_, fmap_, mmap_)
+        (loc, { key; value; static; _method; _ }) -> (* TODO: optional *)
+        Ast.Expression.Object.Property.(match key with
+        | Literal (loc, _)
+        | Computed (loc, _) ->
+            let msg = "illegal name" in
+            Flow_js.add_error cx [Reason_js.mk_reason "" loc, msg];
+            (sfmap_, smmap_, fmap_, mmap_)
 
-  let sfmap, smmap, fmap, mmap = List.fold_left Ast.Type.Object.Property.(
-    fun (sfmap_, smmap_, fmap_, mmap_)
-      (loc, { key; value; static; _method; _ }) -> (* TODO: optional *)
-      Ast.Expression.Object.Property.(match key with
-      | Literal (loc, _)
-      | Computed (loc, _) ->
-          let msg = "illegal name" in
-          Flow_js.add_error cx [Reason_js.mk_reason "" loc, msg];
-          (sfmap_, smmap_, fmap_, mmap_)
-
-      | Identifier (loc, { Ast.Identifier.name; _ }) ->
-          let t = convert cx map value in
-          (* check for overloads in static and instance method maps *)
-          let map_ = if static then smmap_ else mmap_ in
-          let t = match SMap.get name map_ with
-            | None -> t
-            | Some (IntersectionT (reason, seen_ts)) ->
-                IntersectionT (reason, seen_ts @ [t])
-            | Some seen_t ->
-                IntersectionT (Reason_js.mk_reason id_name loc, [seen_t; t])
-          in
-          (* TODO: additionally check that the four maps are disjoint *)
-          (match static, _method with
-          | true, true ->  (sfmap_, SMap.add name t smmap_, fmap_, mmap_)
-          | true, false -> (SMap.add name t sfmap_, smmap_, fmap_, mmap_)
-          | false, true -> (sfmap_, smmap_, fmap_, SMap.add name t mmap_)
-          | false, false -> (sfmap_, smmap_, SMap.add name t fmap_, mmap_)
-          )
-      )
-  ) (SMap.empty, SMap.empty, SMap.empty, SMap.empty) properties
-  in
-  let fmap = Ast.Type.Object.Indexer.(match indexers with
-  | [] -> fmap
-  | [(_, { key; value; _; })] ->
-      let keyt = convert cx map key in
-      let valuet = convert cx map value in
-      fmap |> SMap.add "$key" keyt |> SMap.add "$value" valuet
-  (* TODO *)
-  | _ -> failwith "Unimplemented: multiple indexers")
-  in
-  let calls = callProperties |> List.map (function
-    | loc, { Ast.Type.Object.CallProperty.value = (_, ft); static; } ->
-      (static, convert cx map (loc, Ast.Type.Function ft))
-  ) in
-  let scalls, calls = List.partition fst calls in
-  let smmap = match scalls with
-    | [] -> smmap
-    | [_,t] -> SMap.add "$call" t smmap
-    | _ -> let scalls = List.map snd scalls in
-           SMap.add "$call" (IntersectionT (mk_reason id_name loc,
-                                            scalls)) smmap
-  in
-  let mmap = match calls with
-    | [] -> mmap
-    | [_,t] -> SMap.add "$call" t mmap
-    | _ ->
-      let calls = List.map snd calls in
-      SMap.add "$call" (IntersectionT (mk_reason id_name loc,
-                                            calls)) mmap
-  in
-  let mmap = match SMap.get "constructor" mmap with
-    | None ->
-      let constructor_funtype =
-        Flow_js.mk_functiontype [] ~params_names:[] VoidT.t in
-      let funt = (FunT (Reason_js.mk_reason "constructor" loc,
-        Flow_js.dummy_static, Flow_js.dummy_prototype, constructor_funtype))
-      in
-      SMap.add "constructor" funt mmap
-    | Some _ ->
-      mmap
-  in
-  reason, typeparams, map, (sfmap, smmap, fmap, mmap)
+        | Identifier (loc, { Ast.Identifier.name; _ }) ->
+            let t = convert cx map value in
+            (* check for overloads in static and instance method maps *)
+            let map_ = if static then smmap_ else mmap_ in
+            let t = match SMap.get name map_ with
+              | None -> t
+              | Some (IntersectionT (reason, seen_ts)) ->
+                  IntersectionT (reason, seen_ts @ [t])
+              | Some seen_t ->
+                  IntersectionT (Reason_js.mk_reason id_name loc, [seen_t; t])
+            in
+            (* TODO: additionally check that the four maps are disjoint *)
+            (match static, _method with
+            | true, true ->  (sfmap_, SMap.add name t smmap_, fmap_, mmap_)
+            | true, false -> (SMap.add name t sfmap_, smmap_, fmap_, mmap_)
+            | false, true -> (sfmap_, smmap_, fmap_, SMap.add name t mmap_)
+            | false, false -> (sfmap_, smmap_, SMap.add name t fmap_, mmap_)
+            )
+        )
+    ) (SMap.empty, SMap.empty, SMap.empty, SMap.empty) properties
+    in
+    let fmap = Ast.Type.Object.Indexer.(match indexers with
+    | [] -> fmap
+    | [(_, { key; value; _; })] ->
+        let keyt = convert cx map key in
+        let valuet = convert cx map value in
+        fmap |> SMap.add "$key" keyt |> SMap.add "$value" valuet
+    (* TODO *)
+    | _ -> failwith "Unimplemented: multiple indexers")
+    in
+    let calls = callProperties |> List.map (function
+      | loc, { Ast.Type.Object.CallProperty.value = (_, ft); static; } ->
+        (static, convert cx map (loc, Ast.Type.Function ft))
+    ) in
+    let scalls, calls = List.partition fst calls in
+    let smmap = match scalls with
+      | [] -> smmap
+      | [_,t] -> SMap.add "$call" t smmap
+      | _ -> let scalls = List.map snd scalls in
+             SMap.add "$call" (IntersectionT (mk_reason id_name loc,
+                                              scalls)) smmap
+    in
+    let mmap = match calls with
+      | [] -> mmap
+      | [_,t] -> SMap.add "$call" t mmap
+      | _ ->
+        let calls = List.map snd calls in
+        SMap.add "$call" (IntersectionT (mk_reason id_name loc,
+                                              calls)) mmap
+    in
+    let mmap = match SMap.get "constructor" mmap with
+      | None ->
+        let constructor_funtype =
+          Flow_js.mk_functiontype [] ~params_names:[] VoidT.t in
+        let funt = (FunT (Reason_js.mk_reason "constructor" loc,
+          Flow_js.dummy_static, Flow_js.dummy_prototype, constructor_funtype))
+        in
+        SMap.add "constructor" funt mmap
+      | Some _ ->
+        mmap
+    in
+    typeparams, map, (sfmap, smmap, fmap, mmap)
+  )
 
 and variable cx (loc, vdecl) = Ast.(
   let { Statement.VariableDeclaration.Declarator.id; init } = vdecl in
@@ -5125,10 +5141,16 @@ and extract_getter_type = function
   | FunT (_, _, _, { return_t; _; }) -> return_t
   | _ -> failwith "Getter property with unexpected type"
 
-and extract_class_name class_loc  = Ast.Class.(function {id; _;} ->
+and extract_class_name class_loc = Ast.Class.(function {id; _;} ->
   match id with
   | Some(name_loc, {Ast.Identifier.name; _;}) -> (name_loc, name)
   | None -> (class_loc, "<<anonymous class>>")
+)
+
+and extract_class_type_name class_loc = Ast.Type.Class.(function {id; _;} ->
+  match id with
+  | Some(name_loc, {Ast.Identifier.name; _;}) -> (name_loc, name)
+  | None -> (class_loc, "<<anonymous class type>>")
 )
 
 (* Process a class definition, returning a (polymorphic) class type. A class
@@ -5445,25 +5467,6 @@ and mk_interface cx reason_i typeparams map (sfmap, smmap, fmap, mmap) extends s
   if typeparams = []
   then ClassT(this)
   else PolyT (typeparams, ClassT(this))
-
-and mk_cls_t cx reason typeparams map (sfmap, smmap, fmap, mmap) =
-  let ct_arg_polarities = map |> SMap.map (fun t -> match t with
-  | BoundT { polarity; _ } -> polarity
-  | _ -> assert_false (spf "Expected BoundT but found %s" (string_of_ctor t))
-  ) in
-
-  let cls_type = {
-    ct_type_args = map;
-    ct_arg_polarities;
-    ct_fields_tmap = Flow_js.mk_propmap cx fmap;
-    ct_methods_tmap = Flow_js.mk_propmap cx mmap;
-    ct_sfields_tmap = Flow_js.mk_propmap cx sfmap;
-    ct_smethods_tmap = Flow_js.mk_propmap cx smmap;
-  } in
-
-  if typeparams = []
-  then ClsT (reason, cls_type)
-  else PolyT (typeparams, ClsT (reason, cls_type))
 
 (* Given a function declaration and types for `this` and `super`, extract a
    signature consisting of type parameters, parameter types, parameter names,

--- a/tests/interface/test.js
+++ b/tests/interface/test.js
@@ -78,10 +78,10 @@ function ab1(m: AI&BI): number {
 
 function ab2(M: Class<AI>&Class<BI>): string {
   /*
-   * Operator `Interface<.> would be handy for stripping an interface from a
+   * Operator `Interface<.>` would be handy for stripping an interface from a
    * class and for shifting interfaces (Class<SomeInterface> errors).
    */
-  return M.asMethod1() + M.asMethod2();
+  return M.asMethod1() + M.bsMethod1();
 }
 
 var b = new B();
@@ -90,4 +90,4 @@ var x2 = b2(C);
 var x3 = b3(C);
 var d = new D();
 var y1 = ab1(d);
-var y2 = ab2(D);
+//var y2 = ab2(D);

--- a/tests/interface/test.js
+++ b/tests/interface/test.js
@@ -60,12 +60,12 @@ class D extends C {
   }
 }
 
-type EI<T> = class {
+type EI<T> = class EI {
   eMethod1(): T;
   static esMethod1(): Class<T>;
 }
 
-class E {
+class E { // implements EI<B>
   eMethod1() {
     return new B();
   }
@@ -81,7 +81,7 @@ class E {
 }
 
 class F {
-  eMethod1() {
+  eMethod1() { // implements EI<D>, EI<C>, EI<B>
     return new D();
   }
   eMethod2() {
@@ -115,7 +115,7 @@ function ab2(M: Class<AI>&Class<BI>): string {
   return M.asMethod1() + M.bsMethod1();
 }
 
-function e1(N: Class<EI<B>>): string { // Shifted TypeApp
+function e1(N: Class<EI<B>>): string {
   var Bp = N.esMethod1();
   return Bp.bsMethod1() + Bp.bsMethod2();
 }
@@ -145,7 +145,140 @@ var Z3 = e.constructor.esMethod1();
 var Z4 = e.constructor.esNonmethod(b,d); // NG: Type checks despite bad name.
 var Z5 = E.esMethod1();
 var Z6 = F.esMethod1();
+
 var z7 = e1(E);
+/*
+ * If I put this assignment prior to `var f...`, then the `var f` error makes no
+ * mention of `z7`'s site:
+test.js:29:7,7: B
+This type is incompatible with
+test.js:54:7,7: D
+
+test.js:118:25,25: B
+This type is incompatible with
+test.js:54:7,7: D
+Error path:
+:                   MixedT [Object]
+test.js:54:7,7:     ~> ExtendsT [extends D] comes from
+test.js:118:25,25:  . InstanceT [B]
+test.js:54:7,7:     . ~> ExtendsT [extends D] comes from
+test.js:118:25,25:  . . InstanceT [B]
+test.js:54:7,7:     . . ~> InstanceT [D] comes from
+test.js:118:25,25:  . . . OpenT [B]
+test.js:54:7,7:     . . . ~> InstanceT [D] comes from
+test.js:118:25,25:  . . . . AnnotT [B]
+test.js:54:7,7:     . . . . ~> InstanceT [D] comes from
+test.js:118:25,25:  . . . . . AnnotT [B]
+test.js:143:11,11:  . . . . . ~> OpenT [D] comes from
+test.js:118:25,25:  . . . . . . AnnotT [B]
+test.js:143:11,11:  . . . . . . ~> AnnotT [D] comes from
+test.js:64:3,15:    . . . . . . . FunT [function type]
+test.js:69:3,71:3:  . . . . . . . ~> FunT [method eMethod1] comes from
+test.js:142:13,13:  . . . . . . . . InstanceT [E]
+test.js:64:3,15:    . . . . . . . . ~> LookupT [property eMethod1] comes from
+test.js:142:13,13:  . . . . . . . . . InstanceT [E]
+test.js:63:14,66:1: . . . . . . . . . ~> ClsT [EI] comes from
+test.js:142:13,13:  . . . . . . . . . . InstanceT [E]
+test.js:142:13,13:  . . . . . . . . . . ~> OpenT [E] comes from
+test.js:142:13,13:  . . . . . . . . . . . InstanceT [E]
+test.js:142:13,13:  . . . . . . . . . . . ~> AnnotT [E] comes from
+test.js:142:13,13:  . . . . . . . . . . . . ShiftT [class type: E]
+test.js:118:22,26:  . . . . . . . . . . . . ~> ShiftT [shifted type: type application of polymorphic type: type EI] comes from
+test.js:142:10,11:  . . . . . . . . . . . . . FunT [function]
+test.js:142:10,14:  . . . . . . . . . . . . . ~> CallT [function call]
+test.js:69:3,71:3:  . . . . . . . FunT [method eMethod1]
+test.js:64:3,15:    . . . . . . . ~> FunT [function type] comes from
+test.js:68:7,7:     . . . . . . . . InstanceT [E]
+test.js:64:3,15:    . . . . . . . . ~> LookupT [property eMethod1] comes from
+test.js:68:7,7:     . . . . . . . . . InstanceT [E]
+test.js:63:14,66:1: . . . . . . . . . ~> ClsT [EI] comes from
+test.js:68:7,7:     . . . . . . . . . . InstanceT [E]
+test.js:68:7,7:     . . . . . . . . . . ~> OpenT [E] comes from
+test.js:68:7,7:     . . . . . . . . . . . InstanceT [E]
+test.js:68:7,7:     . . . . . . . . . . . ~> AnnotT [E] comes from
+test.js:68:7,7:     . . . . . . . . . . . . InstanceT [E]
+test.js:143:8,12:   . . . . . . . . . . . . ~> TypeAppT [type application of type EI] comes from
+test.js:143:16,22:  . . . . . . . . . . . . . VoidT [undefined]
+test.js:68:7,7:     . . . . . . . . . . . . . ~> ObjTestT [constructor return] comes from
+test.js:68:7,7:     . . . . . . . . . . . . . . FunT [default constructor]
+test.js:143:16,22:  . . . . . . . . . . . . . . ~> CallT [constructor call] comes from
+test.js:68:7,7:     . . . . . . . . . . . . . . . InstanceT [E]
+test.js:143:16,22:  . . . . . . . . . . . . . . . ~> MethodT [constructor call] comes from
+test.js:68:7,7:     . . . . . . . . . . . . . . . . ShiftT [class type: E]
+test.js:143:16,22:  . . . . . . . . . . . . . . . . ~> ConstructorT [constructor call]
+test.js:68:7,7:     . . . . . . . . . . . . . . ShiftT [class type: E]
+test.js:143:16,22:  . . . . . . . . . . . . . . ~> ConstructorT [constructor call]
+ *
+ * However, if I leave this assignment here, then the `var f` error attaches the
+ * second message to the `z7` function call site:
+ *
+test.js:29:7,7: B
+This type is incompatible with
+test.js:54:7,7: D
+
+test.js:150:10,14: function call
+Error:
+test.js:118:25,25: B
+This type is incompatible with
+test.js:54:7,7: D
+Error path:
+:                   MixedT [Object]
+test.js:54:7,7:     ~> ExtendsT [extends D] comes from
+test.js:118:25,25:  . InstanceT [B]
+test.js:54:7,7:     . ~> ExtendsT [extends D] comes from
+test.js:118:25,25:  . . InstanceT [B]
+test.js:54:7,7:     . . ~> InstanceT [D] comes from
+test.js:118:25,25:  . . . OpenT [B]
+test.js:54:7,7:     . . . ~> InstanceT [D] comes from
+test.js:118:25,25:  . . . . AnnotT [B]
+test.js:54:7,7:     . . . . ~> InstanceT [D] comes from
+test.js:118:25,25:  . . . . . AnnotT [B]
+test.js:142:11,11:  . . . . . ~> OpenT [D] comes from
+test.js:118:25,25:  . . . . . . AnnotT [B]
+test.js:142:11,11:  . . . . . . ~> AnnotT [D] comes from
+test.js:64:3,15:    . . . . . . . FunT [function type]
+test.js:69:3,71:3:  . . . . . . . ~> FunT [method eMethod1] comes from
+test.js:150:13,13:  . . . . . . . . InstanceT [E]
+test.js:64:3,15:    . . . . . . . . ~> LookupT [property eMethod1] comes from
+test.js:150:13,13:  . . . . . . . . . InstanceT [E]
+test.js:63:14,66:1: . . . . . . . . . ~> ClsT [EI] comes from
+test.js:150:13,13:  . . . . . . . . . . InstanceT [E]
+test.js:150:13,13:  . . . . . . . . . . ~> OpenT [E] comes from
+test.js:150:13,13:  . . . . . . . . . . . InstanceT [E]
+test.js:150:13,13:  . . . . . . . . . . . ~> AnnotT [E] comes from
+test.js:150:13,13:  . . . . . . . . . . . . ShiftT [class type: E]
+test.js:118:22,26:  . . . . . . . . . . . . ~> ShiftT [shifted type: type application of polymorphic type: type EI] comes from
+test.js:150:10,11:  . . . . . . . . . . . . . FunT [function]
+test.js:150:10,14:  . . . . . . . . . . . . . ~> CallT [function call]
+test.js:69:3,71:3:  . . . . . . . FunT [method eMethod1]
+test.js:64:3,15:    . . . . . . . ~> FunT [function type] comes from
+test.js:142:20,20:  . . . . . . . . InstanceT [E]
+test.js:64:3,15:    . . . . . . . . ~> LookupT [property eMethod1] comes from
+test.js:142:20,20:  . . . . . . . . . InstanceT [E]
+test.js:63:14,66:1: . . . . . . . . . ~> ClsT [EI] comes from
+test.js:142:20,20:  . . . . . . . . . . InstanceT [E]
+test.js:142:20,20:  . . . . . . . . . . ~> OpenT [E] comes from
+test.js:142:20,20:  . . . . . . . . . . . InstanceT [E]
+test.js:142:20,20:  . . . . . . . . . . . ~> AnnotT [E] comes from
+test.js:142:20,20:  . . . . . . . . . . . . InstanceT [E]
+test.js:142:8,12:   . . . . . . . . . . . . ~> TypeAppT [type application of type EI] comes from
+test.js:142:16,22:  . . . . . . . . . . . . . VoidT [undefined]
+test.js:142:20,20:  . . . . . . . . . . . . . ~> ObjTestT [constructor return] comes from
+test.js:68:7,7:     . . . . . . . . . . . . . . FunT [default constructor]
+test.js:142:16,22:  . . . . . . . . . . . . . . ~> CallT [constructor call] comes from
+test.js:142:20,20:  . . . . . . . . . . . . . . . InstanceT [E]
+test.js:142:16,22:  . . . . . . . . . . . . . . . ~> MethodT [constructor call] comes from
+test.js:142:20,20:  . . . . . . . . . . . . . . . . ShiftT [class type: E]
+test.js:142:16,22:  . . . . . . . . . . . . . . . . ~> ConstructorT [constructor call]
+test.js:142:20,20:  . . . . . . . . . . . . . . ShiftT [class type: E]
+test.js:142:16,22:  . . . . . . . . . . . . . . ~> ConstructorT [constructor call]
+ *
+ * These errors are verbatim identical except for the first two lines.  This
+ * looks like a bug in the error handling.  If the EI<E> was cached at the
+ * signature of `e1` and then reused, then this might arise?  Save it for later
+ * when prettying up the error messages.
+ */
+
 var z8 = e1(F);
 var z9 = e2(e);
 /*

--- a/tests/interface/test.js
+++ b/tests/interface/test.js
@@ -125,11 +125,6 @@ function e2(n: EI<B>): string {
   return b.bMethod1() + b.bMethod2();
 }
 
-type GI<T> = class Id<U> { // class<U> currently rejected by parser, right?
-  gMethod1(): U;
-  static gsMethod1(): U;
-};
-
 var b: BI = new B();
 var x1 = b1(b);
 var x2 = b2(C);

--- a/tests/interface/test.js
+++ b/tests/interface/test.js
@@ -16,7 +16,11 @@ function m1(a: AI): number {
 }
 
 function sm1(a: AI): string {
-  return a.constructor.sMethod1();
+  return a.constructor.sMethodAsdf();
+  /*
+   * This passes?! It should map constructor to the class--I think that this is
+   * related to my unmerged PR.
+   */
   /*
    * `class` prefix on the type declaration clarifies that `constructor` exists
    * (ES6 default or spec'ed above).  For an object, the Object constructor
@@ -45,16 +49,17 @@ class A {
     return "a string";
   }
 }
-
+/*
 class B {
   method1(): string {
     return "no good";
   }
   static sMethod1(): number {
-    return "no good";
+    return 7;
   }
 }
-
+*/
+/*
 var a = new A();
 var n1: number = m1(a);
 var s1: string = sm1(a);
@@ -66,3 +71,4 @@ n1 = m1(b);
 s1 = sm1(b);
 s2 = cs1(B);
 n2 = cn1(B);
+*/

--- a/tests/interface/test.js
+++ b/tests/interface/test.js
@@ -6,9 +6,10 @@ type AI = class {
    * ES6 spec, or does the ctor remain unbound?  I think that it should remain
    * unbound.
    */
-  constructor(): void;
+//  constructor(): void;
   method1(): number;
   static sMethod1(): string;
+//  static sMethodK(): number;
 }
 
 function m1(a: AI): number {
@@ -32,8 +33,8 @@ function sm1(a: AI): string {
    */
 }
 
-function cs1(A: Class<AI>): string {
-  return A.sMethod1();
+function cs1(K: Class<Ap>): string {
+  return K.sMethod1();
 }
 
 function cn1(A: Class<AI>): number {
@@ -48,8 +49,17 @@ class A {
   static sMethod1(): string {
     return "a string";
   }
+  static unnecMethod(): number {
+    return 5;
+  }
 }
-/*
+
+class Ap extends A {
+  unnecMethod(): string {
+    return "boring";
+  }
+}
+
 class B {
   method1(): string {
     return "no good";
@@ -58,14 +68,13 @@ class B {
     return 7;
   }
 }
-*/
-/*
+
 var a = new A();
 var n1: number = m1(a);
 var s1: string = sm1(a);
 var s2: string = cs1(A);
+/*
 var n2: number = cn1(A);
-
 var b = new B();
 n1 = m1(b);
 s1 = sm1(b);

--- a/tests/interface/test.js
+++ b/tests/interface/test.js
@@ -1,5 +1,26 @@
 /* @flow */
 
+type AI = class {
+  aMethod1(): number;
+  static asMethod1(): string;
+};
+
+class A {
+  constructor() {};
+  aMethod1(): number {
+    return 13;
+  }
+  aMethod2(): string {
+    return "from A's nonstatic";
+  }
+  static asMethod1(): string {
+    return "from A's static";
+  }
+  static asMethod2(): number {
+    return 7;
+  }
+}
+
 type BI = class {
   bMethod1(): number;
   static bsMethod1(): number;
@@ -30,6 +51,15 @@ class C extends B {
   }
 }
 
+class D extends C {
+  aMethod1(): number {
+    return 98;
+  }
+  static asMethod1(): string {
+    return "asMethod on D";
+  }
+}
+
 function b1(ell: BI): number {
   return ell.bMethod1();
 }
@@ -42,7 +72,22 @@ function b3(Ell: Class<BI>): number {
   return Ell.bsMethod1();
 }
 
+function ab1(m: AI&BI): number {
+  return m.aMethod1() + m.bMethod1();
+}
+
+function ab2(M: Class<AI>&Class<BI>): string {
+  /*
+   * Operator `Interface<.> would be handy for stripping an interface from a
+   * class and for shifting interfaces (Class<SomeInterface> errors).
+   */
+  return M.asMethod1() + M.asMethod2();
+}
+
 var b = new B();
-var y1 = b1(b);
-var y2 = b2(C);
-var y2 = b3(C);
+var x1 = b1(b);
+var x2 = b2(C);
+var x3 = b3(C);
+var d = new D();
+var y1 = ab1(d);
+var y2 = ab2(D);

--- a/tests/interface/test.js
+++ b/tests/interface/test.js
@@ -1,0 +1,68 @@
+/* @flow */
+
+type AI = class {
+  /*
+   * TODO: When absent, does the interface impose the default constructor of the
+   * ES6 spec, or does the ctor remain unbound?  I think that it should remain
+   * unbound.
+   */
+  constructor(): void;
+  method1(): number;
+  static sMethod1(): string;
+}
+
+function m1(a: AI): number {
+  return a.method1();
+}
+
+function sm1(a: AI): string {
+  return a.constructor.sMethod1();
+  /*
+   * `class` prefix on the type declaration clarifies that `constructor` exists
+   * (ES6 default or spec'ed above).  For an object, the Object constructor
+   * exists, so (1)in the absence of an explicit constructor spec or (2)in
+   * the presence of a constructor that is compatible with that of Object, an
+   * object may satisfy the interface.  The `class` prefix is warranted for
+   * self referencing like ES6 classes admit, e.g. type T = class A {...} =>
+   * method signatures on type T can reference interface A.
+   */
+}
+
+function cs1(A: Class<AI>): string {
+  return A.sMethod1();
+}
+
+function cn1(A: Class<AI>): number {
+  var a = new A();
+  return a.method1();
+}
+
+class A {
+  method1(): number {
+    return 5;
+  }
+  static sMethod1(): string {
+    return "a string";
+  }
+}
+
+class B {
+  method1(): string {
+    return "no good";
+  }
+  static sMethod1(): number {
+    return "no good";
+  }
+}
+
+var a = new A();
+var n1: number = m1(a);
+var s1: string = sm1(a);
+var s2: string = cs1(A);
+var n2: number = cn1(A);
+
+var b = new B();
+n1 = m1(b);
+s1 = sm1(b);
+s2 = cs1(B);
+n2 = cn1(B);

--- a/tests/interface/test.js
+++ b/tests/interface/test.js
@@ -1,83 +1,48 @@
 /* @flow */
 
-type AI = class {
-  /*
-   * TODO: When absent, does the interface impose the default constructor of the
-   * ES6 spec, or does the ctor remain unbound?  I think that it should remain
-   * unbound.
-   */
-//  constructor(): void;
-  method1(): number;
-  static sMethod1(): string;
-//  static sMethodK(): number;
-}
-
-function m1(a: AI): number {
-  return a.method1();
-}
-
-function sm1(a: AI): string {
-  return a.constructor.sMethodAsdf();
-  /*
-   * This passes?! It should map constructor to the class--I think that this is
-   * related to my unmerged PR.
-   */
-  /*
-   * `class` prefix on the type declaration clarifies that `constructor` exists
-   * (ES6 default or spec'ed above).  For an object, the Object constructor
-   * exists, so (1)in the absence of an explicit constructor spec or (2)in
-   * the presence of a constructor that is compatible with that of Object, an
-   * object may satisfy the interface.  The `class` prefix is warranted for
-   * self referencing like ES6 classes admit, e.g. type T = class A {...} =>
-   * method signatures on type T can reference interface A.
-   */
-}
-
-function cs1(K: Class<Ap>): string {
-  return K.sMethod1();
-}
-
-function cn1(A: Class<AI>): number {
-  var a = new A();
-  return a.method1();
-}
-
-class A {
-  method1(): number {
-    return 5;
-  }
-  static sMethod1(): string {
-    return "a string";
-  }
-  static unnecMethod(): number {
-    return 5;
-  }
-}
-
-class Ap extends A {
-  unnecMethod(): string {
-    return "boring";
-  }
-}
+type BI = class {
+  bMethod1(): number;
+  static bsMethod1(): number;
+};
 
 class B {
-  method1(): string {
-    return "no good";
-  }
-  static sMethod1(): number {
+  constructor() {};
+  bMethod1(): number {
     return 7;
+  };
+  bMethod2(): string {
+    return "a string";
+  };
+  static bsMethod1(): number {
+    return 123;
+  };
+  static bsMethod2(): string {
+    return "another string";
   }
 }
 
-var a = new A();
-var n1: number = m1(a);
-var s1: string = sm1(a);
-var s2: string = cs1(A);
-/*
-var n2: number = cn1(A);
+class C extends B {
+  a(): number {
+    return 22;
+  }
+  static c(): string {
+    return "c";
+  }
+}
+
+function b1(ell: BI): number {
+  return ell.bMethod1();
+}
+
+function b2(Ell: Class<B>): number {
+  return Ell.bsMethod1();
+}
+
+function b3(Ell: Class<BI>): number {
+  return Ell.bsMethod1();
+}
+
 var b = new B();
-n1 = m1(b);
-s1 = sm1(b);
-s2 = cs1(B);
-n2 = cn1(B);
-*/
+var y1 = b1(b);
+var y2 = b2(C);
+var y2 = b3(C);

--- a/tests/interface/test.js
+++ b/tests/interface/test.js
@@ -60,6 +60,41 @@ class D extends C {
   }
 }
 
+type EI<T> = class {
+  eMethod1(): T;
+  static esMethod1(): Class<T>;
+}
+
+class E {
+  eMethod1() {
+    return new B();
+  }
+  eMethod2() {
+    return 5;
+  }
+  static esMethod1() {
+    return B;
+  }
+  static esMethod2() {
+    return "e static";
+  }
+}
+
+class F {
+  eMethod1() {
+    return new D();
+  }
+  eMethod2() {
+    return "f method";
+  }
+  static esMethod1() {
+    return D;
+  }
+  static esMethod2() {
+    return 1;
+  }
+}
+
 function b1(ell: BI): number {
   return ell.bMethod1();
 }
@@ -77,17 +112,43 @@ function ab1(m: AI&BI): number {
 }
 
 function ab2(M: Class<AI>&Class<BI>): string {
-  /*
-   * Operator `Interface<.>` would be handy for stripping an interface from a
-   * class and for shifting interfaces (Class<SomeInterface> errors).
-   */
   return M.asMethod1() + M.bsMethod1();
 }
 
-var b = new B();
+function e1(N: Class<EI<B>>): string { // Shifted TypeApp
+  var Bp = N.esMethod1();
+  return Bp.bsMethod1() + Bp.bsMethod2();
+}
+
+function e2(n: EI<B>): string {
+  var b = n.eMethod1();
+  return b.bMethod1() + b.bMethod2();
+}
+
+type GI<T> = class Id<U> { // class<U> currently rejected by parser, right?
+  gMethod1(): U;
+  static gsMethod1(): U;
+};
+
+var b: BI = new B();
 var x1 = b1(b);
 var x2 = b2(C);
 var x3 = b3(C);
 var d = new D();
 var y1 = ab1(d);
-//var y2 = ab2(D);
+var y2 = ab2(D);
+var e: EI<B> = new F();
+//var f: EI<D> = new E(); // OK error: E returns B's, which may not have all of the methods of D's
+var z1 = e.eMethod1();
+var z2 = e.eMethod1(b,d); // Too many arguments => okay by Flow.
+var Z3 = e.constructor.esMethod1();
+var Z4 = e.constructor.esNonmethod(b,d); // NG: Type checks despite bad name.
+var Z5 = E.esMethod1();
+var Z6 = F.esMethod1();
+var z7 = e1(E);
+var z8 = e1(F);
+var z9 = e2(e);
+/*
+ * Operator `Interface<.>` would be handy for stripping an interface from a
+ * class and for shifting interfaces (Class<SomeInterface> errors).
+ */


### PR DESCRIPTION
This is a stub demonstrating an extension of Flow's object type notation to class types.  Basically object types, but with statics allowed, e.g.

```
type BI = class {
  bMethod1(): number;
  static bsMethod1(): number;
};
```

These are cute in that intersection provides extension semantics.

Is this worth the time to polish, or will a completed implementation get rejected in favor of some other syntax and/or semantics?