### PR TITLE
`index.js` fallthroughs during module resolution should use the `module.file_ext` extensions

### DIFF
--- a/src/typing/module_js.ml
+++ b/src/typing/module_js.ml
@@ -338,8 +338,10 @@ module Node = struct
                 (SSet.elements opts.FlowConfig.Opts.module_file_exts)
             )
             (fun () ->
-              let path = Filename.concat path "index.js" in
-              path_if_exists path_acc path
+              let path = Filename.concat path "index" in
+              seqf
+                (fun ext -> path_if_exists path_acc (path ^ ext))
+                (SSet.elements opts.FlowConfig.Opts.module_file_exts)
             )
           )
 
@@ -355,7 +357,12 @@ module Node = struct
       )
       (fun () -> seq
         (fun () -> parse_main path_acc (Filename.concat path "package.json"))
-        (fun () -> path_if_exists path_acc (Filename.concat path "index.js"))
+        (fun () -> 
+          let path = Filename.concat path "index" in
+          seqf 
+            (fun ext -> path_if_exists path_acc (path ^ ext))
+            (SSet.elements opts.FlowConfig.Opts.module_file_exts)
+        )
       )
 
   let rec node_module path_acc dir r =

--- a/tests/config_file_extensions/test.js.es6
+++ b/tests/config_file_extensions/test.js.es6
@@ -7,3 +7,5 @@ function foo(x) {
 }
 
 foo('Hello, world!');
+
+require('./test');

--- a/tests/config_file_extensions/test/index.js.es6
+++ b/tests/config_file_extensions/test/index.js.es6
@@ -1,0 +1,3 @@
+// @flow
+
+export var num = 42;


### PR DESCRIPTION
We were hardcoding "index.js", but if someone specifies another file extension (or uses `.jsx`), that should work too