### PR TITLE
Fix parallel runtests.sh for OSX and Travis Linux containers

### DIFF
--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -16,6 +16,8 @@ setup_linux () {
   # TODO: Install js_of_ocaml and test the parser
   # opam install ${OPAM_DEPENDS}
   eval `opam config env`
+
+  export FLOW_RUNTESTS_PARALLELISM=4
 }
 
 setup_osx () {

--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -17,6 +17,8 @@ setup_linux () {
   # opam install ${OPAM_DEPENDS}
   eval `opam config env`
 
+  # For some reason the Linux containers start killing the tests if too many
+  # tests are run in parallel. Luckily we can easily configure that here
   export FLOW_RUNTESTS_PARALLELISM=4
 }
 

--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -16,10 +16,6 @@ setup_linux () {
   # TODO: Install js_of_ocaml and test the parser
   # opam install ${OPAM_DEPENDS}
   eval `opam config env`
-
-  # For some reason the Linux containers start killing the tests if too many
-  # tests are run in parallel. Luckily we can easily configure that here
-  export FLOW_RUNTESTS_PARALLELISM=4
 }
 
 setup_osx () {

--- a/runtests.sh
+++ b/runtests.sh
@@ -218,9 +218,9 @@ runtest() {
 num_to_run_in_parallel=${FLOW_RUNTESTS_PARALLELISM-16}
 printf "Running up to %d test(s) in parallel\n" $num_to_run_in_parallel
 
+# Index N of pids should correspond to the test at index N of dirs
 dirs=(tests/*/)
 pids=()
-running_tests=""
 
 # Starts running a test in the background. If there are no more tests then it
 # does nothing
@@ -228,7 +228,6 @@ next_test_index=0
 start_test() {
     if (( next_test_index < ${#dirs[@]} )); then
         test_dir="${dirs[next_test_index]}"
-        running_tests+=" $test_dir"
         runtest "$test_dir" &
         pids[$next_test_index]=$!
     fi

--- a/runtests.sh
+++ b/runtests.sh
@@ -215,7 +215,9 @@ runtest() {
 }
 
 
-num_to_run_in_parallel=16
+num_to_run_in_parallel=${FLOW_RUNTESTS_PARALLELISM-16}
+printf "Running up to %d test(s) in parallel\n" $num_to_run_in_parallel
+
 dirs=(tests/*/)
 pids=()
 running_tests=""


### PR DESCRIPTION
Two main issues:

1. OSX uses an old version of Bash and thus `declare -A` doesn't exist
2. Travis Linux containers kill processes when too much memory is used.