### PR TITLE
React.cloneElement attribute param type should be $Shape<P>

### DIFF
--- a/lib/react.js
+++ b/lib/react.js
@@ -113,6 +113,12 @@ declare module react {
   // compiler magic
   declare function createClass(spec: any): ReactClass<any, any, any>;
 
+  declare function cloneElement<D, P, S> (
+    element: ReactElement<D, P, S>,
+    attributes: $Shape<P>,
+    children?: any
+  ): ReactElement<D, P, S>;
+
   /**
    * Methods that take an `attributes` argument of type A (= Attributes),
    * describing objects whose properties must cover (at least) the difference
@@ -121,12 +127,6 @@ declare module react {
    * attributes are merged with the default props to obtain the props of a
    * ReactElement / ReactComponent instance.
    */
-  declare function cloneElement<D, P, S, A: $Diff<P, D>> (
-    element: ReactElement<D, P, S>,
-    attributes: A,
-    children?: any
-  ): ReactElement<D, P, S>;
-
   // TODO: React DOM elements
   declare function createElement<D, P, S, A: $Diff<P, D>>(
     name: ReactClass<D, P, S>,


### PR DESCRIPTION
Since you will already have a valid element (flow will complain earlier) `cloneElement` should only take `$Shape<Props>`. You only pass the props you want to change to `cloneElement`.