### PR TITLE
Some small connection fixes

### DIFF
--- a/src/common/flowConfig.ml
+++ b/src/common/flowConfig.ml
@@ -251,6 +251,8 @@ let file_of_root ~tmp_dir root extension =
   mkdir_no_fail tmp_dir;
   let root_part = Path.slash_escaped_string_of_path root in
   Printf.sprintf "%s%s.%s" tmp_dir root_part extension
+  |> Path.make
+  |> Path.to_string
 
 let init_file ~tmp_dir root = file_of_root ~tmp_dir root "init"
 let lock_file ~tmp_dir root = file_of_root ~tmp_dir root "lock"


### PR DESCRIPTION
tests/connect_race was failing sporadically, so I investigated. This fixes a
few things that I found.

1. `flow start` opens a pipe to the server it spawns. It's possible for that pipe to die before the child dies. Adding a 1 second sleep resolves this race.
2. It was wrong for `commandConnect.ml` to call `connect_once` when it fails to start a server. The right thing to do is to consume a retry.
3. The whole `/tmp` -> `/private/tmp` symlink thing is confusing. `FlowConfig` should make sure it normalizes everything whenever it's asked for a path.