### PR TITLE
Lex object keys in normal mode

### DIFF
--- a/src/parser/lexer_flow.mll
+++ b/src/parser/lexer_flow.mll
@@ -639,8 +639,11 @@ rule token env = parse
                        { illegal_number env lexbuf w (T_NUMBER NORMAL) }
   | wholenumber
   | floatnumber        { env, T_NUMBER NORMAL }
+
   (* Keyword or Identifier *)
-  | word as word       {
+  (* TODO: Use [Symbol.iterator] instead of @@iterator. *)
+  | ("@@"? word) as word
+                       {
                          unicode_fix_cols lexbuf;
                          try env, Hashtbl.find keywords word
                          with Not_found -> env, T_IDENTIFIER
@@ -788,11 +791,7 @@ and type_token env = parse
   | floatnumber        { env, T_NUMBER NORMAL }
 
   (* Keyword or Identifier *)
-  (* TODO: Better support for things like @@iterator. At the moment I'm just
-   * declaring it in the type lexer so that declare class and iterators can use
-   * it *)
-  | ("@@"? word) as word
-                       {
+  | word as word       {
                          unicode_fix_cols lexbuf;
                          try env, Hashtbl.find type_keywords word
                          with Not_found -> env, T_IDENTIFIER

--- a/src/parser/parser_flow.ml
+++ b/src/parser/parser_flow.ml
@@ -622,8 +622,12 @@ end = struct
                   typeAnnotation = None;
                 }) in
               false, static_key
-          | true, _ -> true, Parse.object_key env
-          | false, _ -> false, Parse.object_key env in
+          | _ ->
+              Eat.push_lex_mode env NORMAL_LEX;
+              let key = Parse.object_key env in
+              Eat.pop_lex_mode env;
+              static, key
+          in
           let property = match Peek.token env with
           | T_LESS_THAN
           | T_LPAREN -> method_property env start_loc static key

--- a/src/parser/test/hardcoded_tests.js
+++ b/src/parser/test/hardcoded_tests.js
@@ -1291,6 +1291,24 @@ module.exports = {
         }
       ]
     },
+    'declare class A { static implements: number; implements: number }': {
+      'body.0': {
+        'type': 'DeclareClass',
+        'id.name': 'A',
+        'body.properties': [
+          {
+            'key.name': 'implements',
+            'value.type': 'NumberTypeAnnotation',
+            'static': true,
+          },
+          {
+            'key.name': 'implements',
+            'value.type': 'NumberTypeAnnotation',
+            'static': false,
+          },
+        ],
+      },
+    },
   },
   'Invalid syntax': {
     // Duplicates are forbidden if IsSimpleParameterList is false, and rest


### PR DESCRIPTION
Fixes #829, where @sebmck couldn't use `implements` as the key in a
declared class type. This was happening because the key was lexed in
"type mode" which spat out a T_IDENTIFIER instead of a T_IMPLEMENTS, so
later on, in `Parser_flow.identifier_or_reserved_word`, the logic to
explicitly allow reserved words didn't fire, and we fell back to
`identifier`, which complains about the future reserved word.

After this change object keys in a type context are lexed in normal
mode, so the lexer will spit out the more specific token type, and
`identifier_or_reserved_word` can do its job.

This change does allow `@@foo` in object literals and class
declarations, which is absolutely wrong. However, we should really be
using [Symbol.iterator] instead of @@iterator, so adding a bunch of
error handling in the parser (tried it, was ugly) just didn't seem worth
it. Feel free to set me straight if I'm just being lazy... :)