### PR TITLE
Don't havoc const bindings

### DIFF
--- a/src/typing/scope.ml
+++ b/src/typing/scope.ml
@@ -120,6 +120,8 @@ module Entry = struct
    *)
   let havoc ?name make_specific name entry =
     match entry with
+    | Value { kind = Const; _ } ->
+        entry
     | Value v ->
       if Reason_js.is_internal_name name then entry
       else Value { v with specific = make_specific v.general }

--- a/tests/refinements/const.js
+++ b/tests/refinements/const.js
@@ -1,0 +1,4 @@
+const x: ?number = 0;
+if (x) {
+  () => { (x : number) }
+}


### PR DESCRIPTION
Since the value of the binding can't change, the narrowed specific type
can't be made false.