### PR TITLE
add section about mixins for declared classes in docs

### DIFF
--- a/docs/01-declarations.md
+++ b/docs/01-declarations.md
@@ -79,6 +79,24 @@ M.foo(new C());
 No errors!
 ```
 
+### Mixins
+
+Declared classes in interfaces also have the benefit of being able to support mixins. By using the `mixins` keyword, you can declare a class which mixes in other classes and their fields and methods.
+
+{% highlight javascript linenos=table %}
+class A {
+  x: string;
+}
+declare class B {
+  y: string;
+}
+declare class C mixins A, B {
+  z: string;
+}
+{% endhighlight %}
+
+Classes mixed in to a declared class may be concrete or declarations. This feature can be thought of as "implements" for [interfaces](http://www.typescriptlang.org/Handbook#interfaces-class-types) in TypeScript or "with" for [mixins](https://www.dartlang.org/articles/mixins/) in Dart.
+
 ## Paths
 
 A module declaration can also use a string literal to describe the path used to refer to that module in `require` statements.


### PR DESCRIPTION
Related to #833, adds note about mixins for declared classes and adds a note about similarity to TypeScript and Dart.