### PR TITLE
let/const

### DIFF
--- a/src/typing/constraint_js.ml
+++ b/src/typing/constraint_js.ml
@@ -682,11 +682,13 @@ module Scope = struct
 
     and implicit_let_kinds =
       | ClassNameBinding
+      | CatchParamBinding
 
     let string_of_value_kind = function
     | Const -> "const"
     | Let None -> "let"
     | Let (Some ClassNameBinding) -> "class"
+    | Let (Some CatchParamBinding) -> "catch"
     | Var -> "var"
 
     type value_binding = {

--- a/src/typing/constraint_js.ml
+++ b/src/typing/constraint_js.ml
@@ -683,12 +683,14 @@ module Scope = struct
     and implicit_let_kinds =
       | ClassNameBinding
       | CatchParamBinding
+      | FunctionBinding
 
     let string_of_value_kind = function
     | Const -> "const"
     | Let None -> "let"
     | Let (Some ClassNameBinding) -> "class"
     | Let (Some CatchParamBinding) -> "catch"
+    | Let (Some FunctionBinding) -> "function"
     | Var -> "var"
 
     type value_binding = {

--- a/src/typing/constraint_js.ml
+++ b/src/typing/constraint_js.ml
@@ -767,6 +767,13 @@ module Scope = struct
         else Value { v with specific = make_specific v.general }
       | Type _ -> entry
 
+    let is_lex = function
+      | Type _ -> false
+      | Value v ->
+        match v.kind with
+        | Const -> true
+        | Let _ -> true
+        | _ -> false
   end
 
   (* keys for refinements *)
@@ -906,6 +913,10 @@ module Scope = struct
     | Some f -> scope |> update_entries (Entry.havoc ~name f)
     | None -> ()
 
+  let is_lex scope =
+    match scope.kind with
+    | LexScope -> true
+    | _ -> false
 end
 
 (***************************************)

--- a/src/typing/constraint_js.mli
+++ b/src/typing/constraint_js.mli
@@ -292,6 +292,7 @@ module Scope: sig
     and implicit_let_kinds =
       | ClassNameBinding
       | CatchParamBinding
+      | FunctionBinding
 
     val string_of_value_kind: value_kind -> string
 

--- a/src/typing/constraint_js.mli
+++ b/src/typing/constraint_js.mli
@@ -329,6 +329,8 @@ module Scope: sig
 
     val string_of_kind: t -> string
     val havoc: ?name:string -> (Type.t -> Type.t) -> string -> t -> t
+
+    val is_lex: t -> bool
   end
 
   module Key: sig
@@ -381,6 +383,7 @@ module Scope: sig
 
   val havoc: ?name: string -> ?make_specific: (Type.t -> Type.t) -> t -> unit
 
+  val is_lex: t -> bool
 end
 
 (***************************************)

--- a/src/typing/constraint_js.mli
+++ b/src/typing/constraint_js.mli
@@ -289,7 +289,9 @@ module Scope: sig
     val string_of_state: state -> string
 
     type value_kind = Const | Let of implicit_let_kinds option | Var
-    and implicit_let_kinds = ClassNameBinding
+    and implicit_let_kinds =
+      | ClassNameBinding
+      | CatchParamBinding
 
     val string_of_value_kind: value_kind -> string
 

--- a/src/typing/env_js.ml
+++ b/src/typing/env_js.ml
@@ -761,9 +761,11 @@ let merge_env =
         (* ...in which case we can forget them *)
         ()
       (* changeset entry exists only in lex scope *)
-      | None, None, Some e when is_lex scope2 && Entry.is_lex e ->
+      | None, Some _, Some _ when is_lex scope1 && is_lex scope2 ->
         ()
-      | None, Some e, None when is_lex scope1 && Entry.is_lex e ->
+      | None, Some _, None when is_lex scope1 ->
+        ()
+      | None, None, Some _ when is_lex scope2 ->
         ()
       (* otherwise, non-refinement uneven distributions are asserts. *)
       | orig, child1, child2 ->

--- a/src/typing/env_js.ml
+++ b/src/typing/env_js.ml
@@ -824,7 +824,7 @@ let copy_env  = Entry.(
   let rec copy_entry cx reason (env1, env2) name =
     match env1, env2 with
 
-    | scope1 :: env1_, scope2 :: env2_ -> Scope.(
+    | scope1 :: env1, scope2 :: env2 -> Scope.(
       match get_entry name scope1, get_entry name scope2 with
 
       | Some (Value _ as v1), Some (Value _ as v2) ->
@@ -842,10 +842,10 @@ let copy_env  = Entry.(
 
       | None, None ->
         (* not found, try outer scopes *)
-        copy_entry cx reason (env1_, env2_) name
+        copy_entry cx reason (env1, env2) name
 
       (* global lookups may leave new entries in env2 *)
-      | None, Some _ when env1_ = [] ->
+      | None, Some _ when env1 = [] ->
         (* ...in which case we can forget it *)
         ()
 
@@ -854,12 +854,6 @@ let copy_env  = Entry.(
         ()
       | Some e, None when is_lex scope1 && Entry.is_lex e ->
         ()
-
-      (* walk through uneven lex scopes *)
-      | Some _, None when is_lex scope2 ->
-        copy_entry cx reason (env1, env2_) name
-      | None, Some _ when is_lex scope1 ->
-        copy_entry cx reason (env1_, env2) name
 
       | entry1, entry2 ->
         (* uneven distributions *)

--- a/src/typing/env_js.ml
+++ b/src/typing/env_js.ml
@@ -300,7 +300,7 @@ let find_entry_in_var_scope name =
 
 (* Search for the scope which holds the given refinement, through
    the topmost LexScopes and up to the first VarScope. If the
-   entry is not found, return the VarScope where we terminated. *)
+   entry is not found, return None. *)
 let find_refi_in_var_scope key =
   let rec loop = function
     | [] -> assert_false "empty scope list"

--- a/src/typing/env_js.ml
+++ b/src/typing/env_js.ml
@@ -343,7 +343,7 @@ let already_bound_error =
 let bind_entry cx name entry =
   (* lex scopes can only hold let/const bindings
    * var scopes can hold all bindings
-   * type entries should not be scoped -- hoist to outermost scope *)
+   * type entries are hoisted to var scope *)
   let rec find_scope = function
     | [] -> assert_false "empty scope list"
     | scope::scopes -> Scope.(

--- a/src/typing/env_js.ml
+++ b/src/typing/env_js.ml
@@ -765,11 +765,6 @@ let merge_env =
         ()
       | None, Some e, None when is_lex scope1 && Entry.is_lex e ->
         ()
-      (* walk through uneven lex scopes *)
-      | Some _, Some _, None when is_lex scope2 ->
-        merge_entry cx reason (env0, env1, env2_) name
-      | Some _, None, Some _ when is_lex scope1 ->
-        merge_entry cx reason (env0, env1_, env2) name
       (* otherwise, non-refinement uneven distributions are asserts. *)
       | orig, child1, child2 ->
         let print_entry_kind_opt = function

--- a/src/typing/env_js.ml
+++ b/src/typing/env_js.ml
@@ -734,12 +734,12 @@ let merge_env =
     match env0, env1, env2 with
     | [], [], [] ->
       ()
-    | scope0 :: env0_, scope1 :: env1_, scope2 :: env2_ -> Scope.(
+    | scope0 :: env0, scope1 :: env1, scope2 :: env2 -> Scope.(
       let get = get_entry name in
       match get scope0, get scope1, get scope2 with
       (* entry not found in this scope - recurse *)
       | None, None, None ->
-        merge_entry cx reason (env0_, env1_, env2_) name
+        merge_entry cx reason (env0, env1, env2) name
       (* merge child value types back to original *)
       | Some (Value v as orig),
         Some (Value _ as child1), Some (Value _ as child2) ->
@@ -757,7 +757,7 @@ let merge_env =
           (string_of_reason reason)
           name)
       (* global lookups may leave new entries in one or both child envs *)
-      | None, _, _ when env0_ = [] ->
+      | None, _, _ when env0 = [] ->
         (* ...in which case we can forget them *)
         ()
       (* changeset entry exists only in lex scope *)

--- a/src/typing/env_js.ml
+++ b/src/typing/env_js.ml
@@ -284,9 +284,9 @@ let find_entry cx name reason =
   in
   loop !scopes
 
-(* Look for scope that holds binding for a given name, though the
+(* Search for the scope which binds the given name, through the
    topmost LexScopes and up to the first VarScope. If the entry
-   is not found, still return the VarScope where we terminated. *)
+   is not found, return the VarScope where we terminated. *)
 let find_entry_in_var_scope name =
   let rec loop = function
     | [] -> assert_false "empty scope list"
@@ -298,23 +298,9 @@ let find_entry_in_var_scope name =
   in
   loop !scopes
 
-(* Look for scope that holds binding for a given name, though the
-   topmost LexScopes and up to the first VarScope. If the entry
-   is not found, still return the VarScope where we terminated. *)
-let find_entry_in_var_scope name =
-  let rec loop = function
-    | [] -> assert_false "empty scope list"
-    | scope::scopes ->
-        match Scope.get_entry name scope, scope.kind with
-        | Some entry, _ -> scope, Some entry
-        | None, VarScope _ -> scope, None
-        | None, LexScope -> loop scopes
-  in
-  loop !scopes
-
-(* Look for scope that holds refinement for a given key, through
+(* Search for the scope which holds the given refinement, through
    the topmost LexScopes and up to the first VarScope. If the
-   refinement is not found, return None. *)
+   entry is not found, return the VarScope where we terminated. *)
 let find_refi_in_var_scope key =
   let rec loop = function
     | [] -> assert_false "empty scope list"

--- a/src/typing/env_js.ml
+++ b/src/typing/env_js.ml
@@ -346,7 +346,7 @@ let already_bound_error =
 let bind_entry cx name entry reason =
   (* lex scopes can only hold let/const bindings
    * var scopes can hold all bindings
-   * var scopes can't shadow lex bindings
+   * var bindings can't shadow lex bindings
    * type entries are hoisted to var scope *)
   let rec find_scope = function
     | [] -> assert_false "empty scope list"

--- a/src/typing/env_js.mli
+++ b/src/typing/env_js.mli
@@ -92,7 +92,7 @@ val init_type: context -> string -> Type.t -> reason -> unit
 val pseudo_init_declared_type: context -> string -> reason -> unit
 
 module LookupMode: sig
-  type t = ForValue | ForType | ForTypeof
+  type t = ForValue | ForUpdate | ForType | ForTypeof
 end
 
 val get_var: ?lookup_mode:LookupMode.t -> context -> string ->

--- a/src/typing/env_js.mli
+++ b/src/typing/env_js.mli
@@ -59,6 +59,7 @@ val bind_implicit_let:
     -> Type.t
     -> reason
     -> unit
+val bind_fun: ?state:Entry.state -> context -> string -> Type.t -> reason -> unit
 val bind_const: ?state:Entry.state -> context -> string -> Type.t -> reason -> unit
 val bind_type: context -> string -> Type.t -> reason -> unit
 
@@ -84,6 +85,7 @@ val init_implicit_let:
     -> Type.t
     -> reason
     -> unit
+val init_fun: context -> string -> Type.t -> reason -> unit
 val init_const: context -> string -> has_anno:bool -> Type.t -> reason -> unit
 val init_type: context -> string -> Type.t -> reason -> unit
 

--- a/src/typing/env_js.mli
+++ b/src/typing/env_js.mli
@@ -39,6 +39,10 @@ val push_env: context -> Scope.t -> unit
 
 val pop_env: unit -> unit
 
+val push_lex: unit -> unit
+
+val pop_lex: unit -> unit
+
 val init_env: context -> Scope.t -> unit
 
 val update_env: context -> Scope.t list -> unit
@@ -123,8 +127,6 @@ val widen_env: context -> reason -> unit
 val copy_env: context -> reason ->
   Scope.t list * Scope.t list ->
   changeset -> unit
-
-val let_env: string -> Entry.t -> (unit -> 'a) -> unit
 
 val havoc_all: unit -> unit
 

--- a/src/typing/env_js.mli
+++ b/src/typing/env_js.mli
@@ -49,20 +49,20 @@ val update_env: context -> Scope.t list -> unit
 
 (***)
 
-val bind_var: ?state:Entry.state -> context -> string -> Type.t -> Loc.t -> unit
-val bind_let: ?state:Entry.state -> context -> string -> Type.t -> Loc.t -> unit
+val bind_var: ?state:Entry.state -> context -> string -> Type.t -> reason -> unit
+val bind_let: ?state:Entry.state -> context -> string -> Type.t -> reason -> unit
 val bind_implicit_let:
   ?state:Entry.state
     -> Entry.implicit_let_kinds
     -> context
     -> string
     -> Type.t
-    -> Loc.t
+    -> reason
     -> unit
-val bind_const: ?state:Entry.state -> context -> string -> Type.t -> Loc.t -> unit
-val bind_type: context -> string -> Type.t -> Loc.t -> unit
+val bind_const: ?state:Entry.state -> context -> string -> Type.t -> reason -> unit
+val bind_type: context -> string -> Type.t -> reason -> unit
 
-val bind_declare_var: context -> string -> Type.t -> Loc.t -> unit
+val bind_declare_var: context -> string -> Type.t -> reason -> unit
 val bind_declare_fun: context -> string -> Type.t -> reason -> unit
 
 val declare_const: context -> string -> reason -> unit

--- a/src/typing/flow_js.ml
+++ b/src/typing/flow_js.ml
@@ -3277,6 +3277,10 @@ and flow_addition cx trace reason l r u =
   | (NumT _, StrT _) ->
     rec_flow cx trace (StrT.why reason, u)
 
+  | (AnyT _, _)
+  | (_, AnyT _) ->
+    rec_flow cx trace (AnyT.why reason, u)
+
   | (MixedT _, _)
   | (_, MixedT _) ->
     rec_flow cx trace (MixedT.why reason, u)

--- a/src/typing/type_inference_js.ml
+++ b/src/typing/type_inference_js.ml
@@ -1350,8 +1350,13 @@ and statement cx type_params_map = Ast.Statement.(
           Env_js.push_lex ();
           Scope.Entry.(Env_js.bind_implicit_let
             ~state:Initialized CatchParamBinding cx name t r);
-          List.iter (statement_decl cx type_params_map) b.Block.body;
-          toplevels cx type_params_map b.Block.body;
+          Abnormal.exception_handler
+            (fun () ->
+              List.iter (statement_decl cx type_params_map) b.Block.body;
+              toplevels cx type_params_map b.Block.body)
+            (fun exn ->
+              Env_js.pop_lex ();
+              Abnormal.raise_exn exn);
           Env_js.pop_lex ()
 
       | loc, Identifier (_, { Ast.Identifier.name; _ }) ->

--- a/src/typing/type_inference_js.ml
+++ b/src/typing/type_inference_js.ml
@@ -1136,7 +1136,7 @@ and statement_decl cx type_params_map = Ast.Statement.(
         let r = mk_reason (spf "%sfunction %s"
           (if async then "async " else "") name) loc in
         let tvar = Flow_js.mk_tvar cx r in
-        Env_js.bind_var cx name tvar r
+        Env_js.bind_fun cx name tvar r
       | None -> failwith (
           "Flow Error: Nameless function declarations should always be given " ^
           "an implicit name before they get hoisted!"
@@ -2101,7 +2101,7 @@ and statement cx type_params_map = Ast.Statement.(
       Hashtbl.replace cx.type_table loc fn_type;
       (match id with
       | Some(_, {Ast.Identifier.name; _ }) ->
-        Env_js.init_var cx name ~has_anno:false fn_type reason
+        Env_js.init_fun cx name fn_type reason
       | None -> ())
 
   | (loc, DeclareVariable { DeclareVariable.id; })

--- a/tests/binding/binding.exp
+++ b/tests/binding/binding.exp
@@ -1,39 +1,127 @@
 
-rebinding.js:19:8,8: A
+rebinding.js:16:8,8: A
 name is already bound
-rebinding.js:18:8,8: type A
+rebinding.js:15:8,8: type A
 
-rebinding.js:24:9,9: A
+rebinding.js:21:9,9: A
 name is already bound
-rebinding.js:23:8,8: type A
+rebinding.js:20:8,8: type A
 
-rebinding.js:34:7,7: A
+rebinding.js:26:7,7: A
 name is already bound
-rebinding.js:33:8,8: type A
+rebinding.js:25:8,8: type A
 
-rebinding.js:39:3,3: A
+rebinding.js:31:9,9: A
+name is already bound
+rebinding.js:30:8,8: type A
+
+rebinding.js:36:7,7: A
+name is already bound
+rebinding.js:35:8,8: type A
+
+rebinding.js:41:3,3: A
 type alias referenced from value position
-rebinding.js:38:8,8: type A
+rebinding.js:40:8,8: type A
 
-rebinding.js:45:8,8: A
+rebinding.js:48:8,8: A
 name is already bound
-rebinding.js:44:9,9: class A
+rebinding.js:47:9,9: class A
 
-rebinding.js:50:9,9: A
+rebinding.js:53:9,9: A
 name is already bound
-rebinding.js:49:9,9: class A
+rebinding.js:52:9,9: class A
 
-rebinding.js:60:7,7: A
+rebinding.js:58:7,7: A
 name is already bound
-rebinding.js:59:9,9: class A
+rebinding.js:57:9,9: class A
 
-rebinding.js:94:8,8: A
+rebinding.js:63:9,9: A
 name is already bound
-rebinding.js:93:7,7: var A
+rebinding.js:62:9,9: class A
 
-rebinding.js:99:9,9: A
+rebinding.js:68:7,7: A
 name is already bound
-rebinding.js:98:7,7: var A
+rebinding.js:67:9,9: class A
+
+rebinding.js:75:8,8: A
+name is already bound
+rebinding.js:74:7,7: let A
+
+rebinding.js:80:9,9: A
+name is already bound
+rebinding.js:79:7,7: let A
+
+rebinding.js:85:7,7: A
+name is already bound
+rebinding.js:84:7,7: let A
+
+rebinding.js:90:9,9: A
+name is already bound
+rebinding.js:89:7,7: let A
+
+rebinding.js:95:7,7: A
+name is already bound
+rebinding.js:94:7,7: let A
+
+rebinding.js:102:8,8: A
+name is already bound
+rebinding.js:101:9,9: const A
+
+rebinding.js:107:9,9: A
+name is already bound
+rebinding.js:106:9,9: const A
+
+rebinding.js:112:7,7: A
+name is already bound
+rebinding.js:111:9,9: const A
+
+rebinding.js:117:9,9: A
+name is already bound
+rebinding.js:116:9,9: const A
+
+rebinding.js:122:7,7: A
+name is already bound
+rebinding.js:121:9,9: const A
+
+rebinding.js:127:3,3: A
+const cannot be reassigned
+rebinding.js:126:9,9: const A
+
+rebinding.js:134:8,8: A
+name is already bound
+rebinding.js:133:7,7: var A
+
+rebinding.js:139:9,9: A
+name is already bound
+rebinding.js:138:7,7: var A
+
+rebinding.js:144:7,7: A
+name is already bound
+rebinding.js:143:7,7: var A
+
+rebinding.js:149:9,9: A
+name is already bound
+rebinding.js:148:7,7: var A
+
+scope.js:6:13,14: string
+This type is incompatible with
+scope.js:3:10,15: number
+
+scope.js:16:15,16: string
+This type is incompatible with
+scope.js:12:10,15: number
+
+scope.js:42:16,17: string
+This type is incompatible with
+scope.js:41:10,15: number
+
+scope.js:52:12,12: string
+This type is incompatible with
+scope.js:51:10,15: number
+
+scope.js:60:31,36: string
+This type is incompatible with
+scope.js:61:10,15: number
 
 tdz.js:33:8,8: identifier C
 Could not resolve name
@@ -46,4 +134,4 @@ tdz.js:49:5,13: undefined
 This type is incompatible with
 tdz.js:49:8,13: number
 
-Found 12 errors
+Found 34 errors

--- a/tests/binding/binding.exp
+++ b/tests/binding/binding.exp
@@ -111,6 +111,10 @@ scope.js:16:15,16: string
 This type is incompatible with
 scope.js:12:10,15: number
 
+scope.js:19:11,11: a
+name is already bound
+scope.js:15:11,11: let a
+
 scope.js:42:16,17: string
 This type is incompatible with
 scope.js:41:10,15: number
@@ -134,4 +138,4 @@ tdz.js:49:5,13: undefined
 This type is incompatible with
 tdz.js:49:8,13: number
 
-Found 34 errors
+Found 35 errors

--- a/tests/binding/binding.exp
+++ b/tests/binding/binding.exp
@@ -103,6 +103,10 @@ rebinding.js:149:9,9: A
 name is already bound
 rebinding.js:148:7,7: var A
 
+rebinding.js:167:5,19: a
+name is already bound
+rebinding.js:166:5,19: function a
+
 scope.js:6:13,14: string
 This type is incompatible with
 scope.js:3:10,15: number
@@ -138,4 +142,4 @@ tdz.js:49:5,13: undefined
 This type is incompatible with
 tdz.js:49:8,13: number
 
-Found 35 errors
+Found 36 errors

--- a/tests/binding/binding.exp
+++ b/tests/binding/binding.exp
@@ -1,4 +1,52 @@
 
+const.js:4:1,1: x
+const cannot be reassigned
+const.js:1:7,7: const x
+
+const.js:5:1,1: x
+const cannot be reassigned
+const.js:1:7,7: const x
+
+const.js:6:1,1: x
+const cannot be reassigned
+const.js:1:7,7: const x
+
+const.js:7:1,1: x
+const cannot be reassigned
+const.js:1:7,7: const x
+
+const.js:8:1,1: x
+const cannot be reassigned
+const.js:1:7,7: const x
+
+const.js:9:1,1: x
+const cannot be reassigned
+const.js:1:7,7: const x
+
+const.js:10:1,1: x
+const cannot be reassigned
+const.js:1:7,7: const x
+
+const.js:11:1,1: x
+const cannot be reassigned
+const.js:1:7,7: const x
+
+const.js:12:1,1: x
+const cannot be reassigned
+const.js:1:7,7: const x
+
+const.js:13:1,1: x
+const cannot be reassigned
+const.js:1:7,7: const x
+
+const.js:14:1,1: x
+const cannot be reassigned
+const.js:1:7,7: const x
+
+const.js:15:1,1: x
+const cannot be reassigned
+const.js:1:7,7: const x
+
 rebinding.js:16:8,8: A
 name is already bound
 rebinding.js:15:8,8: type A
@@ -146,4 +194,4 @@ tdz.js:49:5,13: undefined
 This type is incompatible with
 tdz.js:49:8,13: number
 
-Found 37 errors
+Found 49 errors

--- a/tests/binding/binding.exp
+++ b/tests/binding/binding.exp
@@ -107,6 +107,10 @@ rebinding.js:167:5,19: a
 name is already bound
 rebinding.js:166:5,19: function a
 
+rebinding.js:177:11,11: x
+name is already bound
+rebinding.js:175:9,9: let x
+
 scope.js:6:13,14: string
 This type is incompatible with
 scope.js:3:10,15: number
@@ -142,4 +146,4 @@ tdz.js:49:5,13: undefined
 This type is incompatible with
 tdz.js:49:8,13: number
 
-Found 36 errors
+Found 37 errors

--- a/tests/binding/binding.exp
+++ b/tests/binding/binding.exp
@@ -159,6 +159,10 @@ rebinding.js:177:11,11: x
 name is already bound
 rebinding.js:175:9,9: let x
 
+rebinding.js:186:12,12: x
+name is already bound
+rebinding.js:184:9,9: let x
+
 scope.js:6:13,14: string
 This type is incompatible with
 scope.js:3:10,15: number
@@ -194,4 +198,4 @@ tdz.js:49:5,13: undefined
 This type is incompatible with
 tdz.js:49:8,13: number
 
-Found 49 errors
+Found 50 errors

--- a/tests/binding/const.js
+++ b/tests/binding/const.js
@@ -1,0 +1,15 @@
+const x = 0;
+
+// errors: const cannot be reassigned
+x++;
+x--;
+x += 0;
+x -= 0;
+x /= 0;
+x %= 0;
+x <<= 0
+x >>= 0;
+x >>>= 0;
+x |= 0;
+x ^= 0;
+x &= 0;

--- a/tests/binding/rebinding.js
+++ b/tests/binding/rebinding.js
@@ -153,3 +153,17 @@ function var_var() {
   var A = 0;
   var A = 0;       // OK
 }
+
+// function x *
+
+function function_toplevel() {
+  function a() {};
+  function a() {}; // OK
+}
+
+function function_block() {
+  {
+    function a() {};
+    function a() {}; // error: name already bound
+  }
+}

--- a/tests/binding/rebinding.js
+++ b/tests/binding/rebinding.js
@@ -7,9 +7,6 @@
  * const x    x   x     x   x
  * var   x    x   x
  *
- * TODO add tests using explicit let/const decls.
- * For now, we use class decls as a proxy for let,
- * and leave const out entirely.
  */
 
 // type x *
@@ -19,15 +16,20 @@ function type_type() {
   type A = number;  // error: name already bound
 }
 
-function type_let() {
+function type_class() {
   type A = number;
   class A {}        // error: name already bound
 }
 
-/*function type_const() {
+function type_let() {
+  type A = number;
+  let A = 0;        // error: name already bound
+}
+
+function type_const() {
   type A = number;
   const A = 0;     // error: name already bound
-}*/
+}
 
 function type_var() {
   type A = number;
@@ -38,38 +40,76 @@ function type_reassign() {
   type A = number;
   A = 42;           // error: type alias ref'd from value pos
 }
-// let x *
 
-function let_type() {
+// class x *
+
+function class_type() {
   class A {}
   type A = number;  // error: name already bound
 }
 
-function let_let() {
+function class_class() {
   class A {}
   class A {}        // error: name already bound
 }
 
-/*function let_const() {
+function class_let() {
+  class A {}
+  let A = 0;        // error: name already bound
+}
+
+function class_const() {
   class A {}
   const A = 0;     // error: name already bound
-}*/
+}
 
-function let_var() {
+function class_var() {
   class A {}
   var A = 0;        // error: name already bound
 }
 
+// let x *
+
+function let_type() {
+  let A = 0;
+  type A = number;  // error: name already bound
+}
+
+function let_class() {
+  let A = 0;
+  class A {}        // error: name already bound
+}
+
+function let_let() {
+  let A = 0;
+  let A = 0;        // error: name already bound
+}
+
+function let_const() {
+  let A = 0;
+  const A = 0;     // error: name already bound
+}
+
+function let_var() {
+  let A = 0;
+  var A = 0;        // error: name already bound
+}
+
 // const x *
-/*
+
 function const_type() {
   const A = 0;
   type A = number;  // error: name already bound
 }
 
-function const_let() {
+function const_class() {
   const A = 0;
   class A {}        // error: name already bound
+}
+
+function const_let() {
+  const A = 0;
+  let A = 0;        // error: name already bound
 }
 
 function const_const() {
@@ -86,7 +126,7 @@ function const_reassign() {
   const A = 0;
   A = 42;           // error: cannot be reassigned
 }
-*/
+
 // var x *
 
 function var_type() {
@@ -94,12 +134,22 @@ function var_type() {
   type A = number;  // error: name already bound
 }
 
-function var_let() {
+function var_class() {
   var A = 0;
   class A {}        // error: name already bound
 }
 
-/*function var_const() {
+function var_let() {
+  var A = 0;
+  let A = 0;        // error: name already bound
+}
+
+function var_const() {
   var A = 0;
   const A = 0;      // error: name already bound
-}*/
+}
+
+function var_var() {
+  var A = 0;
+  var A = 0;       // OK
+}

--- a/tests/binding/rebinding.js
+++ b/tests/binding/rebinding.js
@@ -178,3 +178,12 @@ function var_shadow_nested_scope() {
     }
   }
 }
+
+function type_shadow_nested_scope() {
+  {
+    let x = 0;
+    {
+      type x = string; // error: name already bound
+    }
+  }
+}

--- a/tests/binding/rebinding.js
+++ b/tests/binding/rebinding.js
@@ -167,3 +167,14 @@ function function_block() {
     function a() {}; // error: name already bound
   }
 }
+
+// corner cases
+
+function var_shadow_nested_scope() {
+  {
+    let x = 0;
+    {
+      var x = 0; // error: name already bound
+    }
+  }
+}

--- a/tests/binding/scope.js
+++ b/tests/binding/scope.js
@@ -1,0 +1,63 @@
+function block_scope() {
+  let a: number = 0;
+  var b: number = 0;
+  {
+    let a = ""; // ok: local to block
+    var b = ""; // error: string ~> number
+  }
+}
+
+function switch_scope(x: string) {
+  let a: number = 0;
+  var b: number = 0;
+  switch (x) {
+    case "foo":
+      let a = ""; // ok: local to switch
+      var b = ""; // error: string ~> number
+      break;
+    case "bar":
+      let a = ""; // TODO error: a already bound in switch
+      break;
+  }
+}
+
+function try_scope() {
+  let a: number = 0;
+  try {
+    let a = ""; // ok
+  } catch (e) {
+    let a = ""; // ok
+  } finally {
+    let a = ""; // ok
+  }
+}
+
+function for_scope_let() {
+  let a: number = 0;
+  for (let a = "" /* ok: local to init */;;) {}
+}
+
+function for_scope_var() {
+  var a: number = 0;
+  for (var a = "" /* error: string ~> number */;;) {}
+}
+
+function for_in_scope_let(o: Object) {
+  let a: number = 0;
+  for (let a /* ok: local to init */ in o) {}
+}
+
+function for_in_scope_var(o: Object) {
+  var a: number = 0;
+  for (var a /* error: string ~> number */ in o) {}
+}
+
+function for_of_scope_let(xs: string[]) {
+  let a: number = 0;
+  for (let a /* ok: local to init */ of xs) {}
+}
+
+function for_of_scope_var(xs: string[]) {
+  var a: number = 0;
+  for (var a /* error: string ~> number */ of xs) {}
+}

--- a/tests/locals/lex.js
+++ b/tests/locals/lex.js
@@ -1,0 +1,60 @@
+function switch_scope(x: mixed) {
+  let a = "";
+  let b = "";
+  switch (x) {
+    case "foo":
+      let a;
+      a = 0; // doesn't add lower bound to outer a
+      b = 0;
+  }
+  (a : string); // OK
+  (b : string); // error: number ~> string
+}
+
+function try_scope_finally() {
+  let a;
+  let b;
+  try {
+    a = "";
+    b = "";
+  } finally {
+    let a;
+    a = 0; // doesn't add lower bound to outer a
+    b = 0;
+  }
+  (a : string); // ok
+  (b : string); // error: number ~> string
+}
+
+function for_scope() {
+  let a = "";
+  let b = "";
+  for (let a;;) {
+    a = 0; // doesn't add lower bound to outer a
+    b = 0;
+  }
+  (a : string);
+  (b : string); // error: number ~> string
+}
+
+function for_in_scope(o: Object) {
+  let a = 0;
+  let b = 0;
+  for (let a in o) {
+    a = ""; // doesn't add lower bound to outer a
+    b = "";
+  }
+  (a : number);
+  (b : number); // error: string ~> number
+}
+
+function for_of_scope(xs: number[]) {
+  let a = "";
+  let b = "";
+  for (let a of xs) {
+    a = 0; // doesn't add lower bound to outer a
+    b = 0;
+  }
+  (a : string);
+  (b : string); // error: number ~> string
+}

--- a/tests/locals/locals.exp
+++ b/tests/locals/locals.exp
@@ -1,4 +1,24 @@
 
+lex.js:8:11,11: number
+This type is incompatible with
+lex.js:11:8,13: string
+
+lex.js:26:4,4: number
+This type is incompatible with
+lex.js:26:8,13: string
+
+lex.js:34:9,9: number
+This type is incompatible with
+lex.js:37:8,13: string
+
+lex.js:45:9,10: string
+This type is incompatible with
+lex.js:48:8,13: number
+
+lex.js:56:9,9: number
+This type is incompatible with
+lex.js:59:8,13: string
+
 locals.js:1:7,12: string
 This type is incompatible with
 locals.js:2:7,12: number
@@ -43,4 +63,4 @@ locals.js:10:25,30: string
 This type is incompatible with
 locals.js:6:17,20: boolean
 
-Found 10 errors
+Found 15 errors

--- a/tests/refi/lex.js
+++ b/tests/refi/lex.js
@@ -1,0 +1,36 @@
+function block_scope(x: string | number) {
+  {
+    let x;
+    x = ""; // doesn't refine outer x
+  }
+  (x : string); // error: number ~> string
+}
+
+function switch_scope(x: string | number) {
+  switch (x) {
+    default:
+      let x;
+      x = ""; // doesn't refine outer x
+  }
+  (x : string); // error: number ~> string
+}
+
+function try_scope(x: string | number) {
+  try {
+    let x;
+    x = ""; // doesn't refine outer x
+  } catch (e) {
+    x = ""; // refinement would only escape if both sides refined
+  }
+  (x : string); // error: number ~> string
+}
+
+function try_scope_catch(x: string | number) {
+  try {
+    x = ""; // refinement would only escape if both sides refined
+  } catch (e) {
+    let x;
+    x = ""; // doesn't refine outer x
+  }
+  (x : string); // error: number ~> string
+}

--- a/tests/refi/refi.exp
+++ b/tests/refi/refi.exp
@@ -59,6 +59,22 @@ heap.js:59:17,22: undefined
 This type is incompatible with
 heap.js:62:15,20: string
 
+lex.js:1:34,39: number
+This type is incompatible with
+lex.js:6:8,13: string
+
+lex.js:9:35,40: number
+This type is incompatible with
+lex.js:15:8,13: string
+
+lex.js:18:32,37: number
+This type is incompatible with
+lex.js:25:8,13: string
+
+lex.js:28:38,43: number
+This type is incompatible with
+lex.js:35:8,13: string
+
 local.js:5:22,22: null
 This type is incompatible with
 local.js:5:13,18: string
@@ -91,4 +107,4 @@ null_tests.js:101:7,12: undefined
 This type is incompatible with
 null_tests.js:147:16,21: string
 
-Found 23 errors
+Found 27 errors


### PR DESCRIPTION
This commit allows for the creation of let/const bindings and ensures
all block-scoped bindings are installed into the appropriate scope. This
involves creating new LexScopes, as outlined in `test/bindings/scope.js`.

Before this change, the environment stack, i.e., frames, changesets, and
scopes, would change in lockstep. Now, lex scopes change separately from
frames and changesets via `push_lex` and `pop_lex`.

When adding heap refinements, we may traverse over lex scopes to find
the scope where the base object was bound.

In unusual cases, like try/catch, envs may have an uneven number of
scopes when merging. The uneven scopes will always be lex. I have
updated `merge_env` to accept this imbalance.

Note that this is not a complete implementation of let/const:
- [x] switch statements should forbid rebinding lexicals between cases
- [x] functions, amazingly, are block scoped *and* hoisted in ES2015
- [ ] numerous TDZ cases, surely, which I have not yet investigated
- [x] can't update const bindings (assignment already handled)
- [x] var bindings can not shadow a lexical binding, ever
- [x] more tests