### PR TITLE
Fix #730 + typo Uninitialized rather than Unintialized

### DIFF
--- a/src/dts/parser_dts.ml
+++ b/src/dts/parser_dts.ml
@@ -1087,7 +1087,11 @@ end = struct
         then begin
           Expect.token env T_ASSIGN;
           Some (Parse.assignment env)
-        end else None in
+        end else Ast.Pattern.(
+          match id with
+          | _, Identifier _ -> None
+          | loc, _ -> error_at env (loc, Error.NoUninitializedDestructuring); None
+        ) in
         let end_loc = match init with
         | Some expr -> fst expr
         | _ -> fst id in
@@ -1133,7 +1137,7 @@ end = struct
       Statement.VariableDeclaration.(
         List.iter (function
           | loc, { Declarator.init = None; _ } ->
-              error_at env (loc, Error.NoUnintializedConst)
+              error_at env (loc, Error.NoUninitializedConst)
           | _ -> ()
         ) (snd ret).declarations
       );

--- a/src/parser/parse_error.ml
+++ b/src/parser/parse_error.ml
@@ -50,7 +50,8 @@ type t =
   | JSXAttributeValueEmptyExpression
   | InvalidJSXAttributeValue
   | ExpectedJSXClosingTag of string
-  | NoUnintializedConst
+  | NoUninitializedConst
+  | NoUninitializedDestructuring
   | NewlineBeforeArrow
   | StrictFunctionStatement
   | AdjacentJSXElements
@@ -110,7 +111,8 @@ module PP =
       | JSXAttributeValueEmptyExpression -> "JSX attributes must only be assigned a non-empty expression"
       | InvalidJSXAttributeValue -> "JSX value should be either an expression or a quoted JSX text"
       | ExpectedJSXClosingTag name -> "Expected corresponding JSX closing tag for "^name
-      | NoUnintializedConst -> "Const must be initialized"
+      | NoUninitializedConst -> "Const must be initialized"
+      | NoUninitializedDestructuring -> "Destructuring assignment must be initialized"
       | NewlineBeforeArrow ->  "Illegal newline before arrow"
       | StrictFunctionStatement -> "In strict mode code, functions can only be"^
           " declared at top level or immediately within another function."

--- a/src/parser/parser_flow.ml
+++ b/src/parser/parser_flow.ml
@@ -946,7 +946,11 @@ end = struct
         then begin
           Expect.token env T_ASSIGN;
           Some (Parse.assignment env)
-        end else None in
+        end else Ast.Pattern.(
+          match id with
+          | _, Identifier _ -> None
+          | loc, _ -> error_at env (loc, Error.NoUninitializedDestructuring); None
+        ) in
         let end_loc = match init with
         | Some expr -> fst expr
         | _ -> fst id in
@@ -992,7 +996,7 @@ end = struct
       Statement.VariableDeclaration.(
         List.iter (function
           | loc, { Declarator.init = None; _ } ->
-              error_at env (loc, Error.NoUnintializedConst)
+              error_at env (loc, Error.NoUninitializedConst)
           | _ -> ()
         ) (snd ret).declarations
       );

--- a/src/typing/type_inference_js.ml
+++ b/src/typing/type_inference_js.ml
@@ -2799,7 +2799,7 @@ and variable cx type_params_map (loc, vdecl) = Ast.(
               Flow_js.flow cx (t, t_);
               destructuring_assignment cx t_ id
           | None ->
-              ()
+              failwith "Parser Error: Destructuring assignment should always be init."
         )
 )
 

--- a/tests/destructuring/destructuring.exp
+++ b/tests/destructuring/destructuring.exp
@@ -69,6 +69,8 @@ destructuring.js:35:27,28: string
 This type is incompatible with
 destructuring.js:35:13,18: number
 
+destructuring_init.js:1:5,9: Destructuring assignment must be initialized
+
 destructuring_param.js:5:17,17: Strict mode function may not have duplicate parameter names
 
-Found 17 errors
+Found 18 errors

--- a/tests/destructuring/destructuring.js
+++ b/tests/destructuring/destructuring.js
@@ -7,8 +7,8 @@ var {m} = {m:0};
 ({m} = {m:m});
 
 var obj;
-var {n: obj.x};
-var [obj.x];
+var {n: obj.x} = {n:3};
+var [obj.x] = ['foo'];
 
 function foo({p, z:[r]}) {
     a = p;

--- a/tests/destructuring/destructuring_init.js
+++ b/tests/destructuring/destructuring_init.js
@@ -1,0 +1,5 @@
+var {foo};
+var [bar];
+var [];
+var {};
+var [], {toz};


### PR DESCRIPTION
I have done the same changes in `parser_dts` because it seems +/- sync with `parser_flow` but I'm not sure at 100%.

Also in `destructuring.js` I added init for 2 decl. (line 10 & 11) to keep the wanted behavior (ie. `unsupported destructuring`).