### PR TITLE
Support `return` and `throw` generator methods

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -330,6 +330,8 @@ type Iterable<T> = $Iterable<T,void,void>;
 interface Generator<Yield,Return,Next> {
     @@iterator(): $Iterator<Yield,Return,Next>;
     next(value?: Next): IteratorResult<Yield,Return>;
+    return(value: Return): IteratorResult<Yield,Return>;
+    throw(error?: any): IteratorResult<Yield,Return>;
 }
 
 /* Maps and Sets */

--- a/lib/core.js
+++ b/lib/core.js
@@ -330,7 +330,7 @@ type Iterable<T> = $Iterable<T,void,void>;
 interface Generator<Yield,Return,Next> {
     @@iterator(): $Iterator<Yield,Return,Next>;
     next(value?: Next): IteratorResult<Yield,Return>;
-    return(value: Return): IteratorResult<Yield,Return>;
+    return<R : Return>(value: R): IteratorResult<Yield,R>;
     throw(error?: any): IteratorResult<Yield,Return>;
 }
 

--- a/src/typing/type_inference_js.ml
+++ b/src/typing/type_inference_js.ml
@@ -5695,11 +5695,11 @@ and mk_body id cx type_params_map ~async ~generator ?(derived_ctor=false)
       TypeAppT (promise, [VoidT.at loc])
     else if generator then
       (* The return value for generators can be provided by consumers via the
-         `throw` method, so it isn't correct to infer Return = VoidT in the
-         absence of a return statement. Instead, return a tvar that can go on to
-         accumulate more lower bounds. *)
+         `throw` method, so return a tvar that can go on to accumulate more
+         lower bounds. *)
       let reason = mk_reason "implicit generator return" loc in
       let ret = Flow_js.mk_tvar cx reason in
+      Flow_js.flow cx (VoidT.at loc, ret);
       Flow_js.get_builtin_typeapp cx reason "Generator" [yield; ret; next]
     else
       VoidT (mk_reason "return undefined" loc)

--- a/tests/async/async.exp
+++ b/tests/async/async.exp
@@ -3,29 +3,29 @@ async.js:12:3,11: async return
 Error:
 async.js:12:10,10: number
 This type is incompatible with
-[LIB] core.js:390:32,45: union type
+[LIB] core.js:392:32,45: union type
 
 async.js:30:30,35: number
 This type is incompatible with
-[LIB] core.js:390:32,45: union type
+[LIB] core.js:392:32,45: union type
 
 async.js:45:22,25: undefined
 This type is incompatible with
-[LIB] core.js:375:1,403:1: Promise
+[LIB] core.js:377:1,405:1: Promise
 
 async2.js:6:3,12: async return
 Error:
 async2.js:6:10,11: number
 This type is incompatible with
-[LIB] core.js:390:32,45: union type
+[LIB] core.js:392:32,45: union type
 
 async2.js:29:21,24: undefined
 This type is incompatible with
-[LIB] core.js:375:1,403:1: Promise
+[LIB] core.js:377:1,405:1: Promise
 
 async2.js:43:28,31: undefined
 This type is incompatible with
-[LIB] core.js:375:1,403:1: Promise
+[LIB] core.js:377:1,405:1: Promise
 
 async2.js:48:3,17: undefined
 This type is incompatible with
@@ -35,7 +35,7 @@ async3.js:23:11,21: await
 Error:
 async3.js:12:10,11: number
 This type is incompatible with
-[LIB] core.js:390:32,45: union type
+[LIB] core.js:392:32,45: union type
 
 await_not_in_async.js:5:9,9: Unexpected number
 

--- a/tests/forof/forof.exp
+++ b/tests/forof/forof.exp
@@ -13,11 +13,11 @@ This type is incompatible with
 
 forof.js:32:12,17: number
 This type is incompatible with
-[LIB] core.js:338:28,33: tuple type
+[LIB] core.js:340:28,33: tuple type
 
 forof.js:39:12,17: number
 This type is incompatible with
-[LIB] core.js:338:28,33: tuple type
+[LIB] core.js:340:28,33: tuple type
 
 forof.js:43:28,33: string
 This type is incompatible with

--- a/tests/generators/generators.exp
+++ b/tests/generators/generators.exp
@@ -117,17 +117,21 @@ return.js:11:26,27: string
 This type is incompatible with
 return.js:9:10,10: number
 
-return.js:16:1,24: call of method return
+return.js:14:1,24: call of method return
 Error:
-return.js:16:23,23: number
+return.js:14:23,23: number
 This type is incompatible with
-return.js:13:43,48: string
+return.js:13:44,49: string
 
-return.js:19:1,25: call of method return
+return.js:17:1,25: call of method return
 Error:
-return.js:19:24,24: number
+return.js:17:24,24: number
 This type is incompatible with
