### PR TITLE
Use full path to executable in Daemon.spawn

### DIFF
--- a/hack/utils/daemon.ml
+++ b/hack/utils/daemon.ml
@@ -173,10 +173,8 @@ let spawn
           fn)  in
   let out_fd =
     Unix.openfile out_path [Unix.O_WRONLY; Unix.O_CREAT; Unix.O_TRUNC] 0o666 in
-  let pid =
-    Unix.create_process
-      Sys.executable_name [|Sys.executable_name|]
-      null_fd out_fd out_fd in
+  let exe = Sys_utils.executable_path () in
+  let pid = Unix.create_process exe [|exe|] null_fd out_fd out_fd in
   Option.iter reason ~f:(fun reason -> PidLog.log ~reason pid);
   Unix.close child_in;
   Unix.close child_out;


### PR DESCRIPTION
(**note**: this PR should be against hack directly, but my plane is landing, I don't have an hhvm checkout, and I'll probably be off the grid for the next couple days so I wanted to get it out)

`argv[0]` is not always correct enough to find the binary. One repro we've found so far is when you have an unexpanded `~` in `PATH`, e.g. `PATH='~/flow/bin/':/usr/bin flow ...` (note the single quotes). Bash does expansion to find `~/flow/bin/flow`, but when ocaml reads `PATH`, it just sees `~/flow/bin/` and doesn't do any expansion, so can't find the executable.

`Sys_utils.executable_path ()` does the expansion.

One concern is that this may not be Windows compatible. However, switching to `Daemon.spawn` caused flow to regress because of this, so we should probably fix it and then unbreak Windows if necessary.