### PR TITLE
Socket connection fixes

### DIFF
--- a/hack/socket/socket.ml
+++ b/hack/socket/socket.ml
@@ -43,6 +43,9 @@ let max_addr_length = 103
 let min_name_length = 17
 
 let get_path path =
+  (* Path will resolve the realpath, in case two processes are referring to the
+   * same socket using different paths (like with symlinks *)
+  let path = path |> Path.make |> Path.to_string in
   let dir = (Filename.dirname path)^"/" in
   let filename = Filename.basename path in
   let root_part = Filename.chop_extension filename in

--- a/src/commands/commandConnectSimple.ml
+++ b/src/commands/commandConnectSimple.ml
@@ -29,6 +29,29 @@ let wait_on_server_restart ic =
      (* Server has exited and hung up on us *)
      ()
 
+module SocketKey = struct
+  type t = Unix.sockaddr 
+  let compare = Pervasives.compare
+end
+module SockMap = Utils.MyMap(SocketKey)
+
+(* We used to open a new connection every time we tried to connect to a socket
+ * and then shut it down if the connection failed or timed out. However on OSX
+ * the shutdown wouldn't really do anything and we were hitting the pending
+ * connection limit set by Unix.listen. So instead we can hang on to the
+ * connection, since there's nothing wrong with it.
+ *)
+let connections = ref SockMap.empty
+let open_connection sockaddr =
+  match SockMap.get sockaddr !connections with
+  | Some conn -> conn
+  | None ->
+      let conn = Unix.open_connection sockaddr in
+      connections := SockMap.add sockaddr conn !connections;
+      (* It's important that we only write this once per connection *)
+      Printf.fprintf (snd conn) "%s\n%!" Build_id.build_id_ohai;
+      conn
+
 let establish_connection ~tmp_dir root =
   let sock_name = Socket.get_path (FlowConfig.socket_file ~tmp_dir root) in
   let sockaddr =
@@ -39,17 +62,11 @@ let establish_connection ~tmp_dir root =
       Unix.(ADDR_INET (inet_addr_loopback, port))
     else
       Unix.ADDR_UNIX sock_name in
-  Result.Ok (Unix.open_connection sockaddr)
+  Result.Ok (open_connection sockaddr)
 
 let get_cstate (ic, oc) =
-  try
-    Printf.fprintf oc "%s\n%!" Build_id.build_id_ohai;
-    let cstate : ServerUtils.connection_state = Marshal.from_channel ic in
-    Result.Ok (ic, oc, cstate)
-  with e ->
-    Unix.shutdown_connection ic;
-    close_in_noerr ic;
-    raise e
+  let cstate : ServerUtils.connection_state = Marshal.from_channel ic in
+  Result.Ok (ic, oc, cstate)
 
 let verify_cstate ic = function
   | ServerUtils.Connection_ok -> Result.Ok ()


### PR DESCRIPTION
This fixes a few things we discovered on OSX.

First on my laptop, `/tmp` is a symlink to `/private/tmp`. Some commands would
get the `realpath` for the tmp dir and some wouldn't so you would end up with
some commands using `/tmp/flow` for the socket path and some using
`/private/tmp/flow`. For socket paths that are less than 104 characters using
`/tmp` and more than 104 characters using `/private/tmp`, you would end up with
clients that can't talk to servers, since the paths > 104 characters would be
shortened automatically.

Second, we set a limit on the number of pending socket connections. During
initialization we were hitting this limit on OSX but not on Linux. It looks like
`Unix.shutdown_connection` and `close_in_noerr` don't actually remove the
connection from the pending connection count on OSX (at least if the server
isn't listening). To fix, we can just memoize the connection during
initialization.