### PR TITLE
Update flow-bin link and use "npm" casing

### DIFF
--- a/docs/00-getting-started.md
+++ b/docs/00-getting-started.md
@@ -37,9 +37,9 @@ $> brew install flow
 
 Brew adds flow to your path as part of the install.
 
-### NPM Wrapper
+### npm wrapper
 
-You can also install flow by using https://github.com/gabelevi/flow-bin. Similarly, only OS X and Linux (64-bit) binaries are provided.
+You can also install flow by using [flow-bin](https://github.com/flowtype/flow-bin). Similarly, only OS X and Linux (64-bit) binaries are provided.
 
 ```bash
 $> npm install flow-bin --global


### PR DESCRIPTION
This updates the flow-bin location to the repo in the "flowtype" org, since it already redirects there anyway (it could arguably point to the npm page instead).

Also, npm cases its own name as "npm". Also sentence-cased the heading like the others.