### PR TITLE
Adding Error.captureStackTrace

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -316,6 +316,9 @@ declare class Error {
     name: string;
     message: string;
     stack: string;
+
+    // note: v8 only (node/chrome)
+    static captureStackTrace(target: Object, constructor?: Function): void;
 }
 
 declare class EvalError extends Error {

--- a/tests/async/async.exp
+++ b/tests/async/async.exp
@@ -1,13 +1,13 @@
 
 async.js:12:10,10: number
 This type is incompatible with
-[LIB] core.js:445:32,45: union: type application of identifier `Promise` | type parameter `T` of async return
+[LIB] core.js:448:32,45: union: type application of identifier `Promise` | type parameter `T` of async return
 Member 1:
-[LIB] core.js:445:32,41: type application of identifier `Promise`
+[LIB] core.js:448:32,41: type application of identifier `Promise`
 Error:
 async.js:12:10,10: number
 This type is incompatible with
-[LIB] core.js:445:32,41: Promise
+[LIB] core.js:448:32,41: Promise
 Member 2:
 async.js:12:3,11: type parameter `T` of async return
 Error:
@@ -17,13 +17,13 @@ async.js:11:30,33: boolean
 
 async.js:31:10,16: number
 This type is incompatible with
-[LIB] core.js:445:32,45: union: type application of identifier `Promise` | type parameter `T` of async return
+[LIB] core.js:448:32,45: union: type application of identifier `Promise` | type parameter `T` of async return
 Member 1:
-[LIB] core.js:445:32,41: type application of identifier `Promise`
+[LIB] core.js:448:32,41: type application of identifier `Promise`
 Error:
 async.js:31:10,16: number
 This type is incompatible with
-[LIB] core.js:445:32,41: Promise
+[LIB] core.js:448:32,41: Promise
 Member 2:
 async.js:31:3,17: type parameter `T` of async return
 Error:

--- a/tests/core_tests/core_tests.exp
+++ b/tests/core_tests/core_tests.exp
@@ -37,7 +37,7 @@ map.js:29:6,17: call of method `get`
 Error:
 map.js:29:20,26: boolean
 This type is incompatible with
-[LIB] core.js:388:22,25: undefined
+[LIB] core.js:391:22,25: undefined
 
 map.js:30:5,14: call of method `get`
 Error:

--- a/tests/generators/generators.exp
+++ b/tests/generators/generators.exp
@@ -39,7 +39,7 @@ class.js:134:1,44: call of method `next`
 Error:
 class.js:134:42,43: string
 This type is incompatible with
-[LIB] core.js:361:37,40: undefined
+[LIB] core.js:364:37,40: undefined
 
 class.js:137:4,4: number
 This type is incompatible with
@@ -99,7 +99,7 @@ generators.js:95:1,35: call of method `next`
 Error:
 generators.js:95:33,34: string
 This type is incompatible with
-[LIB] core.js:361:37,40: undefined
+[LIB] core.js:364:37,40: undefined
 
 generators.js:101:4,4: number
 This type is incompatible with

--- a/tests/iterable/iterable.exp
+++ b/tests/iterable/iterable.exp
@@ -50,7 +50,7 @@ iterator_result.js:25:16,23: object literal
 
 map.js:13:55,60: string
 This type is incompatible with
-[LIB] core.js:379:28,33: tuple type
+[LIB] core.js:382:28,33: tuple type
 
 set.js:13:28,33: string
 This type is incompatible with

--- a/tests/promises/promises.exp
+++ b/tests/promises/promises.exp
@@ -35,13 +35,13 @@ promise.js:10:1,17:2: call of method `then`
 Error:
 promise.js:11:11,11: number
 This type is incompatible with
-[LIB] core.js:432:25,38: union: type application of identifier `Promise` | type parameter `R` of constructor call
+[LIB] core.js:435:25,38: union: type application of identifier `Promise` | type parameter `R` of constructor call
 Member 1:
-[LIB] core.js:432:25,34: type application of identifier `Promise`
+[LIB] core.js:435:25,34: type application of identifier `Promise`
 Error:
 promise.js:11:11,11: number
 This type is incompatible with
-[LIB] core.js:432:25,34: Promise
+[LIB] core.js:435:25,34: Promise
 Member 2:
 promise.js:10:1,12:2: type parameter `R` of constructor call
 Error:
@@ -53,13 +53,13 @@ promise.js:20:1,26:4: call of method `then`
 Error:
 promise.js:20:42,42: number
 This type is incompatible with
-[LIB] core.js:432:25,38: union: type application of identifier `Promise` | type parameter `R` of constructor call
+[LIB] core.js:435:25,38: union: type application of identifier `Promise` | type parameter `R` of constructor call
 Member 1:
-[LIB] core.js:432:25,34: type application of identifier `Promise`
+[LIB] core.js:435:25,34: type application of identifier `Promise`
 Error:
 promise.js:20:42,42: number
 This type is incompatible with
-[LIB] core.js:432:25,34: Promise
+[LIB] core.js:435:25,34: Promise
 Member 2:
 promise.js:20:1,44: type parameter `R` of constructor call
 Error:
@@ -71,19 +71,19 @@ promise.js:30:11,32:4: constructor call
 Error:
 promise.js:30:11,32:4: Promise
 This type is incompatible with
-[LIB] core.js:432:25,38: union: type application of identifier `Promise` | type parameter `R` of constructor call
+[LIB] core.js:435:25,38: union: type application of identifier `Promise` | type parameter `R` of constructor call
 Member 1:
-[LIB] core.js:432:25,34: type application of identifier `Promise`
+[LIB] core.js:435:25,34: type application of identifier `Promise`
 Error:
 promise.js:31:13,13: number
 This type is incompatible with
-[LIB] core.js:432:25,38: union: type application of identifier `Promise` | type parameter `R` of constructor call
+[LIB] core.js:435:25,38: union: type application of identifier `Promise` | type parameter `R` of constructor call
 Member 1:
-[LIB] core.js:432:25,34: type application of identifier `Promise`
+[LIB] core.js:435:25,34: type application of identifier `Promise`
 Error:
 promise.js:31:13,13: number
 This type is incompatible with
-[LIB] core.js:432:25,34: Promise
+[LIB] core.js:435:25,34: Promise
 Member 2:
 promise.js:30:11,32:4: type parameter `R` of constructor call
 Error:
@@ -101,19 +101,19 @@ promise.js:41:13,43:6: constructor call
 Error:
 promise.js:41:13,43:6: Promise
 This type is incompatible with
-[LIB] core.js:432:25,38: union: type application of identifier `Promise` | type parameter `R` of constructor call
+[LIB] core.js:435:25,38: union: type application of identifier `Promise` | type parameter `R` of constructor call
 Member 1:
-[LIB] core.js:432:25,34: type application of identifier `Promise`
+[LIB] core.js:435:25,34: type application of identifier `Promise`
 Error:
 promise.js:42:15,15: number
 This type is incompatible with
-[LIB] core.js:432:25,38: union: type application of identifier `Promise` | type parameter `R` of constructor call
+[LIB] core.js:435:25,38: union: type application of identifier `Promise` | type parameter `R` of constructor call
 Member 1:
-[LIB] core.js:432:25,34: type application of identifier `Promise`
+[LIB] core.js:435:25,34: type application of identifier `Promise`
 Error:
 promise.js:42:15,15: number
 This type is incompatible with
-[LIB] core.js:432:25,34: Promise
+[LIB] core.js:435:25,34: Promise
 Member 2:
 promise.js:41:13,43:6: type parameter `R` of constructor call
 Error:
@@ -131,13 +131,13 @@ promise.js:51:1,64:2: call of method `then`
 Error:
 promise.js:53:13,14: number
 This type is incompatible with
-[LIB] core.js:432:25,38: union: type application of identifier `Promise` | type parameter `R` of constructor call
+[LIB] core.js:435:25,38: union: type application of identifier `Promise` | type parameter `R` of constructor call
 Member 1:
-[LIB] core.js:432:25,34: type application of identifier `Promise`
+[LIB] core.js:435:25,34: type application of identifier `Promise`
 Error:
 promise.js:53:13,14: number
 This type is incompatible with
-[LIB] core.js:432:25,34: Promise
+[LIB] core.js:435:25,34: Promise
 Member 2:
 promise.js:51:1,57:2: type parameter `R` of constructor call
 Error:
@@ -149,13 +149,13 @@ promise.js:115:1,118:2: call of method `then`
 Error:
 promise.js:115:17,17: number
 This type is incompatible with
-[LIB] core.js:445:32,45: union: type application of identifier `Promise` | type parameter `T` of call of method `resolve`
+[LIB] core.js:448:32,45: union: type application of identifier `Promise` | type parameter `T` of call of method `resolve`
 Member 1:
-[LIB] core.js:445:32,41: type application of identifier `Promise`
+[LIB] core.js:448:32,41: type application of identifier `Promise`
 Error:
 promise.js:115:17,17: number
 This type is incompatible with
-[LIB] core.js:445:32,41: Promise
+[LIB] core.js:448:32,41: Promise
 Member 2:
 promise.js:115:1,18: type parameter `T` of call of method `resolve`
 Error:
@@ -167,19 +167,19 @@ promise.js:121:17,34: call of method `resolve`
 Error:
 promise.js:121:17,34: Promise
 This type is incompatible with
-[LIB] core.js:445:32,45: union: type application of identifier `Promise` | type parameter `T` of call of method `resolve`
+[LIB] core.js:448:32,45: union: type application of identifier `Promise` | type parameter `T` of call of method `resolve`
 Member 1:
-[LIB] core.js:445:32,41: type application of identifier `Promise`
+[LIB] core.js:448:32,41: type application of identifier `Promise`
 Error:
 promise.js:121:33,33: number
 This type is incompatible with
-[LIB] core.js:445:32,45: union: type application of identifier `Promise` | type parameter `T` of call of method `resolve`
+[LIB] core.js:448:32,45: union: type application of identifier `Promise` | type parameter `T` of call of method `resolve`
 Member 1:
-[LIB] core.js:445:32,41: type application of identifier `Promise`
+[LIB] core.js:448:32,41: type application of identifier `Promise`
 Error:
 promise.js:121:33,33: number
 This type is incompatible with
-[LIB] core.js:445:32,41: Promise
+[LIB] core.js:448:32,41: Promise
 Member 2:
 promise.js:121:17,34: type parameter `T` of call of method `resolve`
 Error:
@@ -197,19 +197,19 @@ promise.js:127:33,50: call of method `resolve`
 Error:
 promise.js:127:33,50: Promise
 This type is incompatible with
-[LIB] core.js:445:32,45: union: type application of identifier `Promise` | type parameter `T` of call of method `resolve`
+[LIB] core.js:448:32,45: union: type application of identifier `Promise` | type parameter `T` of call of method `resolve`
 Member 1:
-[LIB] core.js:445:32,41: type application of identifier `Promise`
+[LIB] core.js:448:32,41: type application of identifier `Promise`
 Error:
 promise.js:127:49,49: number
 This type is incompatible with
-[LIB] core.js:445:32,45: union: type application of identifier `Promise` | type parameter `T` of call of method `resolve`
+[LIB] core.js:448:32,45: union: type application of identifier `Promise` | type parameter `T` of call of method `resolve`
 Member 1:
-[LIB] core.js:445:32,41: type application of identifier `Promise`
+[LIB] core.js:448:32,41: type application of identifier `Promise`
 Error:
 promise.js:127:49,49: number
 This type is incompatible with
-[LIB] core.js:445:32,41: Promise
+[LIB] core.js:448:32,41: Promise
 Member 2:
 promise.js:127:33,50: type parameter `T` of call of method `resolve`
 Error:
@@ -227,13 +227,13 @@ promise.js:157:1,162:4: call of method `then`
 Error:
 promise.js:158:32,37: string
 This type is incompatible with
-[LIB] core.js:437:33,46: union: type application of identifier `Promise` | type parameter `U` of call of method `then`
+[LIB] core.js:440:33,46: union: type application of identifier `Promise` | type parameter `U` of call of method `then`
 Member 1:
-[LIB] core.js:437:33,42: type application of identifier `Promise`
+[LIB] core.js:440:33,42: type application of identifier `Promise`
 Error:
 promise.js:158:32,37: string
 This type is incompatible with
-[LIB] core.js:437:33,42: Promise
+[LIB] core.js:440:33,42: Promise
 Member 2:
 promise.js:157:1,158:41: type parameter `U` of call of method `then`
 Error:
@@ -245,9 +245,9 @@ promise.js:166:32,54: call of method `resolve`
 Error:
 promise.js:166:32,54: Promise
 This type is incompatible with
-[LIB] core.js:437:33,46: union: type application of identifier `Promise` | type parameter `U` of call of method `then`
+[LIB] core.js:440:33,46: union: type application of identifier `Promise` | type parameter `U` of call of method `then`
 Member 1:
-[LIB] core.js:437:33,42: type application of identifier `Promise`
+[LIB] core.js:440:33,42: type application of identifier `Promise`
 Error:
 promise.js:166:48,53: string
 This type is incompatible with
@@ -275,19 +275,19 @@ promise.js:174:48,70: call of method `resolve`
 Error:
 promise.js:174:48,70: Promise
 This type is incompatible with
-[LIB] core.js:445:32,45: union: type application of identifier `Promise` | type parameter `T` of call of method `resolve`
+[LIB] core.js:448:32,45: union: type application of identifier `Promise` | type parameter `T` of call of method `resolve`
 Member 1:
-[LIB] core.js:445:32,41: type application of identifier `Promise`
+[LIB] core.js:448:32,41: type application of identifier `Promise`
 Error:
 promise.js:174:64,69: string
 This type is incompatible with
-[LIB] core.js:445:32,45: union: type application of identifier `Promise` | type parameter `T` of call of method `resolve`
+[LIB] core.js:448:32,45: union: type application of identifier `Promise` | type parameter `T` of call of method `resolve`
 Member 1:
-[LIB] core.js:445:32,41: type application of identifier `Promise`
+[LIB] core.js:448:32,41: type application of identifier `Promise`
 Error:
 promise.js:174:64,69: string
 This type is incompatible with
-[LIB] core.js:445:32,41: Promise
+[LIB] core.js:448:32,41: Promise
 Member 2:
 promise.js:174:48,70: type parameter `T` of call of method `resolve`
 Error:
@@ -305,13 +305,13 @@ promise.js:197:1,202:4: call of method `then`
 Error:
 promise.js:198:33,38: string
 This type is incompatible with
-[LIB] core.js:442:34,48: union: ?type application of identifier `Promise` | type parameter `U` of call of method `catch`
+[LIB] core.js:445:34,48: union: ?type application of identifier `Promise` | type parameter `U` of call of method `catch`
 Member 1:
-[LIB] core.js:442:35,44: ?type application of identifier `Promise`
+[LIB] core.js:445:35,44: ?type application of identifier `Promise`
 Error:
 promise.js:198:33,38: string
 This type is incompatible with
-[LIB] core.js:442:35,44: Promise
+[LIB] core.js:445:35,44: Promise
 Member 2:
 promise.js:197:1,198:42: type parameter `U` of call of method `catch`
 Error:
@@ -323,19 +323,19 @@ promise.js:206:33,55: call of method `resolve`
 Error:
 promise.js:206:33,55: Promise
 This type is incompatible with
-[LIB] core.js:442:34,48: union: ?type application of identifier `Promise` | type parameter `U` of call of method `catch`
+[LIB] core.js:445:34,48: union: ?type application of identifier `Promise` | type parameter `U` of call of method `catch`
 Member 1:
-[LIB] core.js:442:35,44: ?type application of identifier `Promise`
+[LIB] core.js:445:35,44: ?type application of identifier `Promise`
 Error:
 promise.js:206:49,54: string
 This type is incompatible with
-[LIB] core.js:445:32,45: union: type application of identifier `Promise` | type parameter `T` of call of method `resolve`
+[LIB] core.js:448:32,45: union: type application of identifier `Promise` | type parameter `T` of call of method `resolve`
 Member 1:
-[LIB] core.js:445:32,41: type application of identifier `Promise`
+[LIB] core.js:448:32,41: type application of identifier `Promise`
 Error:
 promise.js:206:49,54: string
 This type is incompatible with
-[LIB] core.js:445:32,41: Promise
+[LIB] core.js:448:32,41: Promise
 Member 2:
 promise.js:206:33,55: type parameter `T` of call of method `resolve`
 Error:
@@ -353,19 +353,19 @@ promise.js:214:49,71: call of method `resolve`
 Error:
 promise.js:214:49,71: Promise
 This type is incompatible with
-[LIB] core.js:445:32,45: union: type application of identifier `Promise` | type parameter `T` of call of method `resolve`
+[LIB] core.js:448:32,45: union: type application of identifier `Promise` | type parameter `T` of call of method `resolve`
 Member 1:
-[LIB] core.js:445:32,41: type application of identifier `Promise`
+[LIB] core.js:448:32,41: type application of identifier `Promise`
 Error:
 promise.js:214:65,70: string
 This type is incompatible with
-[LIB] core.js:445:32,45: union: type application of identifier `Promise` | type parameter `T` of call of method `resolve`
+[LIB] core.js:448:32,45: union: type application of identifier `Promise` | type parameter `T` of call of method `resolve`
 Member 1:
-[LIB] core.js:445:32,41: type application of identifier `Promise`
+[LIB] core.js:448:32,41: type application of identifier `Promise`
 Error:
 promise.js:214:65,70: string
 This type is incompatible with
-[LIB] core.js:445:32,41: Promise
+[LIB] core.js:448:32,41: Promise
 Member 2:
 promise.js:214:49,71: type parameter `T` of call of method `resolve`
 Error:

--- a/tests/union/union.exp
+++ b/tests/union/union.exp
@@ -3,13 +3,13 @@ issue-198.js:1:9,10:6: call of method `then`
 Error:
 issue-198.js:5:16,28: string
 This type is incompatible with
-[LIB] core.js:437:33,46: union: type application of identifier `Promise` | type parameter `U` of call of method `then`
+[LIB] core.js:440:33,46: union: type application of identifier `Promise` | type parameter `U` of call of method `then`
 Member 1:
-[LIB] core.js:437:33,42: type application of identifier `Promise`
+[LIB] core.js:440:33,42: type application of identifier `Promise`
 Error:
 issue-198.js:5:16,28: string
 This type is incompatible with
-[LIB] core.js:437:33,42: Promise
+[LIB] core.js:440:33,42: Promise
 Member 2:
 issue-198.js:1:9,6:6: type parameter `U` of call of method `then`
 Error:


### PR DESCRIPTION
Slight problem is that this is v8 only, so it makes sense only in Chrome or node.js or similar. Most importantly, it doesn't work in Firefox.