### PR TITLE
Deactivate signals on Windows

### DIFF
--- a/src/flow.ml
+++ b/src/flow.ml
@@ -59,7 +59,7 @@ end = struct
   let main () =
     Daemon.check_entry_point (); (* this call might not return *)
 
-    Sys.set_signal Sys.sigpipe Sys.Signal_ignore;
+    Sys_utils.set_signal Sys.sigpipe Sys.Signal_ignore;
     let default_command = DefaultCommand.command in
     let argv = Array.to_list Sys.argv in
     let default = CommandSpec.name default_command in

--- a/src/server/serverFunctors.ml
+++ b/src/server/serverFunctors.ml
@@ -230,7 +230,7 @@ end = struct
     (* this is to transform SIGPIPE in an exception. A SIGPIPE can happen when
     * someone C-c the client.
     *)
-    Sys.set_signal Sys.sigpipe Sys.Signal_ignore;
+    Sys_utils.set_signal Sys.sigpipe Sys.Signal_ignore;
     let is_check_mode = Options.is_check_mode options in
     (* You need to grab the lock before initializing the pid files *)
     begin if not is_check_mode


### PR DESCRIPTION
We replace `Sys.set_signal` by `Sys_utils.set_signal` that is a noop
on Windows.