### PR TITLE
Fix singleton print

### DIFF
--- a/src/typing/type_printer.ml
+++ b/src/typing/type_printer.ml
@@ -256,6 +256,9 @@ let rec is_printed_type_parsable_impl weak cx enclosure = function
   | BoolT _
   | AnyT _
   | NullT _
+  | SingletonStrT _
+  | SingletonNumT _
+  | SingletonBoolT _
     ->
       true
 

--- a/tests/type-at-pos/test.js
+++ b/tests/type-at-pos/test.js
@@ -6,3 +6,9 @@ str
 
 type Point = [number, string];
 const x:Point = [1, "foo"];
+type MyStr = "cool";
+const y:MyStr = "cool";
+type MyBool = true;
+const z:MyBool = true;
+type MyNum = 42;
+const w:MyNum = 42;

--- a/tests/type-at-pos/test.sh
+++ b/tests/type-at-pos/test.sh
@@ -3,6 +3,9 @@ FLOW=$1
 $FLOW type-at-pos test.js 5 1 --strip-root --json
 $FLOW type-at-pos test.js 5 1 --strip-root --raw
 $FLOW type-at-pos test.js 8 7 --strip-root --json
+$FLOW type-at-pos test.js 10 7 --strip-root --json
+$FLOW type-at-pos test.js 12 7 --strip-root --json
+$FLOW type-at-pos test.js 14 7 --strip-root --json
 $FLOW type-at-pos generics.js 5 1 --strip-root --json
 $FLOW type-at-pos generics.js 10 1 --strip-root --json
 $FLOW type-at-pos generics.js 14 1 --strip-root --json

--- a/tests/type-at-pos/type-at-pos.exp
+++ b/tests/type-at-pos/type-at-pos.exp
@@ -1,6 +1,9 @@
 {"type":"number","reasons":[{"desc":"number","path":"test.js","line":5,"endline":5,"start":1,"end":3}],"path":"test.js","line":5,"endline":5,"start":1,"end":3}
 {"raw_type":"{\n  \"reason\":{\n    \"pos\":{\"file\":\"\",\"start\":{\"line\":0,\"col\":0},\"end\":{\"line\":0,\"col\":0}},\n    \"desc\":\"number\"\n  },\n  \"kind\":\"NumT\"\n}","type":"number","reasons":[{"desc":"number","path":"test.js","line":5,"endline":5,"start":1,"end":3}],"path":"test.js","line":5,"endline":5,"start":1,"end":3}
 {"type":"[number, string]","reasons":[],"path":"test.js","line":8,"endline":8,"start":7,"end":13}
+{"type":"'cool'","reasons":[],"path":"test.js","line":10,"endline":10,"start":7,"end":13}
+{"type":"true","reasons":[],"path":"test.js","line":12,"endline":12,"start":7,"end":14}
+{"type":"42","reasons":[],"path":"test.js","line":14,"endline":14,"start":7,"end":13}
 {"type":"C<number>","reasons":[],"path":"generics.js","line":5,"endline":5,"start":1,"end":2}
 {"type":"C<number>","reasons":[],"path":"generics.js","line":10,"endline":10,"start":1,"end":2}
 {"type":"E<number>","reasons":[],"path":"generics.js","line":14,"endline":14,"start":1,"end":2}


### PR DESCRIPTION
The type printer already has logic to print these types, but the
`is_printed_type_parseable` fn didn't seem to know that. This fixes #1440, and
now singleton strings, numbers, and bools don't foul up `type-at-pos`
reporting.
