### PR TITLE
Fix broken link to React example.

### DIFF
--- a/website/docs/five-simple-examples.doc.js
+++ b/website/docs/five-simple-examples.doc.js
@@ -319,6 +319,6 @@ var res = foo('Hello') + foo(42);
   new project with Flow and use the [offline transform tool](http://devbig687.ash4.facebook.com:8080/docs/running.html#using-the-offline-transform-tool)
   to compile type annotations before publishing. Or you could incrementally
   [try Flow using flow on some existing code](/docs/existing.html). You may also
-  want to check out our much bigger [React example](/docs/react-example.html) to
+  want to check out our much bigger [React example](/docs/react.html) to
   see Flow in more representative use cases.
 */


### PR DESCRIPTION
This pull request updates the broken link to the React example in the documentation. It might be worthwhile to run [html-proofer](https://github.com/gjtorikian/html-proofer) on Travis builds to avoid broken links in the documentation in the future. I am more than happy to take a look at it if it sounds useful.

Fixes #1494.