### PR TITLE
Remove call to external commands

### DIFF
--- a/hack/find/find.ml
+++ b/hack/find/find.ml
@@ -11,71 +11,71 @@
 (*****************************************************************************)
 (* Prelude *)
 (*****************************************************************************)
-(*
- * For the initialization of the server we use the plain 'find' command
- * to find the list of files to analyze.
- *)
 
 open Core
 
-let escape_spaces = Str.global_replace (Str.regexp " ") "\\ "
+let fold_files (type t)
+    ?max_depth ?(filter=(fun _ -> true))
+    (paths: Path.t list) (action: string -> t -> t) (init: t) =
+  let rec fold depth acc dir =
+    let recurse = max_depth <> Some depth in
+    let files = Sys.readdir dir in
+    Array.fold_left
+      (fun acc file ->
+         let open Unix in
+         let file = Filename.concat dir file in
+         match (lstat file).st_kind with
+         | S_REG when filter file -> action file acc
+         | S_DIR when recurse -> fold (depth+1) acc file
+         | _ -> acc)
+      acc files in
+  if max_depth <> Some 0 then
+    let paths = List.map paths Path.to_string in
+    List.fold_left paths ~init ~f:(fold 1)
+  else
+    init
 
-let paths_to_path_string paths =
-  let stringed_paths = List.map paths Path.to_string in
-  let escaped_paths =  List.map stringed_paths escape_spaces in
-  String.concat " " escaped_paths
+let iter_files ?max_depth ?filter paths action =
+  fold_files ?max_depth ?filter paths (fun file _ -> action file) ()
 
-let find_with_name paths pattern =
-  let paths = paths_to_path_string paths in
-  let cmd = Utils.spf "find %s -name \"%s\"" paths pattern in
-  let ic = Unix.open_process_in cmd in
-  let buf = Buffer.create 16 in
-  (try
-    while true do
-      Buffer.add_channel buf ic 1
-    done
-  with End_of_file -> ());
-  (try ignore (Unix.close_process_in ic) with _ -> ());
-  Str.split (Str.regexp "\n") (Buffer.contents buf)
+let find ?max_depth ?filter paths =
+  fold_files ?max_depth ?filter paths List.cons []
+
+let find_with_name ?max_depth paths name =
+  find ?max_depth ~filter:(fun x -> x = name) paths
 
 (*****************************************************************************)
 (* Main entry point *)
 (*****************************************************************************)
 
-let make_next_files ?(name="") filter ?(others=[]) root =
-  let paths = paths_to_path_string (root::others) in
-  let ic = Unix.open_process_in ("find "^paths^" -type f") in
-  let done_ = ref false in
-  let time_taken = ref 0.0 in
-  (* This is subtle, but to optimize latency, we open the process and
-   * then return a closure immediately. That way 'find' gets started
-   * in parallel and will be ready when we need to get the list of
-   * files (although it will be stopped very soon as the pipe buffer
-   * will get full very quickly).
-   *)
-  fun () ->
-    if !done_
-    (* see multiWorker.mli, this is the protocol for nextfunc *)
-    then []
+type stack =
+  | Nil
+  | Dir of string list * string * stack
+
+let max_files = 1000
+
+let make_next_files ?name:_ ?(filter = fun _ -> true) ?(others=[]) root =
+  let rec process sz acc files dir stack =
+    if sz >= max_files then
+      (acc, Dir (files, dir, stack))
     else
-      let t = Unix.gettimeofday () in
-      let result = ref [] in
-      let i = ref 0 in
-      try
-        while !i < 1000 do
-          let path = input_line ic in
-          if filter path
-          then begin
-            result := path :: !result;
-            incr i;
-          end
-        done;
-        let result = List.rev !result in
-        time_taken := !time_taken +. (Unix.gettimeofday () -. t);
-        result
-      with End_of_file ->
-        done_ := true;
-        EventLogger.find_done ~time_taken:!time_taken ~name;
-        Hh_logger.log "Spent %.2fs indexing %s files" !time_taken name;
-        (try ignore (Unix.close_process_in ic) with _ -> ());
-        !result
+      match files with
+      | [] -> process_stack sz acc stack
+      | file :: files ->
+          let file = if dir = "" then file else Filename.concat dir file in
+          let open Unix in
+          match (lstat file).st_kind with
+          | S_REG when filter file ->
+              process (sz+1) (file :: acc) files dir stack
+          | S_DIR ->
+              let dirfiles = Array.to_list @@ Sys.readdir file in
+              process sz acc dirfiles file (Dir (files, dir, stack))
+          | _ -> process sz acc files dir stack
+  and process_stack sz acc = function
+    | Nil -> (acc, Nil)
+    | Dir (files, dir, stack) -> process sz acc files dir stack in
+  let state = ref (Dir (Path.to_string root :: List.map ~f:Path.to_string others, "", Nil)) in
+  fun () ->
+    let res, st = process_stack 0 [] !state in
+    state := st;
+    res

--- a/hack/find/find.mli
+++ b/hack/find/find.mli
@@ -8,8 +8,18 @@
  *
  *)
 
-val make_next_files: ?name: string ->
-  (string -> bool) -> ?others: Path.t list -> Path.t ->
+val make_next_files:
+  ?name: string ->
+  ?filter:(string -> bool) -> ?others: Path.t list -> Path.t ->
   (unit -> string list)
 
