### PR TITLE
Adding refresh to plugin API

### DIFF
--- a/lib/bom.js
+++ b/lib/bom.js
@@ -112,6 +112,7 @@ declare class PluginArray {
     length: number;
     item(index: number): Plugin;
     namedItem(name: string): Plugin;
+    refresh(): void;
     [key: number | string]: Plugin;
 }
 


### PR DESCRIPTION
Plugins are old and slowly-but-surely unsupported technology, but we still need that API for some legacy apps.