### PR TITLE
Correcting pbkdf2 behavior

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -302,13 +302,15 @@ declare module "crypto" {
     salt: string | Buffer,
     iterations: number,
     keylen: number,
-    callback: (err: ?Error, derivedKey: string) => void
+    digestOrCallback: string | ((err: ?Error, derivedKey: string) => void),
+    callback?: (err: ?Error, derivedKey: string) => void
   ): void;
   declare function pbkdf2Sync(
     password: string | Buffer,
     salt: string | Buffer,
     iterations: number,
-    keylen: number
+    keylen: number,
+    digest?: string
   ): string;
   // `UNUSED` argument strictly enforces arity to enable overloading this
   // function with 1-arg and 2-arg variants.

--- a/lib/node.js
+++ b/lib/node.js
@@ -298,15 +298,15 @@ declare module "crypto" {
   declare function getDiffieHellman(group_name: string): crypto$DiffieHellman;
   declare function getHashes(): Array<string>;
   declare function pbkdf2(
-    password: string,
-    salt: string,
+    password: string | Buffer,
+    salt: string | Buffer,
     iterations: number,
     keylen: number,
     callback: (err: ?Error, derivedKey: string) => void
   ): void;
   declare function pbkdf2Sync(
-    password: string,
-    salt: string,
+    password: string | Buffer,
+    salt: string | Buffer,
     iterations: number,
     keylen: number
   ): string;

--- a/lib/node.js
+++ b/lib/node.js
@@ -302,8 +302,8 @@ declare module "crypto" {
     salt: string | Buffer,
     iterations: number,
     keylen: number,
-    digestOrCallback: string | ((err: ?Error, derivedKey: string) => void),
-    callback?: (err: ?Error, derivedKey: string) => void
+    digestOrCallback: string | ((err: ?Error, derivedKey: Buffer) => void),
+    callback?: (err: ?Error, derivedKey: Buffer) => void
   ): void;
   declare function pbkdf2Sync(
     password: string | Buffer,
@@ -311,7 +311,7 @@ declare module "crypto" {
     iterations: number,
     keylen: number,
     digest?: string
-  ): string;
+  ): Buffer;
   // `UNUSED` argument strictly enforces arity to enable overloading this
   // function with 1-arg and 2-arg variants.
   declare function pseudoRandomBytes(size: number, UNUSED: void): Buffer;


### PR DESCRIPTION
Salt and password can be both string or Buffer in pbkdf2 (and pbkdf2sync). 

I have checked it in both Node source and browserify-crypto code.