-return.js:18:46,51: string
+return.js:16:46,51: string
+
+return.js:26:27,55: undefined
+This type is incompatible with
+return.js:26:43,48: string
 
 throw.js:8:26,49: call of method throw
 Error:
@@ -141,4 +145,4 @@ throw.js:18:11,11: catch
 This type is incompatible with
 throw.js:24:23,29: boolean
 
-Found 31 errors
+Found 32 errors

--- a/tests/generators/generators.exp
+++ b/tests/generators/generators.exp
@@ -49,8 +49,6 @@ class.js:108:41,42: string
 This type is incompatible with
 class.js:50:15,20: number
 
-class.js:114:1,44: call of method next
-Error:
 class.js:114:42,43: string
 This type is incompatible with
 [LIB] core.js:322:37,40: undefined
@@ -99,8 +97,6 @@ generators.js:85:12,13: string
 This type is incompatible with
 generators.js:88:10,15: number
 
-generators.js:95:1,35: call of method next
-Error:
 generators.js:95:33,34: string
 This type is incompatible with
 [LIB] core.js:322:37,40: undefined
@@ -109,4 +105,40 @@ generators.js:97:45,50: number
 This type is incompatible with
 generators.js:101:8,13: string
 
-Found 25 errors
+return.js:2:26,50: call of method return
+Error:
+return.js:2:48,49: string
+This type is incompatible with
+return.js:5:25,30: number
+
+return.js:11:1,28: call of method return
+Error:
+return.js:11:26,27: string
+This type is incompatible with
+return.js:9:10,10: number
+
+return.js:16:1,24: call of method return
+Error:
+return.js:16:23,23: number
+This type is incompatible with
+return.js:13:43,48: string
+
+return.js:19:1,25: call of method return
+Error:
+return.js:19:24,24: number
+This type is incompatible with
+return.js:18:46,51: string
+
+throw.js:8:26,49: call of method throw
+Error:
+throw.js:5:12,12: catch
+This type is incompatible with
+throw.js:11:23,29: boolean
+
+throw.js:21:26,49: call of method throw
+Error:
+throw.js:18:11,11: catch
+This type is incompatible with
+throw.js:24:23,29: boolean
+
+Found 31 errors

--- a/tests/generators/return.js
+++ b/tests/generators/return.js
@@ -10,9 +10,7 @@ function *explicit_return() {
 }
 explicit_return().return(""); // error: string ~> number
 
-function *annot_return(): Generator<void, string, void> {
-  // TODO: No explicit return currently allowed. Should it be?
-}
+function *annot_return(): Generator<void, ?string, void> { }
 annot_return().return(0); // error: number ~> string
 
 declare var declared_return: Generator<void, string, void>;
@@ -23,4 +21,9 @@ function bound_return(
   g: Generator<string, ?string, void>
 ): IteratorResult<string, string> {
   return g.return("");
+}
+
+function *default_void(): Generator<void, string, void> {
+  // no explicit return ~> void return
+  // error: void ~> string
 }

--- a/tests/generators/return.js
+++ b/tests/generators/return.js
@@ -1,0 +1,19 @@
+function *infer_return() {}
+var infer_return_value = infer_return().return("").value;
+if (typeof infer_return_value === "undefined") {
+} else {
+  (infer_return_value : number); // error: string ~> number
+}
+
+function *explicit_return() {
+  return 0;
+}
+explicit_return().return(""); // error: string ~> number
+
+function *annot_return(): Generator<void, string, void> {
+  // TODO: No explicit return currently allowed. Should it be?
+}
+annot_return().return(0); // error: number ~> string
+
+declare var declared_return: Generator<void, string, void>;
+declared_return.return(0); // error: number ~> string

--- a/tests/generators/return.js
+++ b/tests/generators/return.js
@@ -17,3 +17,10 @@ annot_return().return(0); // error: number ~> string
 
 declare var declared_return: Generator<void, string, void>;
 declared_return.return(0); // error: number ~> string
+
+// IteratorResult return is string because we returned a string
+function bound_return(
+  g: Generator<string, ?string, void>
+): IteratorResult<string, string> {
+  return g.return("");
+}

--- a/tests/generators/throw.js
+++ b/tests/generators/throw.js
@@ -1,0 +1,24 @@
+function *catch_return() {
+  try {
+    yield 0;
+  } catch (e) {
+    return e;
+  }
+}
+var catch_return_value = catch_return().throw("").value;
+invariant(typeof catch_return_value !== "undefined");
+invariant(typeof catch_return_value !== "number");
+(catch_return_value : boolean); // error: catch (mixed) ~> boolean
+
+function *yield_return() {
+  try {
+    yield 0;
+    return;
+  } catch (e) {
+    yield e;
+  }
+}
+var yield_return_value = yield_return().throw("").value;
+invariant(typeof yield_return_value !== "undefined");
+invariant(typeof yield_return_value !== "number");
+(yield_return_value : boolean); // error: catch (mixed) ~> boolean

