### PR TITLE
Restore state on slave after the fork/exec.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ npm-debug.log
 *.diff
 *.err
 *.swp
+slave_*.log

--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -24,6 +24,7 @@ setup_linux () {
   # For some reason the Linux containers start killing the tests if too many
   # tests are run in parallel. Luckily we can easily configure that here
   export FLOW_RUNTESTS_PARALLELISM=4
+  export FLOW_SHMDIR=/tmp
 }
 
 setup_osx () {

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 #                            Variables to override                             #
 ################################################################################
 
-EXTRA_INCLUDE_PATHS=
+EXTRA_INCLUDE_PATHS=hack/utils
 EXTRA_LIB_PATHS=
 
 ################################################################################
@@ -21,6 +21,7 @@ ifeq ($(OS), Linux)
   INOTIFY_STUBS=$(INOTIFY)/inotify_stubs.o
   FSNOTIFY=fsnotify_linux
   ELF=elf
+  RT=rt
   FRAMEWORKS=
   SECTCREATE=
 endif
@@ -29,6 +30,7 @@ ifeq ($(OS), Darwin)
   INOTIFY_STUBS=$(INOTIFY)/fsevents_stubs.o
   FSNOTIFY=fsnotify_darwin
   ELF=
+  RT=
   FRAMEWORKS=CoreServices CoreFoundation
   SECTCREATE=-cclib -sectcreate -cclib __text -cclib flowlib -cclib $(abspath $(FLOWLIB))
 endif
@@ -64,6 +66,9 @@ MODULES=\
   hack/$(INOTIFY)\
   hack/$(FSNOTIFY)
 
+HEADER_FILES=\
+  hack/utils/handle.h
+
 NATIVE_OBJECT_FILES=\
   hack/$(INOTIFY_STUBS)\
   hack/heap/hh_shared.o\
@@ -83,7 +88,8 @@ OCAML_LIBRARIES=\
   str
 
 NATIVE_LIBRARIES=\
-  $(ELF)
+  $(ELF)\
+  $(RT)
 
 FILES_TO_COPY=\
   $(wildcard lib/*.js)
@@ -126,7 +132,7 @@ build-flow-debug: build-flow-native-deps $(FLOWLIB)
 
 build-flow-native-deps: build-flow-stubs
 	ocamlbuild -ocamlc "ocamlopt $(EXTRA_INCLUDE_OPTS) $(CC_OPTS)"\
-		$(NATIVE_OBJECT_FILES)
+		$(HEADER_FILES) $(NATIVE_OBJECT_FILES)
 
 build-flow-stubs:
 	echo "const char* const BuildInfo_kRevision = \"$$(git rev-parse HEAD 2>/dev/null || hg identify -i)\";" > hack/utils/get_build_id.gen.c

--- a/build.ocp
+++ b/build.ocp
@@ -12,6 +12,8 @@ begin library "ROOTPROJECT"
   files = []
 end
 
+ccopt = [ "-Ihack/utils" ]
+
 requires = [ "hh-utils" ] (* everything depends on this *)
 
 (* This library is used to extract the archive embedded in the Elf binary.
@@ -94,7 +96,7 @@ begin library "flow-server-base"
 end
 
 begin library "flow-typing"
-  requires += [ "flow-server-base" "flow-parsing" ]
+  requires += [ "flow-server-base" "flow-parsing" "flow-common" ]
   files = [
     "src/typing/key.ml"
     "src/typing/changeset.ml"
@@ -126,6 +128,7 @@ begin library "flow-server"
     "src/server/serverUtils.ml"
     "src/server/serverProt.ml"
     "src/server/searchService_js.ml"
+    "src/server/serverWorker.ml"
     "src/server/serverEnvBuild.ml"
     "src/server/serverPeriodical.ml"
     "src/server/serverFunctors.ml"

--- a/hack/Makefile
+++ b/hack/Makefile
@@ -2,7 +2,7 @@
 #                            Variables to override                             #
 ################################################################################
 
-EXTRA_INCLUDE_PATHS=
+EXTRA_INCLUDE_PATHS=utils
 EXTRA_LIB_PATHS=
 EXTRA_CC_FLAGS=
 
@@ -65,6 +65,9 @@ MODULES=\
   $(FSNOTIFY)\
   $(INOTIFY)
 
+LOCAL_HEADER_FILES=\
+  utils/handle.h
+
 NATIVE_OBJECT_FILES=\
   heap/hh_shared.o\
   hhi/hhi_elf.o\
@@ -89,6 +92,7 @@ OCAML_LIBRARIES=\
 
 NATIVE_LIBRARIES=\
   pthread\
+  rt\
   $(ELF)
 
 TARGETS=_build/hh_server.native _build/hh_client.native \
@@ -154,7 +158,7 @@ $(TARGETS): $(ALL_SRC_FILES)
 	touch $(TARGETS)
 
 build-hack-native-deps: build-hack-stubs
-	ocamlbuild -cflags "-g $(EXTRA_INCLUDE_OPTS) $(EXTRA_CC_OPTS)" $(NATIVE_OBJECT_FILES)
+	ocamlbuild -cflags "-g $(EXTRA_INCLUDE_OPTS) $(EXTRA_CC_OPTS)" $(LOCAL_HEADER_FILES) $(NATIVE_OBJECT_FILES)
 
 # If you modify this rule, do not forget to edit the file
 # `$(ROOT)/scripts/gen_build_id.ml` used on Windows.

--- a/hack/build.ocp
+++ b/hack/build.ocp
@@ -26,6 +26,8 @@ if have_lz4 then {
   ccopt += [ "-DNO_LZ4" ]
 }
 
+ccopt += [ "-Isrc/utils" ]
+
 requires = [ "unix" "str" "threads" ]
 
 begin library "hh-third-party"
@@ -180,7 +182,7 @@ begin library "hh-find"
 end
 
 begin library "hh-heap"
-  requires += [ "hh-third-party"  "hh-utils" "hh-stubs" ]
+  requires += [ "hh-third-party"  "hh-utils" "hh-stubs" "hh-globals" ]
 
   files = [
     "heap/prefix.ml"

--- a/hack/format/format_diff.ml
+++ b/hack/format/format_diff.ml
@@ -96,7 +96,7 @@ end = struct
     let filename = String.sub line 4 (String.length line - 4) in
     (* Getting rid of the prefix b/ *)
     let filename =
-      if filename = "/dev/null"
+      if filename = Path.(to_string null_path)
       then None
       else if String.length filename >= 2 && String.sub filename 0 2 = "b/"
       then Some (String.sub filename 2 (String.length filename - 2))

--- a/hack/globals/globalConfig.ml
+++ b/hack/globals/globalConfig.ml
@@ -33,3 +33,7 @@ let tmp_dir =
   with _ ->
     Path.to_string @@
     Path.concat Path.temp_dir_name "hh_server"
+
+let shm_dir =
+  try Sys.getenv "HH_SHMDIR"
+  with _ -> "/dev/shm"

--- a/hack/heap/sharedMem.ml
+++ b/hack/heap/sharedMem.ml
@@ -20,16 +20,37 @@ let default_config =
   let gig = 1024 * 1024 * 1024 in
   {global_size = gig; heap_size = 20 * gig}
 
+(* Allocated in C only. *)
+type handle = private {
+  h_fd: Unix.file_descr;
+  h_global_size: int;
+  h_heap_size: int;
+}
+
+
+exception Out_of_shared_memory
+
+let () =
+  Callback.register_exception "out_of_shared_memory" Out_of_shared_memory
+
+
 (*****************************************************************************)
 (* Initializes the shared memory. Must be called before forking. *)
 (*****************************************************************************)
-external hh_shared_init: global_size:int -> heap_size:int -> unit
-= "hh_shared_init"
+external hh_shared_init
+  : global_size:int -> heap_size:int -> shm_dir:string -> handle
+  = "hh_shared_init"
 
-let init config =
+let init config shm_dir =
   hh_shared_init
     ~global_size:config.global_size
     ~heap_size:config.heap_size
+    ~shm_dir
+
+let init_default () : handle =
+  init default_config GlobalConfig.shm_dir
+
+external connect : handle -> unit = "hh_worker_init"
 
 (*****************************************************************************)
 (* The shared memory garbage collector. It must be called every time we

--- a/hack/heap/sharedMem.mli
+++ b/hack/heap/sharedMem.mli
@@ -25,11 +25,26 @@ type config = {
 
 val default_config : config
 
+type handle = private {
+  h_fd: Unix.file_descr;
+  h_global_size: int;
+  h_heap_size: int;
+}
+
+exception Out_of_shared_memory
+
 (*****************************************************************************)
 (* Initializes the shared memory. Must be called before forking! *)
 (*****************************************************************************)
 
-val init: config -> unit
+val init: config -> string -> handle
+val init_default: unit -> handle
+
+(*****************************************************************************)
+(* Connect a slave to the shared heap *)
+(*****************************************************************************)
+
+val connect: handle -> unit
 
 (*****************************************************************************)
 (* The shared memory garbage collector. It must be called every time we

--- a/hack/hh_client.ml
+++ b/hack/hh_client.ml
@@ -39,7 +39,7 @@
  *)
 
 let () =
-  (* Ignore SIGPIPE since we might get a serer hangup and don't care (can
+  (* Ignore SIGPIPE since we might get a server hangup and don't care (can
    * detect and handle better than a signal). Ignore SIGUSR1 since we sometimes
    * use that for the server to tell us when it's done initializing, but if we
    * aren't explicitly listening we don't care. *)

--- a/hack/hh_emitter.ml
+++ b/hack/hh_emitter.ml
@@ -98,7 +98,7 @@ let emit_file { filename; read_stdin; is_test } () =
 
 let main_hack options =
   EventLogger.init (Daemon.devnull ()) 0.0;
-  SharedMem.(init default_config);
+  let _handle = SharedMem.init_default () in
 
   (* The emitter needs to track the names of identifiers in order to
    * preserve the names in the output bytecode. *)

--- a/hack/hh_matcher/test/code_extent_tests.ml
+++ b/hack/hh_matcher/test/code_extent_tests.ml
@@ -173,7 +173,7 @@ let run_test file : unit =
 let _ =
   begin
   let fname = Sys.argv.(1) in
-  SharedMem.(init default_config);
+  let _handle = SharedMem.init_default () in
   Hhi.set_hhi_root_for_unit_test (Path.make "/tmp/hhi");
   run_test (Relative_path.create Relative_path.Dummy fname);
   end

--- a/hack/hh_matcher/test/matcher_test.ml
+++ b/hack/hh_matcher/test/matcher_test.ml
@@ -32,7 +32,7 @@ let run_test file : unit =
 let _ =
   begin
   let fname = Sys.argv.(1) in
-  SharedMem.(init default_config);
+  let _handle = SharedMem.init_default () in
   Hhi.set_hhi_root_for_unit_test (Path.make "/tmp/hhi");
   run_test (Relative_path.create Relative_path.Dummy fname);
   end

--- a/hack/hh_matcher/test/patcher_api_test.ml
+++ b/hack/hh_matcher/test/patcher_api_test.ml
@@ -69,7 +69,7 @@ let run_patch_test file = begin
 let _ =
   begin
   let fname = Sys.argv.(1) in
-  SharedMem.(init default_config);
+  let _handle = SharedMem.init_default () in
   Hhi.set_hhi_root_for_unit_test (Path.make "/tmp/hhi");
   let fpath = (Relative_path.create Relative_path.Dummy fname) in
   run_patch_test fpath

--- a/hack/hh_matcher/test/patcher_module_test.ml
+++ b/hack/hh_matcher/test/patcher_module_test.ml
@@ -33,7 +33,7 @@ let run_test (file : Relative_path.t) : unit =
 let _ =
   begin
   let fname = Sys.argv.(1) in
-  SharedMem.(init default_config);
+  let _handle = SharedMem.init_default () in
   Hhi.set_hhi_root_for_unit_test (Path.make "/tmp/hhi");
   run_test (Relative_path.create Relative_path.Dummy fname);
   end

--- a/hack/hh_matcher/test/patcher_test.ml
+++ b/hack/hh_matcher/test/patcher_test.ml
@@ -38,7 +38,7 @@ let run_test (file : Relative_path.t) : unit =
 let _ =
   begin
   let fname = Sys.argv.(1) in
-  SharedMem.(init default_config);
+  let _handle = SharedMem.init_default () in
   Hhi.set_hhi_root_for_unit_test (Path.make "/tmp/hhi");
   run_test (Relative_path.create Relative_path.Dummy fname);
   end

--- a/hack/hh_single_type_check.ml
+++ b/hack/hh_single_type_check.ml
@@ -405,7 +405,7 @@ let main_hack { filename; mode; } =
     ignore (Sys.signal Sys.sigusr1
               (Sys.Signal_handle Typing.debug_print_last_pos));
   EventLogger.init (Daemon.devnull ()) 0.0;
-  SharedMem.(init default_config);
+  let _handle = SharedMem.init_default () in
   let tmp_hhi = Path.concat Path.temp_dir_name "hhi" in
   Hhi.set_hhi_root_for_unit_test tmp_hhi;
   let outer_do f = match mode with

--- a/hack/procs/multiWorker.ml
+++ b/hack/procs/multiWorker.ml
@@ -38,57 +38,52 @@ let single_threaded_call_dynamic job merge neutral next =
   done;
   !acc
 
+let multi_threaded_call_dynamic
+  (type a) (type b)
+  workers (job: b -> a list -> b)
+  (merge: b -> b -> b)
+  (neutral: b)
+  (next: a nextlist_dynamic) =
+  let rec dispatch workers handles acc =
+    (* 'worker' represents available workers. *)
+    (* 'handles' represents pendings jobs. *)
+    (* 'acc' are the accumulated results. *)
+    match workers with
+    | [] when handles = [] -> acc
+    | [] ->
+        (* No worker available: wait for some workers to finish. *)
+        collect [] handles acc
+    | worker :: workers ->
+        (* At least one worker is available... *)
+        match next () with
+        | Wait -> collect (worker :: workers) handles acc
+        | Job [] ->
+            (* ... but no more job to be distributed, let's collect results. *)
+            dispatch [] handles acc
+        | Job bucket ->
+            (* ... send a job to the worker.*)
+            let handle =
+              Worker.call worker
+                (fun xl -> job neutral xl)
+                bucket in
+            dispatch workers (handle :: handles) acc
+  and collect workers handles acc =
+    let { Worker.readys; waiters } = Worker.select handles in
+    let workers = List.map ~f:Worker.get_worker readys @ workers in
+    (* Collect the results. *)
+    let acc =
+      List.fold_left
+        ~f:(fun acc h -> merge (Worker.get_result h) acc)
+        ~init:acc
+        readys in
+    (* And continue.. *)
+    dispatch workers waiters acc in
+  dispatch workers [] neutral
+
 let call_dynamic workers ~job ~merge ~neutral ~next =
   match workers with
   | None -> single_threaded_call_dynamic job merge neutral next
-  | Some workers ->
-    let acc = ref neutral in
-    let procs = ref workers in
-    let busy = ref 0 in
-    let waiting_procs = ref [] in
-      try
-        while true do
-          List.iter !procs begin fun proc ->
-            let bucket_opt = next () in
-            match bucket_opt with
-            | Wait -> waiting_procs := proc::!waiting_procs (* wait *)
-            | Job bucket -> (
-              if bucket = [] then raise Exit;
-              incr busy;
-              ignore (Worker.call proc
-                        begin fun xl ->
-                          job neutral xl
-                        end
-                        bucket
-              );
-            )
-          end;
-          let ready_procs = Worker.select workers in
-          List.iter ready_procs begin fun proc ->
-            let res = Worker.get_result proc (Obj.magic 0) in
-            decr busy;
-            acc := merge res !acc
-          end;
-          if ready_procs = [] then
-            (* nothing changed, so no use calling next with the waiting procs,
-               since they would end up waiting again *)
-            procs := []
-          else (
-            (* call next with read_procs and waiting_procs *)
-            procs := List.rev_append !waiting_procs ready_procs;
-            waiting_procs := [];
-          )
-        done;
-        assert false
-      with Exit ->
-        while !busy > 0 do
-          List.iter (Worker.select workers) begin fun proc ->
-            let res = Worker.get_result proc (Obj.magic 0) in
-            decr busy;
-            acc := merge res !acc;
-          end;
-        done;
-        !acc
+  | Some workers -> multi_threaded_call_dynamic workers job merge neutral next
 
 (* special case of call_dynamic with no waiting, useful for static worklists *)
 type 'a nextlist =

--- a/hack/procs/worker.ml
+++ b/hack/procs/worker.ml
@@ -10,289 +10,374 @@
 
 open Core
 
-external hh_worker_init: unit -> unit = "hh_worker_init"
-
-(*****************************************************************************)
-(* Module building workers
+(*****************************************************************************
+ * Module building workers
+ *
  * A worker is a subprocess executing an arbitrary function
+ *
  * You should first create a fixed amount of workers and then use those
  * because the amount of workers is limited and to make the load-balancing
  * of tasks better (cf multiWorker.ml)
- *)
-(*****************************************************************************)
+ *
+ * On Unix, we "spawn" workers when initializing Hack. Then, this
+ * worker, "fork" a slave for each incoming request. The forked "slave"
+ * will die after processing a single request.
+ *
+ * On Windows, we do not "prespawn" when initializing Hack, but we just
+ * allocate all the required information into a record. Then, we
+ * spawn a slave for each incoming request. It will also die after
+ * one request.
+ *
+ * A worker never handle more than one request at a time.
+ *
+ *****************************************************************************)
+
+(* Should we 'prespawn' the worker ? *)
+let use_prespawned = not Sys.win32
 
 (* The maximum amount of workers *)
 let max_workers = 1000
 
-(*****************************************************************************)
-(* The handle is what we get back when we start a job. It's a "future"
+
+
+(*****************************************************************************
+ * The job executed by the worker.
+ *
+ * The 'serializer' is the job continuation: it is a function that must
+ * be called at the end of the request ir order to send back the result
+ * to the master (this is "internal business", this is not visible outside
+ * this module). The slave will provide the expected function.
+ * cf 'send_result' in 'slave_main'.
+ *
+ *****************************************************************************)
+
+type request = Request of (serializer -> unit)
+and serializer = { send: 'a. 'a -> unit }
+and void (* an empty type *)
+
+
+
+(*****************************************************************************
+ * Everything we need to know about a worker.
+ *
+ *****************************************************************************)
+
+type t = {
+
+  id: int; (* Simple id for the worker. This is not the worker pid: on
+              Windows, we spawn a new worker for each job. *)
+
+  (* Sanity check: is the worker still available ? *)
+  mutable killed: bool;
+
+  (* Sanity check: is the worker currently busy ? *)
+  mutable busy: bool;
+
+  (* On Unix, a reference to the 'prespawned' worker. *)
+  prespawned: (void, request) Daemon.handle option;
+
+  (* On Windows, a function to spawn a slave. *)
+  spawn: unit -> (void, request) Daemon.handle;
+
+}
+
+
+
+(*****************************************************************************
+ * The handle is what we get back when we start a job. It's a "future"
  * (sometimes called a "promise"). The scheduler uses the handle to retrieve
  * the result of the job when the task is done (cf multiWorker.ml).
- * Note that the scheduler has to use a handle for that. But the handle
- * is just a trick to get type-checking on workers, a handle is a
- * phantom type, it doesn't really have a value.
- *)
-(*****************************************************************************)
-type 'a handle
+ *
+ *****************************************************************************)
 
-(*****************************************************************************)
-(* Pipes, we need to keep some extra descriptors around to make select work.
- *)
-(*****************************************************************************)
+type 'a handle = 'a delayed ref
 
-type ('a, 'b) pipe = {
+and 'a delayed =
+  | Processing of 'a slave
+  | Cached of 'a
+  | Failed of exn
 
-    (* Inputs *)
-    pipe_descr_in  : Unix.file_descr ;
-    pipe_fin       : (unit -> 'a)    ;
+and 'a slave = {
 
-    (* Outputs *)
-    pipe_descr_out : Unix.file_descr ;
-    pipe_fout      : ('b -> unit)    ;
-  }
+  worker: t;      (* The associated worker *)
+  slave_pid: int; (* The actual slave pid *)
 
-let (make_pipe: unit -> ('a, 'b) pipe) = fun () ->
-  let descr_ic, descr_oc = Unix.pipe() in
-  (* close descriptors on exec so they are not leaked *)
-  Unix.set_close_on_exec descr_ic;
-  Unix.set_close_on_exec descr_oc;
+  (* The file descriptor we might pass to select in order to
+     wait for the slave to finish its job. *)
+  infd: Unix.file_descr;
 
-  let ic = Unix.in_channel_of_descr descr_ic in
-  let oc = Unix.out_channel_of_descr descr_oc in
-  let input() = Marshal.from_channel ic in
-  let output data = Marshal.to_channel oc data [Marshal.Closures]; flush oc in
-  { pipe_descr_in = descr_ic;
-    pipe_fin = input;
-    pipe_descr_out = descr_oc;
-    pipe_fout = output;
-  }
+  (* A blocking function that returns the job result. *)
+  result: unit -> 'a;
 
-(*****************************************************************************)
-(* The job executed by the worker. The worker will execute (msg.job msg.arg)
- *)
-(*****************************************************************************)
+}
 
-type ('a, 'b) msg = {
-    job: ('a -> 'b) ;
-    arg: 'a         ;
-  }
 
-(*****************************************************************************)
-(* Everything we need to know about a worker.
- * It is called real_t and not t because the type-system is not flexible
- * enough in this case. A worker is something very polymorphic, we want
- * to be able to use the same worker with any type.
- * To do so, we force the type-checker to consider a worker as a black-box.
- * Internally (within this file), a worker is a "real_t" (to preserve as much
- * typing as we can), externally it is a "t" (an abstract type).
- * We force the conversion using Obj.magic.
- *)
-(*****************************************************************************)
 
-type ('a, 'b) real_t = {
+(*****************************************************************************
+ * Entry point for spawned worker.
+ *
+ *****************************************************************************)
 
-    (* Unix process ID *)
-    pid         : int                    ;
+(* A builder is function that "spawn" a worker. Externally, this is an
+   abstract type which correspond to the return value of the function
+   'register_entry_point', which is a specialized version of
+   'Deamon.register_entry_point' *)
+type builder =
+    Builder of
+      (Gc.control -> SharedMem.handle -> int -> unit -> (void, request) Daemon.handle)
 
-    (* Used by the worker to output the result of the job *)
-    send_task   : (('a, 'b) msg -> unit) ;
+let slave_main ic oc =
+  let send_result res = Marshal.to_channel oc res []; flush oc in
+  try
+    let Request do_process = Daemon.from_channel ic in
+    do_process { send = send_result };
+    exit 0
+  with
+  | End_of_file ->
+      exit 1
+  | SharedMem.Out_of_shared_memory ->
+      Exit_status.(exit Out_of_shared_memory)
+  | e ->
+      let e_str = Printexc.to_string e in
+      Printf.printf "Exception: %s\n" e_str;
+      EventLogger.worker_exception e_str;
+      print_endline "Potential backtrace:";
+      Printexc.print_backtrace stdout;
+      exit 2
 
-    (* Used by the scheduler to retrieve the result of a job *)
-    recv_result : (unit -> 'b)           ;
+let win32_worker_main restore state (ic, oc) =
+  restore state;
+  let oc = Daemon.cast_out oc in
+  slave_main ic oc
 
-    (* We need to keep this file descriptors around to use Unix.select *)
-    descr_recv  : Unix.file_descr        ;
+let unix_worker_main restore state (ic, oc) =
+  restore state;
+  let oc = Daemon.cast_out oc in
+  let in_fd = Daemon.descr_of_in_channel ic in
+  if !Utils.profile then begin
+    let f = open_out (string_of_int (Unix.getpid ())^".log") in
+    Utils.log := (fun s -> Printf.fprintf f "%s\n" s)
+  end;
+  try
+    while true do
+      (* Wait for an incoming job : is there something to read?
+         But we don't read it yet. It will be read by the forked slave. *)
+      let readyl, _, _ = Unix.select [in_fd] [] [] (-1.0) in
+      if readyl = [] then exit 0;
+      (* We fork a slave for every incoming request.
+         And let it die after one request. This is the quickest GC. *)
+      match Fork.fork() with
+      | 0 -> slave_main ic oc
+      | pid ->
+          (* Wait for the slave termination... *)
+          match snd (Unix.waitpid [] pid) with
+          | Unix.WEXITED 0 -> ()
+          | Unix.WEXITED 1 ->
+              raise End_of_file
+          | Unix.WEXITED 15 -> exit 15
+          | Unix.WEXITED x ->
+              Printf.printf "Worker exited (code: %d)\n" x;
+              flush stdout;
+              raise End_of_file
+          | Unix.WSIGNALED x ->
+              let sig_str = PrintSignal.string_of_signal x in
+              Printf.printf "Worker interrupted with signal: %s\n" sig_str;
+              exit 2
+          | Unix.WSTOPPED x ->
+              Printf.printf "Worker stopped with signal: %d\n" x;
+              exit 3
+    done;
+    assert false
+  with End_of_file -> exit 0
 
-    (* parent's write end that should be closed by other worker childs *)
-    descr_send  : Unix.file_descr        ;
-  }
+let entry_cpt = ref 0
+let register_entry_point ~save ~restore =
+  incr entry_cpt;
+  let restore (st, gc_control, heap_handle) =
+    restore st;
+    SharedMem.connect heap_handle;
+    Gc.set gc_control in
+  let name = Printf.sprintf "slave_%d" !entry_cpt in
+  let entry =
+    Daemon.register_entry_point
+      name
+      (if use_prespawned then
+         unix_worker_main restore
+       else
+         win32_worker_main restore) in
+  let builder gc_control heap_handle =
+    let saved_state = save () in
+    fun worker_id ->
+      (* On Windows, the slave is `spawned` at each request, but we
+         want to clear the log file only once. Hence, partial
+         application in [make_one]. *)
+      let log_file = Printf.sprintf "slave_%d.log" worker_id in
+      Sys_utils.unlink_no_fail log_file;
+      fun () ->
+        Unix.clear_close_on_exec heap_handle.SharedMem.h_fd;
+        let handle =
+          Daemon.spawn
+            (* ~log_file *)
+            ~log_mode:Daemon.Log_append
+            ~reason:"worker" entry
+            (saved_state, gc_control, heap_handle) in
+        Unix.set_close_on_exec heap_handle.SharedMem.h_fd;
+        handle in
+  Builder builder
 
-(* The type of a worker visible to the outside world *)
-type t
 
-(*****************************************************************************)
-(* Our polling primitive on workers
- * Given a list workers, returns the ones that a ready for more work.
- *)
-(*****************************************************************************)
+(**************************************************************************
+ * Creates a pool of workers.
+ *
+ **************************************************************************)
 
-type ('a, 'b) worker_list = ('a, 'b) real_t list
+let workers = ref []
 
-let select: ('a, 'b) worker_list -> ('a, 'b) worker_list =
-fun tl ->
-  let fdl = List.map tl (fun x -> x.descr_recv) in
-  let readyl, _, _ = Unix.select fdl [] [] (-1.0) in
-  let res = List.filter tl (fun x -> List.mem readyl x.descr_recv) in
-  res
+(* Build one worker. *)
+let make_one =
+  let cpt = ref 0 in
+  fun spawn ->
+    let id = !cpt in
+    if id >= max_workers then failwith "Too many workers";
+    incr cpt;
+    (* Partial application: remove log file on Windows
+       (see register_entry_point). *)
+    let spawn = spawn id in
+    let prespawned = if not use_prespawned then None else Some (spawn ()) in
+    let worker = { id; busy = false; killed = false; prespawned; spawn } in
+    workers := worker :: !workers;
+    worker
 
-(*****************************************************************************)
-(* Creates a pool of workers. It's important to create them all at once,
- * because we would duplicate some file descriptors during the fork otherwise.
- *)
-(*****************************************************************************)
+let make (Builder builder) n gc_control heap_handle =
+  (* Partial application: save the current state... *)
+  let spawn = builder gc_control heap_handle in
+  (* ...and loop. *)
+  let rec make n = if n <= 0 then [] else make_one spawn :: make (pred n) in
+  make n
 
-module MakeWorker = struct
 
-  (* The type of the accumulator *)
-  type ('a, 'b) acc = ('a, 'b) worker_list
+(**************************************************************************
+ * Send a job to a worker
+ *
+ **************************************************************************)
 
-  (* The current amount of "live" workers *)
-  let current_workers = ref 0
+let call w (type a) (type b) (f : a -> b) (x : a) : b handle =
+  if w.killed then Printf.ksprintf failwith "killed worker (%d)" w.id;
+  if w.busy then Printf.ksprintf failwith "busy worker (%d)" w.id;
+  (* Spawn the slave, if not prespawned. *)
+  let { Daemon.pid = slave_pid; channels = (inc, outc) } as h =
+    match w.prespawned with
+    | None -> w.spawn ()
+    | Some handle -> handle in
+  (* Prepare ourself to read answer from the slave. *)
+  let result () : b =
+    match Unix.waitpid [Unix.WNOHANG] slave_pid with
+    | 0, _ | _, Unix.WEXITED 0 ->
+        let res : b = input_value (Daemon.cast_in inc) in
+        if w.prespawned = None then Daemon.close h;
+        res
+    | _, Unix.WEXITED i when i = Exit_status.(to_int Out_of_shared_memory) ->
+        raise SharedMem.Out_of_shared_memory
+    | _, Unix.WEXITED i ->
+        Printf.ksprintf failwith "Subprocess(%d): fail %d" slave_pid i
+    | _, Unix.WSTOPPED i ->
+        Printf.ksprintf failwith "Subprocess(%d): stopped %d" slave_pid i
+    | _, Unix.WSIGNALED i ->
+        Printf.ksprintf failwith "Subprocess(%d): signaled %d" slave_pid i in
+  (* Mark the worker as busy. *)
+  let infd = Daemon.descr_of_in_channel inc in
+  let slave = { result; slave_pid; infd; worker = w; } in
+  w.busy <- true;
+  (* Send the job to the slave. *)
+  Daemon.to_channel outc
+    ~flush:true ~flags:[Marshal.Closures]
+    (Request (fun { send } -> send (f x)));
+  (* And returned the 'handle'. *)
+  ref (Processing slave)
 
-  let rec make: ('a, 'b) acc -> int -> Gc.control -> ('a, 'b) acc =
-  fun acc n gc_control ->
-    incr current_workers;
-    if !current_workers > max_workers
-    then failwith "Too many workers"
-    else if n <= 0
-    then acc
-    else make_ acc n gc_control
 
-  and make_: ('a, 'b) acc -> int -> Gc.control -> ('a, 'b) acc =
-  fun acc n gc_control ->
-    (* Initializing a bidirectional pipe *)
-    let pipe_parent_reads_child_sends = make_pipe() in
-    let pipe_parent_sends_child_reads = make_pipe() in
-    let {
-      (* Parent reads *)
-      pipe_descr_in = descr_parent_reads;
-      pipe_fin = parent_reads_result;
+(**************************************************************************
+ * Read results from a handle.
+ * This might block if the worker hasn't finished yet.
+ *
+ **************************************************************************)
 
-      (* Child sends *)
-      pipe_descr_out = descr_child_sends;
-      pipe_fout = child_sends_result;
-    } = pipe_parent_reads_child_sends in
-    let {
-      (* Child reads *)
-      pipe_descr_in = descr_child_reads;
-      pipe_fin = child_reads_task;
+let get_result d =
+  match !d with
+  | Cached x -> x
+  | Failed exn -> raise exn
+  | Processing s ->
+      try
+        let res = s.result () in
+        s.worker.busy <- false;
+        d := Cached res;
+        res
+      with exn ->
+        s.worker.busy <- false;
+        d := Failed exn;
+        raise exn
 
-      (* Parent sends *)
-      pipe_descr_out = descr_parent_sends;
-      pipe_fout = parent_sends_task;
-    } = pipe_parent_sends_child_reads in
-    match Fork.fork_and_log ~reason:"worker" () with
-    | -1 ->
-        failwith "Could not create process"
-    | 0 ->
-        (* CHILD *)
-        (* Unix duplicates file descriptors during a fork, we make sure
-         * we close all the ones we don't need anymore.
-         *)
-        hh_worker_init();
-        Gc.set gc_control;
-        close_parent descr_parent_reads descr_parent_sends acc;
-        if !Utils.profile
-        then begin
-          let f = open_out (string_of_int (Unix.getpid ())^".log") in
-          Utils.log := (fun s -> Printf.fprintf f "%s\n" s)
-        end;
-        (* And now start the daemon worker *)
-        start_worker descr_child_reads child_reads_task child_sends_result
-    | pid ->
-        (* PARENT *)
-        close_child descr_child_sends descr_child_reads;
-        let worker = {
-          pid = pid;
-          send_task = parent_sends_task;
-          recv_result = parent_reads_result;
-          descr_recv = descr_parent_reads;
-          descr_send = descr_parent_sends;
-        } in
-        let acc = worker :: acc in
-        make acc (n-1) gc_control
 
-  and close_parent: Unix.file_descr -> Unix.file_descr -> ('a, 'b) acc
-    -> unit =
-  fun descr_parent_reads descr_parent_sends acc ->
-    close_in stdin;
-    Unix.close descr_parent_reads;
-    Unix.close descr_parent_sends;
-    (* Disconnect from the previously created workers
-     * This is a bit subtle. When we fork, the parent process has
-     * a file descriptor open on the pipe for the worker.
-     * When we fork for the next worker, all the previous pipes
-     * are duplicated. To avoid this, we need to close the pipes
-     * of the previously created workers.
-     *)
-    List.iter acc (fun w -> Unix.close w.descr_recv; Unix.close w.descr_send);
-    ()
+(*****************************************************************************
+ * Our polling primitive on workers
+ * Given a list of handle, returns the ones that are ready.
+ *
+ *****************************************************************************)
 
-  and start_worker: Unix.file_descr -> (unit -> 'a) -> ('b -> unit) -> 'c =
-  fun descr_in child_reads_task child_sends_result ->
-    (* Daemon *)
-    try
-      while true do
-        (* This is a trick to use less memory and to be faster.
-         * If we fork now, the heap is very small, because no job
-         * was sent in yet.
-         *)
-        let readyl, _, _ = Unix.select [descr_in] [] [] (-1.0) in
-        if readyl = [] then exit 0;
-        match Fork.fork() with
-        | 0 ->
-            (try
-              let { job = job; arg = arg } = child_reads_task() in
-              let result = job arg in
-              child_sends_result result;
-              (* This is the interesting part. Since we die here,
-               * all the memory allocated during the job is reclaimed
-               * by the system. This makes memory consumption much much
-               * lower.
-               *)
-              exit 0
-            with
-            | End_of_file ->
-                exit 1
-            | e ->
-                let e_str = Printexc.to_string e in
-                Printf.printf "Exception: %s\n" e_str;
-                EventLogger.worker_exception e_str;
-                print_endline "Potential backtrace:";
-                Printexc.print_backtrace stdout;
-                exit 2
-            )
-        | pid ->
-            (match snd (Unix.waitpid [] pid) with
-            | Unix.WEXITED 0 -> ()
-            | Unix.WEXITED 1 ->
-                raise End_of_file
-            | Unix.WEXITED x ->
-                Printf.printf "Worker exited (code: %d)\n" x;
-                flush stdout;
-                raise End_of_file
-            | Unix.WSIGNALED x ->
-                let sig_str = PrintSignal.string_of_signal x in
-                Printf.printf "Worker interrupted with signal: %s\n" sig_str;
-                exit 2
-            | Unix.WSTOPPED x ->
-                Printf.printf "Worker stopped with signal: %d\n" x;
-                exit 3
-            )
-      done;
-      assert false
-    with End_of_file ->
-      exit 0
+type 'a selected = {
+  readys: 'a handle list;
+  waiters: 'a handle list;
+}
 
-  and close_child: Unix.file_descr -> Unix.file_descr -> unit =
-  fun descr_child_sends descr_child_reads ->
-    Unix.close descr_child_sends;
-    Unix.close descr_child_reads;
-    ()
+let get_processing ds =
+  List.fold_left
+    ~f:(fun ps d ->
+      match !d with
+      | Cached c -> ps
+      | Failed exn -> ps
+      | Processing p -> p::ps)
+    ~init:[]
+    ds
 
-end
+let select ds =
+  let processing = get_processing ds in
+  let fds = List.map ~f:(fun {infd; _} -> infd) processing in
+  let ready_fds, _, _ =
+    if fds = [] || List.length processing <> List.length ds then
+      [], [], []
+    else
+      Unix.select fds [] [] ~-.1. in
+  List.fold_right
+    ~f:(fun d { readys ; waiters } ->
+      match !d with
+      | Cached _ | Failed _ ->
+          { readys = d :: readys ; waiters }
+      | Processing s when List.mem ready_fds s.infd ->
+          { readys = d :: readys ; waiters }
+      | Processing _ ->
+          { readys ; waiters = d :: waiters})
+    ~init:{ readys = [] ; waiters = [] }
+    ds
 
-(*****************************************************************************)
-(* As explained in the header, we wrap every function with Obj.magic, because
- * the type-checker does not allow us to have a polymorphic worker.
- *)
-(*****************************************************************************)
-let get_pid proc = (Obj.magic proc).pid
-let call proc f x = proc.send_task ({ job = f; arg = x })
-let get_result proc _ = proc.recv_result()
-let make heap gc_control = Obj.magic (MakeWorker.make [] heap gc_control)
-let call proc = Obj.magic (call (Obj.magic proc))
-let select procl = Obj.magic (select (Obj.magic procl))
-let get_result proc = get_result (Obj.magic proc)
-let get_file_descr proc = (Obj.magic proc).descr_recv
-let kill proc = try Unix.kill (Obj.magic proc).pid 9 with _ -> ()
+let get_worker h =
+  match !h with
+  | Processing {worker; _} -> worker
+  | Cached _
+  | Failed _ -> invalid_arg "Worker.get_worker"
+
+
+
+(**************************************************************************
+ * Worker termination
+ **************************************************************************)
+
+let kill w =
+  if not w.killed then begin
+    w.killed <- true;
+    match w.prespawned with
+    | None -> ()
+    | Some handle -> Daemon.kill handle
+  end
+
+let killall () =
+  List.iter ~f:kill !workers

--- a/hack/server/serverArgs.ml
+++ b/hack/server/serverArgs.ml
@@ -21,7 +21,7 @@ type options = {
   convert          : Path.t option;
   no_load          : bool;
   save_filename    : (state_kind * string) option;
-  waiting_client   : Handle.handle option;
+  waiting_client   : Unix.file_descr option;
 }
 
 and state_kind =
@@ -85,7 +85,7 @@ let parse_options () =
   let set_ai   = fun s -> ai_mode := Some (Ai_options.prepare ~server:true s) in
   let set_save      = fun s -> save := Some (Complete, s) in
   let set_save_mini = fun s -> save := Some (Mini, s) in
-  let set_wait      = fun fd -> waiting_client := Some fd in
+  let set_wait      = fun fd -> waiting_client := Some (Handle.wrap_handle fd) in
   let options =
     ["--debug"         , Arg.Set debug         , Messages.debug;
      "--ai"            , Arg.String set_ai     , Messages.ai;

--- a/hack/server/serverArgs.mli
+++ b/hack/server/serverArgs.mli
@@ -22,7 +22,7 @@ type options = {
   convert          : Path.t option;
   no_load          : bool;
   save_filename    : (state_kind * string) option;
-  waiting_client   : Handle.handle option;
+  waiting_client   : Unix.file_descr option;
 }
 
 and state_kind =
@@ -44,4 +44,4 @@ val should_detach       : options -> bool
 val convert             : options -> Path.t option
 val no_load             : options -> bool
 val save_filename       : options -> (state_kind * string) option
-val waiting_client      : options -> Handle.handle option
+val waiting_client      : options -> Unix.file_descr option

--- a/hack/server/serverEnvBuild.ml
+++ b/hack/server/serverEnvBuild.ml
@@ -16,19 +16,13 @@ open ServerEnv
 
 module SLC = ServerLocalConfig
 
-let make_genv options config local_config =
+let make_genv options config local_config handle =
   let root = ServerArgs.root options in
   let check_mode   = ServerArgs.check_mode options in
-  let gc_control   = ServerConfig.gc_control config in
   Typing_deps.trace :=
     not check_mode || ServerArgs.convert options <> None ||
     ServerArgs.save_filename options <> None;
-  let nbr_procs = GlobalConfig.nbr_procs in
-  let workers =
-    if Sys.win32 then
-      None (* No parallelism on Windows yet, Work-in-progress *)
-    else
-      Some (Worker.make nbr_procs gc_control) in
+  let workers = ServerWorker.make options config handle in
   let watchman =
     if check_mode || not local_config.SLC.use_watchman
     then None

--- a/hack/server/serverLocalConfig.ml
+++ b/hack/server/serverLocalConfig.ml
@@ -18,6 +18,7 @@ type t = {
   type_decl_bucket_size: int;
   io_priority: int;
   cpu_priority: int;
+  shm_dir: string;
 }
 
 let default = {
@@ -28,6 +29,7 @@ let default = {
   type_decl_bucket_size = 1000;
   io_priority = 7;
   cpu_priority = 10;
+  shm_dir = GlobalConfig.shm_dir;
 }
 
 let path =
@@ -51,6 +53,7 @@ let load_ fn =
     int_ "watchman_init_timeout" ~default:10 config in
   let io_priority = int_ "io_priority" ~default:7 config in
   let cpu_priority = int_ "cpu_priority" ~default:10 config in
+  let shm_dir = string_ "shm_dir" ~default:default.shm_dir config in
   {
     use_watchman;
     watchman_init_timeout;
@@ -59,6 +62,7 @@ let load_ fn =
     type_decl_bucket_size;
     io_priority;
     cpu_priority;
+    shm_dir;
   }
 
 let load () =

--- a/hack/server/serverMain.mli
+++ b/hack/server/serverMain.mli
@@ -8,5 +8,4 @@
  *
  *)
 
-val daemon_main: ServerArgs.options ->
-  Unix.file_descr -> Unix.file_descr -> unit
+val typechecker_entry: (ServerArgs.options, char, char) Daemon.entry

--- a/hack/server/serverMonitor.ml
+++ b/hack/server/serverMonitor.ml
@@ -72,10 +72,10 @@ let setup_autokill_typechecker_on_exit typechecker =
   | _ ->
     Hh_logger.log "Failed to set signal handler"
 
-let start_hh_server options typechecker_entry log_mode =
+let start_hh_server options log_mode =
   let log_file =
     match log_mode with
-    | Daemon.Log_file ->
+    | Daemon.Log_file | Daemon.Log_append ->
       let log_link = ServerFiles.log_link (ServerArgs.root options) in
       (try Sys.rename log_link (log_link ^ ".old") with _ -> ());
       let log_file = ServerFiles.make_link_of_timestamped log_link in
@@ -88,8 +88,8 @@ let start_hh_server options typechecker_entry log_mode =
   in
   let start_t = Unix.time () in
   let {Daemon.pid; Daemon.channels} =
-    Daemon.spawn ~channel_mode:`socket ~log_file ~log_mode typechecker_entry
-      options in
+    Daemon.spawn ~channel_mode:`socket ~log_file ~log_mode
+      ServerMain.typechecker_entry options in
   let ic, oc = channels in
   Hh_logger.log "Just started typechecker server with pid: %d." pid;
   let typechecker =
@@ -224,7 +224,7 @@ let ack_and_handoff_client typechecker fd =
     raise e
 
 let check_and_run_loop (_: ServerArgs.options) typechecker
-    (lock_file: string) (socket: Unix.file_descr) _ =
+    (lock_file: string) (socket: Unix.file_descr) =
   if not (Lock.grab lock_file) then
     (Hh_logger.log "Lost lock; terminating.\n%!";
      HackEventLogger.lock_stolen lock_file;
@@ -254,7 +254,7 @@ let check_and_run_loop (_: ServerArgs.options) typechecker
 (** Main method of the server monitor daemon. The daemon is responsible for
  * listening to socket requests from hh_client, checking Build ID, and relaying
  * requests to the typechecker process. *)
-let monitor_daemon_main (options: ServerArgs.options) typechecker_entry
+let monitor_daemon_main (options: ServerArgs.options)
     typechecker_log_mode =
   if Sys_utils.is_test_mode ()
   then EventLogger.init (Daemon.devnull ()) 0.0
@@ -270,50 +270,37 @@ let monitor_daemon_main (options: ServerArgs.options) typechecker_entry
     (Hh_logger.log "Monitor daemon already running. Killing";
      Exit_status.exit Exit_status.Ok);
   let socket = Socket.init_unix_socket (ServerFiles.socket_file www_root) in
-  let typechecker = start_hh_server options typechecker_entry
-      typechecker_log_mode in
+  let typechecker = start_hh_server options typechecker_log_mode in
   while true do
-    try check_and_run_loop
-      options typechecker lock_file socket typechecker_entry
+    try check_and_run_loop options typechecker lock_file socket
     with
     | _ -> ()
   done
+
+let daemon_entry =
+  Daemon.register_entry_point
+    "monitor_daemon_main"
+    (fun (
+       (options: ServerArgs.options))
+       ((_ic: char Daemon.in_channel), (_oc: char Daemon.out_channel)) ->
+       monitor_daemon_main options Daemon.Log_file)
 
 (* Starts a monitor daemon if one doesn't already exist. Otherwise,
  * immediately exits with non-zero exit code. This is because the monitor
  * should never actually be attempted to be started if one is already running
  * (i.e. hh_client should play nice and only start a server monitor if one
  * isn't running by first checking the liveness lock file.) *)
-let daemon_starter options daemon_entry typechecker_entry =
+let daemon_starter options =
   let www_root = (ServerArgs.root options) in
   let log_link = ServerFiles.server_monitor_log_link www_root in
   (try Sys.rename log_link (log_link ^ ".old") with _ -> ());
   let log_file_path = ServerFiles.make_link_of_timestamped log_link in
   let {Daemon.pid; _} = Daemon.spawn ~log_file:log_file_path
-      daemon_entry (options, typechecker_entry) in
+      daemon_entry options in
   Printf.eprintf "Spawned %s (child pid=%d)\n" Program.name pid;
   Printf.eprintf "Logs will go to %s\n%!"
     (if Sys.win32 then log_file_path else log_link);
   Exit_status.Ok
-
-let typechecker_entry =
-  Daemon.register_entry_point
-    "main"
-    (fun options
-      (** Must explicitly provide provide phantom types since they will
-       * never be inferred because they're immediately stripped away. *)
-      ((ic: char Daemon.in_channel), (oc: char Daemon.out_channel)) ->
-      let in_fd = Daemon.descr_of_in_channel ic in
-      let out_fd = Daemon.descr_of_out_channel oc in
-      ServerMain.daemon_main options in_fd out_fd)
-
-let daemon_entry =
-  Daemon.register_entry_point
-    "monitor_daemon_main"
-    (fun (
-       (options: ServerArgs.options), typechecker_entry)
-       ((_ic: char Daemon.in_channel), (_oc: char Daemon.out_channel)) ->
-       monitor_daemon_main options typechecker_entry Daemon.Log_file)
 
 (** Either starts a monitor daemon (which will spawn a typechecker daemon),
  * or just runs the typechecker if detachment not enabled. *)
@@ -322,6 +309,6 @@ let start () =
   let options = ServerArgs.parse_options () in
   if ServerArgs.should_detach options
   then
-    Exit_status.exit (daemon_starter options daemon_entry typechecker_entry)
+    Exit_status.exit (daemon_starter options)
   else
-    monitor_daemon_main options typechecker_entry Daemon.Parent_streams
+    monitor_daemon_main options Daemon.Parent_streams

--- a/hack/server/serverProcessTools.ml
+++ b/hack/server/serverProcessTools.ml
@@ -45,7 +45,7 @@ let check_exit_status proc_stat typechecker =
   | _ ->
     let exit_kind, exit_code = Exit_status.unpack proc_stat in
     match typechecker.log_mode with
-    | Daemon.Log_file ->
+    | Daemon.Log_file | Daemon.Log_append ->
       let oc = open_out_gen [Open_creat; Open_append; Open_binary] 0o666
         typechecker.log_file in
       Printf.fprintf oc "hh_server %s with exit code %d\n"

--- a/hack/server/serverWorker.ml
+++ b/hack/server/serverWorker.ml
@@ -1,0 +1,28 @@
+(**
+ * Copyright (c) 2014, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the "hack" directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ *)
+
+type slave_state = string option * string option
+let save () =
+  Path.make (Relative_path.(path_of_prefix Root)),
+  Path.make (Relative_path.(path_of_prefix Hhi))
+let restore (saved_root, saved_hhi) =
+  HackSearchService.attach_hooks ();
+  Relative_path.(set_path_prefix Root saved_root);
+  Relative_path.(set_path_prefix Hhi saved_hhi)
+
+(* As for [Daemon.register_entry_point], this should stay
+   at toplevel, in order to be executed before
+   [Daemon.check_entry_point]. *)
+let builder = Worker.register_entry_point ~save ~restore
+
+let make options config handle =
+  let gc_control = ServerConfig.gc_control config in
+  let nbr_procs  = GlobalConfig.nbr_procs in
+  Some (Worker.make builder nbr_procs gc_control handle)

--- a/hack/utils/config_file.ml
+++ b/hack/utils/config_file.ml
@@ -40,6 +40,9 @@ let parse fn =
 
 module Getters = struct
 
+  let string_ key ~default config =
+    Option.value (SMap.get key config) ~default
+
   let int_ key ~default config =
     Option.value_map (SMap.get key config) ~default ~f:int_of_string
 

--- a/hack/utils/daemon.ml
+++ b/hack/utils/daemon.ml
@@ -18,8 +18,13 @@ type ('in_, 'out) handle = {
   pid : int;
 }
 
+(* Windows: ensure thar the serialize/desarialize functions
+   for the custom block of "Unix.file_descr" are registred. *)
+let () = Lazy.force Handle.init
+
 type log_mode =
 | Log_file
+| Log_append
 | Parent_streams
 
 let to_channel :
@@ -95,13 +100,16 @@ end = struct
         "Unknown entry point %S" name
 
   let set_context entry param (ic, oc) =
-    let data =
-      (Handle.get_handle ic,
-       Handle.get_handle oc,
-       param) in
-    let data_str = String.escaped (Marshal.to_string data []) in
+    let data = (ic, oc, param) in
     Unix.putenv "HH_SERVER_DAEMON" entry;
-    Unix.putenv "HH_SERVER_DAEMON_PARAM" data_str
+    let file, oc =
+      Filename.open_temp_file
+        ~mode:[Open_binary]
+        ~temp_dir:(Path.to_string Path.temp_dir_name)
+        "daemon_param" ".bin" in
+    output_value oc data;
+    close_out oc;
+    Unix.putenv "HH_SERVER_DAEMON_PARAM" file
 
   (* How this works on Unix: It may appear like we are passing file descriptors
    * from one process to another here, but in_handle / out_handle are actually
@@ -115,12 +123,17 @@ end = struct
     let entry = Unix.getenv "HH_SERVER_DAEMON" in
     let (in_handle, out_handle, param) =
       try
-        let raw = Sys.getenv "HH_SERVER_DAEMON_PARAM" in
-        Marshal.from_string (Scanf.unescaped raw) 0
-      with _ -> failwith "Can't find daemon parameters." in
+        let file = Sys.getenv "HH_SERVER_DAEMON_PARAM" in
+        let ic = Sys_utils.open_in_bin_no_fail file in
+        let res = Marshal.from_channel ic in
+        Sys_utils.close_in_no_fail "Daemon.get_context" ic;
+        Sys.remove file;
+        res
+      with exn ->
+        failwith "Can't find daemon parameters." in
     (entry, param,
-     (Unix.in_channel_of_descr (Handle.wrap_handle in_handle),
-      Unix.out_channel_of_descr (Handle.wrap_handle out_handle)))
+     (Unix.in_channel_of_descr in_handle,
+      Unix.out_channel_of_descr out_handle))
 
 end
 
@@ -212,7 +225,7 @@ let spawn
     Unix.openfile null_path [Unix.O_RDONLY; Unix.O_CREAT] 0o777 in
   let out_fd, err_fd =
     match log_mode with
-    | Log_file ->
+    | Log_file | Log_append ->
       let out_path =
         Option.value_map log_file
           ~default:null_path
@@ -220,8 +233,23 @@ let spawn
               Sys_utils.mkdir_no_fail (Filename.dirname fn);
               fn)  in
       let out_fd =
-        Unix.openfile out_path [Unix.O_WRONLY; Unix.O_CREAT; Unix.O_TRUNC]
-        0o666 in
+        match log_mode with
+        | Log_file ->
+          Unix.openfile out_path [Unix.O_WRONLY; Unix.O_CREAT; Unix.O_TRUNC]
+            0o666
+        | Log_append ->
+          (* Used for slave's on Windows, where `O_APPEND` is ignored.
+             See [Worker.register_entry_point]. *)
+          if Sys.file_exists out_path then begin
+            let fd = Unix.openfile out_path [Unix.O_WRONLY] 0o666 in
+            ignore (Unix.lseek fd 0 Unix.SEEK_END) ;
+            fd
+          end else begin
+            Unix.openfile out_path [Unix.O_WRONLY; Unix.O_CREAT]
+              0o666
+          end
+        | Parent_streams -> assert false
+      in
       out_fd, out_fd
     | Parent_streams ->
       Unix.stdout, Unix.stderr
@@ -261,3 +289,6 @@ let close { channels = (ic, oc); _ } =
 let kill h =
   close h;
   Unix.kill h.pid Sys.sigkill
+
+let cast_in x = x
+let cast_out x = x

--- a/hack/utils/daemon.mli
+++ b/hack/utils/daemon.mli
@@ -16,6 +16,7 @@ type ('in_, 'out) channel_pair = 'in_ in_channel * 'out out_channel
 
 type log_mode =
 | Log_file
+| Log_append
 | Parent_streams
 
 val to_channel :
@@ -27,6 +28,8 @@ val flush : 'a out_channel -> unit
 (* This breaks the type safety, but is necessary in order to allow select() *)
 val descr_of_in_channel : 'a in_channel -> Unix.file_descr
 val descr_of_out_channel : 'a out_channel -> Unix.file_descr
+val cast_in : 'a in_channel -> Pervasives.in_channel
+val cast_out : 'a out_channel -> Pervasives.out_channel
 
 (** Spawning new process *)
 

--- a/hack/utils/exit_status.ml
+++ b/hack/utils/exit_status.ml
@@ -35,38 +35,42 @@ type t =
   | Watchman_failed
   | Hhconfig_deleted
   | Server_shutting_down
+  | Out_of_shared_memory
 
 exception Exit_with of t
 
+let to_int = function
+  | Ok -> 0
+  | Build_error -> 2
+  | Build_terminated -> 1
+  | Checkpoint_error -> 8
+  | Input_error -> 10
+  | Kill_error -> 1
+  | No_server_running -> 6
+  | Out_of_time -> 7
+  | Out_of_retries -> 7
+  | Server_already_exists -> 77
+  | Server_initializing -> 1
+  | Server_shutting_down -> 1
+  | Type_error -> 2
+  | Build_id_mismatch -> 9
+  | Unused_server -> 5
+  | Lock_stolen -> 11
+  | Lost_parent_monitor -> 12
+  | Out_of_shared_memory -> 15
+  | Interrupted -> -6
+  | Missing_hhi -> 97
+  | Socket_error -> 98
+  | Dfind_died -> 99
+  | Dfind_unresponsive -> 100
+  | EventLogger_Timeout -> 101
+  | CantRunAI -> 102
+  | Watchman_failed -> 103
+  | Hhconfig_deleted -> 104
+
+
 let exit t =
-  let ec = match t with
-    | Ok -> 0
-    | Build_error -> 2
-    | Build_terminated -> 1
-    | Checkpoint_error -> 8
-    | Input_error -> 10
-    | Kill_error -> 1
-    | No_server_running -> 6
-    | Out_of_time -> 7
-    | Out_of_retries -> 7
-    | Server_already_exists -> 77
-    | Server_initializing -> 1
-    | Server_shutting_down -> 1
-    | Type_error -> 2
-    | Build_id_mismatch -> 9
-    | Unused_server -> 5
-    | Lock_stolen -> 11
-    | Lost_parent_monitor -> 12
-    | Interrupted -> -6
-    | Missing_hhi -> 97
-    | Socket_error -> 98
-    | Dfind_died -> 99
-    | Dfind_unresponsive -> 100
-    | EventLogger_Timeout -> 101
-    | CantRunAI -> 102
-    | Watchman_failed -> 103
-    | Hhconfig_deleted -> 104
-  in
+  let ec = to_int t in
   Pervasives.exit ec
 
 let to_string = function
@@ -96,6 +100,7 @@ let to_string = function
   | CantRunAI -> "CantRunAI"
   | Watchman_failed -> "Watchman_failed"
   | Hhconfig_deleted -> "Hhconfig_deleted"
+  | Out_of_shared_memory -> "Out_of_shared_memory"
 
 let unpack = function
   | Unix.WEXITED n -> "exit", n

--- a/hack/utils/handle.h
+++ b/hack/utils/handle.h
@@ -1,4 +1,4 @@
-(**
+/**
  * Copyright (c) 2015, Facebook, Inc.
  * All rights reserved.
  *
@@ -6,10 +6,14 @@
  * LICENSE file in the "hack" directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  *
- *)
+ */
 
-val make_genv:
-  ServerArgs.options -> ServerConfig.t -> ServerLocalConfig.t ->
-  SharedMem.handle -> ServerEnv.genv
+#include <caml/mlvalues.h>
+#include <caml/unixsupport.h>
 
-val make_env: ServerConfig.t -> ServerEnv.env
+#ifdef _WIN32
+#define Val_handle(fd) (win_alloc_handle(fd))
+#else
+#define Handle_val(fd) (Long_val(fd))
+#define Val_handle(fd) (Val_long(fd))
+#endif

--- a/hack/utils/handle.ml
+++ b/hack/utils/handle.ml
@@ -17,6 +17,17 @@ external raw_get_handle :
   Unix.file_descr -> handle = "caml_hh_worker_get_handle" "noalloc"
 external raw_wrap_handle :
   handle -> Unix.file_descr = "caml_hh_worker_create_handle"
+external win_setup_handle_serialization :
+  unit -> unit = "win_setup_handle_serialization"
+
+let init =
+  (* Windows: register the serialize/desarialize functions
+     for the custom block of "Unix.file_descr". *)
+  lazy begin
+    win_setup_handle_serialization ()
+  end
+
+let () = Lazy.force init
 
 let () = assert (Sys.win32 || Obj.is_int (Obj.repr Unix.stdin))
 let get_handle =

--- a/hack/utils/handle_stubs.c
+++ b/hack/utils/handle_stubs.c
@@ -8,29 +8,54 @@
  *
  */
 
+
 #include <caml/mlvalues.h>
-#include <caml/unixsupport.h>
+#include <caml/intext.h>
+#include <caml/custom.h>
+#include <stdio.h>
 
-#ifdef __WIN32__
+#include "handle.h"
 
 value caml_hh_worker_get_handle(value x) {
-    HANDLE h = Handle_val(x);
-    return Val_long(h);
+    return Val_long(Handle_val(x));
 }
 
 value caml_hh_worker_create_handle(value x) {
-    HANDLE h1 = (HANDLE)Long_val(x);
-    return win_alloc_handle(h1);
-}
-
+#ifdef _WIN32
+  return Val_handle((HANDLE)Long_val(x));
 #else
-
-value caml_hh_worker_get_handle(value x) {
-    return x;
-}
-
-value caml_hh_worker_create_handle(value x) {
-    return x;
-}
-
+  return Val_handle(Long_val(x));
 #endif
+}
+
+#ifdef _WIN32
+static void win_handle_serialize(value h, uintnat *wsize_32, uintnat *wsize_64) {
+  serialize_int_8((int64)Handle_val(h));
+  serialize_int_1(Descr_kind_val(h));
+  serialize_int_1(CRT_fd_val(h));
+  serialize_int_1(Flags_fd_val(h));
+  *wsize_32 = sizeof(struct filedescr);
+  *wsize_64 = sizeof(struct filedescr);
+}
+
+static uintnat win_handle_deserialize(void * dst) {
+  struct filedescr *h= (struct filedescr *)dst;
+  h->fd.handle = (HANDLE)caml_deserialize_sint_8();
+  h->kind = caml_deserialize_uint_1();
+  h->crt_fd = caml_deserialize_sint_1();
+  h->flags_fd = caml_deserialize_uint_1();
+  return sizeof(struct filedescr);
+}
+#endif
+
+value win_setup_handle_serialization(value unit) {
+#ifdef _WIN32
+  value handle = win_alloc_handle((HANDLE)0); // Dummy handle
+  struct custom_operations *win_handle_ops = (struct custom_operations *)Field(handle, 0);
+  win_handle_ops->serialize = win_handle_serialize;
+  win_handle_ops->deserialize = win_handle_deserialize;
+  caml_register_custom_operations(win_handle_ops);
+#endif
+  return Val_unit;
+}
+

--- a/hack/utils/relative_path.mli
+++ b/hack/utils/relative_path.mli
@@ -16,6 +16,7 @@ type prefix =
   | Dummy
 
 val set_path_prefix : prefix -> Path.t -> unit
+val path_of_prefix : prefix -> string
 
 module S : sig
   type t

--- a/hack/utils/sys_utils.ml
+++ b/hack/utils/sys_utils.ml
@@ -43,7 +43,7 @@ let open_in_bin_no_fail fn =
   try open_in_bin fn
   with e ->
     let e = Printexc.to_string e in
-    Printf.fprintf stderr "Could not open_in: '%s' (%s)\n" fn e;
+    Printf.fprintf stderr "Could not open_in_bin: '%s' (%s)\n" fn e;
     exit 3
 
 let close_in_no_fail fn ic =
@@ -57,6 +57,13 @@ let open_out_no_fail fn =
   with e ->
     let e = Printexc.to_string e in
     Printf.fprintf stderr "Could not open_out: '%s' (%s)\n" fn e;
+    exit 3
+
+let open_out_bin_no_fail fn =
+  try open_out_bin fn
+  with e ->
+    let e = Printexc.to_string e in
+    Printf.fprintf stderr "Could not open_out_bin: '%s' (%s)\n" fn e;
     exit 3
 
 let close_out_no_fail fn oc =

--- a/src/commands/commandConnect.ml
+++ b/src/commands/commandConnect.ml
@@ -17,6 +17,7 @@ type env = {
   retry_if_init : bool;
   expiry : float option;
   tmp_dir : string;
+  shm_dir : string;
   log_file : string;
 }
 
@@ -66,7 +67,7 @@ let msg_of_tail tail_env =
     "[processing]"
 
 (* Starts up a flow server by literally calling flow start *)
-let start_flow_server ~tmp_dir root =
+let start_flow_server ~tmp_dir ~shm_dir root =
   Utils.prerr_endlinef
     "Launching Flow server for %s"
     (Path.to_string root);
@@ -79,6 +80,7 @@ let start_flow_server ~tmp_dir root =
       Unix.(create_process exe
               [| exe; "start";
                  "--temp-dir"; tmp_dir;
+                 "--shm-dir"; shm_dir;
                  "--from"; from_arg;
                  Path.to_string root |]
               stdin stdout stderr) in
@@ -151,7 +153,8 @@ let rec connect env retries start_time tail_env =
   | Result.Error CCS.Server_missing ->
       if env.autostart then begin
         let retries =
-          if start_flow_server ~tmp_dir:env.tmp_dir env.root
+          if start_flow_server
+               ~tmp_dir:env.tmp_dir ~shm_dir:env.shm_dir env.root
           then begin
             Printf.eprintf
               "Started a new flow server: %s%!"

--- a/src/commands/commandUtils.ml
+++ b/src/commands/commandUtils.ml
@@ -116,6 +116,12 @@ let temp_dir_flag prev = CommandSpec.ArgSpec.(
       ~doc:"Directory in which to store temp files (default: /tmp/flow/)"
 )
 
+let shm_dir_flag prev = CommandSpec.ArgSpec.(
+  prev
+  |> flag "--shm-dir" string
+      ~doc:"Directory in which to store shared memory heap (default: /dev/shm/)"
+)
+
 let from_flag prev = CommandSpec.ArgSpec.(
   prev
   |> flag "--from" (optional string)
@@ -164,10 +170,11 @@ type command_params = {
   timeout : int;
   no_auto_start : bool;
   temp_dir : string;
+  shm_dir : string;
 }
 
 let collect_server_flags
-  main timeout retries retry_if_init no_auto_start temp_dir from =
+  main timeout retries retry_if_init no_auto_start temp_dir shm_dir from =
   let default def = function
   | Some x -> x
   | None -> def in
@@ -179,6 +186,7 @@ let collect_server_flags
     timeout = (default 0 timeout);
     no_auto_start = no_auto_start;
     temp_dir = (default FlowConfig.default_temp_dir temp_dir);
+    shm_dir = (default FlowConfig.default_shm_dir shm_dir);
   }
 
 
@@ -194,11 +202,13 @@ let server_flags prev = CommandSpec.ArgSpec.(
   |> flag "--no-auto-start" no_arg
       ~doc:"If the server is not running, do not start it; just exit"
   |> temp_dir_flag
+  |> shm_dir_flag
   |> from_flag
 )
 
 let connect server_flags root =
   let tmp_dir = server_flags.temp_dir in
+  let shm_dir = server_flags.shm_dir in
   let config_options = FlowConfig.((get root).options) in
   let log_file =
     Path.to_string (FlowConfig.log_file ~tmp_dir root config_options) in
@@ -215,6 +225,7 @@ let connect server_flags root =
       retry_if_init;
       expiry;
       tmp_dir;
+      shm_dir;
       log_file;
     } in
     connect env

