### PR TITLE
Do not throw in normalize_type_impl for AbstractT.

### DIFF
--- a/src/typing/type_normalizer.ml
+++ b/src/typing/type_normalizer.ml
@@ -258,8 +258,10 @@ let rec normalize_type_impl cx ids t = match t with
   | KeysT (_, t) ->
       KeysT (reason_of_string "key set", normalize_type_impl cx ids t)
 
+  | AbstractT t ->
+      AbstractT (normalize_type_impl cx ids t)
+
   | FunProtoT _
-  | AbstractT _
   | EvalT (_, _, _)
   | ExistsT _
   | ModuleT (_, _)


### PR DESCRIPTION
Autocompletion for react components doesn't work with current master. It happens because `state` field has abstract type.

More concise example where autocompletion doesn't work:

```javascript
class A {
  state: $Abstract<{}>;
}

class B extends A {
  render() {
    this.<cursor here>
  }
}
```