### PR TITLE
callable interfaces

### DIFF
--- a/src/typing/flow_js.ml
+++ b/src/typing/flow_js.ml
@@ -2432,7 +2432,8 @@ let rec __flow cx (l, u) trace =
     (****************************************)
     (* You can cast an object to a function *)
     (****************************************)
-    | (ObjT (reason, _), (FunT (reason_op, _, _, _) | CallT (reason_op, _))) ->
+    | ((ObjT (reason, _) | InstanceT (reason, _, _, _)),
+       (FunT (reason_op, _, _, _) | CallT (reason_op, _))) ->
       let tvar = mk_tvar cx (suffix_reason " used as a function" reason) in
       lookup_prop cx trace l reason_op (Some reason) "$call" tvar;
       rec_flow cx trace (tvar, u)

--- a/tests/callable/callable.exp
+++ b/tests/callable/callable.exp
@@ -3,4 +3,10 @@ primitives.js:6:1,6: function call
 Callable signature not found in
 primitives.js:6:1,4: object type
 
-Found 1 error
+primitives.js:12:1,8: function call
+Error:
+primitives.js:12:7,7: number
+This type is incompatible with
+primitives.js:9:7,12: string
+
+Found 2 errors

--- a/tests/callable/primitives.js
+++ b/tests/callable/primitives.js
@@ -4,3 +4,9 @@ foo(Boolean);
 
 var dict: { [k: string]: any } = {};
 dict(); // error, callable signature not found
+
+interface ICall {
+  (x: string): void;
+}
+declare var icall: ICall;
+icall(0); // error, number ~> string


### PR DESCRIPTION
Before this commit, interfaces with callable signatures couldn't be
called.

For the included test, the pre-change failure was:

```
primitives.js:12:1,8: function call
Function cannot be called on
primitives.js:12:1,5: ICall
```

After this change, the expected failure correctly complains about the
parameter type.