### PR TITLE
Support `new this(...)` within static methods

### DIFF
--- a/src/typing/type_inference_js.ml
+++ b/src/typing/type_inference_js.ml
@@ -5361,6 +5361,7 @@ and mk_class_elements cx instance_info static_info body = Ast.Class.(
         let ret = Flow_js.subst cx map_ ret in
         (* determine if we are in a derived constructor *)
         let derived_ctor = match super with
+          | ClassT (MixedT _) -> false
           | MixedT _ -> false
           | _ -> name = "constructor"
         in

--- a/src/typing/type_inference_js.ml
+++ b/src/typing/type_inference_js.ml
@@ -5552,7 +5552,7 @@ and mk_class = Ast.Class.(
 
     mk_class_elements cx
       (this, super, methods_, getters_, setters_)
-      (static, super_static, smethods_, sgetters_, ssetters_)
+      (ClassT this, super_static, smethods_, sgetters_, ssetters_)
       body;
   );
 

--- a/tests/class_statics/class_statics.exp
+++ b/tests/class_statics/class_statics.exp
@@ -1,7 +1,7 @@
 
 test.js:1:7,7: A
 This type is incompatible with
-test.js:37:2,2: B
+test.js:44:2,2: B
 
 test.js:2:13,18: number
 This type is incompatible with
@@ -51,30 +51,30 @@ test.js:19:7,9: property `qux`
 Property not found in
 test.js:9:7,7: statics of B
 
-test.js:30:5,12: call of method foo
+test.js:36:5,12: call of method foo
 Error:
-test.js:30:7,9: property `foo`
+test.js:36:7,9: property `foo`
 Property not found in
-test.js:28:7,7: statics of D
+test.js:34:7,7: statics of D
 
-test.js:32:5,12: call of method bar
+test.js:38:5,12: call of method bar
 Error:
-test.js:32:11,11: number
+test.js:38:11,11: number
 This type is incompatible with
-test.js:28:19,24: string
+test.js:34:19,24: string
 
-test.js:36:6,6: A
+test.js:43:6,6: A
 This type is incompatible with
 test.js:1:7,7: class type: A
 
-test.js:42:5,14: call of method bar
+test.js:49:5,14: call of method bar
 Error:
-test.js:42:10,12: property `bar`
+test.js:49:10,12: property `bar`
 Property not found in
-test.js:39:7,7: statics of E
+test.js:46:7,7: statics of E
 
-test.js:43:12,17: number
+test.js:50:12,17: number
 This type is incompatible with
-test.js:41:17,22: string
+test.js:48:17,22: string
 
 Found 15 errors

--- a/tests/class_statics/test.js
+++ b/tests/class_statics/test.js
@@ -18,17 +18,17 @@ class B extends A {
     B.bar(0); // error
     B.qux(0); // error
   }
-//  static create(): A {
-//    return new this();
-//  }
+  static create(): A {
+    return new this();
+  }
 }
 
 class C<X> {
   static x: X;
   static bar(x: X) { }
-//  static create(): C {
-//    return new this();
-//  }
+  static create(): C {
+    return new this();
+  }
 }
 
 class D extends C<string> {
@@ -39,7 +39,7 @@ class D extends C<string> {
   }
 }
 
-//var d: D = D.create();
+var d: C = D.create();
 (new A: typeof A);
 (B: typeof A);
 

--- a/tests/class_statics/test.js
+++ b/tests/class_statics/test.js
@@ -18,11 +18,17 @@ class B extends A {
     B.bar(0); // error
     B.qux(0); // error
   }
+//  static create(): A {
+//    return new this();
+//  }
 }
 
 class C<X> {
   static x: X;
   static bar(x: X) { }
+//  static create(): C {
+//    return new this();
+//  }
 }
 
 class D extends C<string> {
@@ -33,6 +39,7 @@ class D extends C<string> {
   }
 }
 
+//var d: D = D.create();
 (new A: typeof A);
 (B: typeof A);
 


### PR DESCRIPTION
Bind `this` within class static methods to the class itself rather than just the statics.  This is necessary to allow instantiating `this`.

I would still like to admit polymorphic statics that yield derived instances, e.g.

```js
class A {
  static create<T: A>(): T {
    return new this();
  }
}

class B extends A {}

var b: B = B.create(); // NG
```