--- a/src/commands/convertCommand.ml
+++ b/src/commands/convertCommand.ml
@@ -135,7 +135,7 @@ let main error_flags outpath recurse dir () =
   if ! Sys.interactive
   then ()
   else
-    SharedMem.(init default_config);
+    let _handle = SharedMem.(init default_config FlowConfig.default_shm_dir) in
     convert path recurse error_flags outpath
 
 let command = CommandSpec.command spec main

--- a/src/commands/serverCommands.ml
+++ b/src/commands/serverCommands.ml
@@ -52,6 +52,7 @@ module OptionParser(Config : CONFIG) = struct
     |> verbose_flags
     |> strip_root_flag
     |> temp_dir_flag
+    |> shm_dir_flag
     |> from_flag
     |> anon "root" (optional string) ~doc:"Root directory"
   )
@@ -110,7 +111,7 @@ module OptionParser(Config : CONFIG) = struct
   let result = ref None
   let main error_flags json profile quiet log_file wait debug
            all weak traces lib no_flowlib munge_underscore_members max_workers
-           verbose strip_root temp_dir from
+           verbose strip_root temp_dir shm_dir from
            root () =
     FlowEventLogger.set_from from;
     let root = CommandUtils.guess_root root in
@@ -136,6 +137,10 @@ module OptionParser(Config : CONFIG) = struct
     let opt_temp_dir = match temp_dir with
     | Some x -> x
     | None -> Path.to_string (FlowConfig.(flowconfig.options.Opts.temp_dir))
