### PR TITLE
adding getAuthTag for ciphers

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -249,6 +249,7 @@ type crypto$Decipher = {
   update(data: any, input_encoding?: string, output_encoding?: string): any;
   final(output_encoding?: string): any;
   setAutoPadding(auto_padding?: boolean): void;
+  setAuthTag(tag: Buffer): void;
 }
 
 type crypto$Hash = {

--- a/lib/node.js
+++ b/lib/node.js
@@ -223,6 +223,7 @@ type crypto$Cipher = {
   final(output_encoding?: string): any;
   setAutoPadding(auto_padding?: boolean): void;
   update(data: any, input_encoding?: string, output_encoding?: string): any;
+  getAuthTag(): Buffer;
 }
 
 type crypto$Credentials = {


### PR DESCRIPTION
getAuthTag makes sense only for ciphers with GCM mode; however, that would be a little hard to encode into type system, so I am adding it for all cipher modes.