### PR TITLE
Fix Object.create definition

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -33,7 +33,7 @@ declare class Object {
     static getPrototypeOf(o: any): any; // compiler magic
     static getOwnPropertyDescriptor(o: any, p: any): any;
     static getOwnPropertyNames(o: any): Array<string>;
-    static create(o: any, properties?: any): any; // compiler magic
+    static create(o?: any, properties?: any): any; // compiler magic
     static defineProperty(o: any, p: any, attributes: any): any;
     static defineProperties(o: any, properties: any): any;
     static seal(o: any): any;


### PR DESCRIPTION
The prototype argument to `Object.create` is nullable, see [spec](http://www.ecma-international.org/ecma-262/6.0/#sec-object.create).