### PR TITLE
Create binding for named class expressions

### DIFF
--- a/src/typing/type_inference_js.ml
+++ b/src/typing/type_inference_js.ml
@@ -3436,7 +3436,6 @@ and expression_ ~is_cond cx loc e = Ast.Expression.(match e with
           Env_js.push_env cx scope;
           let class_t = mk_class cx loc reason c in
           Env_js.pop_env ();
-          Hashtbl.replace cx.type_table loc class_t;
           Flow_js.flow cx (class_t, tvar);
           class_t;
       | None -> mk_class cx loc reason c)

--- a/src/typing/type_inference_js.ml
+++ b/src/typing/type_inference_js.ml
@@ -3425,8 +3425,21 @@ and expression_ ~is_cond cx loc e = Ast.Expression.(match e with
 
   | Class c ->
       let (name_loc, name) = extract_class_name loc c in
-      let reason = mk_reason name name_loc in
-      mk_class cx loc reason c
+      let reason = mk_reason (spf "class expr %s" name) loc in
+      (match c.Ast.Class.id with
+      | Some id ->
+          let tvar = Flow_js.mk_tvar cx reason in
+          let scope = Scope.fresh () in
+          Scope.add name
+            (Scope.create_entry tvar tvar (Some name_loc))
+            scope;
+          Env_js.push_env cx scope;
+          let class_t = mk_class cx loc reason c in
+          Env_js.pop_env ();
+          Hashtbl.replace cx.type_table loc class_t;
+          Flow_js.flow cx (class_t, tvar);
+          class_t;
+      | None -> mk_class cx loc reason c)
 
   (* TODO *)
   | Yield _

--- a/tests/classes/classes.exp
+++ b/tests/classes/classes.exp
@@ -43,4 +43,18 @@ class_shapes.js:31:6,11: number
 This type is incompatible with
 class_shapes.js:5:6,11: string
 
-Found 11 errors
+expr.js:14:13,15: identifier Baz
+Could not resolve name
+
+expr.js:17:8,10: identifier Qux
+Could not resolve name
+
+expr.js:24:14,28:1: class expr Alias
+This type is incompatible with
+expr.js:23:7,11: Alias
+
+expr.js:29:25,30: class expr Alias
+This type is incompatible with
+expr.js:23:7,11: Alias
+
+Found 15 errors

--- a/tests/classes/expr.js
+++ b/tests/classes/expr.js
@@ -1,0 +1,30 @@
+var Bar = class Foo {
+  static factory(): Foo { // OK: Foo is a type in this scope
+    return new Foo()      // OK: Foo is a runtime binding in this scope
+  }
+};
+
+var bar1: Bar = new Bar() // OK
+var bar2: Bar = Bar.factory() // OK
+
+// NB: Don't write expected errors using Foo to avoid error collapse hiding an
+// unexpected failure in the above code.
+
+var B = class Baz { }
+var b = new Baz(); // error: Baz is not a runtime binding in this scope
+
+var C = class Qux { }
+var c: Qux = new C(); // error: Qux is not a type in this scope
+
+// OK: anon classes create no binding, but can be bound manually
+var Anon = class { }
+var anon: Anon = new Anon();
+
+class Alias { }
+var _Alias = class Alias {
+  static factory(): Alias {
+    return new Alias();
+  }
+}
+var alias1: Alias = new _Alias(); // error: bad pun
+var alias2: Alias = _Alias.factory(); // error: bad pun


### PR DESCRIPTION
If a class expression specifies a name, that name serves as a binding to
the class itself within the expression only.

I initially attempted to do this by converting the `Ast.Class` into a
`Ast.Statement.ClassDeclaration`, then running that through
`statement_decl` and `toplevels`, but in order to return the type from
the `expression` function, I needed to read the entry from the
environment, which doesn't work if the class expr is anonymous.

So, instead, I copied in the relevant parts of `statement_decl` and
`toplevels` into this part of the code. This kind of manual env
management inside of `expression` isn't unprecedented, but I'm open to
suggestions to improve this.

Fixes #699