### PR TITLE
Allow `crossOrigin` to be nullable for HTMLImageElement, and HTMLMediaElement.

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -754,7 +754,7 @@ declare class HTMLFormElement extends HTMLElement {
 declare class HTMLImageElement extends HTMLElement {
     alt: string;
     complete: boolean; // readonly
-    crossOrigin: string;
+    crossOrigin: ?string;
     currentSrc: string; // readonly
     height: number;
     isMap: boolean;
@@ -882,7 +882,7 @@ declare class HTMLMediaElement extends HTMLElement {
     src: string;
     srcObject: ?any;
     currentSrc: string;
-    crossOrigin: string;
+    crossOrigin: ?string;
     NETWORK_EMPTY: number;
     NETWORK_IDLE: number;
     NETWORK_LOADING: number;


### PR DESCRIPTION
This pull request updates the definition of the `crossOrigin` property for HTMLImageElement, and HTMLMediaElement, so they are nullable as mentioned in https://github.com/facebook/flow/issues/1117.