### PR TITLE
Fix and Regression test for #819

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -677,7 +677,9 @@ type RenderingContext = CanvasRenderingContext2D | WebGLRenderingContext;
 declare class HTMLCanvasElement extends HTMLElement {
     width: number;
     height: number;
-    getContext(contextId: string, ...args: any): ?RenderingContext;
+    getContext(contextId: "2d", ...args: any): ?CanvasRenderingContext2D;
+    getContext(contextId: "webgl", ...args: any): ?WebGLRenderingContext;
+    getContext(contextId: string, ...args: any): ?RenderingContext; // fallback
     toDataURL(type?: string, ...args: any): string;
     toBlob(callback: (v: File) => void, type?: string, ...args: any): void;
 }

--- a/tests/canvas/.flowconfig
+++ b/tests/canvas/.flowconfig
@@ -1,0 +1,3 @@
+[options]
+module.system=haste
+

--- a/tests/canvas/canvas.exp
+++ b/tests/canvas/canvas.exp
@@ -1,0 +1,14 @@
+
+canvastest.js:8:3,22: call of method `moveTo`
+Error:
+canvastest.js:8:14,16: string
+This type is incompatible with
+[LIB] dom.js:660:15,20: number
+
+canvastest.js:8:3,22: call of method `moveTo`
+Error:
+canvastest.js:8:19,21: string
+This type is incompatible with
+[LIB] dom.js:660:26,31: number
+
+Found 2 errors

--- a/tests/canvas/canvastest.js
+++ b/tests/canvas/canvastest.js
@@ -1,0 +1,9 @@
+var el = document.createElement('canvas');
+var ctx: ?CanvasRenderingContext2D = el.getContext('2d');
+if (ctx == null) {
+  // error handling
+} else {
+  // ctx here is specifically a CanvasRenderingContext2D (not a WebGL context)
+  ctx.fillRect(0, 0, 200, 100);
+  ctx.moveTo('0', '1');  // error: should be numbers
+}


### PR DESCRIPTION
Fixes #819 
See also #61 

This _should_ work, but I'm running into another bug. `canvastest.js` produces this error instead of the expected one:

```
canvastest.js:4:11,29: call of method getContext
Function cannot be called on
[LIB] dom.js:649:5,14: HTMLCanvasElement

Found 1 error
```

This is caused by overloading string parameters to `getContext` in `lib/dom.js`. If there's just one declaration, it works as expected.

It looks like something similar is going on for the existing `createElement` declarations. For example, this line:

```
var el = document.createElement('canvas');
```

produces this non-sense error:

```
canvastest.js:2:10,41: call of method createElement
Function cannot be called on
[LIB] dom.js:235:5,17: Document
```

@samwgoldman thoughts? Is this the same as #583?