### PR TITLE
Call Daemon.check_entry_point ASAP

### DIFF
--- a/src/flow.ml
+++ b/src/flow.ml
@@ -56,6 +56,8 @@ end = struct
   let commands = ShellCommand.command :: commands
 
   let main () =
+    Daemon.check_entry_point (); (* this call might not return *)
+
     Sys.set_signal Sys.sigpipe Sys.Signal_ignore;
     let default_command = DefaultCommand.command in
     let argv = Array.to_list Sys.argv in


### PR DESCRIPTION
`Daemon.spawn` sets an environment variable and then calls `flow`, expecting to hit a call to `Daemon.check_entry_point ()` which will hijack execution to call into the "entry point" specified in the environment variable.

We weren't calling `Daemon.check_entry_point ()`. Hack calls it in `serverMain.ml`, but since they have separate client and server binaries, `serverMain.ml` gets hit. our server codepath doesn't get hit unless you call `flow server`; everything else is a client command that execs `flow server`, so we have to do this right upfront.