### PR TITLE
Allow null type annotation. (Fix #375)

### DIFF
--- a/src/parser/estree_translator.ml
+++ b/src/parser/estree_translator.ml
@@ -828,6 +828,7 @@ end with type t = Impl.t) = struct
     match t with
     | Any -> any_type loc
     | Void -> void_type loc
+    | Null -> null_type loc
     | Number -> number_type loc
     | String -> string_type loc
     | Boolean -> boolean_type loc
@@ -849,6 +850,8 @@ end with type t = Impl.t) = struct
   and any_type loc = node "AnyTypeAnnotation" loc [||]
 
   and void_type loc = node "VoidTypeAnnotation" loc [||]
+
+  and null_type loc = node "NullTypeAnnotation" loc [||]
 
   and number_type loc = node "NumberTypeAnnotation" loc [||]
 

--- a/src/parser/lexer_flow.mll
+++ b/src/parser/lexer_flow.mll
@@ -524,6 +524,7 @@
       "number",  T_NUMBER_TYPE;
       "string",  T_STRING_TYPE;
       "void",    T_VOID_TYPE;
+      "null",    T_NULL;
     ]
 }
 

--- a/src/parser/parser_flow.ml
+++ b/src/parser/parser_flow.ml
@@ -365,6 +365,7 @@ end = struct
       | T_NUMBER_TYPE  -> Some Type.Number
       | T_STRING_TYPE  -> Some Type.String
       | T_VOID_TYPE    -> Some Type.Void
+      | T_NULL         -> Some Type.Null
       | _ -> None
 
     and tuple =

--- a/src/parser/spider_monkey_ast.ml
+++ b/src/parser/spider_monkey_ast.ml
@@ -140,6 +140,7 @@ and Type : sig
   and t' =
     | Any
     | Void
+    | Null
     | Number
     | String
     | Boolean

--- a/src/typing/type_inference_js.ml
+++ b/src/typing/type_inference_js.ml
@@ -595,6 +595,8 @@ let rec convert cx type_params_map = Ast.Type.(function
 
   | loc, Void -> void_ loc
 
+  | loc, Null -> NullT.at loc
+
   | loc, Number -> NumT.at loc
 
   | loc, String -> StrT.at loc

--- a/tests/annot/annot.exp
+++ b/tests/annot/annot.exp
@@ -37,4 +37,8 @@ annot.js:37:26,72: property `path`
 Property not found in
 annot.js:46:14,50:7: object literal
 
-Found 9 errors
+annot.js:55:18,18: number
+This type is incompatible with
+annot.js:55:11,14: null
+
+Found 10 errors

--- a/tests/annot/annot.js
+++ b/tests/annot/annot.js
@@ -51,3 +51,10 @@ function param_anno2(
     });
     // ...
   }
+
+var toz : null = 3;
+
+var zer : null = null;
+
+function foobar(n : ?number) : number | null | void { return n; }
+function barfoo(n : number | null | void) : ?number { return n; }


### PR DESCRIPTION
Allow `null` type annotation, ensure `number | null | void` is equivalent to `?number`.

```javascript
function bar(lol : ?number) { }

function foo(lol : number | null | void) { }

function foobar(lol : ?number) : number | null | void { return lol; }
function barfoo(lol : number | null | void) : ?number { return lol; }

var n : ?number = 3;;
var k : number | null | void = 3;
var p : number | null | void = n;

foo(n);
foo(p);

bar(k);
bar(p);
```