### PR TITLE
add innerText to Node, with a ?

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -11,7 +11,7 @@
 
 declare class Blob {
     constructor(blobParts?: Array<any>, options?: {
-        type?: string;b
+        type?: string;
         endings?: string;
     }): void;
     type: string;

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -11,7 +11,7 @@
 
 declare class Blob {
     constructor(blobParts?: Array<any>, options?: {
-        type?: string;
+        type?: string;b
         endings?: string;
     }): void;
     type: string;
@@ -366,7 +366,7 @@ declare class Element extends Node {
     hasAttribute(name: string): boolean;
     hasAttributeNS(namespaceURI: string, localName: string): boolean;
     insertAdjacentHTML(position: string, text: string): void;
-    insertAdjacentElement?: (position: ('beforebgin' | 'afterbegin' | 'beforeend' | 'afterend'), node: Node) => void;
+    insertAdjacentElement?: (position: ('beforebegin' | 'afterbegin' | 'beforeend' | 'afterend'), node: Node) => void;
     removeAttribute(name?: string): void;
     removeAttributeNS(namespaceURI: string, localName: string): void;
     removeAttributeNode(oldAttr: Attr): Attr;

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -344,6 +344,7 @@ declare class Element extends Node {
     clientWidth: number;
     id: string;
     innerHTML: string;
+    innerText?: string;
     nextElementSibling: Element;
     outerHTML: string;
     previousElementSibling: Element;

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -265,7 +265,7 @@ declare class Document extends Node {
     createRange(): Range;
     elementFromPoint(x: number, y: number): HTMLElement;
     defaultView: any;
-    compatMode: string;
+    compatMode: 'BackCompat' | 'CSS1Compat';
     activeElement: HTMLElement;
     hidden: boolean;
 
@@ -347,6 +347,7 @@ declare class Element extends Node {
     innerText?: string;
     nextElementSibling: Element;
     outerHTML: string;
+    outerText?: string;
     previousElementSibling: Element;
     scrollHeight: number;
     scrollLeft: number;
@@ -365,6 +366,7 @@ declare class Element extends Node {
     hasAttribute(name: string): boolean;
     hasAttributeNS(namespaceURI: string, localName: string): boolean;
     insertAdjacentHTML(position: string, text: string): void;
+    insertAdjacentElement?: (position: ('beforebgin' | 'afterbegin' | 'beforeend' | 'afterend'), node: Node) => void;
     removeAttribute(name?: string): void;
     removeAttributeNS(namespaceURI: string, localName: string): void;
     removeAttributeNode(oldAttr: Attr): Attr;


### PR DESCRIPTION
innerText may be non-standard, but it is supported by all non-Firefox browsers and so it's relatively well supported.
It also has some unique benefits over textContent.

I've added it to the Node Class with a `?` so you can't use it without checking for it first.