### PR TITLE
typing custom element lifecycle callbacks

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -255,7 +255,18 @@ declare class HTMLCollection {
 
 // from http://w3c.github.io/webcomponents/spec/custom/#extensions-to-document-interface-to-register
 type ElementRegistrationOptions = {
-    prototype?: any;
+    prototype?: {
+      // from http://w3c.github.io/webcomponents/spec/custom/#types-of-callbacks
+      createdCallback?: () => void;
+      attachedCallback?: () => void;
+      detachedCallback?: () => void;
+      attributeChangedCallback?: (
+        attributeLocalName: string,
+        oldAttributeValue: ?string,
+        newAttributeValue: ?string,
+        attributeNamespace: ?string
+      ) => void;
+    };
     extends?: string;
 }
 

--- a/tests/dom/dom.exp
+++ b/tests/dom/dom.exp
@@ -3,13 +3,13 @@ CanvasRenderingContext2D.js:11:5,24: call of method `moveTo`
 Error:
 CanvasRenderingContext2D.js:11:16,18: string
 This type is incompatible with
-[LIB] dom.js:708:15,20: number
+[LIB] dom.js:719:15,20: number
 
 CanvasRenderingContext2D.js:11:5,24: call of method `moveTo`
 Error:
 CanvasRenderingContext2D.js:11:21,23: string
 This type is incompatible with
-[LIB] dom.js:708:26,31: number
+[LIB] dom.js:719:26,31: number
 
 eventtarget.js:9:6,40: call of method `attachEvent`
 Function cannot be called on possibly undefined value

--- a/tests/dom/registerElement.js
+++ b/tests/dom/registerElement.js
@@ -1,0 +1,68 @@
+// @flow
+
+let tests = [
+  // should work with Object.create()
+  function() {
+    document.registerElement('custom-element', {
+      prototype: Object.create(HTMLElement.prototype, {
+        createdCallback: { value: function createdCallback () {
+        }},
+        attachedCallback: { value: function attachedCallback () {
+        }},
+        detachedCallback: { value: function detachedCallback () {
+        }},
+        attributeChangedCallback: {
+          value: function attributeChangedCallback (
+            attributeLocalName,
+            oldAttributeValue,
+            newAttributeValue,
+            attributeNamespace
+          ) {
+          }
+        }
+      })
+    })
+  },
+  // or with Object.assign()
+  function() {
+    document.registerElement('custom-element', {
+      prototype: Object.assign(Object.create(HTMLElement.prototype), {
+        createdCallback () {
+        },
+        attachedCallback () {
+        },
+        detachedCallback () {
+        },
+        attributeChangedCallback (
+          attributeLocalName,
+          oldAttributeValue,
+          newAttributeValue,
+          attributeNamespace
+        ) {
+        }
+      })
+    })
+  },
+  // should complain about unrecognized callbacks
+  function() {
+    document.registerElement('custom-element', {
+      prototype: Object.create(HTMLElement.prototype, {
+        bogusCallback: { value: function bogusCallback () {
+        }}
+      })
+    })
+  },
+  // should complain about invalid callback parameters
+  function() {
+    document.registerElement('custom-element', {
+      prototype: Object.create(HTMLElement.prototype, {
+        createdCallback: { value: function createdCallback (bogusArg) {
+        }},
+        attachedCallback: { value: function attachedCallback (bogusArg) {
+        }},
+        detachedCallback: { value: function detachedCallback (bogusArg) {
+        }}
+      })
+    })
+  },
+];


### PR DESCRIPTION
I've added types for the four custom element lifecycle callback methods.

If I've read the spec correctly, ideally we would also like to be able to stipulate that

  1. the value of `ElementRegistrationOptions.prototype` should be an object which includes either `HTMLElement` or `SVGElement` in its prototype chain.
  2. the return value of `document.registerElement()` will be a constructor for a subclass of `HTMLElement` or `SVGElement` or the descendent named in (1).

Does anyone know how this could be expressed in Flow?