### PR TITLE
Do not report function declarations as unreachable.

### DIFF
--- a/src/typing/type_inference_js.ml
+++ b/src/typing/type_inference_js.ml
@@ -1292,15 +1292,13 @@ and toplevels cx stmts =
       if uc < List.length stmts
       then (
         let msg = "unreachable code" in
-        let rec drop n lst =
-          match (n, lst) with
+        let rec drop n lst = match (n, lst) with
           | (_, []) -> []
           | (0, l) -> l
-          | (x, h :: t) -> drop (x-1) t
+          | (x, _ :: t) -> drop (pred x) t
         in
         let trailing = drop uc stmts in
-        trailing |> List.iter Ast.Statement.(fun stmt ->
-          match stmt with
+        trailing |> List.iter Ast.Statement.(function
           (* function declarations are hoisted, so not unreachable *)
           | (_, FunctionDeclaration _ ) -> ()
           (* TODO also skip variable declarations if they do not have

--- a/src/typing/type_inference_js.ml
+++ b/src/typing/type_inference_js.ml
@@ -1302,15 +1302,7 @@ and toplevels cx stmts =
         trailing |> List.iter Ast.Statement.(fun stmt ->
           match stmt with
           (* function declarations are hoisted, so not unreachable *)
-          | (_, FunctionDeclaration {
-                FunctionDeclaration.id;
-                params; defaults; rest;
-                body;
-                returnType;
-                typeParameters;
-                async;
-                _
-              } ) -> ()
+          | (_, FunctionDeclaration _ ) -> ()
           (* TODO also skip variable declarations if they do not have
                   any assignments *)
           | (loc, _) -> Flow_js.add_warning cx [mk_reason "" loc, msg]

--- a/src/typing/type_inference_js.ml
+++ b/src/typing/type_inference_js.ml
@@ -1301,8 +1301,13 @@ and toplevels cx stmts =
         trailing |> List.iter Ast.Statement.(function
           (* function declarations are hoisted, so not unreachable *)
           | (_, FunctionDeclaration _ ) -> ()
-          (* TODO also skip variable declarations if they do not have
-                  any assignments *)
+          (* variable declarations are hoisted, but associated assignments are not,
+             so skip variable declarations with no assignments.
+             Note: this does not seem like a practice anyone would use *)
+          | (_, VariableDeclaration d ) when VariableDeclaration.(d.declarations |>
+              List.for_all Declarator.(function
+              | (_, { init = None }) -> true
+              | _ -> false)) -> ()
           | (loc, _) -> Flow_js.add_warning cx [mk_reason "" loc, msg]
         )
       );

--- a/tests/abnormal/abnormal.exp
+++ b/tests/abnormal/abnormal.exp
@@ -1,5 +1,2 @@
 
-unreachable.js:3:5,14: 
-unreachable code
-
-Found 1 error
+Found 0 errors

--- a/tests/abnormal/unreachable.js
+++ b/tests/abnormal/unreachable.js
@@ -1,4 +1,0 @@
-function foo() {
-    return;
-    var x = 1;
-}

--- a/tests/unreachable/unreachable.exp
+++ b/tests/unreachable/unreachable.exp
@@ -2,7 +2,10 @@
 unreachable.js:13:13,15:3: 
 unreachable code
 
-unreachable.js:21:11,11: 
+unreachable.js:22:11,11: 
 unreachable code
 
-Found 2 errors
+unreachable.js:24:11,11: 
+unreachable code
+
+Found 3 errors

--- a/tests/unreachable/unreachable.exp
+++ b/tests/unreachable/unreachable.exp
@@ -1,0 +1,5 @@
+
+unreachable.js:13:3,15:4: 
+unreachable code
+
+Found 1 error

--- a/tests/unreachable/unreachable.exp
+++ b/tests/unreachable/unreachable.exp
@@ -2,4 +2,7 @@
 unreachable.js:13:3,15:4: 
 unreachable code
 
-Found 1 error
+unreachable.js:21:3,12: 
+unreachable code
+
+Found 2 errors

--- a/tests/unreachable/unreachable.exp
+++ b/tests/unreachable/unreachable.exp
@@ -1,8 +1,8 @@
 
-unreachable.js:13:3,15:4: 
+unreachable.js:13:13,15:3: 
 unreachable code
 
-unreachable.js:21:3,12: 
+unreachable.js:21:11,11: 
 unreachable code
 
 Found 2 errors

--- a/tests/unreachable/unreachable.js
+++ b/tests/unreachable/unreachable.js
@@ -1,0 +1,19 @@
+/* @flow */
+
+function foo(x, y) {
+  "use strict";
+  return bar(x) + baz(y);
+
+  // hoisted, should not generate warning
+  function bar (ecks) {
+    return x + ecks;
+  }
+
+  // assignment not hoisted, should generate warning
+  var baz = function (why) {
+    return y + why;
+  };
+
+}
+
+foo(1, 2);

--- a/tests/unreachable/unreachable.js
+++ b/tests/unreachable/unreachable.js
@@ -4,16 +4,21 @@ function foo(x, y) {
   "use strict";
   return bar(x) + baz(y);
 
-  // hoisted, should not generate warning
+  // function declaration is hoisted, should not generate warning
   function bar (ecks) {
     return x + ecks;
   }
 
-  // assignment not hoisted, should generate warning
+  // assignment is not hoisted, should generate warning
   var baz = function (why) {
     return y + why;
   };
 
+  // variable declaration is hoisted, should not generate warning
+  var x;
+
+  // assignment is not hoisted, should generate warning
+  var y = 5;
 }
 
 foo(1, 2);

--- a/tests/unreachable/unreachable.js
+++ b/tests/unreachable/unreachable.js
@@ -15,10 +15,13 @@ function foo(x, y) {
   };
 
   // variable declaration is hoisted, should not generate warning
-  var x;
+  var x, y, z;
 
-  // assignment is not hoisted, should generate warning
-  var y = 5;
+  // assignments are not hoisted, should generate 2 warnings
+  var t,
+      u = 5,
+      v,
+      w = 7;
 }
 
 foo(1, 2);


### PR DESCRIPTION
See #125 

This should fix the warning for hoisted functions. I'm having some trouble with types for also skipping a warning on variable declarations that have no assignment, so I will deal with that separately.

This is my first ever OCaml, and my first ML in a few years, so please let me know how I could have written it better.

I haven't added any tests yet, I've just been manually running it against a file like this:

```
/* @flow */

function foo(x, y) {
  "use strict";
  return bar(x) + baz(y);

  // should not generate warning
  function bar (ecks) {
    return x + ecks;
  }

  // should generate warning
  var baz = function (why) {
    return y + why;
  }

  // should not generate warning
  var z;

  // should generate warning
  var w = 'w';
}

foo(1, 2);
```
