### PR TITLE
Make flow opt-out by default, add gradual=true and @noflow options

### DIFF
--- a/runtests.sh
+++ b/runtests.sh
@@ -74,10 +74,7 @@ do
         # get config flags.
         # for now this is kind of ad-hoc:
         #
-        # 1. The default flow command is check with the --all flag. This flag
-        # can be overriden here with the line "all: false". Anything besides
-        # "false" is ignored, and the setting itself is ignored if a command
-        # besides check is run.
+        # 1. The default flow command is check.
         #
         # 2. The default flow command can be overriden here by supplying the
         # entire command on a line that begins with "cmd:". (Note: for writing
@@ -93,18 +90,12 @@ do
         # as argument ($1). We start the server before running the script and
         # stop the server after the script exits.
         #
-        all=" --all"
         shell=""
         cmd="check"
         stdin=""
         stderr_dest="$err_file"
         if [ -e ".testconfig" ]
         then
-            # all
-            if [ "$(awk '$1=="all:"{print $2}' .testconfig)" == "false" ]
-            then
-                all=""
-            fi
             # ignore_stderr
             if [ "$(awk '$1=="ignore_stderr:"{print $2}' .testconfig)" == "false" ]
             then
@@ -130,8 +121,8 @@ do
         # run test
         if [ "$cmd" == "check" ]
         then
-            # default command is check with configurable --all
-            $FLOW check . $all --strip-root --show-all-errors --old-output-format 1> $out_file 2> $stderr_dest
+            # default command is check
+            $FLOW check . --strip-root --show-all-errors --old-output-format 1> $out_file 2> $stderr_dest
         else
             # otherwise, run specified flow command, then kill the server
 

--- a/src/commands/serverCommands.ml
+++ b/src/commands/serverCommands.ml
@@ -113,6 +113,7 @@ module OptionParser(Config : CONFIG) = struct
     FlowEventLogger.set_from from;
     let root = CommandUtils.guess_root root in
     let flowconfig = FlowConfig.get root in
+    let opt_all = all || FlowConfig.(flowconfig.options.gradual = false) in
     let opt_module = FlowConfig.(match flowconfig.options.moduleSystem with
     | Node -> "node"
     | Haste -> "haste") in
@@ -163,7 +164,7 @@ module OptionParser(Config : CONFIG) = struct
       Options.opt_should_detach = Config.(mode = Detach);
       Options.opt_debug = debug;
       Options.opt_verbose;
-      Options.opt_all = all;
+      Options.opt_all;
       Options.opt_weak = weak;
       Options.opt_traces;
       Options.opt_json = json;

--- a/src/commands/serverCommands.ml
+++ b/src/commands/serverCommands.ml
@@ -113,7 +113,6 @@ module OptionParser(Config : CONFIG) = struct
     FlowEventLogger.set_from from;
     let root = CommandUtils.guess_root root in
     let flowconfig = FlowConfig.get root in
-    let opt_all = all || FlowConfig.(flowconfig.options.gradual = false) in
     let opt_module = FlowConfig.(match flowconfig.options.moduleSystem with
     | Node -> "node"
     | Haste -> "haste") in
@@ -164,7 +163,7 @@ module OptionParser(Config : CONFIG) = struct
       Options.opt_should_detach = Config.(mode = Detach);
       Options.opt_debug = debug;
       Options.opt_verbose;
-      Options.opt_all;
+      Options.opt_all = all;
       Options.opt_weak = weak;
       Options.opt_traces;
       Options.opt_json = json;

--- a/src/common/files_js.ml
+++ b/src/common/files_js.ml
@@ -202,7 +202,7 @@ let wanted config =
 let make_next_files root =
   let config = FlowConfig.get root in
   let filter = wanted config in
-  let others = config.FlowConfig.include_stems in
+  let others = FlowConfig.(config.includes.stems) in
   let sroot = Path.to_string root in
   let realpath_filter path = is_valid_path path && filter path in
   let path_filter path =
@@ -245,7 +245,7 @@ let package_json root =
     (str_starts_with path sroot || FlowConfig.is_included config path)
     && realpath_filter path
   in
-  let others = config.FlowConfig.include_stems in
+  let others = FlowConfig.(config.includes.stems) in
   let get_next = make_next_files_following_symlinks
     ~path_filter
     ~realpath_filter