+    in
+    let opt_shm_dir = match shm_dir with
+    | Some x -> x
+    | None -> Path.to_string (FlowConfig.(flowconfig.options.Opts.shm_dir))
     in
     let opt_log_file = match log_file with
       | Some s ->
@@ -177,6 +182,7 @@ module OptionParser(Config : CONFIG) = struct
       Options.opt_no_flowlib = no_flowlib;
       Options.opt_munge_underscores = opt_munge_underscores;
       Options.opt_temp_dir;
+      Options.opt_shm_dir;
       Options.opt_max_workers;
     };
     ()

--- a/src/common/files_js.ml
+++ b/src/common/files_js.ml
@@ -48,6 +48,10 @@ let get_lib_fileset () = match !lib_files with
 | None -> SSet.empty
 | Some (files, fileset) -> fileset
 
+let restore_lib_files s =
+  assert (!lib_files = None);
+  lib_files := Some s
+
 let realpath path = match Sys_utils.realpath path with
 | Some path -> path
 | None -> path (* perhaps this should error? *)

--- a/src/common/files_js.mli
+++ b/src/common/files_js.mli
@@ -48,3 +48,6 @@ val construct_path: string -> string list -> string
 val package_json: Path.t -> Utils.SSet.t
 
 val relative_path: string -> string -> string
