### PR TITLE
allow string in React.createElement

### DIFF
--- a/lib/react.js
+++ b/lib/react.js
@@ -171,7 +171,7 @@ declare module react {
    */
   // TODO: React DOM elements
   declare function createElement<Config>(
-    name: ReactClass<Config>,
+    name: ReactClass<Config>|string,
     config: Config,
     children?: any
   ): React$Element<Config>;

--- a/tests/react/createElementRequiredProp_string.js
+++ b/tests/react/createElementRequiredProp_string.js
@@ -1,0 +1,22 @@
+// @flow
+import React from 'react';
+
+class Bar extends React.Component {
+  props: {
+    test: number,
+  };
+  render() {
+    return (
+      <div>
+        {this.props.test}
+      </div>
+    )
+  }
+}
+
+class Foo extends React.Component {
+  render() {
+    const Cmp = Math.random() < 0.5 ? 'div' : Bar;
+    return (<Cmp/>);
+  }
+}

--- a/tests/react/createElement_string.js
+++ b/tests/react/createElement_string.js
@@ -1,0 +1,11 @@
+// @flow
+import React from 'react';
+
+class Bar extends React.Component {}
+
+class Foo extends React.Component {
+  render() {
+    const Cmp = Math.random() < 0.5 ? 'div' : Bar;
+    return (<Cmp/>);
+  }
+}

--- a/tests/react/react.exp
+++ b/tests/react/react.exp
@@ -1,3 +1,9 @@
+createElementRequiredProp_string.js:5
+  5:   props: {
+              ^ property `test`. Property not found in
+ 20:     return (<Cmp/>);
+                 ^^^^^^ props of React element `Cmp`
+
 import_react.js:7
   7: var b: number = new react.Component(); // Error: ReactComponent ~> number
                      ^^^^^^^^^^^^^^^^^^^^^ constructor call
@@ -95,4 +101,4 @@ proptype_oneOfType.js:23
              ^^^^^^^^^^^^^^^^^^^^^^ string
 
 
-Found 10 errors
+Found 11 errors


### PR DESCRIPTION
Very simple change. It does allow something like this though:
```javascript
render() {
    const Cmp = true ? 'div' : Foo; // Foo is a React Component
    return (<Cmp/>);
  }
```
As JSX is basically React.createElement calls flow should allow strings - just like the documentation says.