### PR TITLE
Fixing command in getting-started.doc.js

### DIFF
--- a/website/docs/getting-started.doc.js
+++ b/website/docs/getting-started.doc.js
@@ -17,7 +17,7 @@ next: five-simple-examples.html
   ```bash
   $> mkdir -p get_started
   $> cd get_started
-  $> echo '{"name": "get_started", "scripts": {"flow": "flow; [[ $?=0||$?=2 ]]"}}' > package.json
+  $> echo '{"name": "get_started", "scripts": {"flow": "flow; test $? -eq 0 -o $? -eq 2"}}' > package.json
   ```
 
   Next we'll add Flow to our project:


### PR DESCRIPTION
The `npm run-script flow` command was not correct on some systems where the default shell is not bash (e.g. dash on Debian Jessie). The problem was the "[[ ]]" syntax that was replaced with a "test" expression in this fix.