### PR TITLE
Improve errors for node_modules that sit outside the project root

### DIFF
--- a/hack/utils/path.mli
+++ b/hack/utils/path.mli
@@ -32,3 +32,5 @@ val cat: t -> string
 
 val slash_escaped_string_of_path: t -> string
 val path_of_slash_escaped_string: string -> t
+
+val is_parent_of: t -> t -> bool

--- a/runtests.sh
+++ b/runtests.sh
@@ -102,7 +102,7 @@ runtest() {
         return $RUNTEST_SKIP
     elif [[ -z $filter || $name =~ $filter ]]
     then
-        if ([ ! -e "$exp_file" ] || [ ! -e ".flowconfig" ])
+        if ([ ! -e "$exp_file" ] || [[ ! -e ".flowconfig" && ! -e ".testconfig" ]])
         then
             cd ../.. || exit 1
             if [ "$name" = "auxiliary" ] ||

--- a/src/server/server.ml
+++ b/src/server/server.ml
@@ -335,7 +335,17 @@ struct
 
   let find_module (moduleref, filename) oc =
     let file = Loc.SourceFile filename in
-    let module_name = Module_js.imported_module file moduleref in
+    let cx =
+      Context.make Context.({
+        checked = false;
+        weak = false;
+        munge_underscores = false;
+        verbose = None;
+        is_declaration_file = false;
+      }) file (Modulename.Filename file)
+    in
+    let loc = {Loc.none with Loc.source = Some file;} in
+    let module_name = Module_js.imported_module cx loc moduleref in
     let response: filename option = Module_js.get_module_file module_name in
     Marshal.to_channel oc response [];
     flush oc

--- a/src/typing/getDef_js.ml
+++ b/src/typing/getDef_js.ml
@@ -13,7 +13,7 @@ open Utils
 type getdef_type =
 | Gdloc of Loc.t
 | Gdmem of (string * Type.t)
-| Gdrequire of string
+| Gdrequire of string * Loc.t
 
 let getdef_id (state, loc1) cx name loc2 =
   if Reason_js.in_range loc1 loc2
@@ -54,7 +54,7 @@ let getdef_call (state, loc1) cx name loc2 this_t =
 let getdef_require (state, loc1) cx name loc2 =
   if (Reason_js.in_range loc1 loc2)
   then (
-    state := Some (Gdrequire (name))
+    state := Some (Gdrequire (name, loc2))
   )
 
 let getdef_get_result cx state =
@@ -70,8 +70,8 @@ let getdef_get_result cx state =
           Type.loc_of_t t
       | None ->
           Loc.none)
-  | Some Gdrequire name ->
-      let module_name = Module_js.imported_module (Context.file cx) name in
+  | Some Gdrequire (name, loc) ->
+      let module_name = Module_js.imported_module cx loc name in
       let f = Module_js.get_module_file module_name in
       (match f with
       | Some file -> Loc.({ none with source = Some file })

--- a/src/typing/module_js.ml
+++ b/src/typing/module_js.ml
@@ -230,7 +230,7 @@ module type MODULE_SYSTEM = sig
   (* Given a file and a reference in it to an imported module, make the name of
      the module it refers to. If given an optional reference to an accumulator,
      record paths that were looked up but not found during resolution. *)
-  val imported_module: ?path_acc:SSet.t ref -> filename -> string -> Modulename.t
+  val imported_module: Context.t -> Loc.t -> ?path_acc:SSet.t ref -> string -> Modulename.t
 
   (* for a given module name, choose a provider from among a set of
     files with that exported name. also check for duplicates and
@@ -340,7 +340,7 @@ module Node = struct
       lazy (path_if_exists path_acc (path ^ ext))
     ))
 
-  let parse_main path_acc package =
+  let parse_main cx loc path_acc package =
     let package = resolve_symlinks package in
     if not (file_exists package) ||
       FlowConfig.(is_excluded (get_unsafe ()) package)
@@ -348,8 +348,26 @@ module Node = struct
     else
       let tokens = match PackageHeap.get package with
       | Some tokens -> tokens
-      | None -> failwith (spf
-          "internal error: package %s not found in PackageHeap" package)
+      | None -> 
+          let reason = Reason.mk_reason "" loc in
+
+          let project_root = FlowConfig.((get_unsafe ()).root) in
+          let msg = 
+            if Path.is_parent_of project_root (Path.make package) then (
+              "Internal Error! This package not found in PackageHeap. " ^
+              "Please report this error to the Flow team."
+            ) else (
+              spf (
+                "This module resolves to %S, which is a path that sits " ^^
+                "outside the directory that contains the .flowconfig file " ^^
+                "for this project. Flow can only see modules that are " ^^
+                "somewhere within this directory!"
+              ) package
+            )
+          in
+
+          Flow_js.add_error cx [(reason, msg)];
+          SMap.empty
       in
       let dir = Filename.dirname package in
       match get_key "main" tokens with
