### PR TITLE
Fix build caused by warn 50.

### DIFF
--- a/_tags
+++ b/_tags
@@ -1,9 +1,9 @@
-<**/*.ml*>: ocaml, warn_A, warn(-4-6-29-35-44-48), warn_error_A
-<hack/utils/*.ml*>: warn(-3-27)
-<hack/heap/*.ml*>: warn(-27-34)
-<src/commands/*.ml*>: warn(-27-32-34-45)
-<src/common/*.ml*>: warn(-27-32-34-45)
-<src/dts/*.ml*>: warn(-27-32-34-45)
-<src/parsing/*.ml*>: warn(-27-32-34-45)
-<src/server/*.ml*>: warn(-27-32-34-45)
-<src/typing/*.ml*>: warn(-27-32-34-45)
+<**/*.ml*>: ocaml, warn_A, warn(-4-6-29-35-44-48-50), warn_error_A
+<hack/utils/*.ml*>: warn(-3-27-50)
+<hack/heap/*.ml*>: warn(-27-34-50)
+<src/commands/*.ml*>: warn(-27-32-34-45-50)
+<src/common/*.ml*>: warn(-27-32-34-45-50)
+<src/dts/*.ml*>: warn(-27-32-34-45-50)
+<src/parsing/*.ml*>: warn(-27-32-34-45-50)
+<src/server/*.ml*>: warn(-27-32-34-45-50)
+<src/typing/*.ml*>: warn(-27-32-34-45-50)


### PR DESCRIPTION
The build is currently broken because of `warn 50`.

`warn 50` was introduced in ocaml 4.02.2 with the PR#149, documentation comments are since attached to parsetree, so they should be on expected places.
Flow use a lot of documentation comments but it seems it's more for having a different color in text editors ?

The travis build for 4.01.0 seems to be also broken but it's weird because `warn 50` comes from 4.02.2 :/