--- a/tests/iterable/iterable.exp
+++ b/tests/iterable/iterable.exp
@@ -25,7 +25,7 @@ This type is incompatible with
 
 map.js:13:55,60: string
 This type is incompatible with
-[LIB] core.js:338:28,33: tuple type
+[LIB] core.js:340:28,33: tuple type
 
 set.js:13:28,33: string
 This type is incompatible with

--- a/tests/promises/promises.exp
+++ b/tests/promises/promises.exp
@@ -3,78 +3,78 @@ promise.js:10:1,17:2: call of method then
 Error:
 promise.js:11:11,11: number
 This type is incompatible with
-[LIB] core.js:377:25,38: union type
+[LIB] core.js:379:25,38: union type
 
 promise.js:21:11,23:4: constructor call
 Error:
 promise.js:22:13,13: number
 This type is incompatible with
-[LIB] core.js:377:25,38: union type
+[LIB] core.js:379:25,38: union type
 
 promise.js:32:13,34:6: constructor call
 Error:
 promise.js:33:15,15: number
 This type is incompatible with
-[LIB] core.js:377:25,38: union type
+[LIB] core.js:379:25,38: union type
 
 promise.js:42:1,55:2: call of method then
 Error:
 promise.js:44:13,14: number
 This type is incompatible with
-[LIB] core.js:377:25,38: union type
+[LIB] core.js:379:25,38: union type
 
 promise.js:106:1,109:2: call of method then
 Error:
 promise.js:106:17,17: number
 This type is incompatible with
-[LIB] core.js:390:32,45: union type
+[LIB] core.js:392:32,45: union type
 
 promise.js:112:17,34: call of method resolve
 Error:
 promise.js:112:33,33: number
 This type is incompatible with
-[LIB] core.js:390:32,45: union type
+[LIB] core.js:392:32,45: union type
 
 promise.js:118:33,50: call of method resolve
 Error:
 promise.js:118:49,49: number
 This type is incompatible with
-[LIB] core.js:390:32,45: union type
+[LIB] core.js:392:32,45: union type
 
 promise.js:148:1,153:4: call of method then
 Error:
 promise.js:149:32,37: string
 This type is incompatible with
-[LIB] core.js:382:33,46: union type
+[LIB] core.js:384:33,46: union type
 
 promise.js:157:32,54: call of method resolve
 Error:
 promise.js:157:48,53: string
 This type is incompatible with
-[LIB] core.js:390:32,45: union type
+[LIB] core.js:392:32,45: union type
 
 promise.js:165:48,70: call of method resolve
 Error:
 promise.js:165:64,69: string
 This type is incompatible with
-[LIB] core.js:390:32,45: union type
+[LIB] core.js:392:32,45: union type
 
 promise.js:188:1,193:4: call of method then
 Error:
 promise.js:189:33,38: string
 This type is incompatible with
-[LIB] core.js:387:34,48: union type
+[LIB] core.js:389:34,48: union type
 
 promise.js:197:33,55: call of method resolve
 Error:
 promise.js:197:49,54: string
 This type is incompatible with
-[LIB] core.js:390:32,45: union type
+[LIB] core.js:392:32,45: union type
 
 promise.js:205:49,71: call of method resolve
 Error:
 promise.js:205:65,70: string
 This type is incompatible with
-[LIB] core.js:390:32,45: union type
+[LIB] core.js:392:32,45: union type
 
 Found 13 errors

--- a/tests/union/union.exp
+++ b/tests/union/union.exp
@@ -3,7 +3,7 @@ issue-198.js:1:9,10:6: call of method then
 Error:
 issue-198.js:5:16,28: string
 This type is incompatible with
-[LIB] core.js:382:33,46: union type
+[LIB] core.js:384:33,46: union type
 
 issue-324.js:3:7,9: Bar
 This type is incompatible with


### PR DESCRIPTION
Per the spec[1], generator objects have two methods which I neglected to
implement on the first go 'round.

`return` is somewhat special, because it means the return type can be
widened outside the generator function declaration itself. The argument
passed to `return` becomes the completion value of the generator itself,
and return value is the iterator result with `done:true` and the
provided value.

`throw` is more straightforward, but led me to a (perhaps controversial)
change: I think the type of the catch parameter should be `mixed`,
instead of an open tvar. In a perfect world, Flow would know exactly
what type was thrown, but barring that, we should be pessimistic and
require the user to do a dynamic type test (`invariant()` is useful for
this).

This change is unrelated to generators, but I think the throw API
invites people to pass values into a generator, and I don't want Flow to
ignore potential runtime errors caused by that use.

1. http://www.ecma-international.org/ecma-262/6.0/#sec-generator-objects