### PR TITLE
Refactor ImportDeclaration ast structure

### DIFF
--- a/src/parser/estree_translator.ml
+++ b/src/parser/estree_translator.ml
@@ -271,20 +271,23 @@ end with type t = Impl.t) = struct
         |]
       )
     | loc, ImportDeclaration import -> ImportDeclaration.(
-        let specifiers = (match import.default with
-        | None -> []
-        | Some default -> [import_default_specifier default]) in
-        let specifiers = (match import.specifier with
-        | Some (NameSpace ns) -> import_namespace_specifier ns :: specifiers
-        | Some (Named (_, sl)) -> (List.rev (List.map import_specifier sl)) @ specifiers
-        | None -> specifiers) in
+        let specifiers = import.specifiers |> List.map (function
+          | ImportDefaultSpecifier id -> 
+              import_default_specifier id
+          | ImportNamedSpecifier {local; remote;} -> 
+              import_named_specifier local remote
+          | ImportNamespaceSpecifier id ->
+              import_namespace_specifier id
+        ) in
+
         let import_kind = match import.importKind with
         | ImportType -> "type"
         | ImportTypeof -> "typeof"
         | ImportValue -> "value"
         in
+
         node "ImportDeclaration" loc [|
-          "specifiers", array (Array.of_list (List.rev specifiers));
+          "specifiers", array (Array.of_list specifiers);
           "source", literal import.source;
           "importKind", string (import_kind);
         |]
@@ -1156,12 +1159,16 @@ end with type t = Impl.t) = struct
       "id", identifier id;
     |]
 
-  and import_specifier (loc, specifier) = Statement.ImportDeclaration.NamedSpecifier.(
-    node "ImportSpecifier" loc [|
-      "id", identifier specifier.id;
-      "name", option identifier specifier.name;
+  and import_named_specifier local_id remote_id = (*(local_loc, specifier) = *)
+    let span_loc = 
+      match local_id with
+      | Some local_id -> Loc.btwn (fst remote_id) (fst local_id)
+      | None -> fst remote_id
+    in
+    node "ImportSpecifier" span_loc [|
+      "id", identifier remote_id;
+      "name", option identifier local_id;
     |]
-  )
 
   and comment_list comments = array_of_list comment comments
 

--- a/src/parser/parser_flow.ml
+++ b/src/parser/parser_flow.ml
@@ -3104,7 +3104,6 @@ end = struct
         Loc.btwn start_loc (fst body),
         Statement.(DeclareModule DeclareModule.({ id; body; }))
 
-
     and declare ?(in_module=false) env =
       if not (should_parse_types env)
       then error env Error.UnexpectedTypeDeclaration;
@@ -3426,6 +3425,8 @@ end = struct
         )
 
       and import_declaration =
+        let open Statement.ImportDeclaration in
+
         let source env =
           Expect.contextual env "from";
           match Peek.token env with
@@ -3447,42 +3448,40 @@ end = struct
           | T_EOF
           | T_RCURLY -> List.rev acc
           | _ ->
-              let id, err = Parse.identifier_or_reserved_keyword env in
-              let end_loc, name = if Peek.value env = "as"
-              then begin
-                Expect.contextual env "as";
-                let name = Parse.identifier env in
-                fst name, Some name
-              end else begin
-                (match err with
-                | Some err -> error_at env err
-                | None -> ());
-                fst id, None
-              end in
-              let loc = Loc.btwn (fst id) end_loc in
+              let remote, err = Parse.identifier_or_reserved_keyword env in
+              let (local, remote) = 
+                if Peek.value env = "as" then begin
+                  Expect.contextual env "as";
+                  let local = Parse.identifier env in
+                  (Some local, remote)
+                end else begin
+                  (match err with Some err -> error_at env err | None -> ());
+                  (None, remote)
+                end 
+              in
               let specifier =
-                loc, Statement.ImportDeclaration.NamedSpecifier.({
-                  id;
-                  name;
-                }) in
+                ImportNamedSpecifier {
+                  local;
+                  remote;
+                }
+              in
               if Peek.token env = T_COMMA
               then Expect.token env T_COMMA;
               specifier_list env (specifier::acc)
 
