### PR TITLE
Add MouseEvent

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -88,6 +88,28 @@ declare class Event {
     BUBBLING_PHASE: number;
 }
 
+declare class UIEvent extends Event {
+    detail: number;
+}
+
+declare class MouseEvent extends UIEvent {
+    altKey: boolean;
+    button: number;
+    buttons: number;
+    clientX: number;
+    clientY: number;
+    ctrlKey: boolean;
+    metaKey: boolean;
+    movementX: number;
+    movementY: number;
+    region: number;
+    screenX: number;
+    screenY: number;
+    shiftKey: boolean;
+    relatedTarget: ?EventTarget;
+    getModifierState(keyArg: string): boolean;
+}
+
 declare class ProgressEvent extends Event {
     lengthComputable: boolean;
     loaded: number;


### PR DESCRIPTION
Adding definition for MouseEvent based on docs:

https://w3c.github.io/uievents/#interface-MouseEvent  and https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent

fixes #774 