### PR TITLE
Add missing pageX & pageY properties to MouseEvent

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -104,6 +104,8 @@ declare class MouseEvent extends UIEvent {
     metaKey: boolean;
     movementX: number;
     movementY: number;
+    pageX: number;
+    pageY: number;
     region: ?string;
     screenX: number;
     screenY: number;

--- a/tests/dom/dom.exp
+++ b/tests/dom/dom.exp
@@ -3,13 +3,13 @@ CanvasRenderingContext2D.js:11:5,24: call of method `moveTo`
 Error:
 CanvasRenderingContext2D.js:11:16,18: string
 This type is incompatible with
-[LIB] dom.js:705:15,20: number
+[LIB] dom.js:707:15,20: number
 
 CanvasRenderingContext2D.js:11:5,24: call of method `moveTo`
 Error:
 CanvasRenderingContext2D.js:11:21,23: string
 This type is incompatible with
-[LIB] dom.js:705:26,31: number
+[LIB] dom.js:707:26,31: number
 
 eventtarget.js:9:6,40: call of method `attachEvent`
 Function cannot be called on possibly undefined value

--- a/tests/taint-libs/taint-libs.exp
+++ b/tests/taint-libs/taint-libs.exp
@@ -3,6 +3,6 @@ D2172778-tainted.js:8:7,23: assignment of property `location`
 Error:
 D2172778-tainted.js:8:27,38: taint
 This type is incompatible with
-[LIB] dom.js:332:15,22: Location
+[LIB] dom.js:334:15,22: Location
 
 Found 1 error

--- a/tests/taint/taint.exp
+++ b/tests/taint/taint.exp
@@ -83,7 +83,7 @@ globals.js:6:5,21: assignment of property `location`
 Error:
 globals.js:6:25,25: taint
 This type is incompatible with
-[LIB] dom.js:332:15,22: Location
+[LIB] dom.js:334:15,22: Location
 
 taint2.js:8:5,37: call of method `assign`
 Error:


### PR DESCRIPTION
* [`pageX`](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/pageX)
* [`pageY`](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/pageY)

Implemented by every major browser (and have been for some time) and will be in the spec soon. Closes #1258 