### PR TITLE
Warn when rest parameters are annotated with a tuple type

### DIFF
--- a/src/typing/type_inference_js.ml
+++ b/src/typing/type_inference_js.ml
@@ -933,7 +933,7 @@ and mk_rest cx = function
   | ArrT (_, t, []) -> RestT t
   | AnyT _ as t -> RestT t
   | ArrT (r, t, _) ->
-      let msg = "Tuple type should not be used to annotate rest parameters" in
+      let msg = "rest parameters should be an array type, got a tuple type instead" in
       Flow_js.add_warning cx [r,msg];
       RestT t
   | t ->

--- a/src/typing/type_inference_js.ml
+++ b/src/typing/type_inference_js.ml
@@ -930,8 +930,12 @@ and convert_qualification ?(lookup_mode=ForType) cx reason_prefix
 )
 
 and mk_rest cx = function
-  | ArrT(_, t, []) -> RestT t
+  | ArrT (_, t, []) -> RestT t
   | AnyT _ as t -> RestT t
+  | ArrT (r, t, _) ->
+      let msg = "Tuple type should not be used to annotate rest parameters" in
+      Flow_js.add_warning cx [r,msg];
+      RestT t
   | t ->
       (* unify t with Array<e>, return (RestT e) *)
       let reason = prefix_reason "element of " (reason_of_t t) in

--- a/tests/function/function.exp
+++ b/tests/function/function.exp
@@ -12,6 +12,6 @@ This type is incompatible with
 function.js:31:10,17: function type
 
 rest.js:8:31,33: tuple type
-Tuple type should not be used to annotate rest parameters
+rest parameters should be an array type, got a tuple type instead
 
 Found 4 errors

--- a/tests/function/function.exp
+++ b/tests/function/function.exp
@@ -11,4 +11,7 @@ function.js:31:21,21: object type
 This type is incompatible with
 function.js:31:10,17: function type
 
-Found 3 errors
+rest.js:8:31,33: tuple type
+Tuple type should not be used to annotate rest parameters
+
+Found 4 errors

--- a/tests/function/rest.js
+++ b/tests/function/rest.js
@@ -1,0 +1,20 @@
+/* regression tests */
+
+function rest_array<T>(...xs: Array<T>): T {
+  return xs[0];
+}
+
+// Warn, singleton tuple types don't represent rest params
+function rest_tuple<T>(...xs: [T]): T {
+  return xs[0];
+}
+
+function rest_any(...xs: any): any {
+  return xs[0];
+}
+
+/* TODO -- mk_rest unifies T with Array<tvar>, but T is BoundT
+function rest_t<U, T: Array<U>>(...xs: T): U {
+  return xs[0];
+}
+*/


### PR DESCRIPTION
Before this change, annotating a rest parameter with a tuple type could
lead to an ugly exception, "Did not expect BoundT"

Instead, warn the user when this pattern occurs, because a tuple type
does not represent rest parameters well. The tuple type implies a fixed
number of elements, but there can be any number of rest parameters, by
definition.

While debugging this, I also noticed an issue with bound type parameters
in another rest parameter use case: `fn<T>(...xs: T)`. Currently, this
also throws the ugly exception, but it's a bit tricker to resolve
because the error is thrown from the unification that occurs before the
type param can be substituted.

Fixes #762