### PR TITLE
Fix type widening for switch statements without break statements

### DIFF
--- a/tests/switch/switch.exp
+++ b/tests/switch/switch.exp
@@ -3,4 +3,24 @@ switch.js:23:19,20: string
 This type is incompatible with
 switch.js:28:13,15: number
 
-Found 1 error
+switch_default_fallthrough.js:9:13,13: number
+This type is incompatible with
+switch_default_fallthrough.js:5:13,14: string
+
+switch_default_fallthrough.js:11:13,13: number
+This type is incompatible with
+switch_default_fallthrough.js:6:13,14: string
+
+switch_default_fallthrough.js:23:13,13: number
+This type is incompatible with
+switch_default_fallthrough.js:32:10,15: string
+
+switch_default_fallthrough.js:28:13,13: number
+This type is incompatible with
+switch_default_fallthrough.js:33:10,15: string
+
+switch_default_fallthrough.js:35:12,14: string
+This type is incompatible with
+switch_default_fallthrough.js:17:25,30: number
+
+Found 6 errors

--- a/tests/switch/switch_default_fallthrough.js
+++ b/tests/switch/switch_default_fallthrough.js
@@ -1,0 +1,36 @@
+/**
+ * @flow
+ */
+function foo(x : mixed): string {
+    var a = "";
+    var b = "";
+    switch (x) {
+      case "foo":
+        a = 0;
+      default:
+        b = 0;
+    }
+    (a : string);
+    return b;
+}
+
+function baz(x: mixed): number {
+    var a = "";
+    var b = "";
+
+    switch (x) {
+      case "baz":
+        a = 0;
+        break;
+      case "bar":
+        a = "";
+      default:
+        b = 0;
+      
+    }
+
+    (a : string);
+    (b : string);
+
+    return a+b;
+}    


### PR DESCRIPTION
In response to #786, in switch statements without any break statements (that is, every branch falls through) where there is a default case, the type refinements from the different case branches are not preserved.

The cause for this is that after gathering type information from the branches, we wipe the changeset and have a special case for switch statements without default statements that has the side effect of adding in any of the type information we were going to wipe.  Additionally, if there was a break statement at all in the code, we havoc the variables.  This happens to leave out the case where we have a default and every case falls through.