### PR TITLE
Use heap refinements in destructuring assignment

### DIFF
--- a/tests/refi/heap.js
+++ b/tests/refi/heap.js
@@ -81,4 +81,12 @@ var tests =
       var z : string = x.p; // ok
     }
   },
+
+  function() {
+    var x : {p:?string} = {p:"xxx"};
+    if (x.p != null) {
+      var {p} = x; // TODO: annot checked against type of x
+      (p : string); // ok
+    }
+  },
 ];


### PR DESCRIPTION
Basic premise is `{p} = o` is the same as `p = o.p`, so the same heap
refinement logic can apply.

Refinements are keyed on the member expression chain, so this code
builds up such an expression as it recurses through the pattern.

The destructuring helper now depends on the Refinement module, so I
pushed the module definition up. It is otherwise unchanged.

The TODO in the test is for this other issue I found, but did not
address here, where annotations for destructuring assignments are
checked against the RHS expression type instead of the destructured type
-- which may now be refined & different, but could always be rebound &
different:

```javascript
var o: { p: string } = { p: "" };
var { p: x } : { x: string } = o; // unexpected error
```

Fixes #975