### PR TITLE
Decompose AnyObjT into AnyT

### DIFF
--- a/tests/object_api/object_api.exp
+++ b/tests/object_api/object_api.exp
@@ -25,6 +25,10 @@ object_keys.js:14:4,4: key of object type
 This type is incompatible with
 object_keys.js:14:8,13: number
 
+object_keys.js:18:14,16: key of object type
+This type is incompatible with
+object_keys.js:18:26,31: number
+
 object_prototype.js:38:26,35: function type
 This type is incompatible with
 object_prototype.js:38:17,22: number
@@ -97,4 +101,4 @@ object_prototype.js:155:32,47: function type
 This type is incompatible with
 object_prototype.js:155:23,28: number
 
-Found 24 errors
+Found 25 errors

--- a/tests/object_api/object_assign.js
+++ b/tests/object_api/object_assign.js
@@ -6,4 +6,7 @@ var export_ = Object.assign({}, {
 
 var decl_export_: { foo: any; bar: any } = Object.assign({}, export_);
 
+let anyObj: Object = {};
+Object.assign(anyObj, anyObj); // makes sure this terminates
+
 module.exports = export_;

--- a/tests/object_api/object_keys.js
+++ b/tests/object_api/object_keys.js
@@ -13,3 +13,6 @@ var dict: { [k: number]: string } = {};
 Object.keys(dict).forEach(k => {
   (k : number) // error: number ~> string
 });
+
+var any: Object = {};
+(Object.keys(any): Array<number>); // error, Array<string>

--- a/tests/record/record.exp
+++ b/tests/record/record.exp
@@ -15,4 +15,8 @@ test.js:20:6,34: string literal `qux`
 Property not found in
 test.js:19:19,44: object type
 
-Found 4 errors
+test.js:23:21,26: key of object type
+Expected string literal
+test.js:24:16,21: key set
+
+Found 5 errors

--- a/tests/record/test.js
+++ b/tests/record/test.js
@@ -19,3 +19,6 @@ class C<X> {
 class D extends C<{foo: number, bar: string}> {
   x: { foo: number, qux: boolean }; // error: qux not found
 }
+
+type AnyKey = $Keys<Object>;
+var o3: {[key: AnyKey]: number} = { foo: 0 };

--- a/tests/spread/spread.exp
+++ b/tests/spread/spread.exp
@@ -19,4 +19,8 @@ test6.js:10:5,30: property `abc`
 Property not found in
 test6.js:10:2,2: object literal
 
-Found 5 errors
+test7.js:6:6,11: object literal
+This type is incompatible with
+test7.js:6:14,17: undefined
+
+Found 6 errors

--- a/tests/spread/test7.js
+++ b/tests/spread/test7.js
@@ -1,0 +1,8 @@
+// @flow
+
+let tests = [
+  function(x: Object) {
+    ({...x}: Object);
+    ({...x}: void); // error, Object
+  },
+];

--- a/tests/taint/any_object.js
+++ b/tests/taint/any_object.js
@@ -1,0 +1,25 @@
+// @flow
+
+let tests = [
+  // setting a property
+  function(x: $Tainted<string>, y: string) {
+    let obj: Object = {};
+    obj.foo = x; // error, taint ~> any
+    obj[y] = x; // error, taint ~> any
+  },
+
+  // getting a property
+  function() {
+    let obj: Object = { foo: 'foo' };
+    (obj.foo: $Tainted<string>); // ok
+  },
+
+  // calling a method
+  function(x: $Tainted<string>) {
+    let obj: Object = {};
+    obj.foo(x); // error, taint ~> any
+
+    let foo = obj.foo;
+    foo(x); // TODO: error, taint ~> any
+  },
+];

--- a/tests/taint/taint.exp
+++ b/tests/taint/taint.exp
@@ -23,13 +23,25 @@ adder.js:30:20,24: taint
 This type is incompatible with
 adder.js:30:11,16: string
 
+any_object.js:7:15,15: taint
+This type is incompatible with
+any_object.js:7:5,11: any
+
+any_object.js:8:14,14: taint
+This type is incompatible with
+any_object.js:8:5,10: any
+
+any_object.js:20:13,13: taint
+This type is incompatible with
+any_object.js:20:5,14: any
+
 call-object-property.js:5:7,7: taint
 This type is incompatible with
-any
+call-object-property.js:5:3,8: any
 
 call-object-property.js:11:8,11: taint
 This type is incompatible with
-any
+call-object-property.js:11:3,12: any
 
 comparator.js:4:32,32: number
 Cannot be compared to
@@ -89,4 +101,4 @@ use-types.js:27:33,36: taint
 This type is incompatible with
 use-types.js:27:24,29: number
 
-Found 21 errors
+Found 24 errors


### PR DESCRIPTION
mirrors what `ObjT _, X` does, for each `AnyObjT _, X`.

Flowing things to/from `AnyT` is generally useless because of the `if not (ground_subtype ...)` short circuit at the top of `__flow`, but this did catch a couple of places where we dropped the whole return type on the floor (`{...(x: Object)}: number` was valid, for instance), and the taint stuff relies on flowing `TaintT ~> AnyT`, which this does without needing `parameters_of_taint_op`.