### PR TITLE
Using mixed as input to parseInt/parseFloat

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -14,8 +14,8 @@
 declare var NaN: number;
 declare var Infinity: number;
 
-declare function parseInt(string: string, radix?: number): number;
-declare function parseFloat(string: string): number;
+declare function parseInt(string: mixed, radix?: number): number;
+declare function parseFloat(string: mixed): number;
 declare function isNaN(number: mixed): boolean;
 declare function isFinite(number: mixed): boolean;
 declare function decodeURI(encodedURI: string): string;


### PR DESCRIPTION
I needed something like this recently, when I got input that can be number or string. I am using `parseInt` to convert it to integer, but Flow complains, because it wants string as an input.

The MDN documentation says:

> string: The value to parse. If string is not a string, then it is converted to a string (using the ToString abstract operation). Leading whitespace in the string is ignored.