### PR TITLE
Core libs updates

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -407,7 +407,7 @@ declare class Promise<R> {
 
     then<U>(
       onFulfill?: (value: R) => Promise<U> | U,
-      onReject?: (error: any) => Promise<U> | U
+      onReject?: (error: any) => ?Promise<U> | U
     ): Promise<U>;
 
     catch<U>(

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -945,20 +945,40 @@ declare class HTMLButtonElement extends HTMLElement {
   checkValidity(): boolean;
 }
 
+// http://dev.w3.org/html5/spec-preview/the-textarea-element.html
 declare class HTMLTextAreaElement extends HTMLElement {
+  autofocus: boolean;
   cols: number;
-  defaultValue: string;
+  dirName: string;
   disabled: boolean;
-  form: HTMLFormElement;
+  form: ?HTMLFormElement;
+  maxLength: number;
   name: string;
+  placeholder: string;
   readOnly: boolean;
+  required: boolean;
   rows: number;
-  type: string;
-  value: string;
+  wrap: string;
 
+  type: string;
+  defaultValue: string;
+  value: string;
+  textLength: number;
+
+  willValidate: boolean;
+  validity: Object; // Too be more precise, a ValidityState object
+  validationMessage: string;
   checkValidity(): boolean;
+  setCustomValidity(error: string): void;
+
+  labels: NodeList<HTMLLabelElement>;
+
   select(): void;
-}
+  selectionStart: number;
+  selectionEnd: number;
+  selectionDirection: "forward"|"backward"|"none";
+  setSelectionRange(start: number, end: number, dir?: "forward"|"backward"|"none"): void;
+};
 
 declare class HTMLSelectElement extends HTMLElement {
   disabled: boolean;
@@ -1024,6 +1044,13 @@ declare class HTMLStyleElement extends HTMLElement {
     scoped: boolean;
     sheet: ?StyleSheet;
     type: string;
+}
+
+// http://dev.w3.org/html5/spec-preview/the-label-element.html
+declare class HTMLLabelElement extends HTMLElement {
+    form: ?HTMLFormElement;
+    htmlFor: string;
+    control: ?HTMLElement;
 }
 
 declare class TextRange {


### PR DESCRIPTION
The first commit fixes a problem I mentioned in https://github.com/facebook/flow/issues/900;

The second one adds a bunch of missing properties to HTMLTextAreaElement. I copied the definitions from the official spec, however ignoring the "readonly" flags. It is possible to implement these by converting the properties into getters, but it hasn't been done for any other HTML*Element class...