### PR TITLE
Flat module system (.flowconfig root~baseUrl)

### DIFF
--- a/src/commands/serverCommands.ml
+++ b/src/commands/serverCommands.ml
@@ -116,7 +116,8 @@ module OptionParser(Config : CONFIG) = struct
     let flowconfig = FlowConfig.get root in
     let opt_module = FlowConfig.(match flowconfig.options.moduleSystem with
     | Node -> "node"
-    | Haste -> "haste") in
+    | Haste -> "haste"
+    | Flat -> "flat") in
     let opt_libs = FlowConfig.(match lib with
     | None -> flowconfig.libs
     | Some libs ->

--- a/src/common/flowConfig.ml
+++ b/src/common/flowConfig.ml
@@ -15,7 +15,7 @@ module Json = Hh_json
 
 let version = "0.16.0"
 
-type moduleSystem = Node | Haste
+type moduleSystem = Node | Haste | Flat
 
 type experimental_feature_mode =
   | EXPERIMENTAL_IGNORE
@@ -118,6 +118,7 @@ end = struct
     in let module_system = function
       | Node -> "node"
       | Haste -> "haste"
+      | Flat -> "flat"
 
     in fun o config ->
       let options = config.options in
@@ -459,7 +460,7 @@ let options_parser = OptionsParser.configure [
 
   ("module.system", OptionsParser.({
     flags = [];
-    _parser = enum ["node", Node; "haste", Haste] (fun opts (_, moduleSystem) ->
+    _parser = enum ["node", Node; "haste", Haste; "flat", Flat] (fun opts (_, moduleSystem) ->
       {opts with moduleSystem}
     );
   }));

--- a/src/common/flowConfig.mli
+++ b/src/common/flowConfig.mli
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  *
  *)
-type moduleSystem = Node | Haste
+type moduleSystem = Node | Haste | Flat
 
 type experimental_feature_mode =
   | EXPERIMENTAL_IGNORE

--- a/src/typing/module_js.ml
+++ b/src/typing/module_js.ml
@@ -242,39 +242,30 @@ and file_exists path =
     in SSet.mem (Filename.basename path) files
   )
 
-(!!)
 let resolve_symlinks path =
   Path.to_string (Path.make path)
-(!!)
+
 let relative r =
   Str.string_match Files_js.dir_sep r 0
   || Str.string_match Files_js.current_dir_name r 0
   || Str.string_match Files_js.parent_dir_name r 0
 
 let path_if_exists path =
-  if file_exists path then Some path
-  else None
+  let path = resolve_symlinks path in
+  if not (file_exists path) ||
+    FlowConfig.(is_excluded (get_unsafe ()) path)
+  then None
+  else Some path
 
 let path_is_file path =
+  let path = resolve_symlinks path in
   file_exists path && not (Sys.is_directory path)
-(!!)
 
 (*******************************)
 
 module Node = struct
   let exported_module file comments = file
   let guess_exported_module file _content = file
-
-  let path_if_exists path =
-    let path = resolve_symlinks path in
-    if not (file_exists path) ||
-      FlowConfig.(is_excluded (get_unsafe ()) path)
-    then None
-    else Some path
-
-  let path_is_file path =
-    let path = resolve_symlinks path in
-    file_exists path && not (Sys.is_directory path)
 
   let parse_main package =
     let package = resolve_symlinks package in

--- a/src/typing/module_js.ml
+++ b/src/typing/module_js.ml
@@ -506,7 +506,7 @@ module Flat: MODULE_SYSTEM = struct
          "were provided to Module_js.ml :(")
         import_str
       )
-    | Some({ Options.opt_root = root}) ->
+    | Some({ Options.opt_root = root; _; }) ->
       let path = Path.concat root import_str in
       find_first_valid (Path.to_string path)
     )

--- a/tests/flat/.flowconfig
+++ b/tests/flat/.flowconfig
@@ -1,0 +1,2 @@
+[options]
+module.system=flat

--- a/tests/flat/a.js
+++ b/tests/flat/a.js
@@ -1,0 +1,5 @@
+/* @flow */
+
+export function root(a: string): string {
+  return a;
+}

--- a/tests/flat/corge
+++ b/tests/flat/corge
@@ -1,0 +1,1 @@
+node_modules/qux/

--- a/tests/flat/flat.exp
+++ b/tests/flat/flat.exp
@@ -1,0 +1,2 @@
+
+Found 0 errors

--- a/tests/flat/mod1/a.js
+++ b/tests/flat/mod1/a.js
@@ -1,0 +1,5 @@
+/* @flow */
+
+export function k(a: number): string {
+  return "s" + a;
+}

--- a/tests/flat/node_modules/qux/def.js
+++ b/tests/flat/node_modules/qux/def.js
@@ -1,0 +1,5 @@
+/* @flow */
+
+export default function doc(a: string): string {
+  return a + "q";
+}

--- a/tests/flat/node_modules/qux/index.js
+++ b/tests/flat/node_modules/qux/index.js
@@ -1,0 +1,7 @@
+/* @flow */
+
+import def from "./def";
+
+export function k(a: number): string {
+  return def("s") + a;
+}

--- a/tests/flat/test.js
+++ b/tests/flat/test.js
@@ -1,0 +1,9 @@
+/* @flow */
+
+import { root } from "a";
+import { root } from "./a";
+import { k } from "mod1/a";
+import doc from "node_modules/qux/def";
+import doc2 from "corge/def";
+import doc3 from "./corge/def";
+import { k as ell } from "node_modules/qux/index";


### PR DESCRIPTION
This is a trivial module system intended for use with ES6 modules.  Dump all of your libraries in a directory with a .flowconfig, and you can import with absolute paths.  There's no configuration and/or magic to facilitate single word imports, e.g. `import "someLib";` will not look for `someLib/someMagicFile`, but it would find `someLib.js` in the .flowconfig root.

This admits paths aliasing by symlinks within the .flowconfig root.