-        in let specifier env =
+        in let named_or_namespace_specifier env =
           let start_loc = Peek.loc env in
           match Peek.token env with
           | T_MULT ->
               Expect.token env T_MULT;
               Expect.contextual env "as";
               let id = Parse.identifier env in
-              Statement.ImportDeclaration.NameSpace (Loc.btwn start_loc (fst id), id)
+              [ImportNamespaceSpecifier (Loc.btwn start_loc (fst id), id)]
           | _ ->
               Expect.token env T_LCURLY;
               let specifiers = specifier_list env [] in
-              let end_loc = Peek.loc env in
               Expect.token env T_RCURLY;
-              Statement.ImportDeclaration.Named (Loc.btwn start_loc end_loc, specifiers)
+              specifiers
 
         in fun env ->
           let env = env |> with_strict true in
@@ -3490,7 +3489,7 @@ end = struct
           Expect.token env T_IMPORT;
           (* It might turn out that we need to treat this "type" token as an
            * identifier, like import type from "module" *)
-          let importKind, type_ident = Statement.ImportDeclaration.(
+          let importKind, type_ident = 
             match Peek.token env with
             | T_TYPE ->
               if not (should_parse_types env)
@@ -3502,73 +3501,92 @@ end = struct
               Expect.token env T_TYPEOF;
               ImportTypeof, None
             | _ -> ImportValue, None
-          ) in
-          Statement.ImportDeclaration.(
-            match Peek.token env, Peek.identifier env with
-            | T_STRING (str_loc, value, raw, octal), _
+          in
+          match Peek.token env, Peek.identifier env with
+          (* import "ModuleName"; *)
+          | T_STRING (str_loc, value, raw, octal), _
               when importKind = ImportValue ->
-                (* import "ModuleSpecifier"; *)
-                if octal then strict_error env Error.StrictOctalLiteral;
-                Expect.token env (T_STRING (str_loc, value, raw, octal));
-                let value = Literal.String value in
-                let source = (str_loc, { Literal.value; raw; }) in
-                let end_loc = match Peek.semicolon_loc env with
-                | Some loc -> loc
-                | None -> str_loc in
-                Eat.semicolon env;
-                Loc.btwn start_loc end_loc, Statement.ImportDeclaration {
-                  default = None;
-                  specifier = None;
-                  source;
-                  importKind;
-                }
-            | T_COMMA, _
-            | _, true ->
-                (* import defaultspecifier ... *)
-                let importKind, default = (
-                  match type_ident, Peek.token env, Peek.value env with
-                  | Some _, T_COMMA, _
-                  | Some _, T_IDENTIFIER, "from" ->
-                      (* import type, ... *)
-                      (* import type from ... *)
-                      Statement.ImportDeclaration.ImportValue, type_ident
-                  | _ ->
-                      (* import type foo ...
-                      * import foo ... *)
-                      importKind, Some (Parse.identifier env)
-                ) in
-                let specifier = (match Peek.token env with
-                  | T_COMMA ->
-                      Expect.token env T_COMMA;
-                      Some (specifier env)
-                  | _ -> None) in
-                  let source = source env in
-                  let end_loc = match Peek.semicolon_loc env with
-                  | Some loc -> loc
-                  | None -> fst source in
-                  let source = source in
-                  Eat.semicolon env;
-                  Loc.btwn start_loc end_loc, Statement.ImportDeclaration {
-                    default;
-                    specifier;
-                    source;
-                    importKind;
-                  }
-            | _ ->
-                let specifier = Some (specifier env) in
-                let source = source env in
-                let end_loc = match Peek.semicolon_loc env with
-                | Some loc -> loc
-                | None -> fst source in
-                let source = source in
-                Eat.semicolon env;
-                Loc.btwn start_loc end_loc, Statement.ImportDeclaration {
-                  default = None;
-                  specifier;
-                  source;
-                  importKind;
-                }
-          )
+            if octal then strict_error env Error.StrictOctalLiteral;
+            Expect.token env (T_STRING (str_loc, value, raw, octal));
+            let value = Literal.String value in
+            let source = (str_loc, { Literal.value; raw; }) in
+            let end_loc = match Peek.semicolon_loc env with
+            | Some loc -> loc
+            | None -> str_loc in
+            Eat.semicolon env;
+            Loc.btwn start_loc end_loc, Statement.ImportDeclaration {
+              importKind;
+              source;
+              specifiers = [];
+
+              (*
+              default = None;
+              specifier = None;
+              source;
+              importKind;
+              *)
+            }
+
+          (* import [type] SomeDefault ... *)
+          | T_COMMA, _ (* `import type, ...` *)
+          | _, true -> (* `import type Foo` or `import type from` *)
+              let importKind, default_specifier = (
+                match type_ident, Peek.token env, Peek.value env with
+                | Some type_ident, T_COMMA, _ (* `import type,` *)
+                | Some type_ident, T_IDENTIFIER, "from" -> (* `import type from` *)
+                  ImportValue, ImportDefaultSpecifier type_ident
+                | _ -> (* Either `import type Foo` or `import Foo` *)
+                  importKind, ImportDefaultSpecifier (Parse.identifier env)
+              ) in
+
+              let additional_specifiers = (
+                match Peek.token env with
+                | T_COMMA -> (* `import Foo, ...` *)
+                    Expect.token env T_COMMA;
+                    named_or_namespace_specifier env
+                | _ -> []
+              ) in
+
+              let source = source env in
+              let end_loc = match Peek.semicolon_loc env with
+              | Some loc -> loc
+              | None -> fst source in
+              let source = source in
+              Eat.semicolon env;
+              Loc.btwn start_loc end_loc, Statement.ImportDeclaration {
+                importKind;
+                source;
+                specifiers = default_specifier::additional_specifiers;
+
+                (*
+                default;
+                specifier;
+                source;
+                importKind;
+                *)
+              }
+
+          (* `import [type] { ... } ...` or `import [typeof] * as ...` *)
+          | _ ->
+              let specifiers = named_or_namespace_specifier env in
+              let source = source env in
+              let end_loc = match Peek.semicolon_loc env with
+              | Some loc -> loc
+              | None -> fst source in
+              let source = source in
+              Eat.semicolon env;
+              Loc.btwn start_loc end_loc, Statement.ImportDeclaration {
+                importKind;
+                source;
+                specifiers;
+
+                (*
+                default = None;
+                specifier;
+                source;
+                importKind;
+                *)
+              }
   end
 
   module Pattern = struct