-val find_with_name: Path.t list -> string -> string list
+val find:
+  ?max_depth:int -> ?filter:(string -> bool) ->
+  Path.t list -> string list
+
+val find_with_name:
+  ?max_depth:int -> Path.t list -> string -> string list
+
+val iter_files:
+  ?max_depth:int -> ?filter:(string -> bool) ->
+  Path.t list -> (string -> unit) -> unit

--- a/hack/hh_client.ml
+++ b/hack/hh_client.ml
@@ -39,7 +39,7 @@
  *)
 
 let () =
-  (* Ignore SIGPIPE since we might get a serer hangup and don't care (can
+  (* Ignore SIGPIPE since we might get a server hangup and don't care (can
    * detect and handle better than a signal). Ignore SIGUSR1 since we sometimes
    * use that for the server to tell us when it's done initializing, but if we
    * aren't explicitly listening we don't care. *)

--- a/hack/hh_format.ml
+++ b/hack/hh_format.ml
@@ -116,7 +116,7 @@ let debug_directory dir =
   let path = Path.make dir in
   let next = compose
     (List.map ~f:Path.make)
-    (Find.make_next_files FindUtils.is_php path) in
+    (Find.make_next_files ~filter:FindUtils.is_php path) in
   let workers = Worker.make GlobalConfig.nbr_procs GlobalConfig.gc_control in
   MultiWorker.call
     (Some workers)
@@ -218,7 +218,7 @@ let directory modes dir =
   let path = Path.make dir in
   let next = compose
     (List.map ~f:Path.make)
-    (Find.make_next_files FindUtils.is_php path) in
+    (Find.make_next_files ~filter:FindUtils.is_php path) in
   let workers = Worker.make GlobalConfig.nbr_procs GlobalConfig.gc_control in
   let messages =
     MultiWorker.call

--- a/hack/hh_match.ml
+++ b/hack/hh_match.ml
@@ -166,7 +166,7 @@ let directory dir fn =
   let path = Path.make dir in
   let next = Utils.compose
     (List.map ~f:Path.make)
-    (Find.make_next_files FindUtils.is_php path) in
+    (Find.make_next_files ~filter:FindUtils.is_php path) in
   let workers = Worker.make GlobalConfig.nbr_procs GlobalConfig.gc_control in
   (* Information for the patcher to figure out what transformations to do *)
   let fileschanged =

--- a/hack/hhi/hhi.ml
+++ b/hack/hhi/hhi.ml
@@ -15,8 +15,8 @@ external get_embedded_hhi_data : string -> string option =
 let root = ref None
 
 let touch_root r =
-  let r = Filename.quote (Path.to_string r) in
-  ignore (Unix.system ("find " ^ r ^ " -name '*.hhi' -exec touch '{}' ';'"))
+  let filter file = Filename.check_suffix file ".hhi" in
+  Find.iter_files ~filter [ r ] (Sys_utils.try_touch ~follow_symlinks:true)
 
 let touch () =
   match !root with

--- a/hack/server/serverEnvBuild.ml
+++ b/hack/server/serverEnvBuild.ml
@@ -55,7 +55,7 @@ let make_genv options config local_config =
       let wait_until_ready () = () in
       indexer, notifier, wait_until_ready
     | None ->
-      let indexer filter = Find.make_next_files ~name:"root" filter root in
+      let indexer filter = Find.make_next_files ~name:"root" ~filter root in
       let log_link = ServerFiles.dfind_log root in
       let log_file = ServerFiles.make_link_of_timestamped log_link in
       let dfind =

--- a/hack/server/serverInit.ml
+++ b/hack/server/serverInit.ml
@@ -55,7 +55,8 @@ let make_next_files genv : Relative_path.t MultiWorker.nextlist =
   let hhi_root = Hhi.get_hhi_root () in
   let next_files_hhi = compose
     (List.map ~f:(Relative_path.(create Hhi)))
-    (Find.make_next_files ~name:"hhi" FindUtils.is_php hhi_root) in
+    (Find.make_next_files
+       ~name:"hhi" ~filter:FindUtils.is_php hhi_root) in
   fun () ->
     match next_files_hhi () with
     | [] -> next_files_root ()

--- a/src/embedded/flowlib.ml
+++ b/src/embedded/flowlib.ml
@@ -12,8 +12,8 @@ external get_embedded_flowlib_data : string -> string option =
   "get_embedded_flowlib_data"
 
 let touch_root r =
-  let r = Path.to_string r in
-  ignore (Unix.system ("find \"" ^ r ^ "\" -name \"*.js\" -exec touch '{}' ';'"))
+  let filter = FindUtils.is_js in
+  Find.iter_files ~filter [ r ] (Sys_utils.try_touch ~follow_symlinks:true)
 
 (* There are several verify-use race conditions here (and in Hack's file
  * handling in general, really). Running the server as root is likely to be a

--- a/src/server/server.ml
+++ b/src/server/server.ml
@@ -244,8 +244,14 @@ struct
     let new_file = Filename.temp_file "" "" in
     write_file new_file new_content;
     let patch_file = Filename.temp_file "" "" in
-    spf "diff -u --label old --label new %s %s > %s"
-      file new_file patch_file
+    let diff_cmd =
+      if Sys.win32 then
+        spf "fc %s %s > %s"
+          file new_file patch_file
+      else
+        spf "diff -u --label old --label new %s %s > %s"
+          file new_file patch_file in
+    diff_cmd
     |> Unix.system |> ignore;
     cat patch_file
 


### PR DESCRIPTION
- Replace the call to `find`, by `Find.find` function.
- Replace `diff` equivalent on Windows.

Note: there isn't -u/--label option on Windows, we just do the diff without this extra arguments.