### PR TITLE
Add support for flow prefixes in package.json keys

### DIFF
--- a/src/services/inference/module_js.ml
+++ b/src/services/inference/module_js.ml
@@ -157,12 +157,17 @@ module ReversePackageHeap = SharedMem.WithCache (StringKey) (struct
     let prefix = Prefix.make()
   end)
 
-let get_key key tokens = Ast.(
+let get_key' key tokens = Ast.(
   match SMap.get (spf "\"%s\"" key) tokens with
   | Some (_, Expression.Literal { Literal.value = Literal.String name; _ }) ->
       Some name
   | _ -> None
 )
+
+let get_key key tokens =
+  match get_key' (spf "\"flow:%s\"" key) tokens with
+  | Some x -> Some x
+  | _ -> get_key' (spf "\"%s\"" key) tokens
 
 let get_package_keys filename ast =
   let open Ast in

--- a/tests/declaration_files_incremental_node/node_modules/package_with_dir_flow_main/dir/index.js
+++ b/tests/declaration_files_incremental_node/node_modules/package_with_dir_flow_main/dir/index.js
@@ -1,0 +1,4 @@
+/* @flow */
+
+class Implementation {}
+module.exports.fun = (): Implementation => new Implementation();

--- a/tests/declaration_files_incremental_node/node_modules/package_with_dir_flow_main/dir/index.js.flow.ignored
+++ b/tests/declaration_files_incremental_node/node_modules/package_with_dir_flow_main/dir/index.js.flow.ignored
@@ -1,0 +1,4 @@
+/* @flow */
+
+declare class Definition {}
+declare export var fun: () => Definition;

--- a/tests/declaration_files_incremental_node/node_modules/package_with_dir_flow_main/package.json
+++ b/tests/declaration_files_incremental_node/node_modules/package_with_dir_flow_main/package.json
@@ -1,0 +1,2 @@
+{ "name": "package_with_full_main",
+  "flow:main": "dir" }

--- a/tests/declaration_files_incremental_node/node_modules/package_with_full_flow_main/code.js.flow.ignored
+++ b/tests/declaration_files_incremental_node/node_modules/package_with_full_flow_main/code.js.flow.ignored
@@ -1,0 +1,5 @@
+/* @flow */
+
+declare class Definition {}
+declare var fun: () => Definition;
+declare export { fun };

--- a/tests/declaration_files_incremental_node/node_modules/package_with_full_flow_main/code.js.ignored
+++ b/tests/declaration_files_incremental_node/node_modules/package_with_full_flow_main/code.js.ignored
@@ -1,0 +1,4 @@
+/* @flow */
+
+class Implementation {}
+module.exports.fun = (): Implementation => new Implementation();

--- a/tests/declaration_files_incremental_node/node_modules/package_with_full_flow_main/package.json
+++ b/tests/declaration_files_incremental_node/node_modules/package_with_full_flow_main/package.json
@@ -1,0 +1,2 @@
+{ "name": "package_with_full_main",
+  "flow:main": "./code.js" }

--- a/tests/declaration_files_incremental_node/node_modules/package_with_partial_flow_main/code.js
+++ b/tests/declaration_files_incremental_node/node_modules/package_with_partial_flow_main/code.js
@@ -1,0 +1,4 @@
+/* @flow */
+
+class Implementation {}
+module.exports.fun = (): Implementation => new Implementation();

--- a/tests/declaration_files_incremental_node/node_modules/package_with_partial_flow_main/code.js.flow.ignored
+++ b/tests/declaration_files_incremental_node/node_modules/package_with_partial_flow_main/code.js.flow.ignored
@@ -1,0 +1,2 @@
+declare class Definition {}
+declare export function fun(): Definition;

--- a/tests/declaration_files_incremental_node/node_modules/package_with_partial_flow_main/package.json
+++ b/tests/declaration_files_incremental_node/node_modules/package_with_partial_flow_main/package.json
@@ -1,0 +1,2 @@
+{ "name": "package_with_partial_main",
+  "flow:main": "./code" }

