### PR TITLE
Type definitions for screen and navigator

### DIFF
--- a/lib/bom.js
+++ b/lib/bom.js
@@ -9,9 +9,72 @@
  */
 /* BOM */
 
-declare var screen: any;
+declare class Screen {
+    availHeight: number;
+    availLeft: number;
+    availop: number;
+    availWidth: number;
+    colorDepth: number;
+    height: number;
+    left: number;
+    mozOrientation?: string;
+    onmozorientationchange?: any;
+    orientation?: {
+        angle: number;
+        onchange: any;
+        type: string;
+    };
+    pixelDepth: number;
+    top: number;
+    width: number;
+    mozLockOrientation?: Function;
+    mozUnlockOrientation?: Function;
+}
+
+declare var screen: Screen;
 declare var window: any;
-declare var navigator: any;
+
+declare class Navigator {
+    appCodeName: string;
+    appName: string;
+    appVersion: string;
+    cookieEnabled: boolean;
+    buildId: string;
+    doNotTrack?: any;
+    geolocation: Geolocation;
+    mediaDevices?: Object;
+    hardwareConcurrency: number;
+    language: string;
+    languages: Array<string>;
+    maxTouchPoints: number;
+    mimeTypes: Array<Object>;
+    onLine: boolean;
+    ospu: string;
+    permissions: any;
+    platform: string;
+    plugins: Array<Object>;
+    product: string;
+    productSub: string;
+    serviceWorker?: Object;
+    userAgent: string;
+    vendor: string;
+    vendorSub: string;
+    getBattery?: Function;
+    getGamepads?: Function;
+    getStorageUpdates?: Function;
+    javaEnabled: Function;
+    registerProtocolHandler: Function;
+    requestMIDIAccess?: Function;
+    requestMediaKeySystemAccess?: Function;
+    sendBeacon?: Function;
+    unregisterProtocolHandler: Function;
+    vibrate?: Function;
+    webkitGetUserMedia?: Function;
+    mozGetUserMedia?: Function;
+    taintEnabled?: Function;
+}
+
+declare var navigator: Navigator;
 
 declare class History {
     length: number;


### PR DESCRIPTION
Type definitions for screen and navigator objects. Properties added are a union of the properties from different browsers. Properties that are not found in all browsers has a `?` at the end. This will essentially make you do existential check before using browser-specific APIs.

browsers tested: the latest versions of Chrome, Safari, Firefox