### PR TITLE
[travis] cache opam and ocaml dependencies

### DIFF
--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -1,7 +1,5 @@
 #!/bin/bash -e
 
-TMP=${TMPDIR:-/tmp}
-
 case "$TRAVIS_OS_NAME" in
   linux)
     # For some reason the Linux containers start killing the tests if too many
@@ -10,7 +8,9 @@ case "$TRAVIS_OS_NAME" in
     ;;
 esac
 
-INSTALL_DIR="${TMP%%/}/ocaml-${OCAML_VERSION}_opam-${OPAM_VERSION}"
+PLATFORM=$(uname -s || echo unknown)
+ARCH=$(uname -m || echo unknown)
+INSTALL_DIR="$HOME/.flow_cache/ocaml-${OCAML_VERSION}_opam-${OPAM_VERSION}_${PLATFORM}-${ARCH}"
 export PATH="$INSTALL_DIR/usr/bin:$PATH"
 export OPAMROOT="$INSTALL_DIR/.opam"
 eval "$(opam config env)"

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,10 @@ script: bash -e .travis-ci.sh
 
 before_deploy: bash -e resources/travis/zip_release.sh
 
+cache:
+  directories:
+  - $HOME/.flow_cache
+
 deploy:
 # upload releases to github, from both Mac and Linux
 - provider: releases

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,9 @@ cache:
   directories:
   - $HOME/.flow_cache
 
+before_cache:
+  - rm -rf $HOME/.flow_cache/ocaml-*/.opam/log
+
 deploy:
 # upload releases to github, from both Mac and Linux
 - provider: releases

--- a/resources/travis/install_deps.sh
+++ b/resources/travis/install_deps.sh
@@ -32,22 +32,27 @@ esac
 printf "travis_fold:start:opam_installer\nInstalling ocaml %s and opam %s\n" \
   "$OCAML_VERSION" "$OPAM_VERSION"
 
-INSTALL_DIR="${TMP%%/}/ocaml-${OCAML_VERSION}_opam-${OPAM_VERSION}"
+PLATFORM=$(uname -s || echo unknown)
+ARCH=$(uname -m || echo unknown)
+
+INSTALL_DIR="$HOME/.flow_cache/ocaml-${OCAML_VERSION}_opam-${OPAM_VERSION}_${PLATFORM}-${ARCH}"
 export PREFIX="$INSTALL_DIR/usr"
 export OPAMROOT="$INSTALL_DIR/.opam"
 BINDIR="$PREFIX/bin"
 export PATH="$BINDIR:$PATH"
 
-file="opam-$OPAM_VERSION-$(uname -m || echo unknown)-$(uname -s || echo unknown)"
-
-echo Downloading OPAM...
-getopam "https://github.com/ocaml/opam/releases/download/$OPAM_VERSION" "$file"
-
-mkdir -p "$BINDIR" 2>/dev/null || true
-install -m 755 "$TMP/$file" "$BINDIR/opam"
-rm -f "$TMP/$file"
-
 OPAM="$BINDIR/opam"
+
+if [ -f "$OPAM" ]; then
+  echo "Using existing OPAM..."
+else
+  echo Downloading OPAM...
+  file="opam-$OPAM_VERSION-$ARCH-$PLATFORM"
+  getopam "https://github.com/ocaml/opam/releases/download/$OPAM_VERSION" "$file"
+  mkdir -p "$BINDIR" 2>/dev/null || true
+  install -m 755 "$TMP/$file" "$BINDIR/opam"
+  rm -f "$TMP/$file"
+fi
 
 echo "Initializing OPAM..."
 "$OPAM" init \


### PR DESCRIPTION
saves about 5 min (50%) on the linux builds. caching on open source mac builds isn't supported yet, so we'll have to do our own upload to S3 if we want to cache that.