--- a/tests/declaration_files_incremental_node/test.sh
+++ b/tests/declaration_files_incremental_node/test.sh
@@ -8,6 +8,9 @@ ignore_declaration_files() {
   mv node_modules/package_with_full_main/code.js.flow node_modules/package_with_full_main/code.js.flow.ignored
   mv node_modules/package_with_no_package_json/index.js.flow node_modules/package_with_no_package_json/index.js.flow.ignored
   mv node_modules/package_with_partial_main/code.js.flow node_modules/package_with_partial_main/code.js.flow.ignored
+  mv node_modules/package_with_dir_flow_main/dir/index.js.flow node_modules/package_with_dir_flow_main/dir/index.js.flow.ignored
+  mv node_modules/package_with_full_flow_main/code.js.flow node_modules/package_with_full_flow_main/code.js.flow.ignored
+  mv node_modules/package_with_partial_flow_main/code.js.flow node_modules/package_with_partial_flow_main/code.js.flow.ignored
 }
 
 use_declaration_files() {
@@ -17,6 +20,9 @@ use_declaration_files() {
   mv node_modules/package_with_full_main/code.js.flow.ignored node_modules/package_with_full_main/code.js.flow
   mv node_modules/package_with_no_package_json/index.js.flow.ignored node_modules/package_with_no_package_json/index.js.flow
   mv node_modules/package_with_partial_main/code.js.flow.ignored node_modules/package_with_partial_main/code.js.flow
+  mv node_modules/package_with_dir_flow_main/dir/index.js.flow.ignored node_modules/package_with_dir_flow_main/dir/index.js.flow
+  mv node_modules/package_with_full_flow_main/code.js.flow.ignored node_modules/package_with_full_flow_main/code.js.flow
+  mv node_modules/package_with_partial_flow_main/code.js.flow.ignored node_modules/package_with_partial_flow_main/code.js.flow
 }
 
 ignore_implementation_files() {
@@ -26,6 +32,9 @@ ignore_implementation_files() {
   mv node_modules/package_with_full_main/code.js node_modules/package_with_full_main/code.js.ignored
   mv node_modules/package_with_no_package_json/index.js node_modules/package_with_no_package_json/index.js.ignored
   mv node_modules/package_with_partial_main/code.js node_modules/package_with_partial_main/code.js.ignored
+  mv node_modules/package_with_dir_flow_main/dir/index.js node_modules/package_with_dir_flow_main/dir/index.js.ignored
+  mv node_modules/package_with_full_flow_main/code.js node_modules/package_with_full_flow_main/code.js.ignored
+  mv node_modules/package_with_partial_flow_main/code.js node_modules/package_with_partial_flow_main/code.js.ignored
 }
 
 use_implementation_files() {
@@ -35,6 +44,9 @@ use_implementation_files() {
   mv node_modules/package_with_full_main/code.js.ignored node_modules/package_with_full_main/code.js
   mv node_modules/package_with_no_package_json/index.js.ignored node_modules/package_with_no_package_json/index.js
   mv node_modules/package_with_partial_main/code.js.ignored node_modules/package_with_partial_main/code.js
+  mv node_modules/package_with_dir_flow_main/dir/index.js.ignored node_modules/package_with_dir_flow_main/dir/index.js
+  mv node_modules/package_with_full_main/code.js.ignored node_modules/package_with_full_flow_main/code.js
+  mv node_modules/package_with_partial_flow_main/code.js.ignored node_modules/package_with_partial_flow_main/code.js
 }
 
 printf "======Start off with the .js files but without the .flow file======\n"

--- a/tests/declaration_files_incremental_node/test_absolute.js
+++ b/tests/declaration_files_incremental_node/test_absolute.js
@@ -39,3 +39,12 @@ var E = require('package_with_no_package_json');
 
 var F = require('package_with_dir_main');
 (F.fun(): boolean); // Error either Implementation ~> boolean or Declaration ~> boolean
+
+var G = require('package_with_full_flow_main');
+(G.fun(): boolean); // Error either Implementation ~> boolean or Declaration ~> boolean
+
+var H = require('package_with_partial_flow_main');
+(H.fun(): boolean); // Error either Implementation ~> boolean or Declaration ~> boolean
+
+var I = require('package_with_dir_flow_main');
+(I.fun(): boolean); // Error either Implementation ~> boolean or Declaration ~> boolean

--- a/tests/declaration_files_node/node_modules/package_with_dir_flow_main/dir/index.js
+++ b/tests/declaration_files_node/node_modules/package_with_dir_flow_main/dir/index.js
@@ -1,0 +1,3 @@
+/* @flow */
+
+module.exports.fun = (): string => 'hello there!';

--- a/tests/declaration_files_node/node_modules/package_with_dir_flow_main/dir/index.js.flow
+++ b/tests/declaration_files_node/node_modules/package_with_dir_flow_main/dir/index.js.flow
@@ -1,0 +1,3 @@
+/* @flow */
+
+declare export var fun: () => number;

--- a/tests/declaration_files_node/node_modules/package_with_dir_flow_main/package.json
+++ b/tests/declaration_files_node/node_modules/package_with_dir_flow_main/package.json
@@ -1,0 +1,2 @@
+{ "name": "package_with_full_main",
+  "flow:main": "dir" }

--- a/tests/declaration_files_node/node_modules/package_with_full_flow_main/code.js
+++ b/tests/declaration_files_node/node_modules/package_with_full_flow_main/code.js
@@ -1,0 +1,3 @@
+/* @flow */
+
+module.exports.fun = (): string => 'hello there!';

--- a/tests/declaration_files_node/node_modules/package_with_full_flow_main/code.js.flow
+++ b/tests/declaration_files_node/node_modules/package_with_full_flow_main/code.js.flow
@@ -1,0 +1,4 @@
+/* @flow */
+
+declare var fun: () => number;
+declare export { fun };

--- a/tests/declaration_files_node/node_modules/package_with_full_flow_main/package.json
+++ b/tests/declaration_files_node/node_modules/package_with_full_flow_main/package.json
@@ -1,0 +1,2 @@
+{ "name": "package_with_full_main",
+  "flow:main": "./code.js" }

--- a/tests/declaration_files_node/node_modules/package_with_partial_flow_main/code.js
+++ b/tests/declaration_files_node/node_modules/package_with_partial_flow_main/code.js
@@ -1,0 +1,3 @@
+/* @flow */
+
+module.exports.fun = (): string => 'hello there!';

--- a/tests/declaration_files_node/node_modules/package_with_partial_flow_main/code.js.flow
+++ b/tests/declaration_files_node/node_modules/package_with_partial_flow_main/code.js.flow
@@ -1,0 +1,1 @@
+declare export function fun(): number;

--- a/tests/declaration_files_node/node_modules/package_with_partial_flow_main/package.json
+++ b/tests/declaration_files_node/node_modules/package_with_partial_flow_main/package.json
@@ -1,0 +1,2 @@
+{ "name": "package_with_partial_main",
+  "flow:main": "./code" }

--- a/tests/declaration_files_node/test_absolute.js
+++ b/tests/declaration_files_node/test_absolute.js
@@ -19,3 +19,12 @@ var E = require('package_with_no_package_json');
 
 var F = require('package_with_dir_main');
 (F.fun(): string); // Error number ~> string
+
+var G = require('package_with_full_flow_main');
+(C.fun(): string); // Error number ~> string
+
+var H = require('package_with_partial_flow_main');
+(D.fun(): string); // Error number ~> string
+
+var I = require('package_with_dir_flow_main');
+(F.fun(): string); // Error number ~> string


### PR DESCRIPTION
![WIP](https://img.buzzfeed.com/buzzfeed-static/static/2014-10/26/6/enhanced/webdr08/enhanced-14836-1414320930-8.jpg)

This PR allows you to prefix keys in `package.json` with `flow:`. This is useful as you can trivially get type checking on a Flow project published to npm by just including the `src` directory and adding a `flow:main` field.

This is different to Flow comments as it preserves the original source and is different to the `.flow` extension as it doesn't require any convoluted build system commands.

Completely understand if you'd rather just have `.flow` so feel free to close but I think `flow:main` makes things substantially easier.