### PR TITLE
Filter instance and class types when checking non-existence

### DIFF
--- a/src/typing/flow_js.ml
+++ b/src/typing/flow_js.ml
@@ -3986,10 +3986,13 @@ and filter_not_exists t = match t with
   | StrT (r, (Literal _ | Truthy))
   | ArrT (r, _, _)
   | ObjT (r, _)
+  | InstanceT (r, _, _, _)
   | AnyObjT r
   | FunT (r, _, _, _)
   | AnyFunT r
   | NumT (r, (Literal _ | Truthy)) -> UndefT r
+
+  | ClassT t -> UndefT (reason_of_t t)
 
   (* unknown boolies become falsy *)
   | MaybeT t ->

--- a/tests/refinements/exists.js
+++ b/tests/refinements/exists.js
@@ -1,0 +1,15 @@
+declare class Foo {
+  foo: string;
+}
+
+function foo0(x: ?string): string {
+  return x && x || "";
+}
+
+function foo1(x: ?Foo): string {
+  return x && x.foo || "";
+}
+
+function foo2(x: ?Class<Foo>): string {
+  return x && new x().foo || "";
+}


### PR DESCRIPTION
Values of these types will always be "truthy" in a conditional
expression.

Fixes #757