### PR TITLE
Fix some DOM definition issues

### DIFF
--- a/lib/bom.js
+++ b/lib/bom.js
@@ -90,6 +90,7 @@ declare var history: History;
 
 declare class Location {
     hash: string;
+    origin: string;
     protocol: string;
     search: string;
     href: string;
@@ -130,13 +131,13 @@ declare class MutationRecord {
 declare class MutationObserver {
     constructor(callback: (arr: Array<MutationRecord>, observer: MutationObserver)=>any): void;
     observe(target: Node, options: {
-        childList: boolean;
-        attributes: boolean;
-        characterData: boolean;
-        subtree: boolean;
-        attributeOldValue: boolean;
-        characterDataOldValue: boolean;
-        attributeFilter: Array<string>;
+        childList?: ?boolean;
+        attributes?: ?boolean;
+        characterData?: ?boolean;
+        subtree?: ?boolean;
+        attributeOldValue?: ?boolean;
+        characterDataOldValue?: ?boolean;
+        attributeFilter?: ?Array<string>;
     }): void;
     takeRecords(): Array<MutationRecord>;
     disconnect(): void;

--- a/lib/bom.js
+++ b/lib/bom.js
@@ -131,13 +131,13 @@ declare class MutationRecord {
 declare class MutationObserver {
     constructor(callback: (arr: Array<MutationRecord>, observer: MutationObserver)=>any): void;
     observe(target: Node, options: {
-        childList?: ?boolean;
-        attributes?: ?boolean;
-        characterData?: ?boolean;
-        subtree?: ?boolean;
-        attributeOldValue?: ?boolean;
-        characterDataOldValue?: ?boolean;
-        attributeFilter?: ?Array<string>;
+        childList?: boolean;
+        attributes?: boolean;
+        characterData?: boolean;
+        subtree?: boolean;
+        attributeOldValue?: boolean;
+        characterDataOldValue?: boolean;
+        attributeFilter?: Array<string>;
     }): void;
     takeRecords(): Array<MutationRecord>;
     disconnect(): void;

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -122,7 +122,7 @@ declare class Node extends EventTarget {
     firstChild: Node;
     hasAttributes(): boolean;
     hasChildNodes(): boolean;
-    insertBefore(newChild: Node, refChild?: Node): Node;
+    insertBefore(newChild: Node, refChild?: ?Node): Node;
     isDefaultNamespace(namespaceURI: string): boolean;
     isEqualNode(arg: Node): boolean;
     isSameNode(other: Node): boolean;
@@ -142,6 +142,7 @@ declare class Node extends EventTarget {
     parentNode: Node;
     prefix: string;
     previousSibling: Node;
+    remove(): void;
     removeChild(oldChild: Node): Node;
     replaceChild(newChild: Node, oldChild: Node): Node;
     textContent: string;
@@ -646,13 +647,6 @@ declare class HTMLCanvasElement extends HTMLElement {
     toBlob(callback: (v: File) => void, type?: string, ...args: any): void;
 }
 
-declare class HTMLCollection {
-    [name: number]: Element;
-    length: number;
-    item(nameOrIndex?: any, optionalIndex?: any): Element;
-    namedItem(name: string): Element;
-}
-
 declare class HTMLFormElement extends HTMLElement {
     [name: string]: any;
     acceptCharset: string;
@@ -937,7 +931,7 @@ declare class HTMLSelectElement extends HTMLElement {
   value: string;
 
   add(element: HTMLElement, before?: HTMLElement): void;
-  remove(index: number): void;
+  //remove(index: number): void;
 }
 
 declare class HTMLOptionsCollection {

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -931,7 +931,7 @@ declare class HTMLSelectElement extends HTMLElement {
   value: string;
 
   add(element: HTMLElement, before?: HTMLElement): void;
-  //remove(index: number): void;
+  remove(index?: number): void;
 }
 
 declare class HTMLOptionsCollection {


### PR DESCRIPTION
I'm loving flow, but there's some issues with the DOM definitions that have been driving me crazy!

* document.location.origin was missing.
* All MutationObserverInit properties were marked as required.
* Node.insertBefore didn't allow null for second argument.
* HTMLCollection was declared as two different classes.
* Node.remove was missing. (It conflicted with HTMLSelectElement.remove, so I commented that one out. The remove method can always be called with extra arguments.)