### PR TITLE
Widen type for shadow-bound var in merged-env scenarios

### DIFF
--- a/src/typing/env_js.ml
+++ b/src/typing/env_js.ml
@@ -448,6 +448,8 @@ let init_value_entry kind cx name ~has_anno specific reason =
   | Var, Value ({ kind = Var; _ } as v)
   | Let _, Value ({ kind = Let _; value_state = Undeclared | Declared; _ } as v)
   | Const, Value ({ kind = Const; value_state = Undeclared | Declared; _ } as v) ->
+    if kind = Var && v.value_state = Initialized
+    then ignore (add_change_var name);
     (* NOTE: causes havocing in some cases, so, reentrant *)
     Flow_js.flow cx (specific, v.general);
     let value_binding = { v with value_state = Initialized; specific } in

--- a/tests/locals/locals.exp
+++ b/tests/locals/locals.exp
@@ -43,4 +43,8 @@ locals.js:10:25,30: string
 This type is incompatible with
 locals.js:6:17,20: boolean
 
-Found 10 errors
+locals.js:20:13,14: string
+This type is incompatible with
+locals.js:17:25,30: number
+
+Found 11 errors

--- a/tests/locals/locals.js
+++ b/tests/locals/locals.js
@@ -13,3 +13,11 @@ function sorry(really: bool) {
     }
     foo(x);
 }
+
+function foo0(b: bool): number {
+  var x = 0;
+  if (b) {
+    var x = ""; // error: string ~> number
+  }
+  return x;
+}


### PR DESCRIPTION
Before this change, the included test case did not produce any errors,
when in fact the returned type may be widened.

In order to widen the type of x, we need to add an entry to the
changeset, so the specific value for that binding in the merged-in env
is added as a lower bound in the merged-to env.

For "normal" assignment, e.g., `x = ""`, we go through `set_var` which
does add a changeset entry. A redeclaration, however, bypasses `set_var`.