### PR TITLE
add version for module react-dom

### DIFF
--- a/lib/react.js
+++ b/lib/react.js
@@ -239,6 +239,7 @@ declare module 'react-dom' {
   ): React$Component<$DefaultPropsOf<Config>, $PropsOf<Config>, any>;
 
   declare function unmountComponentAtNode(container: any): boolean;
+  declare var version: string;
 }
 
 // TODO: Delete the corresponding method defs from the 'react' module once React


### PR DESCRIPTION
Add a missed var `version: ReactVersion ` for module `react-dom`.
react-dom in react is declared as :
```
  findDOMNode: findDOMNode,
  render: render,
  unmountComponentAtNode: ReactMount.unmountComponentAtNode,
  version: ReactVersion,
```