### PR TITLE
Fix parser bug that prevented async class properties

### DIFF
--- a/src/parser/parser_flow.ml
+++ b/src/parser/parser_flow.ml
@@ -2385,7 +2385,10 @@ end = struct
             []
         in
         let static = Expect.maybe env T_STATIC in
-        let async = Peek.token ~i:1 env <> T_LPAREN && Declaration.async env in
+        let async =
+          Peek.token ~i:1 env <> T_LPAREN &&
+          Peek.token ~i:1 env <> T_COLON &&
+          Declaration.async env in
         let generator = Declaration.generator env async in
         match (async, generator, key env) with
         | false, false,

--- a/src/parser/test/hardcoded_tests.js
+++ b/src/parser/test/hardcoded_tests.js
@@ -2715,6 +2715,7 @@ module.exports = {
       'var await = { await }': {},
       'var async = { async }': {},
       'var async = { async : foo }': {},
+      'class async { async: number; }': {},
       'async function f() { var await = { await : async function foo() {} } }':
         {},
       'async function f(async, await) { var x = await async; return x; }': {},


### PR DESCRIPTION
Tested via `make test-ocaml` in the parser directory and `make test` at the top-level.