### PR TITLE
setInterval requires ms argument

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -548,7 +548,7 @@ declare function atob(encodedString: string): string;
 declare function clearInterval(intervalId?: number): void;
 declare function clearTimeout(timeoutId?: any): void;
 declare function setTimeout(callback: any, ms?: number, ...args: Array<any>): number;
-declare function setInterval(callback: any, ms?: number, ...args: Array<any>): number;
+declare function setInterval(callback: any, ms: number, ...args: Array<any>): number;
 
 /* CommonJS */
 


### PR DESCRIPTION
Additionally, the return type for `setTimeout` and `setInterval` are different in node. Is there currently a clean way to support overloading the return value of setTimeout and setInterval in node?

In node, both timer methods return on object which has (amongst a few other properties) `ref` and `unref` methods. https://nodejs.org/api/timers.html#timers_settimeout_callback_delay_arg