### PR TITLE
Define WeakSet in lib/core.js

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -386,6 +386,12 @@ declare class Set<T> {
     values(): Iterator<T>;
 }
 
+declare class WeakSet<T: Object> {
+    add(value: T): WeakSet<T>;
+    delete(value: T): boolean;
+    has(value: T): boolean;
+}
+
 /* Promises
    cf. https://github.com/borisyankov/DefinitelyTyped/blob/master/es6-promises/es6-promises.d.ts
 */

--- a/tests/async/async.exp
+++ b/tests/async/async.exp
@@ -1,11 +1,11 @@
 
 async.js:12:10,10: number
 This type is incompatible with
-[LIB] core.js:408:32,45: union type
+[LIB] core.js:414:32,45: union type
 
 async.js:31:10,16: number
 This type is incompatible with
-[LIB] core.js:408:32,45: union type
+[LIB] core.js:414:32,45: union type
 
 async.js:45:22,25: Promise
 This type is incompatible with

--- a/tests/promises/promises.exp
+++ b/tests/promises/promises.exp
@@ -3,85 +3,85 @@ promise.js:10:1,17:2: call of method `then`
 Error:
 promise.js:11:11,11: number
 This type is incompatible with
-[LIB] core.js:395:25,38: union type
+[LIB] core.js:401:25,38: union type
 
 promise.js:20:1,26:4: call of method `then`
 Error:
 promise.js:20:42,42: number
 This type is incompatible with
-[LIB] core.js:395:25,38: union type
+[LIB] core.js:401:25,38: union type
 
 promise.js:30:11,32:4: constructor call
 Error:
 promise.js:31:13,13: number
 This type is incompatible with
-[LIB] core.js:395:25,38: union type
+[LIB] core.js:401:25,38: union type
 
 promise.js:41:13,43:6: constructor call
 Error:
 promise.js:42:15,15: number
 This type is incompatible with
-[LIB] core.js:395:25,38: union type
+[LIB] core.js:401:25,38: union type
 
 promise.js:51:1,64:2: call of method `then`
 Error:
 promise.js:53:13,14: number
 This type is incompatible with
-[LIB] core.js:395:25,38: union type
+[LIB] core.js:401:25,38: union type
 
 promise.js:115:1,118:2: call of method `then`
 Error:
 promise.js:115:17,17: number
 This type is incompatible with
-[LIB] core.js:408:32,45: union type
+[LIB] core.js:414:32,45: union type
 
 promise.js:121:17,34: call of method `resolve`
 Error:
 promise.js:121:33,33: number
 This type is incompatible with
-[LIB] core.js:408:32,45: union type
+[LIB] core.js:414:32,45: union type
 
 promise.js:127:33,50: call of method `resolve`
 Error:
 promise.js:127:49,49: number
 This type is incompatible with
-[LIB] core.js:408:32,45: union type
+[LIB] core.js:414:32,45: union type
 
 promise.js:157:1,162:4: call of method `then`
 Error:
 promise.js:158:32,37: string
 This type is incompatible with
-[LIB] core.js:400:33,46: union type
+[LIB] core.js:406:33,46: union type
 
 promise.js:166:32,54: call of method `resolve`
 Error:
 promise.js:166:48,53: string
 This type is incompatible with
-[LIB] core.js:408:32,45: union type
+[LIB] core.js:414:32,45: union type
 
 promise.js:174:48,70: call of method `resolve`
 Error:
 promise.js:174:64,69: string
 This type is incompatible with
-[LIB] core.js:408:32,45: union type
+[LIB] core.js:414:32,45: union type
 
 promise.js:197:1,202:4: call of method `then`
 Error:
 promise.js:198:33,38: string
 This type is incompatible with
-[LIB] core.js:405:34,48: union type
+[LIB] core.js:411:34,48: union type
 
 promise.js:206:33,55: call of method `resolve`
 Error:
 promise.js:206:49,54: string
 This type is incompatible with
-[LIB] core.js:408:32,45: union type
+[LIB] core.js:414:32,45: union type
 
 promise.js:214:49,71: call of method `resolve`
 Error:
 promise.js:214:65,70: string
 This type is incompatible with
-[LIB] core.js:408:32,45: union type
+[LIB] core.js:414:32,45: union type
 
 promise.js:236:3,239:3: call of method `done`
 Error:

--- a/tests/union/union.exp
+++ b/tests/union/union.exp
@@ -3,7 +3,7 @@ issue-198.js:1:9,10:6: call of method `then`
 Error:
 issue-198.js:5:16,28: string
 This type is incompatible with
-[LIB] core.js:400:33,46: union type
+[LIB] core.js:406:33,46: union type
 
 issue-324.js:6:13,15: Bar
 This type is incompatible with


### PR DESCRIPTION
Closes #832.

I’m sorry I didn’t add tests, but I didn’t know where to put them. There are some tests for `Set` in `tests/iterable`, but a `WeakSet` is *not* enumerable, so this wasn’t a right place. And there are no test for `WeakMap`. Maybe `tests/weakstructs` should be created?