### PR TITLE
Fix refinement keys for string-literal property expressions

### DIFF
--- a/src/typing/refinement.ml
+++ b/src/typing/refinement.ml
@@ -34,8 +34,13 @@ let rec key = Ast.Expression.(function
 
 | _, Member { Member._object;
   (* foo.bar.baz -> Chain [Id baz; Id bar; Id foo] *)
-   property = Member.PropertyIdentifier (_ , { Ast.Identifier.name; _ });
-   _ } -> (
+   property = (
+    Member.PropertyIdentifier (_, { Ast.Identifier.name; _ })
+    | Member.PropertyExpression (_, Ast.Expression.Literal {
+        Ast.Literal.value = Ast.Literal.String name;
+        _;
+      })
+   ); _; } -> (
   match key _object with
   | Some (base, chain) ->
     Some (base, Key.Prop name :: chain)

--- a/tests/refinements/computed_string_literal.js
+++ b/tests/refinements/computed_string_literal.js
@@ -1,0 +1,19 @@
+// @flow
+
+type A = {
+  'b_c': ?string
+};
+
+function stuff(str: string) {}
+
+function testProperty(a: A) {
+  if (a.b_c) {
+    stuff(a.b_c)
+  }
+}
+
+function testLiteralProperty(a: A) {
+  if (a['b_c']) {
+    stuff(a['b_c'])
+  }
+}


### PR DESCRIPTION
String-literal property expressions can be considered the same as identifier properties for the most part.
Here we treat them the same as we do for identifier properties so that behavior like what is described in https://github.com/facebook/flow/issues/1399 remains consistent.