### PR TITLE
Allow export {x as default} specifier

### DIFF
--- a/src/parser/Makefile
+++ b/src/parser/Makefile
@@ -9,7 +9,8 @@ NATIVE_OBJECT_FILES=\
 	hack/utils/files.o\
 	hack/utils/nproc.o\
 	hack/utils/realpath.o\
-	hack/utils/sysinfo.o
+	hack/utils/sysinfo.o\
+	hack/utils/priorities.o
 
 all: build-parser
 

--- a/src/parser/package.json
+++ b/src/parser/package.json
@@ -19,7 +19,7 @@
     "esprima-fb": "15001.1001.0-dev-harmony-fb"
   },
   "dependencies": {
-    "ast-types": "0.8.13",
+    "ast-types": "0.8.14",
     "colors": ">=0.6.2",
     "minimist": ">=0.2.0"
   },

--- a/src/parser/parser_flow.ml
+++ b/src/parser/parser_flow.ml
@@ -3149,8 +3149,8 @@ end = struct
             let name, err, end_loc = if Peek.value env = "as"
             then begin
               Expect.contextual env "as";
-              let name, err = Parse.identifier_or_reserved_keyword env in
-              Some name, err, fst name
+              let name, _ = Parse.identifier_or_reserved_keyword env in
+              Some name, None, fst name
             end else None, err, fst id in
             let loc = Loc.btwn (fst id) end_loc in
             let specifier = loc, {

--- a/src/parser/test/hardcoded_tests.js
+++ b/src/parser/test/hardcoded_tests.js
@@ -2940,6 +2940,7 @@ module.exports = {
       'export { default } from "foo"': {},
       'export { default as foo } from "foo"': {},
       'export { foo as default } from "foo"': {},
+      'export { foo as default }': {},
       'import { default as foo } from "foo"': {}
     },
     'Invalid export/import reserved words': {


### PR DESCRIPTION
Also fixes the parser tests by updating ast-types & including priorities
native object.

Fixes #1119