### PR TITLE
New terminal output format

### DIFF
--- a/hack/utils/tty.ml
+++ b/hack/utils/tty.ml
@@ -25,6 +25,8 @@ type raw_color =
 type style =
   | Normal of raw_color
   | Bold of raw_color
+  | Dim of raw_color
+  | Underline of raw_color
   | NormalWithBG of raw_color * raw_color
   | BoldWithBG of raw_color * raw_color
 
@@ -62,6 +64,8 @@ let color_num = function
 let style_num = function
   | Normal c -> color_num c
   | Bold c   -> color_num c ^ ";1"
+  | Dim c    -> color_num c ^ ";2"
+  | Underline c -> color_num c ^ ";4"
   | NormalWithBG (text, bg) -> (text_num text) ^ ";" ^ (background_num bg)
   | BoldWithBG (text, bg) -> (text_num text) ^ ";" ^ (background_num bg) ^ ";1"
 

--- a/hack/utils/tty.ml
+++ b/hack/utils/tty.ml
@@ -27,6 +27,7 @@ type style =
   | Bold of raw_color
   | Dim of raw_color
   | Underline of raw_color
+  | DimUnderline of raw_color
   | NormalWithBG of raw_color * raw_color
   | BoldWithBG of raw_color * raw_color
 
@@ -66,6 +67,7 @@ let style_num = function
   | Bold c   -> color_num c ^ ";1"
   | Dim c    -> color_num c ^ ";2"
   | Underline c -> color_num c ^ ";4"
+  | DimUnderline c -> color_num c ^ ";2;4"
   | NormalWithBG (text, bg) -> (text_num text) ^ ";" ^ (background_num bg)
   | BoldWithBG (text, bg) -> (text_num text) ^ ";" ^ (background_num bg) ^ ";1"
 

--- a/hack/utils/tty.mli
+++ b/hack/utils/tty.mli
@@ -24,6 +24,7 @@ type style =
   | Bold of raw_color
   | Dim of raw_color
   | Underline of raw_color
+  | DimUnderline of raw_color
   | NormalWithBG of raw_color * raw_color
   | BoldWithBG of raw_color * raw_color
 

--- a/hack/utils/tty.mli
+++ b/hack/utils/tty.mli
@@ -22,6 +22,8 @@ type raw_color =
 type style =
   | Normal of raw_color
   | Bold of raw_color
+  | Dim of raw_color
+  | Underline of raw_color
   | NormalWithBG of raw_color * raw_color
   | BoldWithBG of raw_color * raw_color
 

--- a/runtests.sh
+++ b/runtests.sh
@@ -131,7 +131,7 @@ do
         if [ "$cmd" == "check" ]
         then
             # default command is check with configurable --all
-            $FLOW check . $all --strip-root --show-all-errors 1> $out_file 2> $stderr_dest
+            $FLOW check . $all --strip-root --show-all-errors --old-output-format 1> $out_file 2> $stderr_dest
         else
             # otherwise, run specified flow command, then kill the server
 

--- a/src/commands/checkContentsCommand.ml
+++ b/src/commands/checkContentsCommand.ml
@@ -52,7 +52,12 @@ let main option_values error_flags use_json file () =
       if use_json
       then Errors_js.print_error_json stdout e
       else (
-        Errors_js.print_error_summary ~flags:error_flags e;
+        let stdin_file = match file with
+          | ServerProt.FileContent (None, contents) -> Some ("-", contents)
+          | ServerProt.FileContent (Some (path), contents) -> Some (path, contents)
+          | _ -> None
+        in
+        Errors_js.print_error_summary ~flags:error_flags ~stdin_file:stdin_file e;
         FlowExitStatus.(exit Type_error)
       )
   | ServerProt.NO_ERRORS ->

--- a/src/commands/commandUtils.ml
+++ b/src/commands/commandUtils.ml
@@ -82,7 +82,7 @@ let sleep seconds =
         then timeout_go_boom ()
         else Unix.sleep seconds
 
-let collect_error_flags main color one_line show_all_errors =
+let collect_error_flags main color one_line show_all_errors old_output_format =
   let color = match color with
   | Some "never" -> Tty.Color_Never
   | Some "always" -> Tty.Color_Always
@@ -90,7 +90,7 @@ let collect_error_flags main color one_line show_all_errors =
   | None -> Tty.Color_Auto
   | _ -> assert false (* the enum type enforces this *)
   in
