### PR TITLE
Link to release tag instead of changelog

### DIFF
--- a/_posts/2015-10-07-Version-0.17.0.md
+++ b/_posts/2015-10-07-Version-0.17.0.md
@@ -10,4 +10,4 @@ Today we released Flow v0.17.0! The first thing you may notice is that we change
 
 This should hopefully help our command line users understand many errors without having to refer to their source code. We'll keep iterating on this format, so tell us what you like and what you don't like! Thanks to [@frantic](https://github.com/frantic) for building this feature!
 
-There are a whole bunch of other features and fixes in this release! Head on over to our [Changelog](https://github.com/facebook/flow/blob/master/Changelog.md) for the full list!
+There are a whole bunch of other features and fixes in this release! Head on over to our [Release](https://github.com/facebook/flow/releases/tag/v0.17.0) for the full list!


### PR DESCRIPTION
This makes it so that users can see this specific release's change, and releases are unlikely to change after getting tagged.