### PR TITLE
Fix false negative arising from generics and addition

### DIFF
--- a/src/typing/flow_js.ml
+++ b/src/typing/flow_js.ml
@@ -3450,6 +3450,9 @@ and flow_addition cx trace reason l r u =
      (NumT _ | SingletonNumT _ | BoolT _ | SingletonBoolT _ | NullT _ | VoidT _)) ->
     rec_flow_t cx trace (NumT.why reason, u)
 
+  | (EmptyT _, _)
+  | (_, EmptyT _) -> ()
+
   | (_, _) ->
     let fake_str = StrT.why reason in
     rec_flow_t cx trace (l, fake_str);
@@ -3579,6 +3582,9 @@ and ground_subtype = function
 
   (* Allows call args to propagate  *)
   | (AnyT _, CallT _) -> false
+
+  (* Ensure a+b is mixed if either a or b is mixed *)
+  | (EmptyT _, AdderT _) -> false
 
   | (NumT _, UseT NumT _)
   | (StrT _, UseT StrT _)

--- a/tests/arith/arith.exp
+++ b/tests/arith/arith.exp
@@ -76,6 +76,30 @@ Arith.js:67
  67: str(undefined + "foo"); // error
          ^^^^^^^^^^^^^^^^^ string
 
+generic.js:3
+  3: function f<A,B>(a:A,b:B):A {return a+b} // error: mixed ~> incompatible instantiation
+                                        ^^^ mixed. This type is incompatible with
+  3: function f<A,B>(a:A,b:B):A {return a+b} // error: mixed ~> incompatible instantiation
+     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ some incompatible instantiation of `A`
+
+generic.js:4
+  4: function f<A,B>(a:A,b:B):A {return b+a} // error: mixed ~> incompatible instantiation
+                                        ^^^ mixed. This type is incompatible with
+  4: function f<A,B>(a:A,b:B):A {return b+a} // error: mixed ~> incompatible instantiation
+     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ some incompatible instantiation of `A`
+
+generic.js:5
+  5: function f<A,B>(a:A,b:B):B {return a+b} // error: mixed ~> incompatible instantiation
+                                        ^^^ mixed. This type is incompatible with
+  5: function f<A,B>(a:A,b:B):B {return a+b} // error: mixed ~> incompatible instantiation
+     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ some incompatible instantiation of `B`
+
+generic.js:6
+  6: function f<A,B>(a:A,b:B):B {return b+a} // error: mixed ~> incompatible instantiation
+                                        ^^^ mixed. This type is incompatible with
+  6: function f<A,B>(a:A,b:B):B {return b+a} // error: mixed ~> incompatible instantiation
+     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ some incompatible instantiation of `B`
+
 mult.js:5
   5: num(null * 1);
          ^^^^ null. This type is incompatible with
@@ -179,4 +203,4 @@ relational.js:20
                   ^^^^^^^^^ undefined
 
 
-Found 29 errors
+Found 33 errors

--- a/tests/arith/generic.js
+++ b/tests/arith/generic.js
@@ -1,0 +1,6 @@
+/* @flow */
+
+function f<A,B>(a:A,b:B):A {return a+b} // error: mixed ~> incompatible instantiation
+function f<A,B>(a:A,b:B):A {return b+a} // error: mixed ~> incompatible instantiation
+function f<A,B>(a:A,b:B):B {return a+b} // error: mixed ~> incompatible instantiation
+function f<A,B>(a:A,b:B):B {return b+a} // error: mixed ~> incompatible instantiation


### PR DESCRIPTION
Summary:
This fixes a bad interaction between polymorphic instantiation and the
addition rules. Given generic types A and B and values a:A and b:B, the
expression a+b should always evaluate to `mixed` because we don't know a
or b will be numbers or strings, and thus whether the resulting
expression will be a number or string.

This expectation follows from the existing behavior, but the rule for
ground_subtype that prunes flows with an empty lower bound prevented the
entire addition expression from becoming mixed.

This change allows (EmptyT _, AdderT _) to reach flow_addition and
handles the possible EmptyT internally. This ensures that the addition
expression always gets a lower bound (mixed) which eventually runs into
the empty instantiation of the return annotation.

Fixes #1574 

Test Plan:
added tests