### PR TITLE
Allow more trailing commas in type parameter lists.

### DIFF
--- a/src/parser/parser_flow.ml
+++ b/src/parser/parser_flow.ml
@@ -705,7 +705,9 @@ end = struct
         | T_GREATER_THAN -> List.rev acc
         | _ ->
           Expect.token env T_COMMA;
-          params env acc
+          if Peek.token env = T_GREATER_THAN
+          then List.rev acc
+          else params env acc
 
       in fun env ->
           let start_loc = Peek.loc env in

--- a/src/parser/test/hardcoded_tests.js
+++ b/src/parser/test/hardcoded_tests.js
@@ -788,6 +788,28 @@ module.exports = {
           {'type': 'Identifier', 'name': 'B'},
         ]
       },
+      'class Foo<A,B,> extends Bar<C,D,> {}': {
+        'body.0.typeParameters.params': [
+          { 'type': 'Identifier', 'name': 'A' },
+          { 'type': 'Identifier', 'name': 'B' },
+        ],
+        'body.0.superTypeParameters.params': [
+          { 'type': 'GenericTypeAnnotation', 'id.name': 'C' },
+          { 'type': 'GenericTypeAnnotation', 'id.name': 'D' },
+        ],
+      },
+      'interface Foo<A,B,> {}': {
+        'body.0.typeParameters.params': [
+          {'type': 'Identifier', 'name': 'A'},
+          {'type': 'Identifier', 'name': 'B'},
+        ]
+      },
+      'function f<A,B,>() {}': {
+        'body.0.typeParameters.params': [
+          {'type': 'Identifier', 'name': 'A'},
+          {'type': 'Identifier', 'name': 'B'},
+        ]
+      },
     },
     'Tuples': {
       'var a : [] = [];': {


### PR DESCRIPTION
With 39c156b9aacbd9593e6cc3d1ad11df12f188ad8f, we are now allowed to use trailing commas in type parameter lists when declaring our own types, e.g. `type foo<A,B,> = bar`. However, the example below still causes an `Unexpected token` error to be thrown.

```js
// @flow
class Baz { }
class Quux { }
class Bar<K,V> { }

class Foo extends Bar<Baz,Quux,> {
}
```

This pull request essentially just adds the same conditional introduced in 39c156b9aacbd9593e6cc3d1ad11df12f188ad8f to the `type_parameter_instantiation` function which resolves the issue. Please, note that I have no prior experience with the parser code, so in case I am misunderstanding something, just let me know, and I'll do my best to fix it.