### PR TITLE
Move "Edit on Github" link out of the <h1>

### DIFF
--- a/website/_layouts/docs.html
+++ b/website/_layouts/docs.html
@@ -9,9 +9,9 @@ sectionid: docs
 {% include nav_docs.html %}
 
 <article class='withtoc'>
+    <a class="edit-page-link" href="https://github.com/facebook/flow/tree/master/website/{{ page.path }}" target="_blank">Edit on GitHub</a>
     <h1>
       {{ page.title }}
-      <a class="edit-page-link" href="https://github.com/facebook/flow/tree/master/website/{{ page.path }}" target="_blank">Edit on GitHub</a>
     </h1>
     <p>{{ page.description }}</p>
 

--- a/website/_layouts/post.html
+++ b/website/_layouts/post.html
@@ -11,9 +11,9 @@ sectionid: blog
 {% include nav_blog.html %}
 
 <article class='withtoc'>
+    <a class="edit-page-link" href="https://github.com/facebook/flow/tree/gh-pages/{{ page.path }}" target="_blank">Edit on GitHub</a>
     <h1>
       {{ page.title }}
-      <a class="edit-page-link" href="https://github.com/facebook/flow/tree/gh-pages/{{ page.path }}" target="_blank">Edit on GitHub</a>
     </h1>
     <p class="meta">{{ page.date | date: "%B %e, %Y" }} by {{ author.display_name }}</p>
 

--- a/website/static/flow.css
+++ b/website/static/flow.css
@@ -34,6 +34,7 @@ td {
     vertical-align: top;
 }
 
+.edit-page-link + h1,
 h1:first-child, h2:first-child, h3:first-child, h4:first-child {
     margin-top: 0;
 }
@@ -384,8 +385,7 @@ section.content aside .fb-like {
 .edit-page-link {
     float: right;
     font-size: 12px;
-    font-weight: normal;
-    line-height: 20px;
+    margin-top: 13px;
     opacity: 0.6;
     transition: opacity 0.5s;
 }


### PR DESCRIPTION
Algolia uses `<h1>` in order to figure out what the title is. Moving it outside will fix the headers in search. This will take 24h to update as it is crawling the website once a day :)

<img width="695" alt="screen shot 2016-03-07 at 2 23 10 pm" src="https://cloud.githubusercontent.com/assets/197597/13585350/2c218b4a-e470-11e5-9be7-d990a790a0e8.png">
