### PR TITLE
Use full names for type parameters

### DIFF
--- a/lib/react.js
+++ b/lib/react.js
@@ -11,22 +11,22 @@
 
 /**
  * Base class of all React classes, modeled as a polymorphic class whose type
- * parameters are D (= DefaultProps), P (= PropTypes), S (= State).
+ * parameters are DefaultProps, PropTypes, State.
  */
-declare class ReactComponent<D, P, S> {
-  props: P;
-  state: S;
+declare class ReactComponent<DefaultProps, PropTypes, State> {
+  props: PropTypes;
+  state: State;
   refs: any;
   context: any;
 
-  getInitialState(): S;
+  getInitialState(): State;
   getChildContext(): any;
 
-  setProps(props: $Shape<P>, callback?: () => void): void;
-  replaceProps(props: P, callback?: () => void): void;
+  setProps(props: $Shape<PropTypes>, callback?: () => void): void;
+  replaceProps(props: PropTypes, callback?: () => void): void;
 
-  setState(state: $Shape<S>, callback?: () => void): void;
-  replaceState(state: S, callback?: () => void): void;
+  setState(state: $Shape<State>, callback?: () => void): void;
+  replaceState(state: State, callback?: () => void): void;
 
   render(): ?ReactElement<any, any, any>;
 
@@ -34,40 +34,40 @@ declare class ReactComponent<D, P, S> {
   getDOMNode(): any;
   componentWillMount(): void;
   componentDidMount(component?: any): void;
-  componentWillReceiveProps(nextProps: P, nextContext?: any): void;
-  shouldComponentUpdate(nextProps: P, nextState: S, nextContext: any): boolean;
-  componentWillUpdate(nextProps: P, nextState: S, nextContext: any): void;
-  componentDidUpdate(nextProps: P, nextState: S, nextContext: any, component: any): void;
+  componentWillReceiveProps(nextProps: PropTypes, nextContext?: any): void;
+  shouldComponentUpdate(nextProps: PropTypes, nextState: State, nextContext: any): boolean;
+  componentWillUpdate(nextProps: PropTypes, nextState: State, nextContext: any): void;
+  componentDidUpdate(nextProps: PropTypes, nextState: State, nextContext: any, component: any): void;
   componentWillUnmount(): void;
   isMounted(): bool;
 
-  static propTypes: $Subtype<{[_: $Keys<P>]: any}>; //object whose keys are in P
+  static propTypes: $Subtype<{[_: $Keys<PropTypes>]: any}>; //object whose keys are in PropTypes
   static contextTypes: any;
   static childContextTypes: any;
   static displayName: string;
-  static defaultProps: D;
+  static defaultProps: DefaultProps;
 }
 
 /**
  * Type of a React class (not to be confused with the type of instances of a
  * React class, which is the React class itself). A React class is any subclass
  * of ReactComponent. We make the type of a React class polymorphic over the
- * same type parameters (D, P, S) as ReactComponent. The required constraints
+ * same type parameters (DefaultProps, PropTypes, State) as ReactComponent. The required constraints
  * are set up using a "helper" type alias, that takes an additional type
  * parameter C representing the React class, which is then abstracted with an
  * existential type (*). The * can be thought of as an "auto" instruction to the
  * typechecker, telling it to fill in the type from context.
  */
-type ReactClass<D, P, S> = _ReactClass<D, P, S, *>;
-type _ReactClass<D, P, S, C: ReactComponent<D, P, S>> = Class<C>;
+type ReactClass<DefaultProps, PropTypes, State> = _ReactClass<DefaultProps, PropTypes, State, *>;
+type _ReactClass<DefaultProps, PropTypes, State, C: ReactComponent<DefaultProps, PropTypes, State>> = Class<C>;
 
 /**
  * Type of a React element. React elements are commonly created using JSX
  * literals, which desugar to React.createElement calls (see below).
  */
-declare class ReactElement<D, P, S> {
-    type: ReactClass<D, P, S>;
-    props: P;
+declare class ReactElement<DefaultProps, PropTypes, State> {
+    type: ReactClass<DefaultProps, PropTypes, State>;
+    props: PropTypes;
     key: ?string;
     ref: any;
 }
@@ -113,54 +113,54 @@ declare module react {
   // compiler magic
   declare function createClass(spec: any): ReactClass<any, any, any>;
 
-  declare function cloneElement<D, P, S> (
-    element: ReactElement<D, P, S>,
-    attributes: $Shape<P>,
+  declare function cloneElement<DefaultProps, PropTypes, State> (
+    element: ReactElement<DefaultProps, PropTypes, State>,
+    attributes: $Shape<PropTypes>,
     children?: any
-  ): ReactElement<D, P, S>;
+  ): ReactElement<DefaultProps, PropTypes, State>;
 
   /**
    * Methods that take an `attributes` argument of type A (= Attributes),
    * describing objects whose properties must cover (at least) the difference
-   * between the properties in P (Props) and the properties in D
-   * (DefaultProps). This is intended to model what happens at run time: the
+   * between the properties in PropTypes and the properties in DefaultProps.
+   * This is intended to model what happens at run time: the
    * attributes are merged with the default props to obtain the props of a
    * ReactElement / ReactComponent instance.
    */
   // TODO: React DOM elements
-  declare function createElement<D, P, S, A: $Diff<P, D>>(
-    name: ReactClass<D, P, S>,
+  declare function createElement<DefaultProps, PropTypes, State, A: $Diff<PropTypes, DefaultProps>>(
+    name: ReactClass<DefaultProps, PropTypes, State>,
     attributes: A,
     children?: any
-  ): ReactElement<D, P, S>;
+  ): ReactElement<DefaultProps, PropTypes, State>;
 
   // TODO: React DOM elements
-  declare function createFactory<D, P, S, A: $Diff<P, D>>(
-    name: ReactClass<D, P, S>
-  ): (attributes: A, children?: any) => ReactElement<D, P, S>;
+  declare function createFactory<DefaultProps, PropTypes, State, A: $Diff<PropTypes, DefaultProps>>(
+    name: ReactClass<DefaultProps, PropTypes, State>
+  ): (attributes: A, children?: any) => ReactElement<DefaultProps, PropTypes, State>;
 
   // TODO: React DOM elements
-  declare function constructAndRenderComponent<D, P, S, A: $Diff<P, D>>(
-    name: ReactClass<D, P, S>,
+  declare function constructAndRenderComponent<DefaultProps, PropTypes, State, A: $Diff<PropTypes, DefaultProps>>(
+    name: ReactClass<DefaultProps, PropTypes, State>,
     attributes: A,
     container: any
-  ): ReactComponent<D, P, S>;
+  ): ReactComponent<DefaultProps, PropTypes, State>;
 
   // TODO: React DOM elements
-  declare function constructAndRenderComponentByID<D, P, S, A: $Diff<P, D>>(
-    name: ReactClass<D, P, S>,
+  declare function constructAndRenderComponentByID<DefaultProps, PropTypes, State, A: $Diff<PropTypes, DefaultProps>>(
+    name: ReactClass<DefaultProps, PropTypes, State>,
     attributes: A,
     id: string
-  ): ReactComponent<D, P, S>;
+  ): ReactComponent<DefaultProps, PropTypes, State>;
 
   declare function findDOMNode(
     object: ReactComponent<any, any, any> | HTMLElement
   ): any;
 
-  declare function render<D, P, S>(
-    element: ReactElement<D, P, S>,
+  declare function render<DefaultProps, PropTypes, State>(
+    element: ReactElement<DefaultProps, PropTypes, State>,
     container: any
-  ): ReactComponent<D, P, S>;
+  ): ReactComponent<DefaultProps, PropTypes, State>;
 
   declare function renderToString(
     element: ReactElement<any, any, any>

--- a/tests/more_react/more_react.exp
+++ b/tests/more_react/more_react.exp
@@ -22,6 +22,6 @@ propTypes.js:15:1,18:2: React element: D
 Error:
 propTypes.js:9:3,11: property `name`
 Property not found in
-propTypes.js:15:1,18:2: type parameter `D` of React element: D
+propTypes.js:15:1,18:2: type parameter `DefaultProps` of React element: D
 
 Found 5 errors

--- a/tests/new_react/new_react.exp
+++ b/tests/new_react/new_react.exp
@@ -29,7 +29,7 @@ classes.js:40:25,30: React element: Foo
 Error:
 classes.js:8:10,14: property `x`
 Property not found in
-classes.js:40:25,30: type parameter `D` of React element: Foo
+classes.js:40:25,30: type parameter `DefaultProps` of React element: Foo
 
 classes.js:40:25,30: React element: Foo
 Error:
@@ -53,7 +53,7 @@ classes.js:80:32,43: React element: FooLegacy
 Error:
 classes.js:47:3,11: property `x`
 Property not found in
-classes.js:80:32,43: type parameter `D` of React element: FooLegacy
+classes.js:80:32,43: type parameter `DefaultProps` of React element: FooLegacy
 
 classes.js:80:32,43: React element: FooLegacy
 Error:
@@ -101,7 +101,7 @@ new_react.js:30:16,19: React element: C
 Error:
 new_react.js:5:5,13: property `x`
 Property not found in
-new_react.js:30:16,19: type parameter `D` of React element: C
+new_react.js:30:16,19: type parameter `DefaultProps` of React element: C
 
 new_react.js:32:17,29: string
 This type is incompatible with
@@ -147,13 +147,13 @@ props.js:20:29,33: boolean
 This type is incompatible with
 props.js:5:12,33: string
 
-props.js:20:15,57: type parameter `D` of React element: TestProps
+props.js:20:15,57: type parameter `DefaultProps` of React element: TestProps
 Error:
 props.js:20:29,33: boolean
 This type is incompatible with
 props.js:10:20,21: string
 
-props.js:20:15,57: type parameter `D` of React element: TestProps
+props.js:20:15,57: type parameter `DefaultProps` of React element: TestProps
 Error:
 props.js:20:39,43: boolean
 This type is incompatible with


### PR DESCRIPTION
Although errors regarding `getDefaultProps` still appear at the call-site rather than at definition, and don't mention `getDefaultProps`, at least the error message will contain some reference to DefaultProps.