@@ -366,7 +384,7 @@ module Node = struct
           lazy (path_if_exists_with_file_exts path_acc path_w_index file_exts);
         ]
 
-  let resolve_relative ?path_acc root_path rel_path =
+  let resolve_relative cx loc ?path_acc root_path rel_path =
     let path = Files_js.normalize_path root_path rel_path in
     let opts = get_config_options () in
     if Files_js.is_flow_file path
@@ -377,24 +395,24 @@ module Node = struct
 
       lazy_seq ([
         lazy (path_if_exists_with_file_exts path_acc path file_exts);
-        lazy (parse_main path_acc (Filename.concat path "package.json"));
+        lazy (parse_main cx loc path_acc (Filename.concat path "package.json"));
         lazy (path_if_exists_with_file_exts path_acc path_w_index file_exts);
       ])
     )
 
-  let rec node_module path_acc dir r =
+  let rec node_module cx loc path_acc dir r =
     let opts = get_config_options () in
     lazy_seq [
       lazy (
         lazy_seq (opts.FlowConfig.Opts.node_resolver_dirnames |> List.map (fun dirname ->
-          lazy (resolve_relative ?path_acc dir (spf "%s%s%s" dirname Filename.dir_sep r))
+          lazy (resolve_relative cx loc ?path_acc dir (spf "%s%s%s" dirname Filename.dir_sep r))
         ))
       );
 
       lazy (
         let parent_dir = Filename.dirname dir in
         if dir = parent_dir then None
-        else node_module path_acc (Filename.dirname dir) r
+        else node_module cx loc path_acc (Filename.dirname dir) r
       );
     ]
 
@@ -405,20 +423,20 @@ module Node = struct
     Str.string_match Files_js.current_dir_name r 0
     || Str.string_match Files_js.parent_dir_name r 0
 
-  let resolve_import ?path_acc file import_str =
+  let resolve_import cx loc ?path_acc import_str =
+    let file = string_of_filename (Context.file cx) in
     let dir = Filename.dirname file in
     if explicitly_relative import_str || absolute import_str
-    then resolve_relative ?path_acc dir import_str
-    else node_module path_acc dir import_str
+    then resolve_relative cx loc ?path_acc dir import_str
+    else node_module cx loc path_acc dir import_str
 
-  let imported_module ?path_acc file import_str =
-    let file = string_of_filename file in
+  let imported_module cx loc ?path_acc import_str =
     let candidates = module_name_candidates import_str in
 
     let rec choose_candidate = function
       | [] -> None
       | candidate :: candidates ->
-        match resolve_import ?path_acc file candidate with
+        match resolve_import cx loc ?path_acc candidate with
         | None -> choose_candidate candidates
         | Some _ as result -> result
     in
@@ -488,17 +506,17 @@ module Haste: MODULE_SYSTEM = struct
         )
 
   (* similar to Node resolution, with possible special cases *)
-  let resolve_import ?path_acc file r =
-    let file = string_of_filename file in
+  let resolve_import cx loc ?path_acc r =
+    let file = string_of_filename (Context.file cx) in
     lazy_seq [
-      lazy (Node.resolve_import ?path_acc file r);
+      lazy (Node.resolve_import cx loc ?path_acc r);
       lazy (match expanded_name r with
-        | Some r -> Node.resolve_relative ?path_acc (Filename.dirname file) r
+        | Some r -> Node.resolve_relative cx loc ?path_acc (Filename.dirname file) r
         | None -> None
       );
     ]
 
-  let imported_module ?path_acc file imported_name =
+  let imported_module cx loc ?path_acc imported_name =
     let candidates = module_name_candidates imported_name in
 
     (**
@@ -513,7 +531,7 @@ module Haste: MODULE_SYSTEM = struct
      *)
     let chosen_candidate = List.hd candidates in
 
-    match resolve_import ?path_acc file chosen_candidate with
+    match resolve_import cx loc ?path_acc chosen_candidate with
     | Some(name) -> Modulename.Filename (Loc.SourceFile name)
     | None -> Modulename.String chosen_candidate
 
