### PR TITLE
Fix react-dom/server module name

### DIFF
--- a/lib/react.js
+++ b/lib/react.js
@@ -201,7 +201,7 @@ declare module 'react-dom' {
 
 // TODO: Delete the corresponding method defs from the 'react' module once React
 // 0.15 comes out and removes them.
-declare module 'react-dom-server' {
+declare module 'react-dom/server' {
   declare function renderToString(
     element: ReactElement<any, any, any>
   ): string;


### PR DESCRIPTION
`ReactDOMServer` is found in `react-dom`, it's not its own package.
https://facebook.github.io/react/blog/2015/10/07/react-v0.14.html#major-changes
https://facebook.github.io/react/docs/top-level-api.html#reactdomserver
