### PR TITLE
fix mistakes in code examples

### DIFF
--- a/docs/01-typeof.md
+++ b/docs/01-typeof.md
@@ -70,28 +70,24 @@ whether that is a class, module or some other construct.
 {% highlight javascript linenos=table %}
 /* @flow */
 class Foo { }
+class Bar { }
 // b ends up being a Foo type, since f evaluates to Foo
 var b: { f : typeof Foo } = { f : Foo };
-// Since f is Foo, and b is of a Foo type, we can instantiate b as Foo 
-new b.f();
+// Since the type of b.f is typeof Foo (i.e. Class<Foo>), the following 
+// assignment is valid because the type of the new instance is Foo:
+var inst1: Foo = new b.f();
+// However, this fails because the type of the new instance is not Bar:
+var inst2: Bar = new b.f();
 {% endhighlight %}
 
-Let's see an example where we use `typeof` and Flow will catch a typing error:
-
-{% highlight javascript linenos=table %}
-/* @flow */
-class Foo { }
-class Bar { }
-var b: { f : typeof Foo } = { f : Foo };
-var c: { g : typeof Bar } = { g : Bar };
-// b is of type Foo, not of type Bar (g is a Bar )
-new b.g();
-{% endhighlight %}
 
 ```bbcode
-/tmp/flow/f.js:6:5,7: property g
-Property not found in
-  /tmp/flow/f.js:6:5,5: object type
+tmp/flow/f.js:10
+ 10: var inst2: Bar = new b.f();
+                      ^^^^^^^^^ Foo. This type is incompatible with
+ 10: var inst2: Bar = new b.f();
+                ^^^ Bar
+
 
 Found 1 error
 ```


### PR DESCRIPTION
Saying that `b` is type `Foo` or "of type" `Foo` doesn't make any sense, all you can say is that `b` contains a property of type `Class<Foo>`.

Moreover these code samples were clearly intended to demonstrate that the type of `new b.f()` is `Foo` and as such can be assigned to a variable of type `Foo` but can't be assigned to a variable of type `Bar`.  However, they didn't actually demonstrate that at all.  The missing prop error caused by `new b.g()` is irrelevant to this explanation of `typeof`.

I've updated the code and comments to illustrate the effect of `typeof` on instantiating with `new` clearly.