### PR TITLE
Fix flowconfig parsing crash

### DIFF
--- a/src/common/flowConfig.ml
+++ b/src/common/flowConfig.ml
@@ -591,21 +591,24 @@ let parse_options config lines =
   {config with options}
 
 let parse_version config lines =
-  let ln, version_str = lines
+  let potential_versions = lines
   |> List.map (fun (ln, line) -> ln, String.trim line)
   |> List.filter (fun (_, s) -> s <> "")
-  |> List.hd
   in
 
-  if not (Semver.is_valid_range version_str) then
-    error ln (
-      spf
-        "Expected version to match %%d.%%d.%%d, with an optional leading ^, got %s"
-        version_str
-    );
+  match potential_versions with
+  | (ln, version_str) :: _ ->
+    if not (Semver.is_valid_range version_str) then
+      error ln (
+        spf
+          "Expected version to match %%d.%%d.%%d, with an optional leading ^, got %s"
+          version_str
+      );
 
-  let options = { config.options with Opts.version = Some version_str } in
-  { config with options }
+    let options = { config.options with Opts.version = Some version_str } in
+    { config with options }
+  | _ -> config
+
 
 let parse_section config ((section_ln, section), lines) =
   match section, lines with

--- a/tests/config_version/.flowconfig
+++ b/tests/config_version/.flowconfig
@@ -1,0 +1,1 @@
+[version]

--- a/tests/config_version/config_version.exp
+++ b/tests/config_version/config_version.exp
@@ -1,0 +1,2 @@
+
+Found 0 errors


### PR DESCRIPTION
Before we would get the cryptic error `Fatal error: exception Failure("hd")`

Test plan:
- Added unit test
- Manually checked that it would properly reject if the config contained a different version
- Manually checked that it would run properly if the config contained nothing under [version] or the correct version.