### PR TITLE
Add type definitions for Object.entries and Object.values

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -45,6 +45,8 @@ declare class Object {
     static isExtensible(o: any): boolean;
     static keys(o: any): Array<string>;
     static assign(target: any, ...sources: Array<any>): any;
+    static entries<TKey, TValue>(object: {[key: TKey]: TValue}): Array<[TKey, TValue]>;
+    static values<TKey, TValue>(object: {[key: TKey]: TValue}): Array<TValue>;
     hasOwnProperty(prop: any): boolean;
     propertyIsEnumerable(prop: any): boolean;
     toLocaleString(): string;


### PR DESCRIPTION
Add type definitions for Object.entries and Object.values. See a test here:

http://tryflow.org/#5d9b08200a09cd3b88cae9fc59b5045b