--- a/src/parser/spider_monkey_ast.ml
+++ b/src/parser/spider_monkey_ast.ml
@@ -426,18 +426,34 @@ and Statement : sig
         name: Identifier.t option;
       }
     end
+    type named_specifier = {
+      local: Identifier.t option;
+      remote: Identifier.t;
+    }
     type specifier =
+      | ImportNamedSpecifier of named_specifier
+      | ImportDefaultSpecifier of Identifier.t
+      | ImportNamespaceSpecifier of (Loc.t * Identifier.t)
+
+      (*
       | Named of Loc.t * (NamedSpecifier.t list)
       | NameSpace of (Loc.t * Identifier.t)
+      *)
     type importKind =
       | ImportType
       | ImportTypeof
       | ImportValue
     type t = {
+      importKind: importKind;
+      source: (Loc.t * Literal.t); (* Always a string literal *)
+      specifiers: specifier list;
+
+      (*
       default: Identifier.t option;
       specifier: specifier option;
       source: (Loc.t * Literal.t ); (* String literal *)
       importKind: importKind;
+      *)
     }
   end
   module Expression : sig

--- a/src/typing/type_inference_js.ml
+++ b/src/typing/type_inference_js.ml
@@ -43,6 +43,8 @@ module TypeExSet = Set.Make(struct
   let compare = reasonless_compare
 end)
 
+let ident_name ident = (snd ident).Ast.Identifier.name
+
 let mk_object cx reason =
   Flow_js.mk_object_with_proto cx reason (MixedT reason)
 
