### PR TITLE
Make callbacks optional in node `http` interface

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -675,14 +675,14 @@ declare module "http" {
   declare class ClientRequest extends stream$Writable {
   }
 
-  declare function createServer(listener: Function): Server;
+  declare function createServer(listener?: Function): Server;
   declare function request(
     options: Object | string,
-    callback: (response: IncomingMessage) => void
+    callback?: (response: IncomingMessage) => void
   ): ClientRequest;
   declare function get(
     options: Object | string,
-    callback: (response: IncomingMessage) => void
+    callback?: (response: IncomingMessage) => void
   ): ClientRequest;
 }
 


### PR DESCRIPTION
Node doc links for the three proposed changes:

- `http.createServer`: https://nodejs.org/dist/latest-v4.x/docs/api/http.html#http_http_createserver_requestlistener
- `http.request`: https://nodejs.org/dist/latest-v4.x/docs/api/http.html#http_http_request_options_callback
- `http.get`: https://nodejs.org/dist/latest-v4.x/docs/api/http.html#http_http_get_options_callback