### PR TITLE
Fix build priorities.o

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,7 @@ NATIVE_OBJECT_FILES=\
   hack/utils/nproc.o\
   hack/utils/realpath.o\
   hack/utils/sysinfo.o\
+  hack/utils/priorities.o\
   src/embedded/flowlib_elf.o
 
 OCAML_LIBRARIES=\


### PR DESCRIPTION
It seems to be the second round :p 

I don't know if it useful to add priorities.o to hack/build.ocp and hack/Makefile since it's managed by HHVM.