@@ -1346,82 +1348,63 @@ and statement_decl cx type_params_map = Ast.Statement.(
           "declaration or expression!"
         )
     )
-  | (loc, ImportDeclaration {
-      ImportDeclaration.default;
-      ImportDeclaration.importKind;
-      ImportDeclaration.source;
-      ImportDeclaration.specifier;
-    }) ->
-      let (source_loc, source_literal) = source in
+  | (loc, ImportDeclaration import_decl) ->
+      let open ImportDeclaration in
+
       let module_name = (
+        let (source_loc, source_literal) = import_decl.source in
         match source_literal.Ast.Literal.value with
         | Ast.Literal.String(value) -> value
         | _ -> failwith  (
             "Parser error: Invalid source type! Must be a string literal."
           )
       ) in
+
       let (import_str, isType) = (
-        match importKind with
-        | ImportDeclaration.ImportType -> "import type", true
-        | ImportDeclaration.ImportTypeof -> "import typeof", true
-        | ImportDeclaration.ImportValue -> "import", false
+        match import_decl.importKind with
+        | ImportType -> "import type", true
+        | ImportTypeof -> "import typeof", true
+        | ImportValue -> "import", false
       ) in
 
-      (match default with
-        | Some(_, local_ident) ->
-          let local_name = local_ident.Ast.Identifier.name in
-          let reason_str =
-            (spf "%s %s from \"%s\"" import_str local_name module_name)
-          in
-          let reason = mk_reason reason_str loc in
-          let tvar = Flow_js.mk_tvar cx reason in
-          let state = Scope.State.Initialized in
-          if isType
-          then Env_js.bind_type ~state cx local_name tvar reason
-          else Env_js.bind_var ~state cx local_name tvar reason
-        | None -> ()
-      );
-
-      (match specifier with
-        | Some (ImportDeclaration.Named (_, named_specifiers)) ->
-          let init_specifier (specifier_loc, specifier) = (
-            let loc, remote_ident =
-              specifier.ImportDeclaration.NamedSpecifier.id
-            in
-            let remote_name = remote_ident.Ast.Identifier.name in
-            let local_name, reason = (
-              match specifier.ImportDeclaration.NamedSpecifier.name with
-              | Some (_, { Ast.Identifier.name = local_name; _ }) ->
-                let reason_str =
+      import_decl.specifiers |> List.iter (fun specifier ->
+        let (local_name, reason) = (match specifier with
+          | ImportNamedSpecifier {local; remote;} ->
+            let remote_name = ident_name remote in
+            let (local_name, reason) = (
+              match local with
+              | Some local -> 
+                let local_name = ident_name local in
+                let reason_str = 
                   spf "%s { %s as %s }" import_str remote_name local_name
                 in
-                local_name, (mk_reason reason_str loc)
+                let loc = Loc.btwn (fst remote) (fst local) in
+                (local_name, mk_reason reason_str loc)
               | None ->
                 let reason_str = spf "%s { %s }" import_str remote_name in
-                remote_name, (mk_reason reason_str loc)
+                (remote_name, mk_reason reason_str (fst remote))
             ) in
-            let tvar = Flow_js.mk_tvar cx reason in
-            let spec_reason = repos_reason specifier_loc reason in
-            let state = Scope.State.Initialized in
-            if isType
-            then Env_js.bind_type ~state cx local_name tvar spec_reason
-            else Env_js.bind_var ~state cx local_name tvar spec_reason
-          ) in
-
-          List.iter init_specifier named_specifiers
-
-        | Some (ImportDeclaration.NameSpace (_, (loc, local_ident))) ->
-          let local_name = local_ident.Ast.Identifier.name in
-          let reason =
-            mk_reason (spf "%s * as %s" import_str local_name) loc
-          in
-          let tvar = Flow_js.mk_tvar cx reason in
-          let state = Scope.State.Initialized in
-          if isType
-          then Env_js.bind_type ~state cx local_name tvar reason
-          else Env_js.bind_var ~state cx local_name tvar reason
-
-        | None -> ()
+            (local_name, reason)
+          | ImportDefaultSpecifier local ->
+            let local_name = ident_name local in
+            let reason_str =
+              spf "%s %s from %S" import_str local_name module_name
+            in
+            let reason = mk_reason reason_str (fst local) in
+            (local_name, reason)
+          | ImportNamespaceSpecifier (star_as_loc, local) ->
+            let local_name = ident_name local in
+            let reason_str = 
+              spf "%s * as %s from %S" import_str local_name module_name
+            in
+            let reason = mk_reason reason_str (fst local) in
+            (local_name, reason)
+        ) in
+        let tvar = Flow_js.mk_tvar cx reason in
+        let state = Scope.State.Initialized in
+        if isType
+        then Env_js.bind_type ~state cx local_name tvar reason
+        else Env_js.bind_var ~state cx local_name tvar reason
       )
 )
 
@@ -2684,148 +2667,144 @@ and statement cx type_params_map = Ast.Statement.(
 
       export_statement cx type_params_map loc
         default export_info specifiers source exportKind
-  | (import_loc, ImportDeclaration({
-      ImportDeclaration.default;
-      ImportDeclaration.importKind;
-      ImportDeclaration.source;
-      ImportDeclaration.specifier;
-    })) ->
-      let (source_loc, source_literal) = source in
-      let module_name = (
-        match source_literal.Ast.Literal.value with
-        | Ast.Literal.String(value) -> value
-        | _ -> failwith  (
-            "Parser error: Invalid source type! Must be a string literal."
-          )
-      ) in
-      let (import_str, isType) = (
-        match importKind with
-        | ImportDeclaration.ImportType -> "import type", true
-        | ImportDeclaration.ImportTypeof -> "import typeof", true
-        | ImportDeclaration.ImportValue -> "import", false
-      ) in
 
-      let import_reason = mk_reason
-        (spf "exports of \"%s\"" module_name)
-        source_loc
-      in
-
-      let module_t = import cx module_name source_loc in
-
-      let get_imported_t get_reason set_reason remote_export_name local_name =
-        let imported_t = Flow_js.mk_tvar_where cx get_reason (fun t ->
-          let import_type =
-            if remote_export_name = "default"
-            then ImportDefaultT(get_reason, (local_name, module_name), t)
-            else ImportNamedT(get_reason, remote_export_name, t)
-          in
-          Flow_js.flow cx (module_t, import_type)
-        ) in
-        (match importKind with
-          | ImportDeclaration.ImportType ->
-              Flow_js.mk_tvar_where cx set_reason (fun t ->
-                Flow_js.flow cx (imported_t, ImportTypeT(set_reason, t))
-              )
-          | ImportDeclaration.ImportTypeof ->
-              Flow_js.mk_tvar_where cx set_reason (fun t ->
-                Flow_js.flow cx (imported_t, ImportTypeofT(set_reason, t))
-              )
-          | ImportDeclaration.ImportValue -> imported_t
+  | (import_loc, ImportDeclaration import_decl) -> 
+    let open ImportDeclaration in
+    
+    let module_name = (
+      match (snd import_decl.source).Ast.Literal.value with
+      | Ast.Literal.String value -> value
+      | _ -> failwith (
+          "Internal Parser Error: Invalid import source type! Must be a string " ^
+          "literal."
         )
-      in
+    ) in
 
-      let set_imported_binding reason local_name t =
-        let t_generic =
-          let lookup_mode = if isType then ForType else ForValue in
-          Env_js.get_var_declared_type ~lookup_mode cx local_name reason
+    let (import_str, isType) = (
+      match import_decl.importKind with
+      | ImportType -> "import type", true
+      | ImportTypeof -> "import typeof", true
+      | ImportValue -> "import", false
+    ) in
+
+    let module_t = import cx module_name (fst import_decl.source) in
+
+    let get_imported_t get_reason set_reason remote_export_name local_name =
+      let imported_t = Flow_js.mk_tvar_where cx get_reason (fun t ->
+        let import_type =
+          if remote_export_name = "default"
+          then ImportDefaultT(get_reason, (local_name, module_name), t)
+          else ImportNamedT(get_reason, remote_export_name, t)
         in
-        Flow_js.unify cx t t_generic
-      in
-
-      (match default with
-        | Some(local_ident_loc, local_ident) ->
-          let local_name = local_ident.Ast.Identifier.name in
-
-          let reason = mk_reason
-            (spf "Default import from `%s`" module_name)
-            local_ident_loc
-          in
-          let imported_t = get_imported_t reason reason "default" local_name in
-
-          let reason = mk_reason
-            (spf "%s %s from \"%s\"" import_str local_name module_name)
-            import_loc
-          in
-          set_imported_binding reason local_name imported_t
-        | None -> ()
-      );
-
-      (match specifier with
-        | Some(ImportDeclaration.Named(_, named_specifiers)) ->
-          let import_specifier (specifier_loc, specifier) = (
-            let (remote_ident_loc, remote_ident) =
-              specifier.ImportDeclaration.NamedSpecifier.id
-            in
-            let remote_name = remote_ident.Ast.Identifier.name in
-
-            let get_reason_str =
-              spf "Named import from module `%s`" module_name
-            in
-
-            let (local_name, get_reason, set_reason) = (
-              match specifier.ImportDeclaration.NamedSpecifier.name with
-              | Some(local_ident_loc, { Ast.Identifier.name = local_name; _; }) ->
-                let get_reason = mk_reason get_reason_str remote_ident_loc in
-                let set_reason = mk_reason
-                  (spf "%s { %s as %s }" import_str remote_name local_name)
-                  specifier_loc
-                in
-                (local_name, get_reason, set_reason)
-              | None ->
-                let get_reason = mk_reason get_reason_str specifier_loc in
-                let set_reason = mk_reason
-                  (spf "%s { %s }" import_str remote_name)
-                  specifier_loc
-                in
-                (remote_name, get_reason, set_reason)
-            ) in
-            let imported_t = get_imported_t get_reason set_reason remote_name local_name in
-
-            set_imported_binding get_reason local_name imported_t
-          ) in
-          List.iter import_specifier named_specifiers
-        | Some(ImportDeclaration.NameSpace(_, (ident_loc, local_ident))) ->
-          let local_name = local_ident.Ast.Identifier.name in
-          let reason = mk_reason
-            (spf "%s * as %s" import_str local_name)
-            ident_loc
-          in
-          (match importKind with
-            | ImportDeclaration.ImportType ->
-              let msg = spf (
-                "This is invalid syntax. Maybe you meant: " ^^
-                "`import type %s from \"%s\"`?"
-              ) local_name module_name in
-              let reason = repos_reason import_loc reason in
-              Flow_js.add_error cx [(reason, msg)]
-            | ImportDeclaration.ImportTypeof ->
-              let set_reason = repos_reason import_loc reason in
-              let module_ns_tvar = import_ns cx import_reason module_name source_loc in
-              let module_ns_typeof = Flow_js.mk_tvar_where cx set_reason (fun t ->
-                Flow_js.flow cx (module_ns_tvar, ImportTypeofT(reason, t))
-              ) in
-              let get_reason =
-                mk_reason
-                  (spf "import typeof * as %s from %S" local_name module_name)
-                  import_loc
-              in
-              set_imported_binding get_reason local_name module_ns_typeof
-            | ImportDeclaration.ImportValue ->
-              let module_ns_tvar = import_ns cx import_reason module_name source_loc in
-              set_imported_binding reason local_name module_ns_tvar
-          )
-        | None -> ()
+        Flow_js.flow cx (module_t, import_type)
+      ) in
+      (match import_decl.importKind with
+        | ImportType ->
+            Flow_js.mk_tvar_where cx set_reason (fun t ->
+              Flow_js.flow cx (imported_t, ImportTypeT(set_reason, t))
+            )
+        | ImportTypeof ->
+            Flow_js.mk_tvar_where cx set_reason (fun t ->
+              Flow_js.flow cx (imported_t, ImportTypeofT(set_reason, t))
+            )
+        | ImportValue -> imported_t
       )
+    in
+
+    import_decl.specifiers |> List.iter (fun specifier ->
+      let (reason, local_name, t) = (
+        match specifier with
+        | ImportNamedSpecifier {local; remote;} ->
+          let remote_name = ident_name remote in
+
+          let import_reason_str = 
+            spf "Named import from module `%s`" module_name
+          in
+
+          let (local_name, import_reason, bind_reason) = (
+            match local with
+            | Some local -> 
+              let local_name = ident_name local in
+              let import_reason = mk_reason import_reason_str (fst remote) in
+              let bind_reason_str =
+                spf "%s { %s as %s }" import_str remote_name local_name
+              in
+              let bind_loc = Loc.btwn (fst remote) (fst local) in
+              let bind_reason = mk_reason bind_reason_str bind_loc in
+              (local_name, import_reason, bind_reason)
+            | None ->
+              let import_reason = mk_reason import_reason_str (fst remote) in
+              let bind_reason_str = spf "%s { %s }" import_str remote_name in
+              let bind_reason = mk_reason bind_reason_str (fst remote) in
+              (remote_name, import_reason, bind_reason)
+          ) in
+          let imported_t = 
+            get_imported_t import_reason bind_reason remote_name local_name
+          in
+          (bind_reason, local_name, imported_t)
+
+        | ImportDefaultSpecifier local ->
+          let local_name = ident_name local in
+
+          let import_reason_str = spf "Default import from `%s`" module_name in
+          let import_reason = mk_reason import_reason_str (fst local) in
+
+          let bind_reason_str = 
+            spf "%s %s from %S" import_str local_name module_name 
+          in
+          let bind_reason = mk_reason bind_reason_str (fst local) in
+
+          let imported_t = 
+            get_imported_t import_reason bind_reason "default" local_name 
+          in
+          (bind_reason, local_name, imported_t)
+
+        | ImportNamespaceSpecifier (star_as_loc, local) ->
+          let local_name = ident_name local in
+
+          let import_reason_str = spf "%s * as %s" import_str local_name in
+          let import_reason = mk_reason import_reason_str import_loc in
+
+          (match import_decl.importKind with
+            | ImportType ->
+              let msg = 
+                spf 
+                  ("This is invalid syntax. Maybe you meant: `import type " ^^
+                   "%s from %S`?")
+                  local_name
+                  module_name
+              in
+              Flow_js.add_error cx [(import_reason, msg)];
+              (import_reason, local_name, AnyT.why import_reason)
+            | ImportTypeof ->
+              let bind_reason = repos_reason (fst local) import_reason in
+              let module_ns_t = 
+                import_ns cx import_reason module_name (fst import_decl.source)
+              in
+              let module_ns_typeof = 
+                Flow_js.mk_tvar_where cx bind_reason (fun t ->
+                  Flow_js.flow cx (module_ns_t, ImportTypeofT(bind_reason, t))
+                )
+              in
+              (import_reason, local_name, module_ns_typeof)
+            | ImportValue ->
+              let reason = 
+                mk_reason (spf "exports of %S" module_name) import_loc 
+              in
+              let module_ns_t = 
+                import_ns cx reason module_name (fst import_decl.source)
+              in
+              let bind_reason = mk_reason import_reason_str (fst local) in
+              (bind_reason, local_name, module_ns_t)
+          )
+      ) in
+
+      let t_generic =
+        let lookup_mode = if isType then ForType else ForValue in
+        Env_js.get_var_declared_type ~lookup_mode cx local_name reason
+      in
+      Flow_js.unify cx t t_generic
+    );
 )
 
 

--- a/tests/import_type/import_type.exp
+++ b/tests/import_type/import_type.exp
@@ -5,7 +5,7 @@ import_type.js:13:9,14: number
 
 import_type.js:14:5,13: ClassFoo1
 type referenced from value position
-import_type.js:9:1,51: type ClassFoo1
+import_type.js:9:13,21: type ClassFoo1
 
 import_type.js:24:18,25: ClassFoo2
 This type is incompatible with
@@ -17,7 +17,7 @@ import_type.js:20:14,22: type ClassFoo2
 
 import_type.js:34:5,14: ClassFoo3T
 type referenced from value position
-import_type.js:31:1,55: type ClassFoo3T
+import_type.js:31:13,22: type ClassFoo3T
 
 import_type.js:44:18,25: ClassFoo4
 This type is incompatible with
@@ -46,6 +46,6 @@ import_type.js:71:14,21: import type { numValue }
 
 import_type.js:81:3,11: ClassFoo6
 type referenced from value position
-import_type.js:79:1,41: type ClassFoo6
+import_type.js:79:13,21: type ClassFoo6
 
 Found 12 errors

--- a/tests/import_typeof/import_typeof.exp
+++ b/tests/import_typeof/import_typeof.exp
@@ -7,7 +7,7 @@ import_typeof.js:13:9,18: class type: ClassFoo1
 
 import_typeof.js:14:5,14: ClassFoo1T
 type referenced from value position
-import_typeof.js:9:1,54: type ClassFoo1T
+import_typeof.js:9:15,24: type ClassFoo1T
 
 import_typeof.js:24:22,36: constructor call
 Error:

--- a/tests/type_only_vars/type_only_vars.exp
+++ b/tests/type_only_vars/type_only_vars.exp
@@ -1,7 +1,7 @@
 
 bad_shadowing.js:13:5,13: A
 name is already bound
-bad_shadowing.js:5:1,28: type A
+bad_shadowing.js:5:13,13: type A
 
 bad_shadowing.js:14:5,15: Foo
 name is already bound
@@ -17,7 +17,7 @@ bad_shadowing.js:8:6,9: type duck
 
 good_shadowing.js:8:5,5: A
 name is already bound
-good_shadowing.js:5:1,28: type A
+good_shadowing.js:5:13,13: type A
 
 good_shadowing.js:9:5,7: Foo
 name is already bound
@@ -25,7 +25,7 @@ good_shadowing.js:6:14,16: type Foo
 
 good_shadowing.js:9:11,11: A
 type referenced from value position
-good_shadowing.js:5:1,28: type A
+good_shadowing.js:5:13,13: type A
 
 good_shadowing.js:10:5,7: Baz
 name is already bound
@@ -33,11 +33,11 @@ good_shadowing.js:6:19,28: type Baz
 
 good_shadowing.js:10:11,11: A
 type referenced from value position
-good_shadowing.js:5:1,28: type A
+good_shadowing.js:5:13,13: type A
 
 good_shadowing.js:13:9,9: A
 type referenced from value position
-good_shadowing.js:5:1,28: type A
+good_shadowing.js:5:13,13: type A
 
 good_shadowing.js:14:9,11: Foo
 type referenced from value position
@@ -53,15 +53,15 @@ good_shadowing.js:6:14,16: type Foo
 
 good_shadowing.js:19:18,18: A
 type referenced from value position
-good_shadowing.js:5:1,28: type A
+good_shadowing.js:5:13,13: type A
 
 good_shadowing.js:20:6,6: A
 type referenced from value position
-good_shadowing.js:5:1,28: type A
+good_shadowing.js:5:13,13: type A
 
 import_type.js:11:9,9: A
 type referenced from value position
-import_type.js:5:1,28: type A
+import_type.js:5:13,13: type A
 
 import_type.js:12:9,11: Foo
 type referenced from value position


### PR DESCRIPTION
A while back ESTree simplified its [`ImportDeclaration` spec](https://github.com/estree/estree/blob/master/es6.md#imports) into a much less confusing, less error-prone data structure. We've been converting to that structure for a while now in estree_converter, but it's time we did ourselves a favor just used it internally too.

So this refactors our internal AST type to better match ESTree and updates type_inference handling as such. It also narrows in some error locations (mostly just points a few places at the variable symbol in the import statement rather than spanning the entire import statement -- which could include multiple variable symbols)

It's so beautiful!! 
![image](https://cloud.githubusercontent.com/assets/498293/12134009/f31f5432-b3f8-11e5-980c-b9ebb06961a2.png)
