### PR TITLE
anyfun anyobj typeof refi

### DIFF
--- a/src/typing/flow_js.ml
+++ b/src/typing/flow_js.ml
@@ -3983,8 +3983,8 @@ and filter cx trace t l pred =
 
 and is_string = function StrT _ -> true | _ -> false
 and is_number = function NumT _ -> true | _ -> false
-and is_function = function FunT _ -> true | _ -> false
-and is_object = function (ObjT _ | ArrT _ | NullT _) -> true | _ -> false
+and is_function = function AnyFunT _ | FunT _ -> true | _ -> false
+and is_object = function (AnyObjT _ | ObjT _ | ArrT _ | NullT _) -> true | _ -> false
 and is_array = function ArrT _ -> true | _ -> false
 and is_bool = function BoolT _ -> true | _ -> false
 

--- a/tests/refinements/typeof.js
+++ b/tests/refinements/typeof.js
@@ -30,3 +30,17 @@ function fn1() {
     BAZ.stuff(123); // error, refinement is gone
   }
 }
+
+function anyfun(x: number | Function): number {
+  if (typeof x === "function") {
+    return 0;
+  }
+  return x; // OK, x refined to `number`
+}
+
+function anyobj(x: number | Object): number {
+  if (typeof x === "object") {
+    return 0;
+  }
+  return x; // OK, x refined to `number`
+}


### PR DESCRIPTION
Before this change, the two added test cases resulted in a type error,
because the conditional did not result in a refinement. This is because
`Function` and `Object` annotations are represented as `AnyFunT` and
`AnyObjT` internally, respectively. These types were erroneously
excluded from the pattern match `is_function` and `is_object`,
respectively.

Fixes #936