### PR TITLE
TLSSocket extends Socket

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -990,23 +990,17 @@ declare module "string_decoder" {
   // TODO
 }
 
-declare class tls$TLSSocket {
-  constructor(socket: typeof net$Socket, options?: Object): void;
-  address(): net$Socket$address;
+declare class tls$TLSSocket extends net$Socket {
+  constructor(socket: net$Socket, options?: Object): void;
   authorized: boolean;
-  authorizationError?: string;
-  static encrypted: boolean;
-  getCiphier(): Object;
-  getEphemeralKeyInfo(): Object;
-  getPeerCertificate(detailed?: boolean): Object;
-  getSession(): Buffer;
-  getTLSTicket(): Buffer;
-  localAddress: string;
-  localPort: number;
-  remoteAddress: string;
-  remoteFamily: string;
-  remotePort: number;
-  renegotiate(options: Object, callback: Function): void;
+  authorizationError: string | null;
+  encrypted: true;
+  getCipher(): { name: string, version: string } | null;
+  getEphemeralKeyInfo(): { type: 'DH', size: number } | { type: 'EDHC', name: string, size: number } | null;
+  getPeerCertificate(detailed?: boolean): Object | null;
+  getSession(): ?Buffer;
+  getTLSTicket(): Buffer | void;
+  renegotiate(options: Object, callback: Function): boolean | void;
   setMaxSendFragment(size: number): boolean;
 }
 


### PR DESCRIPTION
also fixed some of the other annotations based on their actual implementations, since the docs don't have typed signatures:

https://github.com/nodejs/node/blob/5f76b24e5ee440b7c2d2bdc74a9bb94374df9f2a/lib/_tls_wrap.js
https://github.com/nodejs/node/blob/4f875747645099a0127299cf38c149f85e764816/src/node_crypto.cc