### PR TITLE
Object indexer should not imply callable signature

### DIFF
--- a/src/typing/flow_js.ml
+++ b/src/typing/flow_js.ml
@@ -3478,6 +3478,13 @@ and is_object_prototype_method = function
   | "valueOf" -> true
   | _ -> false
 
+(* neither object prototype methods nor callable signatures should be
+ * implied by an object indexer type *)
+and is_dictionary_exempt = function
+  | x when is_object_prototype_method x -> true
+  | "$call" -> true
+  | _ -> false
+
 (* only on use-types - guard calls with is_use t *)
 and err_operation = function
   | GetPropT _ -> "Property cannot be accessed on"
@@ -4025,8 +4032,7 @@ and ensure_prop_for_read cx strict mapr x proto dict_t reason_obj reason_op trac
   let t = match (read_prop_opt cx mapr x, dict_t) with
   | Some t, _ -> Some t
   | None, Some { key; value; _ } ->
-    (* Object.prototype methods are exempt from the dictionary rules *)
-    if is_object_prototype_method x
+    if is_dictionary_exempt x
     then None
     else (
       rec_flow cx trace (string_key x reason_op, key);
@@ -5086,8 +5092,7 @@ and dictionary cx trace keyt valuet = function
       rec_flow cx trace (keyt, key);
       begin match keyt with
       | StrT (_, Literal str) ->
-        (* Object.prototype methods are exempt from the dictionary rules *)
-        if not (is_object_prototype_method str)
+        if not (is_dictionary_exempt str)
         then rec_flow cx trace (valuet, value)
       | _ ->
         rec_flow cx trace (valuet, value)

--- a/tests/callable/callable.exp
+++ b/tests/callable/callable.exp
@@ -1,0 +1,6 @@
+
+primitives.js:6:1,6: function call
+Callable signature not found in
+primitives.js:6:1,4: object type
+
+Found 1 error

--- a/tests/callable/primitives.js
+++ b/tests/callable/primitives.js
@@ -1,3 +1,6 @@
 var x = Boolean(4);
 function foo(fn:(value:any)=>boolean) { }
 foo(Boolean);
+
+var dict: { [k: string]: any } = {};
+dict(); // error, callable signature not found


### PR DESCRIPTION
Callable signatures are implemented (in a kind of hacky way) by adding a
property named "$call" to the propmap of an object type. When an object
is called as a function, Flow looks for the "$call" property on the
object.

When the object has an indexer with a string key, this lookup would
succeed. I do not think it should succeed, because the property lookup
is part of the hacky nature of callable objects. Imagine if the propmap
stored the callable signature separately (as it should be -- what if I
want to make an object with a $call property?).