### PR TITLE
Remove call to external commands.

### DIFF
--- a/src/embedded/flowlib.ml
+++ b/src/embedded/flowlib.ml
@@ -12,8 +12,8 @@ external get_embedded_flowlib_data : string -> string option =
   "get_embedded_flowlib_data"
 
 let touch_root r =
-  let r = Path.to_string r in
-  ignore (Unix.system ("find \"" ^ r ^ "\" -name \"*.js\" -exec touch '{}' ';'"))
+  let filter = FindUtils.is_js in
+  Find.iter_files ~filter [ r ] (Sys_utils.try_touch ~follow_symlinks:true)
 
 (* There are several verify-use race conditions here (and in Hack's file
  * handling in general, really). Running the server as root is likely to be a

--- a/src/server/server.ml
+++ b/src/server/server.ml
@@ -257,7 +257,7 @@ struct
         spf "diff -u --label old --label new %s %s > %s"
           file new_file patch_file in
     diff_cmd
-    |> Unix.system |> ignore;
+    |> Sys.command |> ignore;
     cat patch_file
 
   (* NOTE: currently, not only returns list of annotations, but also rewrites

--- a/src/server/server.ml
+++ b/src/server/server.ml
@@ -249,9 +249,15 @@ struct
     let new_file = Filename.temp_file "" "" in
     write_file new_file new_content;
     let patch_file = Filename.temp_file "" "" in
-    spf "diff -u --label old --label new %s %s > %s"
-      file new_file patch_file
-    |> Sys.command |> ignore;
+    let diff_cmd =
+      if Sys.win32 then
+        spf "fc %s %s > %s"
+          file new_file patch_file
+      else
+        spf "diff -u --label old --label new %s %s > %s"
+          file new_file patch_file in
+    diff_cmd
+    |> Unix.system |> ignore;
     cat patch_file
 
   (* NOTE: currently, not only returns list of annotations, but also rewrites


### PR DESCRIPTION
- Replace the call to find, by Find.find function.

- Replace diff equivalent on Windows.

  Note: there isn't -u/--label option on Windows, we just do the diff
  without this extra arguments.