--- a/src/common/flowConfig.ml
+++ b/src/common/flowConfig.ml
@@ -24,6 +24,7 @@ type experimental_feature_mode =
 type options = {
   enable_unsafe_getters_and_setters: bool;
   experimental_decorators: experimental_feature_mode;
+  gradual: bool;
   moduleSystem: moduleSystem;
   module_name_mappers: (Str.regexp * string) list;
   munge_underscores: bool;
@@ -85,6 +86,7 @@ let default_module_system = Node
 let default_options root = {
   enable_unsafe_getters_and_setters = false;
   experimental_decorators = EXPERIMENTAL_WARN;
+  gradual = false;
   moduleSystem = default_module_system;
   module_name_mappers = [];
   munge_underscores = false;
@@ -435,6 +437,12 @@ let options_parser = OptionsParser.configure [
     _parser = experimental_feature_flag (fun opts (_, value) ->
       { opts with experimental_decorators = value; }
     );
+  }));
+
+  ("gradual", OptionsParser.({
+    flags = [];
+    _parser = boolean
+      (fun opts (_, gradual) -> { opts with gradual });
   }));
 
   ("suppress_comment", OptionsParser.({

--- a/src/common/flowConfig.mli
+++ b/src/common/flowConfig.mli
@@ -16,6 +16,7 @@ type experimental_feature_mode =
 type options = {
   enable_unsafe_getters_and_setters: bool;
   experimental_decorators: experimental_feature_mode;
+  gradual: bool;
   moduleSystem: moduleSystem;
   module_name_mappers: (Str.regexp * string) list;
   munge_underscores: bool;

--- a/src/common/flowConfig.mli
+++ b/src/common/flowConfig.mli
@@ -16,7 +16,6 @@ type experimental_feature_mode =
 type options = {
   enable_unsafe_getters_and_setters: bool;
   experimental_decorators: experimental_feature_mode;
-  gradual: bool;
   moduleSystem: moduleSystem;
   module_name_mappers: (Str.regexp * string) list;
   munge_underscores: bool;
@@ -35,15 +34,19 @@ val default_options: Path.t -> options
 
 module PathMap : Utils.MapSig with type key = Path.t
 
+type path_matcher = {
+  paths: Path.t list;
+  stems: Path.t list;
+  stem_map: ((string * Str.regexp) list) PathMap.t;
+}
+
 type config = {
   (* file blacklist *)
   excludes: (string * Str.regexp) list;
   (* user-specified non-root include paths. may contain wildcards *)
-  includes: Path.t list;
-  (* stems extracted from includes *)
-  include_stems: Path.t list;
-  (* map from include_stems to list of (original path, regexified path) *)
-  include_map: ((string * Str.regexp) list) PathMap.t;
+  includes: path_matcher;
+  (* gradually typed files *)
+  gradual: path_matcher;
   (* library paths. no wildcards *)
   libs: Path.t list;
   (* config options *)
@@ -69,3 +72,6 @@ val is_included: config -> string -> bool
 
 (* true if a file path matches an exclude (ignore) entry in config *)
 val is_excluded: config -> string -> bool
+
+(* true if a file path matches a `gradual` regex in config *)
+val is_gradual: config -> string -> bool

--- a/src/parsing/parsing_service_js.ml
+++ b/src/parsing/parsing_service_js.ml
@@ -31,9 +31,10 @@ module ParserHeap = SharedMem.WithCache (Loc.FilenameKey) (struct
 (* . matches any character except the newline, so this is a little more
  * complicated than one might think *)
 let flow_check_regexp = (Str.regexp "\\(.\\|\n\\)*@flow")
+let noflow_check_regexp = (Str.regexp "\\(.\\|\n\\)*@noflow")
 
-let is_flow content =
-  Str.string_match flow_check_regexp content 0
+let is_flow content = Str.string_match flow_check_regexp content 0
+let is_noflow content = Str.string_match noflow_check_regexp content 0
 
 let is_lib_file = Loc.(function
 | LibFile _ -> true

--- a/src/parsing/parsing_service_js.mli
+++ b/src/parsing/parsing_service_js.mli
@@ -52,3 +52,4 @@ val do_parse:
 
 (* true if file is in flow, i.e. is to be checked. CAUTION expensive *)
 val in_flow: string -> filename -> bool
+val is_noflow: string -> bool

--- a/src/server/server.ml
+++ b/src/server/server.ml
@@ -443,7 +443,7 @@ struct
 
   let get_watch_paths options =
     let config = FlowConfig.get (Options.root options) in
-    config.FlowConfig.include_stems
+    FlowConfig.(config.includes.stems)
 
   (* filter a set of updates coming from dfind and return
      a ServerEnv.PathSet. updates may be coming in from

--- a/src/typing/module_js.mli
+++ b/src/typing/module_js.mli
@@ -24,7 +24,7 @@ type mode = ModuleMode_Checked | ModuleMode_Weak | ModuleMode_Unchecked
 
 val module_name_candidates: string -> string list
 
-val parse_flow: Spider_monkey_ast.Comment.t list -> mode
+val parse_flow: default_mode:mode -> Spider_monkey_ast.Comment.t list -> mode
 
 (* initialize to a module system, given the name of the module system *)
 val init: Options.options -> unit

--- a/src/typing/type_inference_js.ml
+++ b/src/typing/type_inference_js.ml
@@ -550,6 +550,11 @@ let check_type_param_arity cx loc params n f =
     let msg = spf "Incorrect number of type parameters (expected %n)" n in
     error_type cx loc msg
 
+let is_gradual = function
+  | Loc.LibFile _ -> false
+  | Loc.Builtins -> false
+  | Loc.SourceFile file -> FlowConfig.is_gradual (FlowConfig.get_unsafe ()) file
+
 let is_suppress_type type_name = FlowConfig.(
   let config = get_unsafe () in
   SSet.mem type_name config.options.suppress_types
@@ -6218,7 +6223,7 @@ let infer_ast ?module_name ~force_check ~weak_by_default ~verbose ast file =
 
   let checked, weak =
     let open Module_js in
-    let default_mode = if force_check
+    let default_mode = if force_check || not (is_gradual file)
       then ModuleMode_Checked
       else ModuleMode_Unchecked
     in

--- a/src/typing/type_inference_js.ml
+++ b/src/typing/type_inference_js.ml
@@ -6216,13 +6216,20 @@ let infer_ast ?module_name ~force_check ~weak_by_default ~verbose ast file =
 
   let loc, statements, comments = ast in
 
-  let checked, weak = Module_js.(match parse_flow comments with
-  | ModuleMode_Checked ->
-    true, weak_by_default
-  | ModuleMode_Weak ->
-    true, true
-  | ModuleMode_Unchecked ->
-    force_check, weak_by_default) in
+  let checked, weak =
+    let open Module_js in
+    let default_mode = if force_check
+      then ModuleMode_Checked
+      else ModuleMode_Unchecked
+    in
+    match parse_flow ~default_mode comments with
+    | ModuleMode_Checked ->
+      true, weak_by_default
+    | ModuleMode_Weak ->
+      true, true
+    | ModuleMode_Unchecked ->
+      false, weak_by_default
+  in
 
   let _module = match module_name with
     | Some _module -> _module

--- a/tests/parse_error_haste/.flowconfig
+++ b/tests/parse_error_haste/.flowconfig
@@ -1,3 +1,2 @@
 [options]
 module.system=haste
-

--- a/tests/parse_error_haste/.testconfig
+++ b/tests/parse_error_haste/.testconfig
@@ -1,1 +1,0 @@
-all: false

--- a/tests/parse_error_haste/NoProvides.js
+++ b/tests/parse_error_haste/NoProvides.js
@@ -2,6 +2,7 @@
  * Parse errors, imported, not in flow, no provides module.
  * Should see a parse error in this file, and module
  * not found in client.
+ * @noflow
  */
 function f(s:string):string { ### // illegal token
   return s;

--- a/tests/parse_error_haste/Provides.js
+++ b/tests/parse_error_haste/Provides.js
@@ -3,6 +3,7 @@
  * Should see a parse error in this file, and module
  * not found in client.
  * @providesModule Foo
+ * @noflow
  */
 function f(s:string):string { ### // illegal token
   return s;

--- a/tests/parse_error_haste/Unimported.js
+++ b/tests/parse_error_haste/Unimported.js
@@ -2,6 +2,7 @@
  * Parse errors but not in flow and not imported.
  * Should see no parse errors for this file.
  * @providesModule Bar
+ * @noflow
  */
 function f(s:string):string { ### // illegal token
   return s;

--- a/tests/parse_error_haste/parse_error_haste.exp
+++ b/tests/parse_error_haste/parse_error_haste.exp
@@ -5,8 +5,8 @@ Required module not found
 Client.js:9:9,31: NoProvides.js
 Required module not found
 
-NoProvides.js:6:31,31: Unexpected token ILLEGAL
+NoProvides.js:7:31,31: Unexpected token ILLEGAL
 
-Provides.js:7:31,31: Unexpected token ILLEGAL
+Provides.js:8:31,31: Unexpected token ILLEGAL
 
 Found 4 errors

--- a/tests/parse_error_node/.flowconfig
+++ b/tests/parse_error_node/.flowconfig
@@ -1,2 +1,2 @@
-[options]
-gradual=true
+[gradual]
+**

--- a/tests/parse_error_node/.flowconfig
+++ b/tests/parse_error_node/.flowconfig
@@ -1,0 +1,2 @@
+[options]
+gradual=true

--- a/tests/parse_error_node/.testconfig
+++ b/tests/parse_error_node/.testconfig
@@ -1,1 +1,0 @@
-all: false


### PR DESCRIPTION
Flow is currently opt-in on a per-file basis (requires you to add `@flow` to each file, in addition to adding a `.flowconfig`). This is great for existing projects, but not great for new projects that want everything to be flow; people have resorted to adding lint checks, for example.

This diff makes Flow opt-out by default (requires you to add `@noflow` to files you want to ignore, or add them to the `[ignores]` in `.flowconfig`). It also adds a `gradual=true` option if you want the current opt-in behavior.

I chose to make `gradual=false` the default even though it's a breaking change because I think it's a much better long term place to be: it's more likely that flow is being used on new projects than added to existing ones; it feels more "pit of success"-y (can no longer forget to add `@flow` and think everything is all good); and it's easy to turn off.

Fixes #284