### PR TITLE
Test proptypes typecheck across module boundaries

### DIFF
--- a/tests/react_modules/createclass-callsite.js
+++ b/tests/react_modules/createclass-callsite.js
@@ -1,6 +1,6 @@
 /* @flow */
 var React = require('react');
-var Hello = require('./createclass-callsite');
+var Hello = require('./createclass-module');
 
 var HelloLocal = React.createClass({
   propTypes: {

--- a/tests/react_modules/createclass-callsite.js
+++ b/tests/react_modules/createclass-callsite.js
@@ -1,0 +1,26 @@
+/* @flow */
+var React = require('react');
+var Hello = require('./createclass-callsite');
+
+var HelloLocal = React.createClass({
+  propTypes: {
+    name: React.PropTypes.string.isRequired,
+  },
+
+  render: function(): React.Element {
+    return <div>{this.props.name}</div>;
+  }
+});
+
+var Callsite = React.createClass({
+  render: function(): React.Element {
+    return (
+      <div>
+        <Hello />
+        <HelloLocal />
+      </div>
+    );
+  }
+});
+
+module.exports = Callsite;

--- a/tests/react_modules/createclass-module.js
+++ b/tests/react_modules/createclass-module.js
@@ -1,0 +1,14 @@
+/* @flow */
+var React = require('react');
+
+var Hello = React.createClass({
+  propTypes: {
+    name: React.PropTypes.string.isRequired,
+  },
+
+  render: function(): React.Element {
+    return <div>{this.props.name}</div>;
+  }
+});
+
+module.exports = Hello;

--- a/tests/react_modules/es6class-proptypes-callsite.js
+++ b/tests/react_modules/es6class-proptypes-callsite.js
@@ -3,8 +3,6 @@ import React from 'react';
 import Hello from './es6class-proptypes-module';
 
 class HelloLocal extends React.Component {
-  static defaultProps: {};
-
   render(): React.Element {
     return <div>{this.props.name}</div>;
   }
@@ -13,6 +11,8 @@ class HelloLocal extends React.Component {
 HelloLocal.propTypes = {
   name: React.PropTypes.string.isRequired,
 };
+
+HelloLocal.defaultProps = {};
 
 class Callsite extends React.Component {
   render(): React.Element {

--- a/tests/react_modules/es6class-proptypes-callsite.js
+++ b/tests/react_modules/es6class-proptypes-callsite.js
@@ -1,6 +1,6 @@
 /* @flow */
 import React from 'react';
-import Hello from './es6class-proptypes-callsite';
+import Hello from './es6class-proptypes-module';
 
 class HelloLocal extends React.Component {
   static defaultProps: {};

--- a/tests/react_modules/es6class-proptypes-callsite.js
+++ b/tests/react_modules/es6class-proptypes-callsite.js
@@ -1,0 +1,28 @@
+/* @flow */
+import React from 'react';
+import Hello from './es6class-proptypes-callsite';
+
+class HelloLocal extends React.Component {
+  static defaultProps: {};
+
+  render(): React.Element {
+    return <div>{this.props.name}</div>;
+  }
+}
+
+HelloLocal.propTypes = {
+  name: React.PropTypes.string.isRequired,
+};
+
+class Callsite extends React.Component {
+  render(): React.Element {
+    return (
+      <div>
+        <Hello />
+        <HelloLocal />
+      </div>
+    );
+  }
+}
+
+module.exports = Callsite;

--- a/tests/react_modules/es6class-proptypes-module.js
+++ b/tests/react_modules/es6class-proptypes-module.js
@@ -2,8 +2,6 @@
 import React from 'react';
 
 class Hello extends React.Component {
-  static defaultProps: {};
-
   render(): React.Element {
     return <div>{this.props.name}</div>;
   }
@@ -12,5 +10,7 @@ class Hello extends React.Component {
 Hello.propTypes = {
   name: React.PropTypes.string.isRequired,
 };
+
+Hello.defaultProps = {};
 
 module.exports = Hello;

--- a/tests/react_modules/es6class-proptypes-module.js
+++ b/tests/react_modules/es6class-proptypes-module.js
@@ -1,0 +1,16 @@
+/* @flow */
+import React from 'react';
+
+class Hello extends React.Component {
+  static defaultProps: {};
+
+  render(): React.Element {
+    return <div>{this.props.name}</div>;
+  }
+}
+
+Hello.propTypes = {
+  name: React.PropTypes.string.isRequired,
+};
+
+module.exports = Hello;

--- a/tests/react_modules/es6class-types-callsite.js
+++ b/tests/react_modules/es6class-types-callsite.js
@@ -1,0 +1,27 @@
+/* @flow */
+import React from 'react';
+import Hello from './es6class-proptypes-callsite';
+
+type Props = {name: string};
+
+class HelloLocal extends React.Component {
+  props: Props;
+  static defaultProps: {};
+
+  render(): React.Element {
+    return <div>{this.props.name}</div>;
+  }
+}
+
+class Callsite extends React.Component {
+  render(): React.Element {
+    return (
+      <div>
+        <Hello />
+        <HelloLocal />
+      </div>
+    );
+  }
+}
+
+module.exports = Callsite;

--- a/tests/react_modules/es6class-types-callsite.js
+++ b/tests/react_modules/es6class-types-callsite.js
@@ -1,6 +1,6 @@
 /* @flow */
 import React from 'react';
-import Hello from './es6class-proptypes-callsite';
+import Hello from './es6class-types-module';
 
 type Props = {name: string};
 

--- a/tests/react_modules/es6class-types-module.js
+++ b/tests/react_modules/es6class-types-module.js
@@ -1,0 +1,15 @@
+/* @flow */
+import React from 'react';
+
+type Props = {name: string};
+
+class Hello extends React.Component {
+  props: Props;
+  static defaultProps: {};
+
+  render(): React.Element {
+    return <div>{this.props.name}</div>;
+  }
+}
+
+module.exports = Hello;

--- a/tests/react_modules/react_modules.exp
+++ b/tests/react_modules/react_modules.exp
@@ -1,4 +1,10 @@
 
+createclass-callsite.js:19:9,17: React element: `Hello`
+Error:
+createclass-module.js:5:3,11: property `name`
+Property not found in
+createclass-callsite.js:19:9,17: type parameter `DefaultProps` of React element: `Hello`
+
 createclass-callsite.js:20:9,22: React element: `HelloLocal`
 Error:
 createclass-callsite.js:6:3,11: property `name`
@@ -11,6 +17,12 @@ es6class-proptypes-callsite.js:22:9,22: type parameter `DefaultProps` of React e
 
 es6class-types-callsite.js:8:10,14: property `name`
 Property not found in
-es6class-types-callsite.js:22:9,22: type parameter `DefaultProps` of React element: `HelloLocal`
+es6class-types-callsite.js:21:9,22: type parameter `DefaultProps` of React element: `HelloLocal`
 
-Found 3 errors
+es6class-types-callsite.js:20:9,17: React element: `Hello`
+Error:
+es6class-types-module.js:7:10,14: property `name`
+Property not found in
+es6class-types-callsite.js:20:9,17: type parameter `DefaultProps` of React element: `Hello`
+
+Found 5 errors

--- a/tests/react_modules/react_modules.exp
+++ b/tests/react_modules/react_modules.exp
@@ -11,7 +11,7 @@ createclass-callsite.js:6:3,11: property `name`
 Property not found in
 createclass-callsite.js:20:9,22: type parameter `DefaultProps` of React element: `HelloLocal`
 
-es6class-proptypes-callsite.js:13:24,15:1: string literal `name`
+es6class-proptypes-callsite.js:11:24,13:1: string literal `name`
 Property not found in
 es6class-proptypes-callsite.js:22:9,22: type parameter `DefaultProps` of React element: `HelloLocal`
 

--- a/tests/react_modules/react_modules.exp
+++ b/tests/react_modules/react_modules.exp
@@ -1,0 +1,16 @@
+
+createclass-callsite.js:20:9,22: React element: `HelloLocal`
+Error:
+createclass-callsite.js:6:3,11: property `name`
+Property not found in
+createclass-callsite.js:20:9,22: type parameter `DefaultProps` of React element: `HelloLocal`
+
+es6class-proptypes-callsite.js:13:24,15:1: string literal `name`
+Property not found in
+es6class-proptypes-callsite.js:22:9,22: type parameter `DefaultProps` of React element: `HelloLocal`
+
+es6class-types-callsite.js:8:10,14: property `name`
+Property not found in
+es6class-types-callsite.js:22:9,22: type parameter `DefaultProps` of React element: `HelloLocal`
+
+Found 3 errors


### PR DESCRIPTION
I'm trying to get proptypes to typecheck across module boundaries. But
despite https://github.com/facebook/flow/issues/475 it doesn't seem to
work for me. I'm not sure if I'm doing something wrong, or if there has
been a regression since that discussion, or what.

I created these test cases to try to work out what is happening. Note
that only the locally defined components typecheck and correctly report
that the name prop is missing.

The identical components from a sibling file don't. Why?