-  main { Errors_js.color; one_line; show_all_errors; }
+  main { Errors_js.color; one_line; show_all_errors; old_output_format; }
 
 let error_flags prev = CommandSpec.ArgSpec.(
   prev
@@ -101,6 +101,8 @@ let error_flags prev = CommandSpec.ArgSpec.(
       ~doc:"Escapes newlines so that each error prints on one line"
   |> flag "--show-all-errors" no_arg
       ~doc:"Print all errors (the default is to truncate after 50 errors)"
+  |> flag "--old-output-format" no_arg
+      ~doc:"Use old output format (absolute file names, line and column numbers)"
 )
 
 let json_flags prev = CommandSpec.ArgSpec.(

--- a/src/common/errors_js.ml
+++ b/src/common/errors_js.ml
@@ -171,7 +171,7 @@ let print_file_at_location main_file loc s = Loc.(
     | Some filename ->
       let content = Sys_utils.cat filename in
       let lines = Str.split_delim (Str.regexp "\n") content in
-      let code_line = if (List.length lines) >= l0 then List.nth lines (l0 - 1) else "" in
+      let code_line = if (List.length lines) >= l0 && (l0 > 0) then List.nth lines (l0 - 1) else "" in
       let code_line = Str.global_replace (Str.regexp_string "\n") "" code_line in
       let highlighted_line = if (l1 == l0) && (String.length code_line) > 0
         then highlight_error_in_line code_line c0 c1

--- a/src/common/errors_js.ml
+++ b/src/common/errors_js.ml
@@ -217,7 +217,12 @@ let append_comment blame comment =
   | BlameM(loc, s) ->
     (match comment with
     | "Error:" -> BlameM(loc, s) (* Almost everywhere we have "Error:" that hurts readability *)
-    | comment -> BlameM(loc, s ^ ". " ^ comment))
+    | comment ->
+      let combined_comment = if String.length s > 0
+        then s ^ ". " ^ comment
+        else comment
+      in
+      BlameM(loc, combined_comment))
   | CommentM(_) -> failwith "should not be comment"
 
 (* TODO: Having a bunch of List.rev's is clowny, there must be another way *)

--- a/src/common/errors_js.ml
+++ b/src/common/errors_js.ml
@@ -146,19 +146,11 @@ let source_fragment_style text = (C.Normal C.Default, text)
 let error_fragment_style text = (C.Normal C.Red, text)
 let line_number_style text = (C.Dim C.Default, text)
 
-(* TODO: Not sure how to handle the usecase when flow reads file content from stdin *)
-let load_file f =
-  let ic = open_in f in
-  let n = in_channel_length ic in
-  let s = Bytes.create n in
-  really_input ic s 0 n;
-  close_in ic;
-  (s)
-
-(* TODO: Add proper support for relative path, for example ../../.. *)
 let relative_path filename =
-  let pwd = (Sys.getcwd ()) ^ "/" in
-  Str.global_replace (Str.regexp_string pwd) "" filename
+  let relname = Files_js.relative_path (Sys.getcwd ()) filename in
+  if String.length relname < String.length filename
+    then relname
+    else filename
 
 let highlight_error_in_line line c0 c1 =
   let prefix = String.sub line 0 c0 in
@@ -177,8 +169,8 @@ let print_file_at_location main_file loc s = Loc.(
   let c1 = loc._end.column in
   match loc.source with
     | Some filename ->
-      let content = load_file filename in
-      let lines = Str.split (Str.regexp "^") content in
+      let content = Sys_utils.cat filename in
+      let lines = Str.split_delim (Str.regexp "\n") content in
       let code_line = if (List.length lines) >= l0 then List.nth lines (l0 - 1) else "" in
       let code_line = Str.global_replace (Str.regexp_string "\n") "" code_line in
       let highlighted_line = if (l1 == l0) && (String.length code_line) > 0

--- a/src/common/errors_js.ml
+++ b/src/common/errors_js.ml
@@ -225,18 +225,17 @@ let append_comment blame comment =
       BlameM(loc, combined_comment))
   | CommentM(_) -> failwith "should not be comment"
 
-(* TODO: Having a bunch of List.rev's is clowny, there must be another way *)
 let maybe_combine_message_text messages message =
   match message with
-    | BlameM (_, _) -> messages @ [message]
+    | BlameM (_, _) -> message :: messages
     | CommentM s ->
-      match List.rev messages with
-      | x :: xs -> (List.rev xs) @ [append_comment x s]
+      match messages with
+      | x :: xs -> (append_comment x s) :: xs
       | _ -> failwith "can't append comment to nonexistent blame"
 
 (* This function merges CommentM messages into previous BlameM messages *)
 let merge_comments_into_blames messages =
-  List.fold_left maybe_combine_message_text [] messages
+  List.fold_left maybe_combine_message_text [] messages |> List.rev
 
 let loc_of_error (err: error) =
   let {messages; _} = err in

--- a/src/common/errors_js.ml
+++ b/src/common/errors_js.ml
@@ -33,12 +33,14 @@ type flags = {
   color: Tty.color_mode;
   one_line: bool;
   show_all_errors: bool;
+  old_output_format: bool;
 }
 
 let default_flags = {
   color = Tty.Color_Auto;
   one_line = false;
   show_all_errors = false;
+  old_output_format = false;
 }
 
 let message_of_reason reason =
@@ -131,8 +133,7 @@ let print_reason_color ~first ~one_line ~color (message: message) =
   (if first then Printf.printf "\n");
   C.print ~color_mode:color to_print
 
-
-let print_error_color ~one_line ~color (e : error) =
+let print_error_color_old ~one_line ~color (e : error) =
   let {kind; messages; trace} = e in
   let messages = prepend_kind_message messages kind in
   let messages = append_trace_reasons messages trace in
@@ -256,7 +257,7 @@ let file_of_error err =
 let remove_newlines (color, text) =
   (color, Str.global_replace (Str.regexp "\n") "\\n" text)
 
-let print_error_color ~one_line ~color error =
+let print_error_color_new ~one_line ~color error =
   let level, messages, trace_reasons = error in
   let messages = append_trace_reasons messages trace_reasons in
   let messages = merge_comments_into_blames messages in
@@ -490,6 +491,10 @@ let print_error_summary ~flags errors =
   let truncate = not (flags.show_all_errors) in
   let one_line = flags.one_line in
   let color = flags.color in
+  let print_error_color = if flags.old_output_format
+    then print_error_color_old
+    else print_error_color_new
+  in
   let print_error_if_not_truncated curr e =
     (if not(truncate) || curr < 50 then print_error_color ~one_line ~color e);
     curr + 1

--- a/src/common/errors_js.ml
+++ b/src/common/errors_js.ml
@@ -170,10 +170,6 @@ let read_file_safe filename =
   try Sys_utils.cat filename with
     | Sys_error _ -> ""
 
-let dbg a =
-  Printf.printf "%s\n" a;
-  a
-
 let read_line_in_file line filename stdin_file =
   let content = match stdin_file with
     | Some (stdin_filename, content) ->

--- a/src/common/errors_js.ml
+++ b/src/common/errors_js.ml
@@ -227,7 +227,7 @@ let print_error_header message =
   let filename = file_of_location loc in
   let relfilename = relative_path filename in
   [
-    file_location_style (Printf.sprintf "%s" relfilename);
+    file_location_style (Printf.sprintf "%s:%d" relfilename Loc.(loc.start.line));
     default_style "\n"
   ]
 
@@ -252,11 +252,9 @@ let maybe_combine_message_text messages message =
       | x :: xs -> (append_comment x s) :: xs
       | _ -> failwith "can't append comment to nonexistent blame"
 
-(* This function merges CommentM messages into previous BlameM messages *)
 let merge_comments_into_blames messages =
   List.fold_left maybe_combine_message_text [] messages |> List.rev
 
-(* TODO: Is this actually needed? Does it make sense with the new format? *)
 let remove_newlines (color, text) =
   (color, Str.global_replace (Str.regexp "\n") "\\n" text)
 

--- a/src/common/errors_js.mli
+++ b/src/common/errors_js.mli
@@ -31,6 +31,8 @@ type flags = {
   old_output_format: bool;
 }
 
+type stdin_file = (string * string) option
+
 val default_flags : flags
 
 val message_of_reason: Reason_js.reason -> message
@@ -49,7 +51,7 @@ val print_reason_color:
   unit
 
 val print_error_color_new:
-  one_line:bool -> color:Tty.color_mode -> error -> unit
+  stdin_file:stdin_file -> one_line:bool -> color:Tty.color_mode -> error -> unit
 
 val loc_of_error : error -> Loc.t
 
@@ -84,6 +86,6 @@ val json_of_errors : Error.t list -> Hh_json.json
 val print_error_json : out_channel -> error list -> unit
 
 (* Human readable output *)
-val print_error_summary: flags:flags -> error list -> unit
+val print_error_summary: flags:flags -> ?stdin_file:stdin_file -> error list -> unit
 val string_of_loc_deprecated: Loc.t -> string
 val print_error_deprecated: out_channel -> error list -> unit

--- a/src/common/errors_js.mli
+++ b/src/common/errors_js.mli
@@ -28,6 +28,7 @@ type flags = {
   color: Tty.color_mode;
   one_line: bool;
   show_all_errors: bool;
+  old_output_format: bool;
 }
 
 val default_flags : flags
@@ -47,7 +48,7 @@ val print_reason_color:
   message ->
   unit
 
-val print_error_color:
+val print_error_color_new:
   one_line:bool -> color:Tty.color_mode -> error -> unit
 
 val loc_of_error : error -> Loc.t

--- a/tests/incremental_basic/test.sh
+++ b/tests/incremental_basic/test.sh
@@ -1,12 +1,12 @@
 FLOW=$1
 mkdir tmp
 cp *.js tmp/
-$FLOW status .
+$FLOW status . --old-output-format
 cp tmp1/*.js ./
-$FLOW status .
+$FLOW status . --old-output-format
 cp tmp2/*.js ./
-$FLOW status .
+$FLOW status . --old-output-format
 cp tmp3/*.js ./
-$FLOW status .
+$FLOW status . --old-output-format
 mv tmp/*.js ./
 rmdir tmp

--- a/tests/incremental_cycle/test.sh
+++ b/tests/incremental_cycle/test.sh
@@ -1,12 +1,12 @@
 FLOW=$1
 mkdir tmp
 cp *.js tmp/
-$FLOW status .
+$FLOW status . --old-output-format
 cp tmp1/*.js ./
-$FLOW status .
+$FLOW status . --old-output-format
 cp tmp2/*.js ./
-$FLOW status .
+$FLOW status . --old-output-format
 cp tmp3/*.js ./
-$FLOW status .
+$FLOW status . --old-output-format
 mv tmp/*.js ./
 rmdir tmp

--- a/tests/integration/test.sh
+++ b/tests/integration/test.sh
@@ -1,5 +1,5 @@
 FLOW=$1
 
 mv bar.js _bar.js
-$FLOW status .
+$FLOW status --old-output-format .
 mv _bar.js bar.js

--- a/tests/liberr/.testconfig
+++ b/tests/liberr/.testconfig
@@ -1,1 +1,1 @@
-cmd: status
+cmd: status --old-output-format

--- a/tests/suppress_traces/.testconfig
+++ b/tests/suppress_traces/.testconfig
@@ -1,1 +1,1 @@
-cmd: check --all --strip-root --show-all-errors --traces 10
+cmd: check --all --strip-root --old-output-format --show-all-errors --traces 10


### PR DESCRIPTION
This commit introduces a new CLI output format that is more user-friendly:
- Source code is printed next to error messages
- Parts of the line that causes error is highlighted
- Each error is clearly separated from each other

*Disclaimer: I've never used OCaml before, any code structuring and style suggestions are very welcome*

### Outstanding issues

- [x] Tests are broken because they rely on the old style of output
- [x] Not sure what the deal is with `--one-line` attribute
- [x] Need to remove old code
- [x] If the terminal has no colors (or the output is redirected to file) error sections in lines are not highlighted. I haven't gotten to it yet, but I'm imagining using `^^^^` on the next line to underline tokens in question, but only if color is not available.
- [x] Printing relative paths
- [x] What if file comes from stdin?
- [x] Warnings vs errors. Looks like flow differentiates between warnings and error. We could incorporate this information into the output if it seems useful. I've experimented with a couple of approaches but neither felt right yet:
  - highlight parts of the lines in red vs yellow (might be confusing)
  - prefix each section with ERROR or WARNING (too intense)

### Demo

Before [see full output](https://dl.dropboxusercontent.com/u/4980295/flow/old-flow.html)

![screen shot 2015-09-23 at 9 39 15 am](https://cloud.githubusercontent.com/assets/192222/10051826/6599bcdc-61d8-11e5-9d04-21ea6df5d30e.png)

After [see full output](https://dl.dropboxusercontent.com/u/4980295/flow/new-flow.html)
![screen shot 2015-09-23 at 9 38 59 am](https://cloud.githubusercontent.com/assets/192222/10051838/725ab048-61d8-11e5-8c56-b53567d687de.png)