### PR TITLE
Clarify available array notations

### DIFF
--- a/website/docs/01-arrays.md
+++ b/website/docs/01-arrays.md
@@ -7,8 +7,8 @@ next: classes.html
 ---
 
 Array types are simply instantiations of a special polymorphic Array class:
-the type `Array<T>` describes arrays whose elements are of type `T`. `T[]` can
-be used as a shorthand to annotated arrays.
+the type `Array<T>` describes arrays whose elements are of type `T`.  The
+shorthand syntax `T[]` is equivalent to `Array<T>`.
 
 ## Type Annotating Arrays
 

--- a/website/docs/01-arrays.md
+++ b/website/docs/01-arrays.md
@@ -7,7 +7,8 @@ next: classes.html
 ---
 
 Array types are simply instantiations of a special polymorphic Array class:
-the type `Array<T>` describes arrays whose elements are of type `T`.
+the type `Array<T>` describes arrays whose elements are of type `T`. `T[]` can
+be used as a shorthand to annotated arrays.
 
 ## Type Annotating Arrays
 


### PR DESCRIPTION
Mention the availability of `T[]` to annotated arrays in the docs.

Fixes #1537.