### PR TITLE
Fix typo in builtins doc 'boolean' -> 'string'

### DIFF
--- a/website/docs/ref/builtins.doc.js
+++ b/website/docs/ref/builtins.doc.js
@@ -37,7 +37,7 @@ next: syntax.html
 */
 
 // $ExpectError
-(1 + 1: boolean); // Error: Numbers are not strings
+(1 + 1: string); // Error: Numbers are not strings
 ("Hello, World": string); // OK: Strings are strings
 
 class A {}


### PR DESCRIPTION
Comment does not fit with example
```js
(1 + 1: boolean); // Error: Numbers are not strings
```

Right variants:
```js
(1 + 1: string); // Error: Numbers are not strings
```
```js
(1 + 1: boolean); // Error: Numbers are not booleans
```

I think it should be first of them because boolean examples are below.