### PR TITLE
adds a missing mandatory step in opam how-to

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ brew install flow
 You can also build and install flow via the OCaml [OPAM](https://opam.ocaml.org) package manager with one command:
 
 ```
+apt-get install libelf-dev # (required for gelf.h)
 opam install flowtype
 ```
 


### PR DESCRIPTION
Otherwise, one gets a dirty:

    # + ocamlopt   -ccopt -DNO_LZ4 -c hack/hhi/hhi_elf.c
    # hack/hhi/hhi_elf.c:26:18: fatal error: gelf.h: No such file or directory
    # compilation terminated.
    # Command exited with code 2. 
    # Makefile:131: recipe for target 'build-flow-native-deps' failed  
    ### stderr ###
    # abort: there is no Mercurial repository here (.hg not found)
    # make: *** [build-flow-native-deps] Error 10