### PR TITLE
include Element.matches

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -429,25 +429,26 @@ declare class Element extends Node {
     tagName: string;
 
     getAttribute(name?: string): string;
-    getAttributeNS(namespaceURI: string, localName: string): string;
     getAttributeNode(name: string): Attr;
     getAttributeNodeNS(namespaceURI: string, localName: string): Attr;
+    getAttributeNS(namespaceURI: string, localName: string): string;
     getBoundingClientRect(): ClientRect;
     getElementsByClassName(names: string): HTMLCollection;
     getElementsByTagName(name: string): HTMLCollection;
     getElementsByTagNameNS(namespaceURI: string, localName: string): NodeList<HTMLElement>;
     hasAttribute(name: string): boolean;
     hasAttributeNS(namespaceURI: string, localName: string): boolean;
-    insertAdjacentHTML(position: string, text: string): void;
     insertAdjacentElement?: (position: ('beforebegin' | 'afterbegin' | 'beforeend' | 'afterend'), node: Node) => void;
+    insertAdjacentHTML(position: string, text: string): void;
+    matches(selector: string): bool;
     removeAttribute(name?: string): void;
-    removeAttributeNS(namespaceURI: string, localName: string): void;
     removeAttributeNode(oldAttr: Attr): Attr;
+    removeAttributeNS(namespaceURI: string, localName: string): void;
     scrollIntoView(top?: boolean): void;
     setAttribute(name?: string, value?: string): void;
-    setAttributeNS(namespaceURI: string, qualifiedName: string, value: string): void;
     setAttributeNode(newAttr: Attr): Attr;
     setAttributeNodeNS(newAttr: Attr): Attr;
+    setAttributeNS(namespaceURI: string, qualifiedName: string, value: string): void;
 
     // from ParentNode interface
     childElementCount: number;

--- a/tests/dom/dom.exp
+++ b/tests/dom/dom.exp
@@ -3,14 +3,14 @@ CanvasRenderingContext2D.js:11
          ^^^^^^^^^^^^^^^^^^^^ call of method `moveTo`
  11:     ctx.moveTo('0', '1');  // error: should be numbers
                     ^^^ string. This type is incompatible with
-number. See: [LIB] dom.js:710
+number. See: [LIB] dom.js:711
 
 CanvasRenderingContext2D.js:11
  11:     ctx.moveTo('0', '1');  // error: should be numbers
          ^^^^^^^^^^^^^^^^^^^^ call of method `moveTo`
  11:     ctx.moveTo('0', '1');  // error: should be numbers
                          ^^^ string. This type is incompatible with
-number. See: [LIB] dom.js:710
+number. See: [LIB] dom.js:711
 
 eventtarget.js:9
   9:     (target.attachEvent('foo', listener): void); // invalid, may be undefined
@@ -29,19 +29,19 @@ path2d.js:9
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call of method `arcTo`
   9:     (path.arcTo(0, 0, 0, 0, 10, '20', 5): void); // invalid
                                      ^^^^ string. This type is incompatible with
-union: number | undefined. See: [LIB] dom.js:585
+union: number | undefined. See: [LIB] dom.js:586
   Member 1:
-  number. See: [LIB] dom.js:585
+  number. See: [LIB] dom.js:586
   Error:
     9:     (path.arcTo(0, 0, 0, 0, 10, '20', 5): void); // invalid
                                        ^^^^ string. This type is incompatible with
-  number. See: [LIB] dom.js:585
+  number. See: [LIB] dom.js:586
   Member 2:
-  undefined. See: [LIB] dom.js:584
+  undefined. See: [LIB] dom.js:585
   Error:
     9:     (path.arcTo(0, 0, 0, 0, 10, '20', 5): void); // invalid
                                        ^^^^ string. This type is incompatible with
-  undefined. See: [LIB] dom.js:584
+  undefined. See: [LIB] dom.js:585
 
 
 Found 5 errors


### PR DESCRIPTION
Include the matches method on the Element Class.
It was implemented as matchesSelector and prefixed versions initially but since more recent Versions it got implemented as specified matches.