### PR TITLE
Generator improvements: working generics and proper variance

### DIFF
--- a/src/typing/type_inference_js.ml
+++ b/src/typing/type_inference_js.ml
@@ -5343,14 +5343,6 @@ and mk_class_elements cx instance_info static_info body = Ast.Class.(
            (_, _, ret, param_types_map, param_loc_map) =
         SMap.find_unsafe name sigs_to_use in
 
-      let yield, next = if generator then (
-        Flow_js.mk_tvar cx (prefix_reason "yield of " reason),
-        Flow_js.mk_tvar cx (prefix_reason "next of " reason)
-      ) else (
-        MixedT (replace_reason "no yield" reason),
-        MixedT (replace_reason "no next" reason)
-      ) in
-
       let save_return_exn = Abnormal.swap Abnormal.Return false in
       let save_throw_exn = Abnormal.swap Abnormal.Throw false in
       Flow_js.generate_tests cx reason typeparams (fun map_ ->
@@ -5365,6 +5357,13 @@ and mk_class_elements cx instance_info static_info body = Ast.Class.(
           | _ -> name = "constructor"
         in
         let function_kind = function_kind ~async ~generator in
+        let yield, next = if generator then (
+          Flow_js.mk_tvar cx (prefix_reason "yield of " reason),
+          Flow_js.mk_tvar cx (prefix_reason "next of " reason)
+        ) else (
+          MixedT (replace_reason "no yield" reason),
+          MixedT (replace_reason "no next" reason)
+        ) in
         mk_body None cx type_params_map ~kind:function_kind ~derived_ctor
           param_types_map param_loc_map ret body this super yield next;
       );
@@ -5745,14 +5744,6 @@ and function_decl id cx type_params_map (reason:reason) ~kind
   let (params, pnames, ret, param_types_map, param_types_loc) =
     mk_params_ret cx type_params_map params (body, ret) in
 
-  let yield, next = if kind = Scope.Generator then (
-    Flow_js.mk_tvar cx (prefix_reason "yield of " reason),
-    Flow_js.mk_tvar cx (prefix_reason "next of " reason)
-  ) else (
-    MixedT (replace_reason "no yield" reason),
-    MixedT (replace_reason "no next" reason)
-  ) in
-
   let save_return_exn = Abnormal.swap Abnormal.Return false in
   let save_throw_exn = Abnormal.swap Abnormal.Throw false in
   Flow_js.generate_tests cx reason typeparams (fun map_ ->
@@ -5761,6 +5752,14 @@ and function_decl id cx type_params_map (reason:reason) ~kind
     let param_types_map =
       param_types_map |> SMap.map (Flow_js.subst cx map_) in
     let ret = Flow_js.subst cx map_ ret in
+
+    let yield, next = if kind = Scope.Generator then (
+      Flow_js.mk_tvar cx (prefix_reason "yield of " reason),
+      Flow_js.mk_tvar cx (prefix_reason "next of " reason)
+    ) else (
+      MixedT (replace_reason "no yield" reason),
+      MixedT (replace_reason "no next" reason)
+    ) in
 
     mk_body id cx type_params_map ~kind
       param_types_map param_types_loc ret body this super yield next;

--- a/src/typing/type_inference_js.ml
+++ b/src/typing/type_inference_js.ml
@@ -1387,6 +1387,10 @@ and statement cx type_params_map = Ast.Statement.(
         List.length (extract_type_param_declarations typeParameters) = 1
       then mk_type_param_declarations cx type_params_map typeParameters
         ~polarities:[Positive]
+      else if (iname = "Generator") &&
+        List.length (extract_type_param_declarations typeParameters) = 3
+      then mk_type_param_declarations cx type_params_map typeParameters
+        ~polarities:[Positive; Positive; Negative]
       else mk_type_param_declarations cx type_params_map typeParameters in
 
     let sfmap, smmap, fmap, mmap = List.fold_left Ast.Type.Object.Property.(

--- a/tests/generators/class.js
+++ b/tests/generators/class.js
@@ -80,6 +80,20 @@ class GeneratorExamples {
   *delegate_return_iterable(xs: Array<number>) {
     var x: void = yield *xs // ok: Iterator has no yield value
   }
+
+  *generic_yield<Y>(y: Y): Generator<Y,void,void> {
+    yield y;
+  }
+
+  *generic_return<R>(r: R): Generator<void,R,void> {
+    return r;
+  }
+
+  *generic_next<N>(): Generator<void,N,N> {
+    var n = yield undefined;
+    invariant(n != null);
+    return n;
+  }
 }
 
 var examples = new GeneratorExamples();

--- a/tests/generators/generators.exp
+++ b/tests/generators/generators.exp
@@ -9,10 +9,6 @@ class.js:15:8,8: number
 This type is incompatible with
 class.js:15:12,17: string
 
-class.js:23:39,44: number
-This type is incompatible with
-class.js:24:12,13: string
-
 class.js:24:12,13: string
 This type is incompatible with
 class.js:23:39,44: number
@@ -62,10 +58,6 @@ generators.js:1:35,40: number
 generators.js:14:6,6: number
 This type is incompatible with
 generators.js:14:10,15: string
-
-generators.js:22:46,51: number
-This type is incompatible with
-generators.js:23:10,11: string
 
 generators.js:23:10,11: string
 This type is incompatible with
@@ -133,4 +125,4 @@ throw.js:24:4,21: number
 This type is incompatible with
 throw.js:24:24,29: string
 
-Found 29 errors
+Found 27 errors

--- a/tests/generators/generators.exp
+++ b/tests/generators/generators.exp
@@ -21,39 +21,39 @@ class.js:68:21,34: string
 This type is incompatible with
 class.js:68:12,17: number
 
-class.js:87:41,41: number
+class.js:101:41,41: number
 This type is incompatible with
-class.js:87:45,50: string
+class.js:101:45,50: string
 
-class.js:89:23,51: call of method `next`
+class.js:103:23,51: call of method `next`
 Error:
-class.js:89:50,50: number
+class.js:103:50,50: number
 This type is incompatible with
 class.js:28:13,19: boolean
 
-class.js:89:23,51: call of method `next`
+class.js:103:23,51: call of method `next`
 Error:
-class.js:93:4,18: string
+class.js:107:4,18: string
 This type is incompatible with
-class.js:93:22,28: boolean
+class.js:107:22,28: boolean
 
-class.js:108:41,42: string
+class.js:122:41,42: string
 This type is incompatible with
 class.js:50:15,20: number
 
-class.js:111:4,4: string
+class.js:125:4,4: string
 This type is incompatible with
-class.js:111:8,13: number
+class.js:125:8,13: number
 
-class.js:114:1,44: call of method `next`
+class.js:128:1,44: call of method `next`
 Error:
-class.js:114:42,43: string
+class.js:128:42,43: string
 This type is incompatible with
 [LIB] core.js:328:37,40: undefined
 
-class.js:117:4,4: number
+class.js:131:4,4: number
 This type is incompatible with
-class.js:117:8,13: string
+class.js:131:8,13: string
 
 generators.js:3:9,10: string
 This type is incompatible with

--- a/tests/generators/generators.js
+++ b/tests/generators/generators.js
@@ -104,3 +104,17 @@ for (var x of delegate_yield_iterable([])) {
 function *delegate_return_iterable(xs: Array<number>) {
   var x: void = yield *xs // ok: Iterator has no yield value
 }
+
+function *generic_yield<Y>(y: Y): Generator<Y,void,void> {
+  yield y;
+}
+
+function *generic_return<R>(r: R): Generator<void,R,void> {
+  return r;
+}
+
+function *generic_next<N>(): Generator<void,N,N> {
+  var n = yield undefined;
+  invariant(n != null);
+  return n;
+}

--- a/tests/generators/variance.js
+++ b/tests/generators/variance.js
@@ -1,0 +1,2 @@
+declare var g1: Generator<string, string, ?string>;
+var g2: Generator<?string, ?string, string> = g1;


### PR DESCRIPTION
The yield and next tvars were created outside of the generate_tests
callback, so naturally we were creating inconsistencies between the
different bounds tests. Each test should use a fresh tvar, because we
only need to be consistent within a test.