### PR TITLE
Correct return and arg types for Stream::pipe

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -766,7 +766,7 @@ declare module "readline" {
 }
 
 declare class stream$Stream extends events$EventEmitter {
-  pipe(dest: any, options?: any): void;
+  pipe(dest: stream$Writable, options?: any): stream$Writable;
 }
 
 declare class stream$Readable extends stream$Stream {

--- a/tests/node_tests/stream/stream.js
+++ b/tests/node_tests/stream/stream.js
@@ -1,6 +1,7 @@
 /* @flow */
 
 var child_process = require('child_process');
+var fs = require('fs');
 var ls = child_process.spawn('ls');
 
 var data = "foo";
@@ -16,3 +17,6 @@ ls.stdin.end(data);
 ls.stdin.end(data, "utf-8");
 ls.stdin.end(data, () => {});
 ls.stdin.end(data, "utf-8", () => {});
+
+var ws = fs.createWriteStream('/dev/null');
+ls.stdout.pipe(ws).end();


### PR DESCRIPTION
[`Stream::pipe`](https://nodejs.org/api/stream.html#stream_readable_pipe_destination_options) both takes a Writable as its destination and returns that Writable so the call to `pipe` can be chained.

Fixes #906