### PR TITLE
Allow trailing commas in type parameter lists

### DIFF
--- a/src/parser/parser_flow.ml
+++ b/src/parser/parser_flow.ml
@@ -678,7 +678,9 @@ end = struct
         | T_GREATER_THAN -> List.rev acc
         | _ ->
           Expect.token env T_COMMA;
-          params env acc
+          if Peek.token env = T_GREATER_THAN
+          then List.rev acc
+          else params env acc
       )
       in fun env ->
           let start_loc = Peek.loc env in

--- a/src/parser/test/hardcoded_tests.js
+++ b/src/parser/test/hardcoded_tests.js
@@ -782,6 +782,12 @@ module.exports = {
       },
       'var a: (number: any, void: any, string: any, any: any, type: any, static: any) => any;': {},
       'var a: {[type: any]: any}': {},
+      'type foo<A,B,> = bar;': {
+        'body.0.typeParameters.params': [
+          {'type': 'Identifier', 'name': 'A'},
+          {'type': 'Identifier', 'name': 'B'},
+        ]
+      },
     },
     'Tuples': {
       'var a : [] = [];': {


### PR DESCRIPTION
Makes this work:

```
type foo<
  A,
  B,
> = bar;
```