### PR TITLE
Add test for default destructuring parameter

### DIFF
--- a/tests/destructuring/destructuring.exp
+++ b/tests/destructuring/destructuring.exp
@@ -81,8 +81,16 @@ destructuring.js:45:6,8: property `baz`
 Property not found in
 destructuring.js:45:4,4: object literal
 
+destructuring.js:49:19,19: property `b`
+Property not found in
+destructuring.js:49:24,41: object literal
+
+destructuring.js:50:55,59: string
+This type is incompatible with
+destructuring.js:50:28,33: number
+
 destructuring_init.js:1:5,9: Destructuring assignment must be initialized
 
 destructuring_param.js:5:17,17: Strict mode function may not have duplicate parameter names
 
-Found 21 errors
+Found 23 errors

--- a/tests/destructuring/destructuring.js
+++ b/tests/destructuring/destructuring.js
@@ -46,4 +46,7 @@ function test() {
   (rest.baz: string); // no error, rest is unsealed
 }
 
+function shab({a, b} = {a : 2, c : 'foo'}) { }
+function toz({a, b} : {a : number, b : number} = {a : 'str', b : 0}) { }
+
 module.exports = corge;


### PR DESCRIPTION
Default parameter value for destructuring was not checked by Flow.

If there is a `default` value, be sure that it correctly typechecks and if not we do nothing to allow this : 
```javascript
function bar(a = 3) { }
bar('lol'); // no error

function foo({a} = {a:3}) { }
foo({a:'lol'}); // it seems that should not error too
```