### PR TITLE
Add missing backtick in the doc

### DIFF
--- a/website/docs/02-advanced-configuration.md
+++ b/website/docs/02-advanced-configuration.md
@@ -74,7 +74,7 @@ This `[ignore]` section will ignore
 
 1. Any file or directory under a directory named `__tests__`
 2. Any file or directory under `.*/src/foo` or under `.*/src/bar`
-3. Any file that ends with the extension `.ignore.js
+3. Any file that ends with the extension `.ignore.js`
 
 ### `[libs]`
 


### PR DESCRIPTION
Just adding a missing backtick in `website/docs/02-advanced-configuration.md`.