### PR TITLE
Add `getSelection` method to Document class and add Selection class

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -327,6 +327,7 @@ declare class Document extends Node {
     xmlVersion: string;
 
     registerElement(type: string, options?: ElementRegistrationOptions): any;
+    getSelection(): Selection | null;
 
     // 6.4.6 Focus management APIs
     activeElement: HTMLElement;
@@ -358,6 +359,30 @@ declare class DocumentFragment extends Node {
     lastElementChild: ?Element;
     querySelector(selector: string): HTMLElement;
     querySelectorAll(selector: string): NodeList<HTMLElement>;
+}
+
+declare class Selection {
+    anchorNode: Node;
+    anchorOffset: number;
+    focusNode: Node;
+    focusOffset: number;
+    isCollapsed: boolean;
+    rangeCount: number;
+    addRange(range: Range): void;
+    getRangeAt(index: number): Range;
+    removeRange(range: Range): void;
+    removeAllRanges(): void;
+    collapse(parentNode: Node, offset: number): void;
+    collapseToStart(): void;
+    collapseToEnd(): void;
+    containsNode(aNode: Node, aPartlyContained: boolean): boolean;
+    deleteFromDocument(): void;
+    extend(parentNode: Node, offset: number): void;
+    empty(): void;
+    selectAllChildren(parentNode: Node): void;
+    setPosition(aNode: Node, offset: number): void;
+    setBaseAndExtent(anchorNode: Node, anchorOffset: number, focusNode: Node, focusOffset: number): void;
+    toString(): string;
 }
 
 declare class Range { // extension


### PR DESCRIPTION
Fixes #1487
Used the following resources to complete the task:
http://w3c.github.io/selection-api/#idl-def-Selection
https://developer.mozilla.org/en-US/docs/Web/API/Selection
https://developer.mozilla.org/en-US/docs/Web/API/Window/getSelection

Used the Range method as reference.
https://dom.spec.whatwg.org/#range