### PR TITLE
Add failing test for class-level esproposal_decorators

### DIFF
--- a/tests/esproposal_decorators.ignore/test.js
+++ b/tests/esproposal_decorators.ignore/test.js
@@ -1,10 +1,11 @@
 /* @flow */
 
+@decorator1
 class Foo {
-  @decorator1
+  @decorator2
   method1() {}
 
-  @decorator2
   @decorator3
+  @decorator4
   method2() {}
 }


### PR DESCRIPTION
The `esproposal_decorators` option does not currently include decorators applied to the class itself.

This change includes a **FAILING test** of class-level decorators to ensure proper support is added.