### PR TITLE
[travis] use opam on OS X

### DIFF
--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -1,19 +1,23 @@
 #!/bin/bash -e
 
-case "$TRAVIS_OS_NAME" in
-  osx)
-    printf "Using ocaml %s\n" "$(ocaml -vnum)"
-    ;;
-  linux)
-    export PATH="$HOME/usr/bin:$PATH"
-    eval "$(opam config env)"
-    printf "Using ocaml %s and opam %s\n" "$(ocaml -vnum)" "$(opam --version)"
+TMP=${TMPDIR:-/tmp}
 
+case "$TRAVIS_OS_NAME" in
+  linux)
     # For some reason the Linux containers start killing the tests if too many
     # tests are run in parallel. Luckily we can easily configure that here
     export FLOW_RUNTESTS_PARALLELISM=4
     ;;
 esac
+
+INSTALL_DIR="${TMP%%/}/ocaml-${OCAML_VERSION}_opam-${OPAM_VERSION}"
+export PATH="$INSTALL_DIR/usr/bin:$PATH"
+export OPAMROOT="$INSTALL_DIR/.opam"
+eval "$(opam config env)"
+
+printf "Using ocaml %s from %s\n  and opam %s from %s\n" \
+  "$(ocaml -vnum)" "$(which ocaml)" \
+  "$(opam --version)" "$(which opam)"
 
 printf "travis_fold:start:make\nBuilding flow\n"
 make

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,12 +20,15 @@ matrix:
     - os: osx
       env: OCAML_VERSION=4.02.1 OPAM_VERSION=1.1.1
     - os: osx
+      env: OCAML_VERSION=4.01.0 OPAM_VERSION=1.2.0
+    - os: osx
       env: OCAML_VERSION=4.01.0 OPAM_VERSION=1.1.1
 
 addons:
   apt:
     packages:
     - libelf-dev
+    - aspcud
 
 install: bash -e resources/travis/install_deps.sh
 


### PR DESCRIPTION
homebrew is actually running ocaml 4.02.3, and in the future will likely move to 4.03.

this installs opam on OS X like we do on linux. it also disables the opam 1.1 build on OS X since it's a waste of time; since no package manager on OS X ships with 1.1, there's no reason to test it. and it builds opam/ocaml in a version-specific directory so that future diffs can try to add Travis caching without the installs stepping on each other.