### PR TITLE
Various path related fix for Windows

### DIFF
--- a/src/common/files_js.ml
+++ b/src/common/files_js.ml
@@ -210,9 +210,10 @@ let is_lib_file p =
 
 let lib_module = ""
 
-let dir_sep = Str.regexp_string Filename.dir_sep
+let dir_sep = Str.regexp "[/\\\\]"
 let current_dir_name = Str.regexp_string Filename.current_dir_name
 let parent_dir_name = Str.regexp_string Filename.parent_dir_name
+let absolute_path = Str.regexp "^\\(/\\|[A-Za-z]:\\)"
 
 let wanted config =
   let is_excluded = FlowConfig.is_excluded config in
@@ -231,6 +232,14 @@ let make_next_files root =
   make_next_files_following_symlinks
     ~path_filter ~realpath_filter (root::others)
 
+let is_windows_root root =
+  Sys.win32 &&
+  String.length root = 2 &&
+  root.[1] = ':' &&
+  match root.[0] with
+    | 'a'..'z' | 'A'..'Z' -> true
+    | _ -> false
+
 let rec normalize_path dir file =
   normalize_path_ dir (Str.split_delim dir_sep file)
 
@@ -245,6 +254,9 @@ and normalize_path_ dir names =
   | ""::names when names <> [] ->
       (* /<names> => /<names> *)
       construct_path Filename.dir_sep names
+  | root::names when is_windows_root root ->
+      (* C:\<names> => C:\<names> *)
+      construct_path (root ^ Filename.dir_sep) names
   | _ ->
       (* <names> => dir/<names> *)
       construct_path dir names
@@ -281,5 +293,8 @@ let relative_path =
         List.fold_left (fun path _ -> Filename.parent_dir_name::path) file root
   in
   fun root file ->
+    (* This functions is only used for displaying error location.
+       We use '/' as file separator even on Windows. This simplify
+       the test-suite script... *)
     make_relative (split_path root, split_path file)
-    |> String.concat Filename.dir_sep
+    |> String.concat "/"

--- a/src/common/files_js.mli
+++ b/src/common/files_js.mli
@@ -32,6 +32,7 @@ val lib_module: string
 val dir_sep: Str.regexp
 val current_dir_name: Str.regexp
 val parent_dir_name: Str.regexp
+val absolute_path: Str.regexp
 
 (* given a root, make a filter for file names *)
 val wanted: FlowConfig.config -> string -> bool

--- a/src/common/flowConfig.ml
+++ b/src/common/flowConfig.ml
@@ -481,7 +481,10 @@ let parse_excludes config lines =
   let excludes = lines
   |> List.map (fun (ln, line) -> String.trim line)
   |> List.filter (fun s -> s <> "")
-  |> List.map (fun s -> (s, Str.regexp s)) in
+  |> List.map (fun s ->
+    (* On Windows, we have to take care about '\'. *)
+    let reg = Str.regexp (Str.global_replace (Str.regexp "/") "[/\\]" s) in
+    (s, reg)) in
   { config with excludes; }
 
 let file_extension = Str.regexp "^\\(\\.[^ \t]+\\)+$"

--- a/src/typing/module_js.ml
+++ b/src/typing/module_js.ml
@@ -373,14 +373,16 @@ module Node = struct
         else node_module path_acc (Filename.dirname dir) r
       )
 
-  let relative r =
-    Str.string_match Files_js.dir_sep r 0
-    || Str.string_match Files_js.current_dir_name r 0
+  let absolute r =
+    Str.string_match Files_js.absolute_path r 0
+
+  let explicitly_relative r =
+    Str.string_match Files_js.current_dir_name r 0
     || Str.string_match Files_js.parent_dir_name r 0
 
   let resolve_import ?path_acc file import_str =
     let dir = Filename.dirname file in
-    if relative import_str
+    if explicitly_relative import_str || absolute import_str
     then resolve_relative ?path_acc dir import_str
     else node_module path_acc dir import_str
 
@@ -453,7 +455,7 @@ module Haste: MODULE_SYSTEM = struct
             Modulename.Filename file
 
   let expanded_name r =
-    match Str.split_delim Files_js.dir_sep r with
+    match Str.split_delim (Str.regexp_string "/") r with
     | [] -> None
     | package_name::rest ->
         ReversePackageHeap.get package_name |> opt_map (fun package ->


### PR DESCRIPTION
This PR:
    
  - fix Files_js.normalize_path: add a special case for absolute paths.
      They start with "C:\".
    
  - fix issue with ROOT_PROJECT variable on Windows
    
  - fix error-location display (use '/' to keep simplify runtests.sh)
    
  - handle backslashes in .flowconfig in the ignore section
    
        We extend the regexp to catch backslashes as a separator for Windows
        compatibility. Thanks to this, there is no need to modify
        .flowconfig on Windows.

PS: This work was done in order to make version 0.19.1 work on
Windows. We couldn't rebase it as it depends on previous PR that have
not been merged in master yet.
