### PR TITLE
Update all copyright headers to 2016.

### DIFF
--- a/build.ocp
+++ b/build.ocp
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/build.ocp
+++ b/hack/build.ocp
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/client/clientAiInfo.ml
+++ b/hack/client/clientAiInfo.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/client/clientArgs.ml
+++ b/hack/client/clientArgs.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/client/clientArgumentInfo.ml
+++ b/hack/client/clientArgumentInfo.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/client/clientAutocomplete.ml
+++ b/hack/client/clientAutocomplete.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/client/clientBuild.ml
+++ b/hack/client/clientBuild.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/client/clientCheck.ml
+++ b/hack/client/clientCheck.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/client/clientCheckStatus.ml
+++ b/hack/client/clientCheckStatus.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/client/clientColorFile.ml
+++ b/hack/client/clientColorFile.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/client/clientCommand.ml
+++ b/hack/client/clientCommand.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
@@ -8,7 +8,7 @@
  *
  *)
 
-type command = 
+type command =
   | CCheck of ClientEnv.client_check_env
   | CStart of ClientStart.env
   | CStop of ClientStop.env

--- a/hack/client/clientConnect.ml
+++ b/hack/client/clientConnect.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/client/clientCoverageMetric.ml
+++ b/hack/client/clientCoverageMetric.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/client/clientCoverageMetric.mli
+++ b/hack/client/clientCoverageMetric.mli
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/client/clientEnv.ml
+++ b/hack/client/clientEnv.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/client/clientFindRefs.ml
+++ b/hack/client/clientFindRefs.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/client/clientLint.ml
+++ b/hack/client/clientLint.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/client/clientLogCommand.ml
+++ b/hack/client/clientLogCommand.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/client/clientMethodJumps.ml
+++ b/hack/client/clientMethodJumps.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/client/clientOutline.ml
+++ b/hack/client/clientOutline.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/client/clientRefactor.ml
+++ b/hack/client/clientRefactor.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/client/clientRestart.ml
+++ b/hack/client/clientRestart.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/client/clientSearch.ml
+++ b/hack/client/clientSearch.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/client/clientStart.ml
+++ b/hack/client/clientStart.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/client/clientStart.mli
+++ b/hack/client/clientStart.mli
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/client/clientStop.ml
+++ b/hack/client/clientStop.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/client/clientStop.mli
+++ b/hack/client/clientStop.mli
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/client/clientSymbolInfo.ml
+++ b/hack/client/clientSymbolInfo.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/client/clientTypeAtPos.ml
+++ b/hack/client/clientTypeAtPos.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/client/colorFile.ml
+++ b/hack/client/colorFile.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/deps/fileInfo.ml
+++ b/hack/deps/fileInfo.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
@@ -73,7 +73,7 @@ let empty_names = {
 (*****************************************************************************)
 (* Functions simplifying the file information. *)
 (*****************************************************************************)
-    
+
 let name_set_of_idl idl =
   List.fold_left idl ~f:(fun acc (_, x) -> SSet.add x acc) ~init:SSet.empty
 

--- a/hack/deps/fileInfo.mli
+++ b/hack/deps/fileInfo.mli
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/deps/typing_deps.ml
+++ b/hack/deps/typing_deps.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/deps/typing_deps.mli
+++ b/hack/deps/typing_deps.mli
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/dfind/dfindAddFile.ml
+++ b/hack/dfind/dfindAddFile.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/dfind/dfindAddFile.mli
+++ b/hack/dfind/dfindAddFile.mli
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/dfind/dfindEnv.ml
+++ b/hack/dfind/dfindEnv.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/dfind/dfindEnv.mli
+++ b/hack/dfind/dfindEnv.mli
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/dfind/dfindLib.ml
+++ b/hack/dfind/dfindLib.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/dfind/dfindLib.mli
+++ b/hack/dfind/dfindLib.mli
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/dfind/dfindMaybe.ml
+++ b/hack/dfind/dfindMaybe.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
@@ -35,9 +35,9 @@ let return x = Some x
 let handle_file_exn path = function
   | Fsnotify.Error (reason, 2) -> ()
       (* The file got deleted in the mean time ... we don't care *)
-  | Fsnotify.Error (reason, errno) -> 
+  | Fsnotify.Error (reason, errno) ->
       (* This is bad ... *)
-      Printf.fprintf !log 
+      Printf.fprintf !log
         "Error: could not add watch to %s [%s, %d]\n" path reason errno
   | e when Sys.file_exists path ->
       (* Logging this makes the system very noisy. There are too many
@@ -47,7 +47,7 @@ let handle_file_exn path = function
   | _ -> ()
 
 (* Calls (f path), never fails, logs the nasty exceptions *)
-let call f path = 
+let call f path =
   try f path
   with e -> handle_file_exn path e; None
 

--- a/hack/dfind/dfindMaybe.mli
+++ b/hack/dfind/dfindMaybe.mli
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/dfind/dfindServer.ml
+++ b/hack/dfind/dfindServer.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/dfind/dfindServer.mli
+++ b/hack/dfind/dfindServer.mli
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/emitter/emitter.ml
+++ b/hack/emitter/emitter.ml
@@ -1,5 +1,5 @@
 (*
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/emitter/emitter_consts.ml
+++ b/hack/emitter/emitter_consts.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/emitter/emitter_core.ml
+++ b/hack/emitter/emitter_core.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/emitter/emitter_expr.ml
+++ b/hack/emitter/emitter_expr.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/emitter/emitter_lit.ml
+++ b/hack/emitter/emitter_lit.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/emitter/emitter_stmt.ml
+++ b/hack/emitter/emitter_stmt.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/emitter/emitter_types.ml
+++ b/hack/emitter/emitter_types.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/emitter/emitter_xhp.ml
+++ b/hack/emitter/emitter_xhp.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/find/find.ml
+++ b/hack/find/find.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/find/find.mli
+++ b/hack/find/find.mli
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/format/format_diff.ml
+++ b/hack/format/format_diff.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/format/format_diff.mli
+++ b/hack/format/format_diff.mli
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/format/format_hack.ml
+++ b/hack/format/format_hack.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/format/format_hack.mli
+++ b/hack/format/format_hack.mli
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/format/format_mode.ml
+++ b/hack/format/format_mode.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/fsevents/fsevents.ml
+++ b/hack/fsevents/fsevents.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
@@ -16,6 +16,6 @@ external get_event_fd : env -> Unix.file_descr = "stub_fsevents_get_event_fd"
 external read_events : env -> event list = "stub_fsevents_read_events"
 
 (* glevi is lazy and didn't implement removing watches since hh_server never
- * actually does that at the moment 
+ * actually does that at the moment
 external rm_watch : env -> string -> string = "stub_fsevents_rm_watch"
 *)

--- a/hack/fsevents/fsevents.mli
+++ b/hack/fsevents/fsevents.mli
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
@@ -12,7 +12,7 @@ type env
 type event = string * string
 val init : unit -> env
 val add_watch : env -> string -> string
-val get_event_fd : env -> Unix.file_descr 
+val get_event_fd : env -> Unix.file_descr
 val read_events : env -> event list
 
 (* Currently unimplemented

--- a/hack/fsnotify_darwin/fsnotify.ml
+++ b/hack/fsnotify_darwin/fsnotify.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/fsnotify_darwin/fsnotify.mli
+++ b/hack/fsnotify_darwin/fsnotify.mli
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/fsnotify_linux/fsnotify.ml
+++ b/hack/fsnotify_linux/fsnotify.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/fsnotify_linux/fsnotify.mli
+++ b/hack/fsnotify_linux/fsnotify.mli
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/fsnotify_win/fsnotify.ml
+++ b/hack/fsnotify_win/fsnotify.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/fsnotify_win/fsnotify.mli
+++ b/hack/fsnotify_win/fsnotify.mli
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/fsnotify_win/fsnotify_stubs.c
+++ b/hack/fsnotify_win/fsnotify_stubs.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/globals/autocomplete.ml
+++ b/hack/globals/autocomplete.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/globals/globalConfig.ml
+++ b/hack/globals/globalConfig.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/globals/ide.ml
+++ b/hack/globals/ide.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/heap/globalStorage.ml
+++ b/hack/heap/globalStorage.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
@@ -10,7 +10,7 @@
 
 (*****************************************************************************)
 (* Module implementing a global storage system, an efficient way for the
- * master to communicate data with the workers (cf hh_shared.c for the 
+ * master to communicate data with the workers (cf hh_shared.c for the
  * underlying C implementation).
  *
  * The master can store data in the global storage, after that, the data

--- a/hack/heap/hh_shared.c
+++ b/hack/heap/hh_shared.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/heap/prefix.ml
+++ b/hack/heap/prefix.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
@@ -10,7 +10,7 @@
 
 
 (*****************************************************************************)
-(* The prefix is used to guarantee that we are not mixing different kind of 
+(* The prefix is used to guarantee that we are not mixing different kind of
  * keys in the heap.
  * It just creates a new prefix every time its called.
 *)

--- a/hack/heap/prefix.mli
+++ b/hack/heap/prefix.mli
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
@@ -10,7 +10,7 @@
 
 
 (*****************************************************************************)
-(* The prefix is used to guarantee that we are not mixing different kind of 
+(* The prefix is used to guarantee that we are not mixing different kind of
  * keys in the heap.
  * It just creates a new prefix every time its called.
 *)

--- a/hack/heap/sharedMem.ml
+++ b/hack/heap/sharedMem.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/heap/sharedMem.mli
+++ b/hack/heap/sharedMem.mli
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
@@ -122,8 +122,8 @@ module type S = sig
   val mem: key -> bool
 
   (* This function takes the elements present in the set and keep the "old"
-   * version in a separate heap. This is useful when we want to compare 
-   * what has changed. We will be in a situation for type-checking 
+   * version in a separate heap. This is useful when we want to compare
+   * what has changed. We will be in a situation for type-checking
    * (cf typing/typing_redecl_service.ml) where we want to compare the type
    * of a class in the previous environment vs the current type.
    *)

--- a/hack/heap/value.ml
+++ b/hack/heap/value.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/heap/value.mli
+++ b/hack/heap/value.mli
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/hh_client.ml
+++ b/hack/hh_client.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/hh_emitter.ml
+++ b/hack/hh_emitter.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/hh_format.ml
+++ b/hack/hh_format.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/hh_match.ml
+++ b/hack/hh_match.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/hh_matcher/astConstructor.ml
+++ b/hack/hh_matcher/astConstructor.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/hh_matcher/ast_code_extent.ml
+++ b/hack/hh_matcher/ast_code_extent.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/hh_matcher/ast_code_extent.mli
+++ b/hack/hh_matcher/ast_code_extent.mli
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/hh_matcher/hh_match_test_utils.ml
+++ b/hack/hh_matcher/hh_match_test_utils.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/hh_matcher/hh_match_test_utils.mli
+++ b/hack/hh_matcher/hh_match_test_utils.mli
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/hh_matcher/hh_match_utils.ml
+++ b/hack/hh_matcher/hh_match_utils.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/hh_matcher/matcher.ml
+++ b/hack/hh_matcher/matcher.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/hh_matcher/matcher.mli
+++ b/hack/hh_matcher/matcher.mli
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/hh_matcher/patcher.ml
+++ b/hack/hh_matcher/patcher.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/hh_matcher/patcher.mli
+++ b/hack/hh_matcher/patcher.mli
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/hh_matcher/test/code_extent_tests.ml
+++ b/hack/hh_matcher/test/code_extent_tests.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/hh_matcher/test/matcher_expr_test.ml
+++ b/hack/hh_matcher/test/matcher_expr_test.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/hh_matcher/test/matcher_test.ml
+++ b/hack/hh_matcher/test/matcher_test.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/hh_matcher/test/patcher_api_test.ml
+++ b/hack/hh_matcher/test/patcher_api_test.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/hh_matcher/test/patcher_expr_test.ml
+++ b/hack/hh_matcher/test/patcher_expr_test.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/hh_matcher/test/patcher_module_test.ml
+++ b/hack/hh_matcher/test/patcher_module_test.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/hh_matcher/test/patcher_test.ml
+++ b/hack/hh_matcher/test/patcher_test.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/hh_server.ml
+++ b/hack/hh_server.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/hh_single_type_check.ml
+++ b/hack/hh_single_type_check.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/hhi/hhi.ml
+++ b/hack/hhi/hhi.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/hhi/hhi.mli
+++ b/hack/hhi/hhi.mli
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/hhi/hhi_win32res.ml
+++ b/hack/hhi/hhi_win32res.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/hhi/hhi_win32res.mli
+++ b/hack/hhi/hhi_win32res.mli
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/hhi/hhi_win32res_stubs.c
+++ b/hack/hhi/hhi_win32res_stubs.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/js/hh_ide.ml
+++ b/hack/js/hh_ide.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/js/hhi.ml
+++ b/hack/js/hhi.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/js/ident.ml
+++ b/hack/js/ident.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/js/path.ml
+++ b/hack/js/path.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/js/pp.ml
+++ b/hack/js/pp.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/js/regexp_utils.ml
+++ b/hack/js/regexp_utils.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/js/sharedMem.ml
+++ b/hack/js/sharedMem.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
@@ -29,15 +29,15 @@ let (local_h: (string, string) Hashtbl.t) = Hashtbl.create 7
 let find_unsafe x =
   Hashtbl.find local_h x
 
-let get x = 
+let get x =
   try Some (find_unsafe x) with Not_found -> None
-    
+
 let mem x = get x <> None
 
-let add x data = 
+let add x data =
   Hashtbl.replace local_h x data
 
-let remove x = 
+let remove x =
   Hashtbl.remove local_h x
 
 let remove_batch x =
@@ -47,7 +47,7 @@ let remove_batch x =
 
 (*****************************************************************************)
 (* The signature of what we are actually going to expose to the user *)
-(*****************************************************************************)        
+(*****************************************************************************)
 module type S = sig
   type t
   type key
@@ -78,7 +78,7 @@ end
 
 (*****************************************************************************)
 (* NoCache means no caching, read and write directly *)
-(*****************************************************************************)        
+(*****************************************************************************)
 module type NoCache_type =
   functor (UserKeyType : UserKeyType) ->
   functor (Value : Value.Type) ->
@@ -120,7 +120,7 @@ module NoCache: NoCache_type =
     KeySet.fold begin fun x acc ->
       SSet.add (Prefix.make_key Value.prefix (UserKeyType.to_string x)) acc
     end xs SSet.empty
-    
+
   let remove_batch xs = remove_batch (make_key_set xs)
 
   let get_batch xs =
@@ -143,5 +143,5 @@ end
 
 (*****************************************************************************)
 (* Same thing but with 4 layers of cache ... Useful for type-checking        *)
-(*****************************************************************************)        
+(*****************************************************************************)
 module WithCache = NoCache

--- a/hack/js/sys_utils.ml
+++ b/hack/js/sys_utils.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/js/typing_deps.ml
+++ b/hack/js/typing_deps.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/libancillary/libancillary-stubs.c
+++ b/hack/libancillary/libancillary-stubs.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/libancillary/libancillary.ml
+++ b/hack/libancillary/libancillary.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/libancillary/libancillary.mli
+++ b/hack/libancillary/libancillary.mli
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/libancillary/libancillaryTest.ml
+++ b/hack/libancillary/libancillaryTest.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/monitor/monitorConnection.ml
+++ b/hack/monitor/monitorConnection.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/monitor/monitorConnection.mli
+++ b/hack/monitor/monitorConnection.mli
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/monitor/prehandoff.ml
+++ b/hack/monitor/prehandoff.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/monitor/serverMonitor.ml
+++ b/hack/monitor/serverMonitor.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/monitor/serverMonitor.mli
+++ b/hack/monitor/serverMonitor.mli
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/monitor/serverMonitorUtils.ml
+++ b/hack/monitor/serverMonitorUtils.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/monitor/serverProcess.ml
+++ b/hack/monitor/serverProcess.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/monitor/serverProcessTools.ml
+++ b/hack/monitor/serverProcessTools.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/naming/attributes.ml
+++ b/hack/naming/attributes.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/naming/naming.ml
+++ b/hack/naming/naming.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/naming/naming.mli
+++ b/hack/naming/naming.mli
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/naming/namingGlobal.ml
+++ b/hack/naming/namingGlobal.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/naming/namingGlobal.mli
+++ b/hack/naming/namingGlobal.mli
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/naming/naming_ast_helpers.ml
+++ b/hack/naming/naming_ast_helpers.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/naming/naming_heap.ml
+++ b/hack/naming/naming_heap.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/naming/naming_hooks.ml
+++ b/hack/naming/naming_hooks.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/naming/naming_special_names.ml
+++ b/hack/naming/naming_special_names.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/naming/nast.ml
+++ b/hack/naming/nast.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/naming/nastVisitor.ml
+++ b/hack/naming/nastVisitor.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/naming/nast_eval.ml
+++ b/hack/naming/nast_eval.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/naming/nast_eval.mli
+++ b/hack/naming/nast_eval.mli
@@ -1,5 +1,5 @@
 (**
- *  Copyright (c) 2015, Facebook, Inc.
+ *  Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/naming/typecheckerOptions.ml
+++ b/hack/naming/typecheckerOptions.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/parsing/ast.ml
+++ b/hack/parsing/ast.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/parsing/astVisitor.ml
+++ b/hack/parsing/astVisitor.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/parsing/ast_utils.ml
+++ b/hack/parsing/ast_utils.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/parsing/lexer_hack.mll
+++ b/hack/parsing/lexer_hack.mll
@@ -1,6 +1,6 @@
 {
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/parsing/namespace_env.ml
+++ b/hack/parsing/namespace_env.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/parsing/namespaces.ml
+++ b/hack/parsing/namespaces.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/parsing/namespaces.mli
+++ b/hack/parsing/namespaces.mli
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/parsing/parser_hack.ml
+++ b/hack/parsing/parser_hack.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/parsing/parser_hack.mli
+++ b/hack/parsing/parser_hack.mli
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/parsing/parser_heap.ml
+++ b/hack/parsing/parser_heap.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/parsing/parsing_hooks.ml
+++ b/hack/parsing/parsing_hooks.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/parsing/parsing_service.ml
+++ b/hack/parsing/parsing_service.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/parsing/parsing_service.mli
+++ b/hack/parsing/parsing_service.mli
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/procs/bucket.ml
+++ b/hack/procs/bucket.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/procs/multiWorker.ml
+++ b/hack/procs/multiWorker.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/procs/multiWorker.mli
+++ b/hack/procs/multiWorker.mli
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/procs/worker.ml
+++ b/hack/procs/worker.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/procs/worker.mli
+++ b/hack/procs/worker.mli
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
@@ -12,7 +12,7 @@
 (*****************************************************************************)
 (* Module building workers.
  * A worker is a subprocess executing an arbitrary function.
- * You should first create a fixed amount of workers and then use those 
+ * You should first create a fixed amount of workers and then use those
  * because the amount of workers is limited and to make the load-balancing
  * of tasks better (cf multiWorker.ml).
  *)

--- a/hack/search/fuzzySearchService.ml
+++ b/hack/search/fuzzySearchService.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/search/hackSearchService.ml
+++ b/hack/search/hackSearchService.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/search/searchService.ml
+++ b/hack/search/searchService.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/search/searchUtils.ml
+++ b/hack/search/searchUtils.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/search/trieSearchService.ml
+++ b/hack/search/trieSearchService.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/server/argumentInfoService.ml
+++ b/hack/server/argumentInfoService.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/server/autocompleteService.ml
+++ b/hack/server/autocompleteService.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/server/fileOutline.ml
+++ b/hack/server/fileOutline.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/server/findLocalsService.ml
+++ b/hack/server/findLocalsService.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/server/findRefsService.ml
+++ b/hack/server/findRefsService.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/server/hhServerMonitor.ml
+++ b/hack/server/hhServerMonitor.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/server/hhServerMonitor.mli
+++ b/hack/server/hhServerMonitor.mli
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/server/identifySymbolService.ml
+++ b/hack/server/identifySymbolService.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/server/inferAtPosService.ml
+++ b/hack/server/inferAtPosService.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/server/methodJumps.ml
+++ b/hack/server/methodJumps.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/server/serverArgs.ml
+++ b/hack/server/serverArgs.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/server/serverArgs.mli
+++ b/hack/server/serverArgs.mli
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/server/serverArgumentInfo.ml
+++ b/hack/server/serverArgumentInfo.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/server/serverAutoComplete.ml
+++ b/hack/server/serverAutoComplete.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/server/serverBuild.ml
+++ b/hack/server/serverBuild.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/server/serverCheckUtils.ml
+++ b/hack/server/serverCheckUtils.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/server/serverCheckpoint.ml
+++ b/hack/server/serverCheckpoint.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/server/serverColorFile.ml
+++ b/hack/server/serverColorFile.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/server/serverCommand.ml
+++ b/hack/server/serverCommand.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/server/serverConfig.ml
+++ b/hack/server/serverConfig.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/server/serverConfig.mli
+++ b/hack/server/serverConfig.mli
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/server/serverConvert.ml
+++ b/hack/server/serverConvert.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/server/serverCoverageMetric.ml
+++ b/hack/server/serverCoverageMetric.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/server/serverEnv.ml
+++ b/hack/server/serverEnv.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/server/serverEnvBuild.ml
+++ b/hack/server/serverEnvBuild.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/server/serverEnvBuild.mli
+++ b/hack/server/serverEnvBuild.mli
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/server/serverError.ml
+++ b/hack/server/serverError.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/server/serverFiles.ml
+++ b/hack/server/serverFiles.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/server/serverFindRefs.ml
+++ b/hack/server/serverFindRefs.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/server/serverFindRefs.mli
+++ b/hack/server/serverFindRefs.mli
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/server/serverIdeUtils.ml
+++ b/hack/server/serverIdeUtils.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/server/serverIdentifyFunction.ml
+++ b/hack/server/serverIdentifyFunction.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/server/serverIdle.ml
+++ b/hack/server/serverIdle.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/server/serverIdle.mli
+++ b/hack/server/serverIdle.mli
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/server/serverInferType.ml
+++ b/hack/server/serverInferType.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/server/serverInit.ml
+++ b/hack/server/serverInit.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/server/serverInit.mli
+++ b/hack/server/serverInit.mli
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/server/serverLint.ml
+++ b/hack/server/serverLint.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/server/serverLocalConfig.ml
+++ b/hack/server/serverLocalConfig.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/server/serverMain.ml
+++ b/hack/server/serverMain.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/server/serverMain.mli
+++ b/hack/server/serverMain.mli
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/server/serverMethodJumps.ml
+++ b/hack/server/serverMethodJumps.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/server/serverRefactor.ml
+++ b/hack/server/serverRefactor.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
@@ -34,7 +34,7 @@ let go action genv env =
         ServerFindRefs.Method (class_name, old_name), new_name
     | FunctionRename (old_name, new_name) ->
         ServerFindRefs.Function old_name, new_name in
-  
+
   let refs = ServerFindRefs.get_refs_with_defs find_refs_action genv env in
   let changes = List.fold_left refs ~f:begin fun acc x ->
     let replacement = {

--- a/hack/server/serverRpc.ml
+++ b/hack/server/serverRpc.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/server/serverSearch.ml
+++ b/hack/server/serverSearch.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/server/serverStamp.ml
+++ b/hack/server/serverStamp.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/server/serverTypeCheck.ml
+++ b/hack/server/serverTypeCheck.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/server/serverTypeCheck.mli
+++ b/hack/server/serverTypeCheck.mli
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/server/serverUtils.ml
+++ b/hack/server/serverUtils.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/server/symbolFunCallService.ml
+++ b/hack/server/symbolFunCallService.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/server/symbolInfoService.ml
+++ b/hack/server/symbolInfoService.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/server/symbolTypeService.ml
+++ b/hack/server/symbolTypeService.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/server/symbolUtils.ml
+++ b/hack/server/symbolUtils.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/socket/socket.ml
+++ b/hack/socket/socket.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/stubs/ai.ml
+++ b/hack/stubs/ai.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/stubs/ai_options.ml
+++ b/hack/stubs/ai_options.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/stubs/buildMain.ml
+++ b/hack/stubs/buildMain.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/stubs/clientMessages.ml
+++ b/hack/stubs/clientMessages.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/stubs/debug.ml
+++ b/hack/stubs/debug.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/stubs/eventLogger.ml
+++ b/hack/stubs/eventLogger.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/stubs/formatEventLogger.ml
+++ b/hack/stubs/formatEventLogger.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/stubs/hackEventLogger.ml
+++ b/hack/stubs/hackEventLogger.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/stubs/linting_service.ml
+++ b/hack/stubs/linting_service.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/stubs/prolog.ml
+++ b/hack/stubs/prolog.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/stubs/prologMain.ml
+++ b/hack/stubs/prologMain.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/typing/coverage_level.ml
+++ b/hack/typing/coverage_level.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/typing/nastCheck.ml
+++ b/hack/typing/nastCheck.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/typing/nastInitCheck.ml
+++ b/hack/typing/nastInitCheck.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/typing/nast_terminality.ml
+++ b/hack/typing/nast_terminality.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/typing/typeVisitor.ml
+++ b/hack/typing/typeVisitor.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/typing/type_mapper.ml
+++ b/hack/typing/type_mapper.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/typing/typing.ml
+++ b/hack/typing/typing.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/typing/typing.mli
+++ b/hack/typing/typing.mli
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/typing/typingEqualityCheck.ml
+++ b/hack/typing/typingEqualityCheck.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/typing/typing_alias.ml
+++ b/hack/typing/typing_alias.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/typing/typing_alias.mli
+++ b/hack/typing/typing_alias.mli
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/typing/typing_arrays.ml
+++ b/hack/typing/typing_arrays.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/typing/typing_async.ml
+++ b/hack/typing/typing_async.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/typing/typing_check_service.ml
+++ b/hack/typing/typing_check_service.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/typing/typing_check_utils.ml
+++ b/hack/typing/typing_check_utils.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/typing/typing_compare.ml
+++ b/hack/typing/typing_compare.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/typing/typing_compare.mli
+++ b/hack/typing/typing_compare.mli
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/typing/typing_decl.ml
+++ b/hack/typing/typing_decl.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/typing/typing_decl.mli
+++ b/hack/typing/typing_decl.mli
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/typing/typing_decl_deps.ml
+++ b/hack/typing/typing_decl_deps.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/typing/typing_decl_service.ml
+++ b/hack/typing/typing_decl_service.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/typing/typing_decl_service.mli
+++ b/hack/typing/typing_decl_service.mli
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/typing/typing_defs.ml
+++ b/hack/typing/typing_defs.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/typing/typing_dependent_type.ml
+++ b/hack/typing/typing_dependent_type.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/typing/typing_dynamic_yield.ml
+++ b/hack/typing/typing_dynamic_yield.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/typing/typing_enum.ml
+++ b/hack/typing/typing_enum.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/typing/typing_env.ml
+++ b/hack/typing/typing_env.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/typing/typing_env.mli
+++ b/hack/typing/typing_env.mli
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/typing/typing_expand.ml
+++ b/hack/typing/typing_expand.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/typing/typing_expand.mli
+++ b/hack/typing/typing_expand.mli
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/typing/typing_extends.ml
+++ b/hack/typing/typing_extends.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/typing/typing_extends.mli
+++ b/hack/typing/typing_extends.mli
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/typing/typing_exts.ml
+++ b/hack/typing/typing_exts.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/typing/typing_generic.ml
+++ b/hack/typing/typing_generic.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/typing/typing_heap.ml
+++ b/hack/typing/typing_heap.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/typing/typing_heap.mli
+++ b/hack/typing/typing_heap.mli
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/typing/typing_hint.ml
+++ b/hack/typing/typing_hint.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/typing/typing_hooks.ml
+++ b/hack/typing/typing_hooks.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/typing/typing_inherit.ml
+++ b/hack/typing/typing_inherit.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/typing/typing_inherit.mli
+++ b/hack/typing/typing_inherit.mli
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/typing/typing_instantiate.ml
+++ b/hack/typing/typing_instantiate.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/typing/typing_instantiate.mli
+++ b/hack/typing/typing_instantiate.mli
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/typing/typing_lenv.ml
+++ b/hack/typing/typing_lenv.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/typing/typing_ops.ml
+++ b/hack/typing/typing_ops.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/typing/typing_phase.ml
+++ b/hack/typing/typing_phase.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/typing/typing_print.ml
+++ b/hack/typing/typing_print.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/typing/typing_print.mli
+++ b/hack/typing/typing_print.mli
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/typing/typing_reason.ml
+++ b/hack/typing/typing_reason.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/typing/typing_redecl_service.ml
+++ b/hack/typing/typing_redecl_service.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/typing/typing_redecl_service.mli
+++ b/hack/typing/typing_redecl_service.mli
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/typing/typing_sequencing.ml
+++ b/hack/typing/typing_sequencing.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/typing/typing_shapes.ml
+++ b/hack/typing/typing_shapes.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/typing/typing_structure.ml
+++ b/hack/typing/typing_structure.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/typing/typing_subst.ml
+++ b/hack/typing/typing_subst.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/typing/typing_subtype.ml
+++ b/hack/typing/typing_subtype.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/typing/typing_suggest.ml
+++ b/hack/typing/typing_suggest.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/typing/typing_suggest_service.ml
+++ b/hack/typing/typing_suggest_service.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/typing/typing_taccess.ml
+++ b/hack/typing/typing_taccess.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/typing/typing_taccess.mli
+++ b/hack/typing/typing_taccess.mli
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/typing/typing_tdef.ml
+++ b/hack/typing/typing_tdef.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/typing/typing_unification_env.ml
+++ b/hack/typing/typing_unification_env.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/typing/typing_unify.ml
+++ b/hack/typing/typing_unify.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/typing/typing_utils.ml
+++ b/hack/typing/typing_utils.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/typing/typing_variance.ml
+++ b/hack/typing/typing_variance.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/typing/typing_visibility.ml
+++ b/hack/typing/typing_visibility.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/typing/typing_visibility.mli
+++ b/hack/typing/typing_visibility.mli
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/utils/build_id.ml
+++ b/hack/utils/build_id.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/utils/config_file.ml
+++ b/hack/utils/config_file.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/utils/core.ml
+++ b/hack/utils/core.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/utils/daemon.ml
+++ b/hack/utils/daemon.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/utils/daemon.mli
+++ b/hack/utils/daemon.mli
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/utils/errors.ml
+++ b/hack/utils/errors.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/utils/errors.mli
+++ b/hack/utils/errors.mli
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/utils/exit_status.ml
+++ b/hack/utils/exit_status.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/utils/file_pos.ml
+++ b/hack/utils/file_pos.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/utils/file_pos.mli
+++ b/hack/utils/file_pos.mli
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/utils/files.c
+++ b/hack/utils/files.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/utils/findUtils.ml
+++ b/hack/utils/findUtils.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/utils/findUtils.mli
+++ b/hack/utils/findUtils.mli
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/utils/fork.ml
+++ b/hack/utils/fork.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/utils/handle.ml
+++ b/hack/utils/handle.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/utils/handle_stubs.c
+++ b/hack/utils/handle_stubs.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/utils/hh_json.ml
+++ b/hack/utils/hh_json.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/utils/hh_json.mli
+++ b/hack/utils/hh_json.mli
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/utils/hh_logger.ml
+++ b/hack/utils/hh_logger.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/utils/ident.ml
+++ b/hack/utils/ident.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/utils/lint.ml
+++ b/hack/utils/lint.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/utils/lint.mli
+++ b/hack/utils/lint.mli
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/utils/lock.ml
+++ b/hack/utils/lock.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/utils/marshal_tools.ml
+++ b/hack/utils/marshal_tools.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/utils/marshal_tools.mli
+++ b/hack/utils/marshal_tools.mli
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/utils/marshal_tools_test.ml
+++ b/hack/utils/marshal_tools_test.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/utils/path.ml
+++ b/hack/utils/path.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/utils/path.mli
+++ b/hack/utils/path.mli
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/utils/php_escaping.ml
+++ b/hack/utils/php_escaping.ml
@@ -1,5 +1,5 @@
 (*
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/utils/pidLog.ml
+++ b/hack/utils/pidLog.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/utils/pos.ml
+++ b/hack/utils/pos.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/utils/pos.mli
+++ b/hack/utils/pos.mli
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/utils/printSignal.ml
+++ b/hack/utils/printSignal.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/utils/priorities.c
+++ b/hack/utils/priorities.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/utils/random_id.ml
+++ b/hack/utils/random_id.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/utils/regexp_utils.ml
+++ b/hack/utils/regexp_utils.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/utils/relative_path.ml
+++ b/hack/utils/relative_path.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/utils/relative_path.mli
+++ b/hack/utils/relative_path.mli
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/utils/stats.ml
+++ b/hack/utils/stats.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/utils/sys_utils.ml
+++ b/hack/utils/sys_utils.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/utils/sysinfo.c
+++ b/hack/utils/sysinfo.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/utils/tail.ml
+++ b/hack/utils/tail.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/utils/tail.mli
+++ b/hack/utils/tail.mli
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/utils/timeout.ml
+++ b/hack/utils/timeout.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/utils/timeout.mli
+++ b/hack/utils/timeout.mli
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/utils/tmp.ml
+++ b/hack/utils/tmp.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/utils/trie.ml
+++ b/hack/utils/trie.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/utils/tty.ml
+++ b/hack/utils/tty.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/utils/tty.mli
+++ b/hack/utils/tty.mli
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/utils/utils.ml
+++ b/hack/utils/utils.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/utils/win32_support.c
+++ b/hack/utils/win32_support.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/utils/wwwroot.ml
+++ b/hack/utils/wwwroot.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/watchman/watchman.ml
+++ b/hack/watchman/watchman.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/hack/watchman/watchman.mli
+++ b/hack/watchman/watchman.mli
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/scripts/gen_build_id.ml
+++ b/scripts/gen_build_id.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/scripts/gen_index.ml
+++ b/scripts/gen_index.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/scripts/utils.ml
+++ b/scripts/utils.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/commands/astCommand.ml
+++ b/src/commands/astCommand.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/commands/commandConnect.ml
+++ b/src/commands/commandConnect.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/commands/commandConnectSimple.ml
+++ b/src/commands/commandConnectSimple.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/commands/commandConnectSimple.mli
+++ b/src/commands/commandConnectSimple.mli
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/commands/commandInfo.ml
+++ b/src/commands/commandInfo.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/commands/commandSpec.ml
+++ b/src/commands/commandSpec.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/commands/commandSpec.mli
+++ b/src/commands/commandSpec.mli
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/commands/coverageCommand.ml
+++ b/src/commands/coverageCommand.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/commands/dumpTypesCommand.ml
+++ b/src/commands/dumpTypesCommand.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/commands/shellCompleteCommand.ml
+++ b/src/commands/shellCompleteCommand.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/commands/versionCommand.ml
+++ b/src/commands/versionCommand.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/common/flow_logger.ml
+++ b/src/common/flow_logger.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/common/options.ml
+++ b/src/common/options.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/common/semver.ml
+++ b/src/common/semver.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/common/semver.mli
+++ b/src/common/semver.mli
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/common/utils_js.ml
+++ b/src/common/utils_js.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/parser/test/hardcoded_test_runner.ml
+++ b/src/parser/test/hardcoded_test_runner.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/parser/test/run_hardcoded_tests.ml
+++ b/src/parser/test/run_hardcoded_tests.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/parsing/docblock.ml
+++ b/src/parsing/docblock.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/server/serverUtils.ml
+++ b/src/server/serverUtils.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/typing/debug_js.ml
+++ b/src/typing/debug_js.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/typing/debug_js.mli
+++ b/src/typing/debug_js.mli
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/typing/gc_js.ml
+++ b/src/typing/gc_js.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/typing/gc_js.mli
+++ b/src/typing/gc_js.mli
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/typing/trace.ml
+++ b/src/typing/trace.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/typing/trace.mli
+++ b/src/typing/trace.mli
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/typing/type_normalizer.ml
+++ b/src/typing/type_normalizer.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/typing/type_normalizer.mli
+++ b/src/typing/type_normalizer.mli
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/typing/type_printer.ml
+++ b/src/typing/type_printer.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/typing/type_printer.mli
+++ b/src/typing/type_printer.mli
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/typing/type_visitor.ml
+++ b/src/typing/type_visitor.ml
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/typing/type_visitor.mli
+++ b/src/typing/type_visitor.mli
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2015, Facebook, Inc.
+ * Copyright (c) 2016, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the


### PR DESCRIPTION
@mroch - Did a find all and replace of `Copyright (c) 2015` to `Copyright (c) 2016`. Also my linter appears to have added an empty new line at EOF if it was missing and it also trimmed trailing white space. :)