+
+(**/**)
+val restore_lib_files: Utils.SSet.elt list * Utils.SSet.t -> unit

--- a/src/common/flowConfig.ml
+++ b/src/common/flowConfig.ml
@@ -18,6 +18,10 @@ let default_temp_dir =
   Path.to_string @@
   Path.concat Path.temp_dir_name "flow"
 
+let default_shm_dir =
+  try Sys.getenv "FLOW_SHMDIR"
+  with _ -> "/dev/shm"
+
 let map_add map (key, value) = SMap.add key value map
 
 let multi_error (errs:(int * string) list) =
@@ -58,6 +62,7 @@ module Opts = struct
     log_file: Path.t option;
     max_workers: int;
     temp_dir: Path.t;
+    shm_dir: Path.t;
   }
 
   type _initializer =
@@ -123,6 +128,7 @@ module Opts = struct
     log_file = None;
     max_workers = Sys_utils.nbr_procs;
     temp_dir = Path.make default_temp_dir;
+    shm_dir = Path.make default_shm_dir;
   }
 
   let parse =
@@ -656,6 +662,15 @@ let parse_options config lines = Opts.(
       });
     })
 
+    |> Opts.define_opt "shm_dir" Opts.({
+      _initializer = USE_DEFAULT;
+      flags = [];
+      optparser = optparse_filepath;
+      setter = (fun opts v -> {
+        opts with shm_dir = v;
+      });
+    })
+
     |> Opts.define_opt "traces" Opts.({
       _initializer = USE_DEFAULT;
       flags = [];
@@ -758,3 +773,5 @@ let get_unsafe () =
   match !cache with
   | Some config -> config
   | None -> failwith "No config loaded"
+
+let restore config = cache := Some config

--- a/src/common/flowConfig.mli
+++ b/src/common/flowConfig.mli
@@ -32,6 +32,7 @@ module Opts : sig
     log_file: Path.t option;
     max_workers: int;
     temp_dir: Path.t;
+    shm_dir: Path.t;
   }
 end
 
@@ -53,6 +54,7 @@ type config = {
 }
 
 val default_temp_dir: string
+val default_shm_dir: string
 
 val get: Path.t -> config
 val get_unsafe: unit -> config
@@ -75,3 +77,6 @@ val is_included: config -> string -> bool
 
 (* true if a file path matches an exclude (ignore) entry in config *)
 val is_excluded: config -> string -> bool
+
+(**/**)
+val restore: config -> unit

