### PR TITLE
Some lib definitions mishandle Array covariance

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -145,7 +145,7 @@ declare class Array<T> {
     @@iterator(): Iterator<T>;
     toLocaleString(): string;
     // concat creates a new array
-    concat<S>(...items: Array<Array<S> | S>): Array<T | S>;
+    concat<S, Item: Array<S> | S>(...items: Array<Item>): Array<T | S>;
     join(separator?: string): string;
     pop(): T;
     push(...items: Array<T>): number;
@@ -429,8 +429,8 @@ declare class Promise<R> {
 
     static resolve<T>(object?: Promise<T> | T): Promise<T>;
     static reject<T>(error?: any): Promise<T>;
-    static all<T>(promises: Array<Promise<T> | T>): Promise<Array<T>>;
-    static race<T>(promises: Array<Promise<T> | T>): Promise<T>;
+    static all<T, Elem: Promise<T> | T>(promises: Array<Elem>): Promise<Array<T>>;
+    static race<T, Elem: Promise<T> | T>(promises: Array<Elem>): Promise<T>;
 
     // Non-standard APIs common in some libraries
 

--- a/lib/node.js
+++ b/lib/node.js
@@ -1181,7 +1181,7 @@ declare class Process extends events$EventEmitter {
   setegid? : (id : number | string) => void;
   seteuid? : (id : number | string) => void;
   setgid? : (id : number | string) => void;
-  setgroups? : (groups : Array<string | number>) => void;
+  setgroups? : <Group: string | number>(groups : Array<Group>) => void;
   setuid? : (id : number | string) => void;
   stderr : stream$Writable | tty$WriteStream;
   stdin : stream$Readable | tty$ReadStream;

--- a/tests/arraylib/arraylib.exp
+++ b/tests/arraylib/arraylib.exp
@@ -27,19 +27,19 @@ array_lib.js:21:24,46: call of method `concat`
 Error:
 array_lib.js:21:33,35: string
 This type is incompatible with
-[LIB] core.js:148:31,42: union type
+[LIB] core.js:148:21,32: union type
 
 array_lib.js:21:24,46: call of method `concat`
 Error:
 array_lib.js:21:38,40: string
 This type is incompatible with
-[LIB] core.js:148:31,42: union type
+[LIB] core.js:148:21,32: union type
 
 array_lib.js:21:24,46: call of method `concat`
 Error:
 array_lib.js:21:43,45: string
 This type is incompatible with
-[LIB] core.js:148:31,42: union type
+[LIB] core.js:148:21,32: union type
 
 array_lib.js:46:3,45: call of method `reduce`
 Function cannot be called on

--- a/tests/promises/covariance.js
+++ b/tests/promises/covariance.js
@@ -1,0 +1,16 @@
+/* @flow */
+
+async function testAll() {
+  /* This is a test case from https://github.com/facebook/flow/issues/1143
+   * which was previously an error due to Array's covariance and an improper
+   * definition of Promise.all */
+    const x: Array<Promise<?string>> = [];
+    const y: Promise<Array<?string>> = Promise.all(x);
+    const z: Array<?string> = await y;
+}
+
+async function testRace() {
+    const x: Array<Promise<?string>> = [];
+    const y: Promise<?string> = Promise.race(x);
+    const z: ?string = await y;
+}


### PR DESCRIPTION
Arrays are not covariant, which means you cannot pass an `Array<string>` to a type
annotation that expects `Array<string | number>`.

Luckily generics can save the day!

Fixes https://github.com/facebook/flow/issues/1143