### PR TITLE
`export interface ...`

### DIFF
--- a/src/parser/parse_error.ml
+++ b/src/parser/parse_error.ml
@@ -68,6 +68,7 @@ type t =
   | DeclareExportLet
   | DeclareExportConst
   | DeclareExportType
+  | DeclareExportInterface
 
 exception Error of (Loc.t * t) list
 
@@ -145,4 +146,6 @@ module PP =
           `declare export var` instead."
       | DeclareExportType -> "`declare export type` is not supported. Use \
           `export type` instead."
+      | DeclareExportInterface -> "`declare export interface` is not supported. Use \
+          `export interface` instead."
   end

--- a/src/parser/test/hardcoded_tests.js
+++ b/src/parser/test/hardcoded_tests.js
@@ -1132,6 +1132,11 @@ module.exports = {
           'type': 'TypeAlias',
         }
       },
+      'export interface foo {p: number}': {
+        'body.0.declaration': {
+	        'type': 'InterfaceDeclaration',
+   	    }
+      }
     },
     'Declare Statements': {
       'declare var foo': {

--- a/src/typing/type_inference_js.ml
+++ b/src/typing/type_inference_js.ml
@@ -2590,6 +2590,9 @@ and statement cx type_params_map = Ast.Statement.(
           | _, TypeAlias({TypeAlias.id=(_, id); _;}) ->
             let name = id.Ast.Identifier.name in
             [(spf "type %s = ..." name, loc, name, None)]
+          | _, InterfaceDeclaration({Interface.id=(_, id); _;}) ->
+            let name = id.Ast.Identifier.name in
+            [(spf "interface %s = ..." name, loc, name, None)]
           | _ -> failwith "Parser Error: Invalid export-declaration type!")
 
       | Some (Expression expr) ->

--- a/tests/export_type/cjs_with_types.js
+++ b/tests/export_type/cjs_with_types.js
@@ -1,5 +1,6 @@
 /* @flow */
 
 export type talias4 = number;
+export interface IFoo { prop: number };
 
 module.exports = {}

--- a/tests/export_type/export_type.exp
+++ b/tests/export_type/export_type.exp
@@ -19,6 +19,14 @@ importer.js:24:18,23: string
 This type is incompatible with
 importer.js:24:8,14: number
 
+importer.js:29:22,27: string
+This type is incompatible with
+types_only.js:15:31,36: number
+
+importer.js:32:23,24: number
+This type is incompatible with
+types_only2.js:5:32,37: string
+
 types_only.js:5:23,28: string
 This type is incompatible with
 types_only.js:5:8,19: number
@@ -27,4 +35,12 @@ types_only.js:11:9,23: standaloneType2
 type referenced from value position
 types_only.js:10:6,20: type standaloneType2
 
-Found 7 errors
+types_only.js:15:31,36: number
+This type is incompatible with
+importer.js:29:22,27: string
+
+types_only2.js:5:32,37: string
+This type is incompatible with
+importer.js:32:23,24: number
+
+Found 11 errors

--- a/tests/export_type/importer.js
+++ b/tests/export_type/importer.js
@@ -4,7 +4,7 @@ import type {
   inlinedType1,
   standaloneType1,
   talias1,
-  talias3
+  talias3,
 } from "./types_only";
 
 var a: inlinedType1 = 42;
@@ -22,3 +22,11 @@ var h: talias3 = 'asdf'; // Error: string ~> number
 import type {talias4} from "./cjs_with_types";
 var i: talias4 = 42;
 var j: talias4 = 'asdf'; // Error: string ~> number
+
+import {IFoo, IFoo2} from "./types_only";
+
+var k: IFoo = {prop: 42};
+var l: IFoo = {prop: 'asdf'}; // Error: {prop:string} ~> {prop:number}
+
+var m: IFoo2 = {prop: 'asdf'};
+var n: IFoo2 = {prop: 42}; // Error: {prop:number} ~> {prop:string}

--- a/tests/export_type/types_only.js
+++ b/tests/export_type/types_only.js
@@ -10,4 +10,6 @@ export type {standaloneType1};
 type standaloneType2 = number;
 export {standaloneType2}; // Error: Missing `type` keyword
 
-export type {talias1, talias2 as talias3} from "./types_only2";
+export type {talias1, talias2 as talias3, IFoo2} from "./types_only2";
+
+export interface IFoo { prop: number };

--- a/tests/export_type/types_only2.js
+++ b/tests/export_type/types_only2.js
@@ -2,3 +2,4 @@
 
 export type talias1 = number;
 export type talias2 = number;
+export interface IFoo2 { prop: string };


### PR DESCRIPTION
Per #1131, adds support for type-exports of the form: `export interface Foo { ... }`