--- a/src/common/flowExitStatus.ml
+++ b/src/common/flowExitStatus.ml
@@ -46,6 +46,9 @@ type t =
   (* The hack code might throw this *)
   | Dfind_unresponsive
 
+  (* When the shared memory is missing space (e.g. full /dev/shm) *)
+  | Out_of_shared_memory
+
   (* A generic something-else-went-wrong *)
   | Unknown_error
 
@@ -75,6 +78,7 @@ let error_code = function
   | Could_not_find_flowconfig -> 12
   | Server_out_of_date -> 13
   | Server_client_directory_mismatch -> 14
+  | Out_of_shared_memory -> 15
   (* EX_USAGE -- command line usage error -- from glibc's sysexits.h *)
   | Commandline_usage_error -> 64
   | Server_start_failed _ -> 78
@@ -113,6 +117,7 @@ let to_string = function
   | Missing_flowlib -> "Missing_flowlib"
   | Dfind_died -> "Dfind_died"
   | Dfind_unresponsive -> "Dfind_unresponsive"
+  | Out_of_shared_memory -> "Out_of_shared_memory"
   | Unknown_error -> "Unknown_error"
   | Commandline_usage_error -> "Commandline_usage_error"
 

--- a/src/common/flowExitStatus.mli
+++ b/src/common/flowExitStatus.mli
@@ -20,6 +20,7 @@ type t =
   | Socket_error
   | Dfind_died
   | Dfind_unresponsive
+  | Out_of_shared_memory
   | Unknown_error
 
 exception Exit_with of t

--- a/src/common/options.ml
+++ b/src/common/options.ml
@@ -32,6 +32,7 @@ type options = {
   opt_traces : int;
   opt_verbose : int option; (* num of spaces to indent; None for not verbose *)
   opt_weak : bool;
+  opt_shm_dir: string;
 }
 
 let all opts = opts.opt_all
@@ -47,5 +48,6 @@ let should_munge_underscores opts = opts.opt_munge_underscores
 let should_strip_root opts = opts.opt_strip_root
 let should_wait opts = opts.opt_should_wait
 let temp_dir opts = opts.opt_temp_dir
+let shm_dir opts = opts.opt_shm_dir
 let verbose opts = opts.opt_verbose
 let weak_by_default opts = opts.opt_weak

--- a/src/flow.ml
+++ b/src/flow.ml
@@ -57,8 +57,6 @@ end = struct
   let commands = ShellCommand.command :: commands
 
   let main () =
-    Daemon.check_entry_point (); (* this call might not return *)
-
     Sys_utils.set_signal Sys.sigpipe Sys.Signal_ignore;
     let default_command = DefaultCommand.command in
     let argv = Array.to_list Sys.argv in
@@ -83,6 +81,8 @@ end = struct
 
 end
 
-let _ = FlowShell.main ()
-(* If we haven't exited yet, let's exit now for logging's sake *)
-let _ = FlowExitStatus.(exit Ok)
+let () =
+  Daemon.check_entry_point (); (* this call might not return *)
+  FlowShell.main ();
+  (* If we haven't exited yet, let's exit now for logging's sake *)
+  FlowExitStatus.(exit Ok)

--- a/src/server/server.ml
+++ b/src/server/server.ml
@@ -34,11 +34,10 @@ struct
 
   let parse_options = OptionParser.parse
 
-  let preinit () =
+  let preinit flow_options =
     (* Do some initialization before creating workers, so that each worker is
      * forked with this information already available. Finding lib files is one
      * example *)
-    let flow_options = OptionParser.parse () in
     Types_js.init_modes flow_options;
     ignore (Flow_js.master_cx ());
     Parsing_service_js.call_on_success SearchService_js.update

--- a/src/server/serverEnvBuild.ml
+++ b/src/server/serverEnvBuild.ml
@@ -14,14 +14,13 @@
 (*****************************************************************************)
 open ServerEnv
 
-let make_genv ~multicore options watch_paths =
+let make_genv ~multicore options watch_paths handle =
   let check_mode   = Options.is_check_mode options in
-  let gc_control   = GlobalConfig.gc_control in
-  let nbr_procs    = Options.max_workers options in
   let workers =
-    if multicore && nbr_procs > 0
-    then Some (Worker.make nbr_procs gc_control)
-    else None
+    if multicore then
+      Some (ServerWorker.make options handle)
+    else
+      None
   in
   let dfind =
     if check_mode then None

--- a/src/server/serverFunctors.ml
+++ b/src/server/serverFunctors.ml
@@ -260,7 +260,7 @@ end = struct
     end;
     FlowEventLogger.init_server root;
     Relative_path.set_path_prefix Relative_path.Root root;
-    Program.preinit ();
+    Program.preinit options;
     let handle = SharedMem.(init default_config shm_dir) in
     (* this is to transform SIGPIPE in an exception. A SIGPIPE can happen when
     * someone C-c the client.
@@ -351,7 +351,7 @@ end = struct
       (new_entry_point ())
       (fun (options, config) (ic, waiting_channel) ->
         ignore(Sys_utils.setsid());
-        Timeout.close_in (Daemon.cast_in ic);
+        close_in (Daemon.cast_in ic);
         FlowConfig.restore config;
         main ~waiting_channel options)
 

--- a/src/server/serverWorker.ml
+++ b/src/server/serverWorker.ml
@@ -1,0 +1,35 @@
+(**
+ * Copyright (c) 2015, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the "hack" directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ *)
+
+type slave_state = Path.t option
+let save () = Path.make (Relative_path.(path_of_prefix Root))
+let restore saved_root =
+  Relative_path.(set_path_prefix Root saved_root)
+
+let builder =
+  let save () =
+    let master_cx = Flow_js.master_cx () in
+    (Files_js.get_lib_files (), Files_js.get_lib_fileset ()),
+    Flow_js.builtins master_cx,
+    Flow_js.master_cx (),
+    save (),
+    FlowConfig.get_unsafe () in
+  let restore (lf, b, cx, rp, fc) =
+    Files_js.restore_lib_files lf;
+    Flow_js.restore_builtins cx b;
+    Flow_js.restore_master_cx cx;
+    restore rp;
+    FlowConfig.restore fc in
+  Worker.register_entry_point ~save ~restore
+
+let make options heap_handle =
+  let gc_control   = GlobalConfig.gc_control in
+  let nbr_procs    = GlobalConfig.nbr_procs in
+  Worker.make builder nbr_procs gc_control heap_handle

--- a/src/typing/flow_js.mli
+++ b/src/typing/flow_js.mli
@@ -143,3 +143,6 @@ end
 module ContextOptimizer: sig
   val sig_context : Context.t list -> unit
 end
+
+val restore_master_cx: Context.t -> unit
+val restore_builtins: Context.t -> Type.t -> unit

--- a/src/typing/types_js.ml
+++ b/src/typing/types_js.ml
@@ -883,10 +883,11 @@ let typecheck workers files removed unparsed opts timing make_merge_input =
       ) in
       if profile_and_not_quiet opts then Gc.print_stat stderr;
       timing
-    with exc ->
-      prerr_endline (Printexc.to_string exc);
-      timing
-    in
+    with
+    | SharedMem.Out_of_shared_memory as exn -> raise exn
+    | exc ->
+        prerr_endline (Printexc.to_string exc);
+        timing in
     (* collate errors by origin *)
     collate_errors to_merge;
     timing, to_merge


### PR DESCRIPTION
Following change in Hack that use 'Daemon.spawn' to create slave, the
'global references' have to be copied "manually" on slave. This is done
in server/serverWorker.ml.

This is tied with D45423.

PS: This work was done in order to make version 0.19.1 work on
Windows. We couldn't rebase it as it depends on previous PR that have
not been merged in master yet.