### PR TITLE
Fix definition of Array reducers when no initial value is provided

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -156,8 +156,20 @@ declare class Array<T> {
     filter(callbackfn: (value: T, index: number, array: Array<T>) => any, thisArg?: any): Array<T>;
     find(callbackfn: (value: T, index: number, array: Array<T>) => any, thisArg?: any): T;
     findIndex(callbackfn: (value: T, index: number, array: Array<T>) => any, thisArg?: any): number;
-    reduce<U>(callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: Array<T>) => U, initialValue?: U): U;
-    reduceRight<U>(callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: Array<T>) => U, initialValue?: U): U;
+    reduce<U>(
+      callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: Array<T>) => U,
+      initialValue: U
+    ): U;
+    reduce<U>(
+      callbackfn: (previousValue: T|U, currentValue: T, currentIndex: number, array: Array<T>) => U
+    ): U;
+    reduceRight<U>(
+      callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: Array<T>) => U,
+      initialValue: U
+    ): U;
+    reduceRight<U>(
+      callbackfn: (previousValue: T|U, currentValue: T, currentIndex: number, array: Array<T>) => U
+    ): U;
     length: number;
     static (...values:Array<any>): Array<any>;
     static isArray(obj: any): bool;

--- a/tests/arraylib/array_lib.js
+++ b/tests/arraylib/array_lib.js
@@ -39,6 +39,12 @@ function reduce_test() {
   var flattened = [[0, 1], [2, 3], [4, 5]].reduce(function(a, b) {
     return a.concat(b);
   });
+
+  /* Added later, because the above is insufficient */
+
+  // acc is element type of array when no init is provided
+  [""].reduce((acc, str) => acc * str.length); // error, string ~> number
+  [""].reduceRight((acc, str) => acc * str.length); // error, string ~> number
 }
 
 function from_test() {

--- a/tests/arraylib/arraylib.exp
+++ b/tests/arraylib/arraylib.exp
@@ -41,4 +41,12 @@ array_lib.js:21:43,45: string
 This type is incompatible with
 [LIB] core.js:139:31,42: union type
 
-Found 7 errors
+array_lib.js:46:3,45: call of method reduce
+Function cannot be called on
+[LIB] core.js:163:5,10: Array
+
+array_lib.js:47:3,50: call of method reduceRight
+Function cannot be called on
+[LIB] core.js:170:5,15: Array
+
+Found 9 errors

--- a/tests/async/async.exp
+++ b/tests/async/async.exp
@@ -3,29 +3,29 @@ async.js:12:3,11: async return
 Error:
 async.js:12:10,10: number
 This type is incompatible with
-[LIB] core.js:375:32,45: union type
+[LIB] core.js:387:32,45: union type
 
 async.js:30:30,35: number
 This type is incompatible with
-[LIB] core.js:375:32,45: union type
+[LIB] core.js:387:32,45: union type
 
 async.js:45:22,25: undefined
 This type is incompatible with
-[LIB] core.js:360:1,388:1: Promise
+[LIB] core.js:372:1,400:1: Promise
 
 async2.js:6:3,12: async return
 Error:
 async2.js:6:10,11: number
 This type is incompatible with
-[LIB] core.js:375:32,45: union type
+[LIB] core.js:387:32,45: union type
 
 async2.js:29:21,24: undefined
 This type is incompatible with
-[LIB] core.js:360:1,388:1: Promise
+[LIB] core.js:372:1,400:1: Promise
 
 async2.js:43:28,31: undefined
 This type is incompatible with
-[LIB] core.js:360:1,388:1: Promise
+[LIB] core.js:372:1,400:1: Promise
 
 async2.js:48:3,17: undefined
 This type is incompatible with
@@ -35,7 +35,7 @@ async3.js:23:11,21: await
 Error:
 async3.js:12:10,11: number
 This type is incompatible with
-[LIB] core.js:375:32,45: union type
+[LIB] core.js:387:32,45: union type
 
 await_not_in_async.js:5:9,9: Unexpected number
 

--- a/tests/call_properties/call_properties.exp
+++ b/tests/call_properties/call_properties.exp
@@ -69,6 +69,6 @@ F.js:6:23,28: number
 
 F.js:9:41,51: call of method toFixed
 Property not found in
-[LIB] core.js:167:1,196:1: String
+[LIB] core.js:179:1,208:1: String
 
 Found 17 errors

--- a/tests/date/date.exp
+++ b/tests/date/date.exp
@@ -9,42 +9,42 @@ date.js:18:1,12: constructor call
 Error:
 date.js:18:10,11: object literal
 This type is incompatible with
-[LIB] core.js:217:25,39: union type
+[LIB] core.js:229:25,39: union type
 
 date.js:19:1,19: constructor call
 Error:
 date.js:19:16,18: string
 This type is incompatible with
-[LIB] core.js:217:50,55: number
+[LIB] core.js:229:50,55: number
 
 date.js:20:1,23: constructor call
 Error:
 date.js:20:19,22: string
 This type is incompatible with
-[LIB] core.js:217:64,69: number
+[LIB] core.js:229:64,69: number
 
 date.js:21:1,27: constructor call
 Error:
 date.js:21:23,26: string
 This type is incompatible with
-[LIB] core.js:217:79,84: number
+[LIB] core.js:229:79,84: number
 
 date.js:22:1,31: constructor call
 Error:
 date.js:22:27,30: string
 This type is incompatible with
-[LIB] core.js:217:96,101: number
+[LIB] core.js:229:96,101: number
 
 date.js:23:1,35: constructor call
 Error:
 date.js:23:31,34: string
 This type is incompatible with
-[LIB] core.js:217:113,118: number
+[LIB] core.js:229:113,118: number
 
 date.js:24:1,40: constructor call
 Error:
 date.js:24:35,39: string
 This type is incompatible with
-[LIB] core.js:217:135,140: number
+[LIB] core.js:229:135,140: number
 
 Found 8 errors

--- a/tests/forof/forof.exp
+++ b/tests/forof/forof.exp
@@ -9,15 +9,15 @@ forof.js:13:9,14: string
 
 forof.js:25:9,14: number
 This type is incompatible with
-[LIB] core.js:168:28,33: string
+[LIB] core.js:180:28,33: string
 
 forof.js:32:12,17: number
 This type is incompatible with
-[LIB] core.js:323:28,33: tuple type
+[LIB] core.js:335:28,33: tuple type
 
 forof.js:39:12,17: number
 This type is incompatible with
-[LIB] core.js:323:28,33: tuple type
+[LIB] core.js:335:28,33: tuple type
 
 forof.js:43:28,33: string
 This type is incompatible with

--- a/tests/generators/generators.exp
+++ b/tests/generators/generators.exp
@@ -53,7 +53,7 @@ class.js:114:1,44: call of method next
 Error:
 class.js:114:42,43: string
 This type is incompatible with
-[LIB] core.js:307:37,40: undefined
+[LIB] core.js:319:37,40: undefined
 
 generators.js:3:9,10: string
 This type is incompatible with
@@ -103,7 +103,7 @@ generators.js:95:1,35: call of method next
 Error:
 generators.js:95:33,34: string
 This type is incompatible with
-[LIB] core.js:307:37,40: undefined
+[LIB] core.js:319:37,40: undefined
 
 generators.js:97:45,50: number
 This type is incompatible with

--- a/tests/include/include.exp
+++ b/tests/include/include.exp
@@ -13,7 +13,7 @@ This type is incompatible with
 Error:
 ../lib/libtest.js:3:7,12: number
 This type is incompatible with
-[LIB] core.js:269:11,16: string
+[LIB] core.js:281:11,16: string
 
 ../lib/libtest.js:4:16,30: function call
 Error:

--- a/tests/iterable/iterable.exp
+++ b/tests/iterable/iterable.exp
@@ -17,7 +17,7 @@ caching_bug.js:21:62,67: string
 
 map.js:13:55,60: string
 This type is incompatible with
-[LIB] core.js:323:28,33: tuple type
+[LIB] core.js:335:28,33: tuple type
 
 set.js:13:28,33: string
 This type is incompatible with
@@ -29,6 +29,6 @@ set.js:13:28,33: string
 
 string.js:5:27,32: number
 This type is incompatible with
-[LIB] core.js:168:28,33: string
+[LIB] core.js:180:28,33: string
 
 Found 8 errors

--- a/tests/lib/lib.exp
+++ b/tests/lib/lib.exp
@@ -13,7 +13,7 @@ libtest.js:3:16,35: property `name`
 Error:
 libtest.js:3:7,12: number
 This type is incompatible with
-[LIB] core.js:269:11,16: string
+[LIB] core.js:281:11,16: string
 
 libtest.js:4:16,30: function call
 Error:

--- a/tests/misc/misc.exp
+++ b/tests/misc/misc.exp
@@ -55,7 +55,7 @@ F.js:5:10,17: property `length`
 Error:
 F.js:4:33,38: string
 This type is incompatible with
-[LIB] core.js:161:13,18: number
+[LIB] core.js:173:13,18: number
 
 G.js:2:12,14: number
 This type is incompatible with
@@ -69,7 +69,7 @@ G.js:6:1,8: assignment of property `length`
 Error:
 G.js:6:12,17: string
 This type is incompatible with
-[LIB] core.js:161:13,18: number
+[LIB] core.js:173:13,18: number
 
 G.js:7:1,10: call of method length
 Function cannot be called on

--- a/tests/object_api/object_api.exp
+++ b/tests/object_api/object_api.exp
@@ -81,7 +81,7 @@ object_prototype.js:122:25,33: property `valueOf`
 Error:
 object_prototype.js:122:16,21: number
 This type is incompatible with
-[LIB] core.js:223:5,21: function type
+[LIB] core.js:235:5,21: function type
 
 object_prototype.js:126:16,21: number
 This type is incompatible with
@@ -91,13 +91,13 @@ object_prototype.js:150:32,47: property `toLocaleString`
 Error:
 object_prototype.js:150:23,28: number
 This type is incompatible with
-[LIB] core.js:220:5,28: function type
+[LIB] core.js:232:5,28: function type
 
 object_prototype.js:151:39,54: property `toLocaleString`
 Error:
 object_prototype.js:151:30,35: number
 This type is incompatible with
-[LIB] core.js:220:23,28: string
+[LIB] core.js:232:23,28: string
 
 object_prototype.js:155:23,28: number
 This type is incompatible with

--- a/tests/overload/overload.exp
+++ b/tests/overload/overload.exp
@@ -3,25 +3,25 @@ overload.js:1:18,28: call of method match
 Error:
 overload.js:1:9,14: number
 This type is incompatible with
-[LIB] core.js:177:43,48: string
+[LIB] core.js:189:43,48: string
 
 overload.js:1:18,28: call of method match
 Error:
 overload.js:1:27,27: number
 This type is incompatible with
-[LIB] core.js:177:19,33: union type
+[LIB] core.js:189:19,33: union type
 
 overload.js:2:18,36: call of method match
 Error:
 overload.js:2:9,14: number
 This type is incompatible with
-[LIB] core.js:177:43,48: string
+[LIB] core.js:189:43,48: string
 
 overload.js:4:18,36: call of method split
 Error:
 overload.js:4:9,14: number
 This type is incompatible with
-[LIB] core.js:184:62,67: string
+[LIB] core.js:196:62,67: string
 
 test2.js:7:2,16: string
 This type is incompatible with

--- a/tests/promises/promises.exp
+++ b/tests/promises/promises.exp
@@ -3,78 +3,78 @@ promise.js:10:1,17:2: call of method then
 Error:
 promise.js:11:11,11: number
 This type is incompatible with
-[LIB] core.js:362:25,38: union type
+[LIB] core.js:374:25,38: union type
 
 promise.js:21:11,23:4: constructor call
 Error:
 promise.js:22:13,13: number
 This type is incompatible with
-[LIB] core.js:362:25,38: union type
+[LIB] core.js:374:25,38: union type
 
 promise.js:32:13,34:6: constructor call
 Error:
 promise.js:33:15,15: number
 This type is incompatible with
-[LIB] core.js:362:25,38: union type
+[LIB] core.js:374:25,38: union type
 
 promise.js:42:1,55:2: call of method then
 Error:
 promise.js:44:13,14: number
 This type is incompatible with
-[LIB] core.js:362:25,38: union type
+[LIB] core.js:374:25,38: union type
 
 promise.js:106:1,109:2: call of method then
 Error:
 promise.js:106:17,17: number
 This type is incompatible with
-[LIB] core.js:375:32,45: union type
+[LIB] core.js:387:32,45: union type
 
 promise.js:112:17,34: call of method resolve
 Error:
 promise.js:112:33,33: number
 This type is incompatible with
-[LIB] core.js:375:32,45: union type
+[LIB] core.js:387:32,45: union type
 
 promise.js:118:33,50: call of method resolve
 Error:
 promise.js:118:49,49: number
 This type is incompatible with
-[LIB] core.js:375:32,45: union type
+[LIB] core.js:387:32,45: union type
 
 promise.js:148:1,153:4: call of method then
 Error:
 promise.js:149:32,37: string
 This type is incompatible with
-[LIB] core.js:367:33,46: union type
+[LIB] core.js:379:33,46: union type
 
 promise.js:157:32,54: call of method resolve
 Error:
 promise.js:157:48,53: string
 This type is incompatible with
-[LIB] core.js:375:32,45: union type
+[LIB] core.js:387:32,45: union type
 
 promise.js:165:48,70: call of method resolve
 Error:
 promise.js:165:64,69: string
 This type is incompatible with
-[LIB] core.js:375:32,45: union type
+[LIB] core.js:387:32,45: union type
 
 promise.js:188:1,193:4: call of method then
 Error:
 promise.js:189:33,38: string
 This type is incompatible with
-[LIB] core.js:372:34,48: union type
+[LIB] core.js:384:34,48: union type
 
 promise.js:197:33,55: call of method resolve
 Error:
 promise.js:197:49,54: string
 This type is incompatible with
-[LIB] core.js:375:32,45: union type
+[LIB] core.js:387:32,45: union type
 
 promise.js:205:49,71: call of method resolve
 Error:
 promise.js:205:65,70: string
 This type is incompatible with
-[LIB] core.js:375:32,45: union type
+[LIB] core.js:387:32,45: union type
 
 Found 13 errors

--- a/tests/union/union.exp
+++ b/tests/union/union.exp
@@ -3,7 +3,7 @@ issue-198.js:1:9,10:6: call of method then
 Error:
 issue-198.js:5:16,28: string
 This type is incompatible with
-[LIB] core.js:367:33,46: union type
+[LIB] core.js:379:33,46: union type
 
 issue-324.js:3:7,9: Bar
 This type is incompatible with


### PR DESCRIPTION
When no initial value is provided to the reducer, the first value from
the array is provided as the initial value of the accumulator.

Before this commit, we assumed that T = U, but that's not true. The
included tests did not raise any error before this change.

The error messages are _very_ unfortunate, but bad error messages
shouldn't prevent us from fixing basic correctness issues.