### PR TITLE
Missing DOM Events

### DIFF
--- a/lib/cssom.js
+++ b/lib/cssom.js
@@ -358,3 +358,9 @@ declare class CSSStyleDeclaration {
   setProperty(property: string, value: ?string, priority: ?string): void;
   setPropertyPriority(property: string, priority: string): void;
 }
+
+declare class TransitionEvent extends Event {
+  elapsedTime: number; // readonly
+  pseudoElement: string; // readonly
+  propertyName: string; // readonly
+}

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -112,6 +112,13 @@ declare class MouseEvent extends UIEvent {
     getModifierState(keyArg: string): boolean;
 }
 
+declare class WheelEvent extends MouseEvent {
+    deltaX: number; // readonly
+    deltaY: number; // readonly
+    deltaZ: number; // readonly
+    deltaMode: number; // readonly
+}
+
 declare class ProgressEvent extends Event {
     lengthComputable: boolean;
     loaded: number;

--- a/tests/dom/dom.exp
+++ b/tests/dom/dom.exp
@@ -3,13 +3,13 @@ CanvasRenderingContext2D.js:11:5,24: call of method `moveTo`
 Error:
 CanvasRenderingContext2D.js:11:16,18: string
 This type is incompatible with
-[LIB] dom.js:698:15,20: number
+[LIB] dom.js:705:15,20: number
 
 CanvasRenderingContext2D.js:11:5,24: call of method `moveTo`
 Error:
 CanvasRenderingContext2D.js:11:21,23: string
 This type is incompatible with
-[LIB] dom.js:698:26,31: number
+[LIB] dom.js:705:26,31: number
 
 eventtarget.js:9:6,40: call of method `attachEvent`
 Function cannot be called on possibly undefined value

--- a/tests/taint-libs/taint-libs.exp
+++ b/tests/taint-libs/taint-libs.exp
@@ -3,6 +3,6 @@ D2172778-tainted.js:8:7,23: assignment of property `location`
 Error:
 D2172778-tainted.js:8:27,38: taint
 This type is incompatible with
-[LIB] dom.js:325:15,22: Location
+[LIB] dom.js:332:15,22: Location
 
 Found 1 error

--- a/tests/taint/taint.exp
+++ b/tests/taint/taint.exp
@@ -83,7 +83,7 @@ globals.js:6:5,21: assignment of property `location`
 Error:
 globals.js:6:25,25: taint
 This type is incompatible with
-[LIB] dom.js:325:15,22: Location
+[LIB] dom.js:332:15,22: Location
 
 taint2.js:8:5,37: call of method `assign`
 Error:


### PR DESCRIPTION
Adds:
* [TransitionEvent](https://developer.mozilla.org/en-US/docs/Web/API/TransitionEvent)
* [WheelEvent](https://developer.mozilla.org/en-US/docs/Web/API/WheelEvent)

Closes #1257