### PR TITLE
Declare both formats of crypto [pseudo]randomBytes

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -310,13 +310,19 @@ declare module "crypto" {
     iterations: number,
     keylen: number
   ): string;
+  // `UNUSED` argument strictly enforces arity to enable overloading this
+  // function with 1-arg and 2-arg variants.
+  declare function pseudoRandomBytes(size: number, UNUSED: void): Buffer;
   declare function pseudoRandomBytes(
     size: number,
     callback: (err: ?Error, buffer: Buffer) => void
   ): void;
+  // `UNUSED` argument strictly enforces arity to enable overloading this
+  // function with 1-arg and 2-arg variants.
+  declare function randomBytes(size: number, UNUSED: void): Buffer;
   declare function randomBytes(
     size: number,
-    callback?: (err: ?Error, buffer: Buffer) => void
+    callback: (err: ?Error, buffer: Buffer) => void
   ): void;
 }
 


### PR DESCRIPTION
[`randomBytes`][0] and [`pseudoRandomBytes`][1] have synchronous and
asynchronous versions determined by arguments. If a single argument is
passed, a `Buffer` is returned synchronously. If a second function
argument is passed, the `Buffer` is asynchronously passed to the
function argument.

[0]:
https://nodejs.org/docs/latest-v0.12.x/api/crypto.html#crypto_crypto_randombytes_size_callback
[1]:
https://nodejs.org/docs/latest-v0.12.x/api/crypto.html#crypto_crypto_pseudorandombytes_size_callback