### PR TITLE
WebSocket statics

### DIFF
--- a/lib/bom.js
+++ b/lib/bom.js
@@ -209,6 +209,10 @@ declare class CloseEvent extends Event {
 }
 
 declare class WebSocket extends EventTarget {
+    static CONNECTING: 0;
+    static OPEN: 1;
+    static CLOSING: 2;
+    static CLOSED: 3;
     constructor(url: string, protocols?: string | Array<string>): void;
     protocol: string;
     readyState: number;
@@ -222,10 +226,10 @@ declare class WebSocket extends EventTarget {
     url: string;
     close(code?: number, reason?: string): void;
     send(data: any): void;
-    OPEN: number;
-    CLOSING: number;
-    CONNECTING: number;
-    CLOSED: number;
+    CONNECTING: 0;
+    OPEN: 1;
+    CLOSING: 2;
+    CLOSED: 3;
 }
 
 declare class Worker extends EventTarget {


### PR DESCRIPTION
It's unclear to me whether these attributes should actually be constants by the [spec](https://html.spec.whatwg.org/multipage/comms.html#websocket), but browsers seem to hang these values off the WebSocket class.

While I'm in here, we can be more specific about the type of these constants, thanks to singleton types.