### PR TITLE
Allow yield without an argument

### DIFF
--- a/src/parser/estree_translator.ml
+++ b/src/parser/estree_translator.ml
@@ -486,7 +486,7 @@ end with type t = Impl.t) = struct
       )
     | loc, Yield yield -> Yield.(
         node "YieldExpression" loc [|
-          "argument", expression yield.argument;
+          "argument", option expression yield.argument;
           "delegate", bool yield.delegate;
         |]
       )

--- a/src/parser/parser_flow.ml
+++ b/src/parser/parser_flow.ml
@@ -1123,8 +1123,14 @@ end = struct
       if not (allow_yield env)
       then error env Error.IllegalYield;
       let delegate = Expect.maybe env T_MULT in
-      let argument = assignment env in
-      Loc.btwn start_loc (fst argument), Expression.(Yield Yield.({
+      let argument =
+        if delegate || not (Expect.maybe env T_SEMICOLON)
+        then Some (assignment env)
+        else None in
+      let end_loc = match argument with
+      | Some expr -> fst expr
+      | None -> start_loc in
+      Loc.btwn start_loc end_loc, Expression.(Yield Yield.({
         argument;
         delegate;
       }))

--- a/src/parser/parser_flow.ml
+++ b/src/parser/parser_flow.ml
@@ -1123,13 +1123,19 @@ end = struct
       if not (allow_yield env)
       then error env Error.IllegalYield;
       let delegate = Expect.maybe env T_MULT in
+      let has_argument = not (
+        Peek.token env = T_SEMICOLON || Peek.is_implicit_semicolon env
+      ) in
       let argument =
-        if delegate || not (Expect.maybe env T_SEMICOLON)
+        if delegate || has_argument
         then Some (assignment env)
         else None in
       let end_loc = match argument with
       | Some expr -> fst expr
-      | None -> start_loc in
+      | None -> (match Peek.semicolon_loc env with
+        | Some loc -> loc
+        | None -> start_loc) in
+      Eat.semicolon env;
       Loc.btwn start_loc end_loc, Expression.(Yield Yield.({
         argument;
         delegate;

--- a/src/parser/spider_monkey_ast.ml
+++ b/src/parser/spider_monkey_ast.ml
@@ -683,7 +683,7 @@ and Expression : sig
   end
   module Yield : sig
     type t = {
-      argument: Expression.t;
+      argument: Expression.t option;
       delegate: bool;
     }
   end

--- a/src/parser/test/hardcoded_tests.js
+++ b/src/parser/test/hardcoded_tests.js
@@ -2650,7 +2650,15 @@ module.exports = {
   'Valid yield expressions': {
     'yield foo;': {},
     'yield* foo;': {},
-    'yield;': {}
+    'yield;': {
+      'body.0.expression.argument': null
+    },
+    'yield\nfoo': {
+      'body.0.expression.argument': null
+    },
+    '{ yield }': {
+      'body.0.body.0.expression.argument': null
+    }
   },
   'Invalid yield expressions': {
     'yield*;': {

--- a/src/parser/test/hardcoded_tests.js
+++ b/src/parser/test/hardcoded_tests.js
@@ -2646,5 +2646,15 @@ module.exports = {
     'import { foo as default } from "foo"': {
       'errors.0.message': 'Unexpected token default'
     }
+  },
+  'Valid yield expressions': {
+    'yield foo;': {},
+    'yield* foo;': {},
+    'yield;': {}
+  },
+  'Invalid yield expressions': {
+    'yield*;': {
+      'errors.0.message': 'Unexpected token ;'
+    }
   }
 };

--- a/src/typing/type_inference_js.ml
+++ b/src/typing/type_inference_js.ml
@@ -3633,7 +3633,9 @@ and expression_ ~is_cond cx type_params_map loc e = Ast.Expression.(match e with
   | Yield { Yield.argument; delegate = false } ->
       let reason = mk_reason "yield" loc in
       let yield = Env_js.get_var cx (internal_name "yield") reason in
-      let t = expression cx type_params_map argument in
+      let t = match argument with
+      | Some expr -> expression cx type_params_map expr
+      | None -> VoidT.at loc in
       Flow_js.flow cx (t, yield);
       let next = Env_js.get_var cx (internal_name "next") reason in
       OptionalT next
@@ -3646,7 +3648,9 @@ and expression_ ~is_cond cx type_params_map loc e = Ast.Expression.(match e with
       let yield = Env_js.get_var cx
         (internal_name "yield")
         (prefix_reason "yield of parent generator in " reason) in
-      let t = expression cx type_params_map argument in
+      let t = match argument with
+      | Some expr -> expression cx type_params_map expr
+      | None -> assert_false "delegate yield without argument" in
 
       let ret = Flow_js.mk_tvar cx
         (prefix_reason "return of child generator in " reason) in

--- a/tests/generators/class.js
+++ b/tests/generators/class.js
@@ -5,12 +5,12 @@ class GeneratorExamples {
   }
 
   *stmt_next(): Generator<void, void, number> {
-    var a = yield undefined;
+    var a = yield;
     if (a) {
       (a : number); // ok
     }
 
-    var b = yield undefined;
+    var b = yield;
     if (b) {
       (b : string); // error: number ~> string
     }
@@ -47,7 +47,7 @@ class GeneratorExamples {
 
   *delegate_next_generator() {
     function *inner() {
-      var x: ?number = yield undefined; // error: string ~> number
+      var x: ?number = yield; // error: string ~> number
     }
     yield *inner();
   }

--- a/tests/generators/generators.js
+++ b/tests/generators/generators.js
@@ -4,12 +4,12 @@ function *stmt_yield(): Generator<number, void, void> {
 }
 
 function *stmt_next(): Generator<void, void, number> {
-  var a = yield undefined;
+  var a = yield;
   if (a) {
     (a : number); // ok
   }
 
-  var b = yield undefined;
+  var b = yield;
   if (b) {
     (b : string); // error: number ~> string
   }
@@ -63,7 +63,7 @@ for (var x of widen_yield()) {
 
 function *delegate_next_generator() {
   function *inner() {
-    var x: ?number = yield undefined; // error: string ~> number
+    var x: ?number = yield; // error: string ~> number
   }
   yield *inner();
 }


### PR DESCRIPTION
The only tricky bit here is that yield* expressions must have an
argument. Personally, I would have preferred a sum type in the AST, but
the estree spec has `Expression | null`, so I wanted to stay close to
that.

Fixes #912