### PR TITLE
Support `new this.constructor(...)` and `new x.constructor(...)`

### DIFF
--- a/src/typing/flow_js.ml
+++ b/src/typing/flow_js.ml
@@ -33,11 +33,8 @@ open Type
    meaningful in all contexts. This part of the design should be revisited:
    perhaps the data types can be refactored to make them more specialized. *)
 
-(* Methods may use a dummy statics object type to carry properties. We do not
-   want to encourage this pattern, but we also don't want to block uses of this
-   pattern. Thus, we compromise by not tracking the property types. *)
 let dummy_static =
-  AnyObjT (reason_of_string "object type for statics")
+  MixedT (reason_of_string "empty statics object")
 
 let dummy_prototype =
   MixedT (reason_of_string "empty prototype object")

--- a/src/typing/flow_js.ml
+++ b/src/typing/flow_js.ml
@@ -2511,6 +2511,9 @@ let rec __flow cx (l, u) trace =
     | InstanceT (_, _, super, _), GetPropT (_, (_, "__proto__"), t) ->
       rec_flow cx trace (super, t)
 
+    | InstanceT _ as instance, GetPropT (_, (_, "constructor"), t) ->
+      rec_flow cx trace (ClassT instance, t)
+
     | InstanceT (reason_c, static, super, instance),
       GetPropT (reason_op, (reason_prop, x), tout) ->
       Ops.push reason_op;

--- a/tests/method_properties/method_properties.exp
+++ b/tests/method_properties/method_properties.exp
@@ -1,8 +1,14 @@
 
+test.js:5:11,28: property `x`
+Error:
+test.js:5:28,28: property `x`
+Property not found in
+test.js:1:7,7: statics of C
+
 test.js:7:1,3: property `x`
 Error:
 test.js:7:3,3: property `x`
 Property not found in
 test.js:1:7,7: statics of C
 
-Found 1 error
+Found 2 errors

--- a/tests/method_properties/method_properties.exp
+++ b/tests/method_properties/method_properties.exp
@@ -11,4 +11,12 @@ test.js:7:3,3: property `x`
 Property not found in
 test.js:1:7,7: statics of C
 
-Found 2 errors
+test.js:8:13,13: property `x`
+Property cannot be accessed on
+empty statics object
+
+test.js:9:7,7: property `x`
+Property cannot be accessed on
+empty statics object
+
+Found 4 errors

--- a/tests/this_ctor/test.js
+++ b/tests/this_ctor/test.js
@@ -1,0 +1,13 @@
+class A {
+  n: number;
+  constructor(n: number) {
+    this.n = n;
+  }
+  clone(): A {
+    return new this.constructor(this.n);
+  }
+}
+
+var a1 = new A(1);
+var a2: A = new a1.constructor(2);
+var a3: A = a2.clone();

--- a/tests/this_ctor/this_ctor.exp
+++ b/tests/this_ctor/this_ctor.exp
@@ -1,0 +1,2 @@
+
+Found 0 errors


### PR DESCRIPTION
This redirects `constructor` property lookups on class instances to the class rather than its constructor function.  With the ctor handled separate from other static methods, #596 can be closed.