### PR TITLE
Allow leading pipes for type aliases

### DIFF
--- a/src/parser/parser_flow.ml
+++ b/src/parser/parser_flow.ml
@@ -2939,6 +2939,9 @@ end = struct
       let id = Parse.identifier env in
       let typeParameters = Type.type_parameter_declaration env in
       Expect.token env T_ASSIGN;
+      (match Peek.token env with
+      | T_BIT_OR | T_BIT_AND -> Eat.token env
+      | _ -> ());
       let right = Type._type env in
       let end_loc = match Peek.semicolon_loc env with
       | None -> fst right

--- a/src/parser/test/hardcoded_tests.js
+++ b/src/parser/test/hardcoded_tests.js
@@ -941,6 +941,22 @@ module.exports = {
           },
         ],
       },
+   	 'type union = | A | B | C': {
+        'body': [
+          {
+            'type': 'TypeAlias',
+            'id.name': 'union',
+            'right': {
+              'type': 'UnionTypeAnnotation',
+              'types': [
+                {'type': 'GenericTypeAnnotation', 'id.name': 'A'},
+                {'type': 'GenericTypeAnnotation', 'id.name': 'B'},
+                {'type': 'GenericTypeAnnotation', 'id.name': 'C'},
+              ]
+            },
+          },
+        ],
+      },
     },
     'Interfaces': {
       'interface A {}': {


### PR DESCRIPTION
Ocaml allows this on pattern matches and it's convenient for larger unions that span one-per-line.

This adds support for this to the flow parser:

```javascript
type Nodes = 
  | {type: "Identifier", ... }
  | {type: "Expression", ... }
  | {type: "Literal", ... }
  ...
;
```

Note that this adds leading-`|` support for type aliases only for now. We could easily expand to other annotations, but I figured it's most useful for type aliases of large unions -- so might as well start there and leave other things constrained for now. Should be easy to open this up to all annotations in the future if we have a good reason to.