### PR TITLE
Key to createHmac can be a buffer

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -291,7 +291,7 @@ declare module "crypto" {
   declare function createDiffieHellman(prime_length: number): crypto$DiffieHellman;
   declare function createDiffieHellman(prime: number, encoding?: string): crypto$DiffieHellman;
   declare function createHash(algorithm: string): crypto$Hash;
-  declare function createHmac(algorithm: string, key: string): crypto$Hmac;
+  declare function createHmac(algorithm: string, key: string | Buffer): crypto$Hmac;
   declare function creatSign(algorithm: string): crypto$Sign;
   declare function createVerify(algorithm: string): crypto$Verify;
   declare function getCiphers(): Array<string>;


### PR DESCRIPTION
If it's not a buffer, it's converted to a buffer anyway, at least in crypto-browserify

see
https://github.com/crypto-browserify/createHmac/blob/master/browser.js