### PR TITLE
fix live example in 02-running

### DIFF
--- a/docs/02-running.md
+++ b/docs/02-running.md
@@ -61,6 +61,7 @@ You can try out the live Flow transpiler below. Just edit the Flow script in the
 <script type="text/javascript" src="http://facebook.github.io/react/js/codemirror.js"></script>
 <script type="text/javascript" src="http://facebook.github.io/react/js/javascript.js"></script>
 <script type="text/javascript" src="http://facebook.github.io/react/js/react.js"></script>
+<script type="text/javascript" src="http://facebook.github.io/react/js/react-dom.js"></script>
 <!-- Right now JSXTransformer on the React website is too old. So I built
 it from master on the React repo and copy/pasted it here. Whenever we ship
 the next version of React we can just use it and remove the local one -->

--- a/static/transformer.js
+++ b/static/transformer.js
@@ -22,7 +22,7 @@ var CompilerPlayground = React.createClass({displayName: 'CompilerPlayground',
     );
   },
 });
-React.render(
+ReactDOM.render(
   React.createElement(CompilerPlayground, null),
   document.getElementById('jsxCompiler')
 );


### PR DESCRIPTION
The live coding example at http://flowtype.org/docs/running.html is broken due to the linked react version having been bumped to 0.14

Unfortunately I am unable to install the missing jekyll dependencies on my ubuntu machine (I gave up after an hour), so I could only test this fix by manually converting the markdown into HTML. If it needs changes to work in the jekyll env let me know.

On a side note, the page is also 404ing on `showdown.js` but I did not want to pull it in from some CDN as I don't know about your policies regarding this.