@@ -557,17 +575,20 @@ let exported_module file info =
   let module M = (val !module_system) in
   M.exported_module file info
 
-let imported_module ?path_acc file r =
+let imported_module cx loc ?path_acc r =
   let module M = (val !module_system) in
-  M.imported_module ?path_acc file r
+  M.imported_module cx loc ?path_acc r
 
-let imported_modules file reqs =
-  (* Resolve all reqs relative to file. Accumulate dependent paths in
+let imported_modules cx =
+  (* Resolve all reqs relative to the given cx. Accumulate dependent paths in
      path_acc. Return the map of reqs to their resolved names, and the set
      containing the resolved names. *)
+  let reqs = Context.required cx in
+  let req_locs = Context.require_loc cx in
   let path_acc = ref SSet.empty in
   let set, map = SSet.fold (fun r (set, map) ->
-    let resolved_r = imported_module ~path_acc file r in
+    let loc = SMap.find_unsafe r req_locs in
+    let resolved_r = imported_module cx loc ~path_acc r in
     NameSet.add resolved_r set, SMap.add r resolved_r map
   ) reqs (NameSet.empty, SMap.empty) in
   set, map, !path_acc
@@ -579,10 +600,11 @@ let cached_resolved_module file r =
   | None -> None
 
 (* Optimized module resolution function that goes through cache. *)
-let find_resolved_module file r =
-  match cached_resolved_module file r with
+let find_resolved_module cx loc r =
+  let context_file = Context.file cx in
+  match cached_resolved_module context_file r with
   | Some resolved_r -> resolved_r
-  | None -> imported_module file r
+  | None -> imported_module cx loc r
 
 let choose_provider m files errmap =
   let module M = (val !module_system) in
@@ -689,16 +711,14 @@ let get_reverse_imports module_name =
 (* Extract and process information from context. In particular, resolve
    references to required modules in a file, and record the results.  *)
 let info_of cx =
-  let file = Context.file cx in
-  let required, resolved_modules, phantom_dependents =
-    imported_modules file (Context.required cx) in
+  let required, resolved_modules, phantom_dependents = imported_modules cx in
   let require_loc = SMap.fold
     (fun r loc require_loc ->
       let resolved_r = SMap.find_unsafe r resolved_modules in
       SMap.add (Modulename.to_string resolved_r) loc require_loc)
     (Context.require_loc cx) SMap.empty in
   {
-    file;
+    file = Context.file cx;
     _module = Context.module_name cx;
     required;
     require_loc;

--- a/src/typing/module_js.mli
+++ b/src/typing/module_js.mli
@@ -37,9 +37,9 @@ val init: Options.options -> unit
 
 (* export and import functions for the module system *)
 val exported_module: filename -> Docblock.t -> Modulename.t
-val imported_module: ?path_acc: SSet.t ref -> filename -> string -> Modulename.t
+val imported_module: Context.t -> Loc.t -> ?path_acc: SSet.t ref -> string -> Modulename.t
 
-val find_resolved_module: filename -> string -> Modulename.t
+val find_resolved_module: Context.t -> Loc.t -> string -> Modulename.t
 
 val module_exists: Modulename.t -> bool
 

--- a/src/typing/types_js.ml
+++ b/src/typing/types_js.ml
@@ -451,8 +451,10 @@ end)
 *)
 let merge_strict_context cache component_cxs =
   let required = List.fold_left (fun required cx ->
+    let require_locs = Context.require_loc cx in
     SSet.fold (fun r ->
-      let resolved_r = Module_js.find_resolved_module (Context.file cx) r in
+      let loc = SMap.find_unsafe r require_locs in
+      let resolved_r = Module_js.find_resolved_module cx loc r in
       check_require (r, resolved_r, cx);
       add_decl (r, resolved_r, cx)
     ) (Context.required cx) required


### PR DESCRIPTION
Our node_module resolution algorithm currently seems to actually resolve package.json files beyond just the project root. However, this means when we go to import said module, we eventually resolve to a file path that we don't have in our indexed modulemap.

We could simply prevent the `node_modules` resolver from going past the project root in the first place, but this is actually a common mistake -- so instead I leave things as-is, detect such a mismatch at the time of resolving the package to a concrete file, and issue a more detailed flow error describing why Flow can't see the module.

To do this I had to thread `cx` through various module_js APIs, but this actually turns out to make sense anyway (many of these APIs where operating relative to the current file -- which you could say generalizes to the current "context").

Fixes https://github.com/facebook/flow/issues/1178