### PR TITLE
Allow declare type when there is an exports entry.

### DIFF
--- a/src/typing/type_inference_js.ml
+++ b/src/typing/type_inference_js.ml
@@ -2468,8 +2468,14 @@ and statement cx type_params_map = Ast.Statement.(
     let for_types, exports_ = Scope.(Entry.(
       match get_entry "exports" module_scope with
       | Some (Value { specific = exports; _ }) ->
-        (* TODO: what happens when other things are also declared? *)
-        SMap.empty(* ???? *), exports
+        (* TODO: what happens when other things(i.e. Value) are also declared? *)
+        let for_types = SMap.filter (fun _ ->
+          function
+          | Value _ -> false
+          | Type _ -> true
+        ) module_scope.entries in
+
+        for_types, exports
 
       | Some _ ->
         assert_false (

--- a/tests/declare_type/declare_type.exp
+++ b/tests/declare_type/declare_type.exp
@@ -6,4 +6,16 @@ import_declare_type.js:11:9,11: number
 import_declare_type.js:12:9,11: identifier `toz`
 Could not resolve name
 
-Found 2 errors
+import_declare_type.js:26:2,8: object literal
+This type is incompatible with
+import_declare_type.js:26:12,14: string
+
+import_declare_type.js:28:2,2: number
+This type is incompatible with
+import_declare_type.js:28:6,8: A
+
+import_declare_type.js:30:2,6: string
+This type is incompatible with
+import_declare_type.js:30:10,19: number
+
+Found 5 errors

--- a/tests/declare_type/import_declare_type.js
+++ b/tests/declare_type/import_declare_type.js
@@ -13,3 +13,18 @@ var k3: toz = foo(k1); // Error: unknown identifier toz
 
 import type {toz} from "ModuleAliasFoo";
 var k4: toz = foo(k1); // works
+
+//////////////////////////////////////////////////////////
+// == Declared Module with exports prop (issue 880) == //
+////////////////////////////////////////////////////////
+
+import blah from 'foo';
+import type { Foo, Bar, Id } from 'foo';
+
+blah(0, 0);
+
+({toz:3} : Foo); // error : {toz : number} ~> string
+
+(3 : Bar); // error : number ~> A
+
+("lol" : Id<number>); // error : string ~> number

--- a/tests/declare_type/lib/declare_type_exports.js
+++ b/tests/declare_type/lib/declare_type_exports.js
@@ -1,0 +1,17 @@
+/* @flow */
+
+declare module 'foo' {
+    declare class A {
+        toz : number
+    }
+
+    declare var n : string;
+
+    declare type Foo = typeof n;
+    declare type Bar = A;
+    declare type Id<T> = T;
+
+    declare var exports : {
+        (a : number, b : number) : number
+    };
+}


### PR DESCRIPTION
As discussed with @samwgoldman `declare type` should be available when there is an `exports` entry in a declared module.

I didn't allow this before because of the TODO comment, but it seems there is no collision possible.

Fix #880.