### PR TITLE
changing vars to ES6 const (and let)

### DIFF
--- a/docs/01-arrays.md
+++ b/docs/01-arrays.md
@@ -14,8 +14,8 @@ the type `Array<T>` describes arrays whose elements are of type `T`.
 
 {% highlight javascript linenos=table %}
 /* @flow */
-var a = [1, 2, 3];
-var b: Array<number> = a.map(function(x) { return x + 1; });
+const a = [1, 2, 3];
+const b: Array<number> = a.map(function(x) { return x + 1; });
 {% endhighlight %}
 
 In this code, we create an array with the literal `[1, 2, 3]`, and call a method map on it, getting another array whose type we annotate as `Array<number>`.
@@ -30,8 +30,8 @@ For example:
 
 {% highlight javascript linenos=table %}
 /* @flow */
-var a = [];
-for (var i = 0; i < 10; ++i) {
+const a = [];
+for (let i = 0; i < 10; ++i) {
   if (i % 2 == 0) {
     a[i] = 0;
   } else {
@@ -90,8 +90,8 @@ for that particular index will be returned.
 
 {% highlight javascript linenos=table %}
 /* @flow */
-var tup = ["1", 1, true, "positive"];
-var b = tup[1] * tup[3];
+const tup = ["1", 1, true, "positive"];
+const b = tup[1] * tup[3];
 {% endhighlight %} 
 
 ```

--- a/docs/01-classes.md
+++ b/docs/01-classes.md
@@ -42,7 +42,7 @@ subtyping, i.e., the following code type checks:
 
 {% highlight javascript linenos=table %}
 ...
-var c: C = new D();
+const c: C = new D();
 {% endhighlight %}
 
 ## Propagation
@@ -53,9 +53,9 @@ based on the example above, the following does not typecheck:
 
 {% highlight javascript linenos=table %}
 ...
-var c: C = D.qux();
+const c: C = D.qux();
 c.foo(0);
-var x: string = c.bar();
+const x: string = c.bar();
 {% endhighlight %}
 
 ```bbcode

--- a/docs/01-declarations.md
+++ b/docs/01-declarations.md
@@ -11,7 +11,7 @@ Take the following code snippet:
 
 {% highlight javascript linenos=table %}
 /* @flow */
-var M = require('M');
+const M = require('M');
 M.foo(new C());
 {% endhighlight %}
 
@@ -71,7 +71,7 @@ available in the file on which it is checking.
 Assuming we have the declarations above, now when running Flow against this code:
 
 {% highlight javascript linenos=table %}
-var M = require('M');
+const M = require('M');
 M.foo(new C());
 {% endhighlight %}
 
@@ -84,7 +84,7 @@ No errors!
 A module declaration can also use a string literal to describe the path used to refer to that module in `require` statements.
 Thus, when you have:
 {% highlight javascript linenos=table %}
-var M = require('path/to/M');
+const M = require('path/to/M');
 ...
 {% endhighlight %}
 

--- a/docs/01-destructuring.md
+++ b/docs/01-destructuring.md
@@ -12,15 +12,15 @@ you to extract data from structured values. Here is a simple example:
 
 {% highlight javascript linenos=table %}
 /* @flow */
-var arr = [1, '', true];
-var [a, b, c] = arr;
+const arr = [1, '', true];
+const [a, b, c] = arr;
 // a: number (1), b: string (''), c : boolean (true)
 {% endhighlight %}
 
 The canonical example of destructuring is swapping:
 
 {% highlight javascript linenos=table %}
-var a = 1, b = 2;
+let a = 1, b = 2;
 [a, b] = [b, a];
 // a = 2, b = 1
 {% endhighlight %}
@@ -31,12 +31,12 @@ Flow can verify that any destructuring in your code is type-safe.
 
 {% highlight javascript linenos=table %}
 /* @flow */
-var arr = [1, '', 'Hello', true];
+const arr = [1, '', 'Hello', true];
 // If you only care about some of the return values, you can skip some
 // elements with , ,
-var [a, b, ,c] = arr;
+const [a, b, ,c] = arr;
 // a: number (1), b: string (''), c : boolean (true)
-var z: number = a * c;
+const z: number = a * c;
 {% endhighlight %} 
 
 Above we have a four (4) element array `arr` (actually a 
@@ -57,9 +57,9 @@ Found 1 error
 
 {% highlight javascript linenos=table %}
 /* @flow */
-var {x, y, ...o} = {x: '', y: 3, o: {z: false} }
+const {x, y, ...o} = {x: '', y: 3, o: {z: false} }
 // x: string, y: number, o: {z: boolean}
-var z: number = o;
+const z: number = o;
 {% endhighlight %}
 
 ```bbcode

--- a/docs/01-dynamic-type-tests.md
+++ b/docs/01-dynamic-type-tests.md
@@ -122,8 +122,8 @@ function test(x: boolean) {
 type NestedArray<T> = Array<T|NestedArray<T>>
 
 function flatten<T>(xs: NestedArray<T>): Array<T> {
-  var result = [];
-  for (var i = 0; i < xs.length; i++) {
+  let result = [];
+  for (let i = 0; i < xs.length; i++) {
     if (Array.isArray(xs[i])) {
       result = result.concat(flatten(xs[i]));
     } else {
@@ -225,7 +225,7 @@ declare function something(): void;
 
 function foo(x: { y: ?string }): string {
   if (x.y) {
-    var y = x.y;
+    const y = x.y;
     something();
     return y; // OK: something couldn't have changed y
   } else {

--- a/docs/01-functions.md
+++ b/docs/01-functions.md
@@ -14,7 +14,7 @@ Functions are ubiquitous in JavaScript. As expected, Flow propagates types throu
 {% highlight javascript linenos=table %}
 /* @flow */
 function foo(x: string): string { return x; }
-var x: number = foo('');
+const x: number = foo('');
 {% endhighlight %}
 
 Running Flow produces the following error:
@@ -36,8 +36,8 @@ as well. For example, the following code does not typecheck:
 {% highlight javascript linenos=table %}
 /* @flow */
 function foo(x) { return this.x; }
-var o = { x: 42, f: foo };
-var x: string = o.f();
+const o = { x: 42, f: foo };
+const x: string = o.f();
 {% endhighlight %}
 
 ```bbcode
@@ -103,8 +103,8 @@ Functions can be polymorphic, just like polymorphic classes.
 /* @flow */
 function foo<X>(x: X): X { return x; }
 
-var x: number = foo(0);
-var y: string = foo('');
+const x: number = foo(0);
+const y: string = foo('');
 {% endhighlight %}
 
 Furthermore, you may have polymorphic methods in polymorphic classes. For

--- a/docs/01-nullable-types.md
+++ b/docs/01-nullable-types.md
@@ -15,7 +15,7 @@ any other type. For example, the following code does not typecheck:
 
 {% highlight javascript linenos=table %}
 /* @flow */
-var o = null;
+const o = null;
 print(o.x);
 {% endhighlight %}
 
@@ -32,7 +32,7 @@ is a maybe type that describes `null` (or `undefined`) or the set of values of `
 
 {% highlight javascript linenos=table %}
 /* @flow */
-var o: ?string = null;
+const o: ?string = null;
 print(o.length);
 {% endhighlight %}
 
@@ -49,7 +49,7 @@ as follows:
 
 {% highlight javascript linenos=table %}
 /* @flow */
-var o: ?string = null;
+let o: ?string = null;
 if (o == null) {
   o = 'hello';
 }

--- a/docs/01-objects.md
+++ b/docs/01-objects.md
@@ -12,7 +12,7 @@ based on their initializers.
 
 {% highlight javascript linenos=table %}
 /* @flow */
-var o = {
+const o = {
   x: 42,
   foo(x) { this.x = x; }
 };
@@ -43,7 +43,7 @@ Here is an example of declaring an object type:
 {% highlight javascript linenos=table %}
 /* @flow */
 class Foo {}
-var obj: {a: boolean; b: string; c: Foo} = {a: true, b: "Hi", c: new Foo()}
+const obj: {a: boolean; b: string; c: Foo} = {a: true, b: "Hi", c: new Foo()}
 {% endhighlight %}
 
 Here is an example of Flow catching a problem with your object type:
@@ -52,7 +52,7 @@ Here is an example of Flow catching a problem with your object type:
 /* @flow */
 class Foo {}
 class Bar {}
-var obj: {a: boolean; b: string; c: Foo} = {a: true, b: "Hi", c: new Bar()}
+const obj: {a: boolean; b: string; c: Foo} = {a: true, b: "Hi", c: new Bar()}
 {% endhighlight %}
 
 ```bbcode
@@ -73,7 +73,7 @@ function sayHello(data: MyType) {
   console.log(data.message);
 }
 
-var mySampleData: MyType = {message: 'Hello World', isAwesome: true};
+const mySampleData: MyType = {message: 'Hello World', isAwesome: true};
 sayHello(mySampleData);
 sayHello({message: 'Hi', isAwesome: false});
 {% endhighlight %}
@@ -85,7 +85,7 @@ optional properties allow objects with missing properties to be typed.
 
 {% highlight javascript linenos=table %}
 /* @flow */
-var obj: { a: string; b?: number } = { a: "hello" };
+const obj: { a: string; b?: number } = { a: "hello" };
 {% endhighlight %}
 
 When optional properties are accessed, Flow tracks the fact that they could
@@ -93,7 +93,7 @@ be `undefined`, and reports errors when they are used as is.
 
 {% highlight javascript linenos=table %}
 /* @flow */
-var obj: { a: string; b?: number } = { a: "hello" };
+const obj: { a: string; b?: number } = { a: "hello" };
 obj.b * 10 // error: undefined is incompatible with number
 {% endhighlight %}
 
@@ -117,8 +117,8 @@ prototype chaining.
 function Foo(x) { this.x = x; }
 Foo.prototype.f = function() { return this.x; }
 
-var o = new Foo(42);
-var x: number = o.f();
+const o = new Foo(42);
+const x: number = o.f();
 {% endhighlight %}
 
 In this code, a `new` object is created by `new Foo(42)`; this object has a
@@ -133,7 +133,7 @@ based on class inheritance.) This means that the following code typechecks:
 
 {% highlight javascript linenos=table %}
 ...
-var o: Foo = new Foo(42);
+const o: Foo = new Foo(42);
 {% endhighlight %}
 
 ## Adding properties
@@ -162,7 +162,7 @@ For example, the following code typechecks:
 function foo(p) { p.x = 42; }
 function bar(q) { q.f(); }
 
-var o = { };
+const o = { };
 o.f = function() { return this.x; };
 
 bar(o);
@@ -179,11 +179,11 @@ Fortunately, though, the following code does not typecheck:
 function foo(p) { p.x = 42; }
 function bar(q) { q.f(); }
 
-var o = { };
+const o = { };
 o.f = function() { return this.x; };
 
 foo(o);
-var x: string = bar(o);
+const x: string = bar(o);
 {% endhighlight %}
 
 ```bbcode

--- a/docs/01-quick-reference.md
+++ b/docs/01-quick-reference.md
@@ -50,11 +50,11 @@ class MyClass {
 function MyConstructorFunc() {}
 MyConstructorFunc.prototype.myMethod = function() { return 42; };
 
-var a: MyClass = new MyClass(); // Valid!
-var b: number = a.myMethod(); // Valid!
+const a: MyClass = new MyClass(); // Valid!
+const b: number = a.myMethod(); // Valid!
 
-var c: MyConstructorFunc = new MyConstructorFunc(); // Valid!
-var d: number = c.myMethod(); // Valid!
+const c: MyConstructorFunc = new MyConstructorFunc(); // Valid!
+const d: number = c.myMethod(); // Valid!
 ```
 
 ## Notes And Caveats
@@ -75,12 +75,12 @@ Using this "backdoor" is dangerous and not recommended, but it is sometimes nece
 Example:
 
 ```javascript
-var a: any = 'some string'; // Valid!
-var b: any = undefined; // Valid!
-var c: any = 42; // Valid!
+const a: any = 'some string'; // Valid!
+const b: any = undefined; // Valid!
+const c: any = 42; // Valid!
 
 function foo(): any { return 42; }
-var d: string = foo(); // Valid! ('any' may flow into any other type!)
+const d: string = foo(); // Valid! ('any' may flow into any other type!)
 ```
 <sub><a href="#built-in-primitive-types">Back To Top</a></sub>
 
@@ -92,12 +92,12 @@ For arrays that have a fixed size and/or elements whose types aren't homogenous,
 Example:
 
 ```javascript
-var a: Array<number> = [42]; // Valid!
-var b: Array<number> = ['some string']; // Type error!
-var c: Array<number> = [42, 'some string']; // Type error!
+const a: Array<number> = [42]; // Valid!
+const b: Array<number> = ['some string']; // Type error!
+const c: Array<number> = [42, 'some string']; // Type error!
 
-var myNumbers: Array<number> = [42];
-var d: number = myNumbers[0]; // Valid!
+const myNumbers: Array<number> = [42];
+const d: number = myNumbers[0]; // Valid!
 ```
 <sub><a href="#built-in-primitive-types">Back To Top</a></sub>
 
@@ -109,9 +109,9 @@ Note that there are many implicit conversions to `boolean` in JavaScript. Flow u
 Example:
 
 ```javascript
-var a: boolean = true; // Valid!
-var b: boolean = false; // Valid!
-var c: boolean = 42; // Type error!
+const a: boolean = true; // Valid!
+const b: boolean = false; // Valid!
+const c: boolean = 42; // Type error!
 ```
 <sub><a href="#built-in-primitive-types">Back To Top</a></sub>
 
@@ -121,8 +121,8 @@ This type describes objects created from JavaScript's built-in `Boolean` constru
 Example:
 
 ```javascript
-var a: Boolean = new Boolean(true); // Valid!
-var b: Boolean = true; // Type error!
+const a: Boolean = new Boolean(true); // Valid!
+const b: Boolean = true; // Type error!
 ```
 <sub><a href="#built-in-primitive-types">Back To Top</a></sub>
 
@@ -140,13 +140,13 @@ class MyClass {
   myMethod() { return 42; }
 }
 
-var a: Class<MyClass> = MyClass; // Valid!
-var b: MyClass = new a(); // Valid!
+const a: Class<MyClass> = MyClass; // Valid!
+const b: MyClass = new a(); // Valid!
 
-var c: Class<MyClass> = new MyClass(); // Type error!
+const c: Class<MyClass> = new MyClass(); // Type error!
 
-var d = 42;
-var e: Class<d> = Number; // Error! 'd' is a runtime value, not a type!
+const d = 42;
+const e: Class<d> = Number; // Error! 'd' is a runtime value, not a type!
 ```
 <sub><a href="#built-in-primitive-types">Back To Top</a></sub>
 
@@ -156,15 +156,15 @@ This type describes *any* function. Any kind of function may flow into it, and a
 Example:
 
 ```javascript
-var a: Function = function() {}; // Valid!
-var b: Function = p => p; // Valid!
-var c: Function = 42; // Type error!
+const a: Function = function() {}; // Valid!
+const b: Function = p => p; // Valid!
+const c: Function = 42; // Type error!
 
 // Valid! (`Function` may flow into any function type)
 function foo(): Function { 
   return function(x: number): number { return x; }
 }
-var d: (str: string) => string = foo(); // Valid!
+const d: (str: string) => string = foo(); // Valid!
 ```
 <sub><a href="#built-in-primitive-types">Back To Top</a></sub>
 
@@ -176,12 +176,12 @@ Beware of the difference between `mixed` and `any`; `mixed` is a taint that ensu
 Example:
 
 ```javascript
-var a: mixed = 'some string'; // Valid!
-var b: mixed = undefined; // Valid!
-var c: mixed = 42; // Valid!
+const a: mixed = 'some string'; // Valid!
+const b: mixed = undefined; // Valid!
+const c: mixed = 42; // Valid!
 
 function foo(): mixed { return 42; }
-var d: string = foo(); // Error! ('mixed' may not flow to any other type!)
+const d: string = foo(); // Error! ('mixed' may not flow to any other type!)
 ```
 <sub><a href="#built-in-primitive-types">Back To Top</a></sub>
 
@@ -191,8 +191,8 @@ This type describes a number in JavaScript.
 Example:
 
 ```javascript
-var a: number = 42; // Valid!
-var b: number = 'str'; // Type error!
+const a: number = 42; // Valid!
+const b: number = 'str'; // Type error!
 ```
 <sub><a href="#built-in-primitive-types">Back To Top</a></sub>
 
@@ -202,8 +202,8 @@ This type describes objects created from JavaScript's built-in `Number` construc
 Example:
 
 ```javascript
-var a: Number = new Number(42); // Valid!
-var b: Number = 42; // Type error!
+const a: Number = new Number(42); // Valid!
+const b: Number = 42; // Type error!
 ```
 <sub><a href="#built-in-primitive-types">Back To Top</a></sub>
 
@@ -213,12 +213,12 @@ This type describes *any* object. Any kind of object may flow into it, and any i
 Example:
 
 ```javascript
-var a: Object = {}; // Valid!
-var b: Object = new RegExp(); // Valid!
-var d: Object = 42; // Type error!
+const a: Object = {}; // Valid!
+const b: Object = new RegExp(); // Valid!
+const d: Object = 42; // Type error!
 
 function foo(): Object { return {}; }
-var e: MyClass = foo(); // Valid! (`Object` may flow into any object type)
+const e: MyClass = foo(); // Valid! (`Object` may flow into any object type)
 ```
 <sub><a href="#built-in-primitive-types">Back To Top</a></sub>
 
@@ -228,8 +228,8 @@ This type describes a string in JavaScript.
 Example:
 
 ```javascript
-var a: string = 'some string'; // Valid!
-var b: string = 42; // Type error!
+const a: string = 'some string'; // Valid!
+const b: string = 42; // Type error!
 ```
 <sub><a href="#built-in-primitive-types">Back To Top</a></sub>
 
@@ -239,8 +239,8 @@ This type describes objects created from JavaScript's built-in `String` construc
 Example:
 
 ```javascript
-var a: String = new String('hai!'); // Valid!
-var b: String = 'hai!'; // Type error!
+const a: String = new String('hai!'); // Valid!
+const b: String = 'hai!'; // Type error!
 ```
 <sub><a href="#built-in-primitive-types">Back To Top</a></sub>
 
@@ -252,8 +252,8 @@ Normally you only want to use this type to describe the return type of functions
 Example:
 
 ```javascript
-var a: void = undefined; // Valid!
-var b: void = 42; // Type error!
+const a: void = undefined; // Valid!
+const b: void = 42; // Type error!
 ```
 <sub><a href="#built-in-primitive-types">Back To Top</a></sub>
 
@@ -264,18 +264,18 @@ Example:
 
 ```javascript
 // Valid!
-var a: {prop1: number, prop2: string} = {
+const a: {prop1: number, prop2: string} = {
   prop1: 42,
   prop2: 'asdf',
 };
 
 // Type error! Missing a `prop2` property
-var b: {prop1: number, prop2: string} = {
+const b: {prop1: number, prop2: string} = {
   prop1: 42,
 };
 
 // Type error! `prop2 property types don't match!
-var c: {prop1: number, prop2: string} = {
+const c: {prop1: number, prop2: string} = {
   prop1: 42,
   prop2: 42, // Type error!
 };
@@ -289,12 +289,12 @@ Example:
 
 ```javascript
 // Valid!
-var add: ((num1: number, num2: number) => number) = function(num1, num2) {
+const add: ((num1: number, num2: number) => number) = function(num1, num2) {
   return num1 + num2;
 };
 
 // Type error! Parameter types don't match!
-var badTypeAnnotation: ((num1: number, num2: number) => number) =
+const badTypeAnnotation: ((num1: number, num2: number) => number) =
   function(str1: string, str2: string) {
     return str1.length + str2.length;
   };
@@ -309,7 +309,7 @@ Example:
 ```javascript
 // Valid!
 function getStrProcessor(token: string): { (str: string): string, token: string} {
-  var processor = function(str) {
+  const processor = function(str) {
     return str.replace(token, '<<PROCESSED>>');
   };
   processor.token = token;

--- a/docs/01-type-aliases.md
+++ b/docs/01-type-aliases.md
@@ -18,7 +18,7 @@ Here is a simple example:
 {% highlight javascript linenos=table %}
 /* @flow */
 type T = number;
-var x: T = 0;
+const x: T = 0;
 {% endhighlight %}
 
 We declare the new type `T` is an alias for the built-in type `number`. 
@@ -32,7 +32,7 @@ Aliases are type checked the same way as any other type.
 {% highlight javascript linenos=table %}
 /* @flow */
 type T = Array<string>;
-var x: T = [];
+const x: T = [];
 x["Hi"] = 2;
 {% endhighlight %}
 
@@ -56,7 +56,7 @@ work:
 {% highlight javascript linenos=table %}
 /* @flow */
 type T = Array<string>;
-var x: T = [];
+const x: T = [];
 x[2] = "Hi";
 {% endhighlight %}
 
@@ -75,8 +75,8 @@ type F<U, V> = (x: U) => V;
 
 // The function foo applies a given function f to a given argument x
 function foo<X, Y>(f: F<X, Y>, x: X): Y { return f(x); }
-var b: boolean = true;
-var result: string = foo (function(x) { return b; }, 0);
+const b: boolean = true;
+const result: string = foo (function(x) { return b; }, 0);
 {% endhighlight %}
 
 We alias a function (via the `=>` syntax), to `F<U, V>`. So whenever `F<U, V>` 

--- a/docs/01-type-annotations.md
+++ b/docs/01-type-annotations.md
@@ -15,7 +15,7 @@ JavaScript code:
 function add(num1, num2) {
   return num1 + num2;
 }
-var x = add(3, '0');
+const x = add(3, '0');
 console.log(x);
 {% endhighlight %}
 
@@ -32,7 +32,7 @@ function parameters, function return types and variable declarations. e.g.,
 
 {% highlight javascript linenos=table %}
 function foo(a: string, b: number): void { ... }
-var x: boolean = someBool;
+const x: boolean = someBool;
 class Bar {
   y: string;
   someMethod(a: number): string { ... }
@@ -49,7 +49,7 @@ annotation `@flow` at the top in a comment block:
 function add(num1, num2) {
   return num1 + num2;
 }
-var x = add(3, '0');
+const x = add(3, '0');
 console.log(x);
 {% endhighlight %}
 
@@ -62,7 +62,7 @@ specify that the parameters to `add` must be `number`s.
 function add(num1: number, num2: number): number {
   return num1 + num2;
 }
-var x: number = add(3, '0');
+const x: number = add(3, '0');
 console.log(x);
 {% endhighlight %}
 
@@ -91,7 +91,7 @@ deduce all that is necessary to type check your code.
 function multPI(num1, num2) {
   return Math.PI * num1 * num2;
 }
-var x = multPI(3, '0');
+const x = multPI(3, '0');
 console.log(x);
 {% endhighlight %}
 
@@ -125,8 +125,8 @@ module.exports = size;
  * UseSize.js
  * @flow
  */
-var size = require('./Size');
-var result = size(null);
+const size = require('./Size');
+const result = size(null);
 {% endhighlight %}
 
 Type annotations are required for the `size` function in `Size.js` because `UseSize.js` imports it and thus crosses the module boundary and isn't inferred.

--- a/docs/01-typeof.md
+++ b/docs/01-typeof.md
@@ -12,8 +12,8 @@ data type of an expression. Here is a simple example:
 
 {% highlight javascript linenos=table %}
 /* @flow */
-var index: number = 10;
-var result: string = typeof index;
+const index: number = 10;
+const result: string = typeof index;
 // result: 'number'
 {% endhighlight %}
 
@@ -27,8 +27,8 @@ Take the following code example:
 {% highlight javascript linenos=table %}
 /* @flow */
 class X {}
-var a = X; // a infers its type from X
-var b: typeof X; // b has the same type as X. It is the same as a
+const a = X; // a infers its type from X
+const b: typeof X; // b has the same type as X. It is the same as a
 {% endhighlight %}
 
 There is no real advantage of using `typeof` for variable typing in the above 
@@ -43,9 +43,9 @@ class X {
     return 'Hi';
   }
 }
-var a: X = new X();
+const a: X = new X();
 a.bar(); // Type error
-var b: typeof X = X;
+const b: typeof X = X;
 b.bar(); // Good
 {% endhighlight %}
 
@@ -71,7 +71,7 @@ whether that is a class, module or some other construct.
 /* @flow */
 class Foo { }
 // b ends up being a Foo type, since f evaluates to Foo
-var b: { f : typeof Foo } = { f : Foo };
+const b: { f : typeof Foo } = { f : Foo };
 // Since f is Foo, and b is of a Foo type, we can instantiate b as Foo 
 new b.f();
 {% endhighlight %}
@@ -82,8 +82,8 @@ Let's see an example where we use `typeof` and Flow will catch a typing error:
 /* @flow */
 class Foo { }
 class Bar { }
-var b: { f : typeof Foo } = { f : Foo };
-var c: { g : typeof Bar } = { g : Bar };
+const b: { f : typeof Foo } = { f : Foo };
+const c: { g : typeof Bar } = { g : Bar };
 // b is of type Foo, not of type Bar (g is a Bar )
 new b.g();
 {% endhighlight %}

--- a/docs/01-union-intersection-types.md
+++ b/docs/01-union-intersection-types.md
@@ -12,7 +12,7 @@ for a value to be one of the input types.
 
 {% highlight javascript linenos=table %}
 /* @flow */
-var x: number | string = 0;
+const x: number | string = 0;
 {% endhighlight %}
 
 `x` can be either a `number` or a `string`. A default value can even be 
@@ -20,7 +20,7 @@ provided of one of those two types.
 
 {% highlight javascript linenos=table %}
 /* @flow */
-declare var f: ((x: number) => void) & ((x: string) => void);
+declare const f: ((x: number) => void) & ((x: string) => void);
 f('');
 {% endhighlight %}
 
@@ -52,7 +52,7 @@ class A {}
 class B {}
 class C {}
 
-var x: A | B | number | C = new C();
+const x: A | B | number | C = new C();
 x = 3;
 x = new B();
 x = true; // Flow will error here
@@ -85,7 +85,7 @@ This type is incompatible with
 /* @flow */
 class Foo {}
 class Bar {}
-declare var f: ((x: Foo) => void) & ((x: Bar) => void);
+declare const f: ((x: Foo) => void) & ((x: Bar) => void);
 f(new Foo());
 f(true); // Flow will error here.
 {% endhighlight %}

--- a/docs/01-variables.md
+++ b/docs/01-variables.md
@@ -15,8 +15,8 @@ you can, if you so choose (e.g. for documentation purposes).
 
 {% highlight javascript linenos=table %}
 /* @flow */
-var x: number = 0;
-var y: any = 4;
+const x: number = 0;
+const y: any = 4;
 {% endhighlight %}
 
 The actual type of a variable can change over its lifetime; at any point, the


### PR DESCRIPTION
I don't *actually* expect this pull request to be merged as-is... however, I made it as an idea/discussion starter/...?

Flow now can do ES6 const/let, and it would be nice to "teach" users to use them in real code, since they are really useful.

So I just changed all `vars` to `const`, where possible, and where not possible, to `let`s.