### PR TITLE
Use typeof consistently

### DIFF
--- a/examples/05_DynamicCode/answer/dynamic.js
+++ b/examples/05_DynamicCode/answer/dynamic.js
@@ -1,7 +1,7 @@
 /* @flow */
 
 function foo(x) {
-  if (typeof(x) === 'string') {
+  if (typeof x === 'string') {
     return x.length;
   } else {
     return x;

--- a/src/parser/test/esprima_test_runner.js
+++ b/src/parser/test/esprima_test_runner.js
@@ -76,7 +76,7 @@ function handleSpecialObjectCompare(esprima, flow, env) {
 
   /** TYPE ANNOTATION COMPATIBILITY **/
   if (esprima.hasOwnProperty("typeAnnotation") &&
-      typeof(esprima.typeAnnotation) == "undefined") {
+      typeof esprima.typeAnnotation == "undefined") {
     esprima.typeAnnotation = null;
   }
 


### PR DESCRIPTION
Since typeof is an operator and not a function it could be confusing for some users to see it used as if it were a function.

Additionally, since all other typeof usage in esprima_test_runner.js was using typeof without parenthesis, I figured making it consistent would be good. 