### PR TITLE
[travis] manually cache Mac builds to S3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,10 @@ env:
   global:
   # GH_BOT_TOKEN (facebook-github-bot-0)
   - secure: I1W8xlf8Ojxkc92n8Rb9AGX7kdCk0DeWEPd6PKRrGQO0FtyCkcvxNo+wp6ApQI7+NqkuFRVngHVOQOd3AqR57IFiSjZ+Cj/BJyg6WOo92olkAAP0OWihmCj53d2xDpp7LaM99srPbZXYE5vSTTKBX/5Soz9UghzsI5Q1ECmV5fU=
-  # S3_ID
-  - secure: 0EVq9e+b8n1tyMJtWNRMbZvrF7Rp72Zi07HU4bsPgL3eM6nTXa0i2KotgI9P3h4TOUhcDrQXT4oJemchjLsH5yMIbaDycfoou2q0ePit03YDLj/iAIkuf8s+coZWgUTGoMp8TtmDsgrhoLOb5DBVL3PpLQ6jSuoppzysl4iOQ50=
-  # S3_SECRET
-  - secure: W59c7k40PEKcCqXjbMHVJcIdKgyHkyyTlprU1zTxNneANXxtPu54Gaz84BfHVgq3SK0G+Eqyr19eZTQ4yhfnZzt0TXgfiyYTmPN5ifLJd1x4C56ndXQmSdhR05To9/k9gLlFXoNxDh6rrP+zq2Zp5KbxHTWrm91a21BUGLqnANY=
+  # AWS_ACCESS_KEY_ID
+  - secure: HMGkDgbay0TcQtiCm5K4F1Y8trtMT5X5S8nRGrTrKBuI4RIEkTQ06VdQVf96gnhe/7IjDQfAUbXWspSmlpWbIKij4BRHOijezU37sooNUkQp4R+EfPpbJECnuv+4WqZI2bMj2i3sw3b8f1oNCFztzHrpxZQ9oOeQbenf/8c2fQs=
+  # AWS_SECRET_ACCESS_KEY
+  - secure: huLKjE7xlxl7HaCLIIVyDaZN9ZsWrR4RcxW+JNUH1F9lM5mbRjAPayawSKRzHViu7u6uUNkjMOJs3lRlWdj8ezH2vnJNm9oNvCOYuSFmBIBELVlXcfbqpX9ZffbJeFiUZ2dOwrDEhm3+WIg6Wr3QbUtVdlMfNvljOJ3CQQc9Yc4=
   # CLOUDFRONT_ID
   - secure: Jr+6c6pF5H0lP4Kt6evlf/xYD/Qjoms3HK7lw1kg8lzwoEXPD3MezgkpOktU8ZBllGolc+ou23h+3hgJwvqi7ANmjzfxyVDdpB7Kiw4y2pEm6tAXYzmatSDb401u7+2sb2H/aSe8yikNrVrizvqaJrDOGeptCBjXQF+a2lNeMC0=
 
@@ -51,9 +51,9 @@ addons:
     - aspcud
 
 install: bash -e resources/travis/install_deps.sh
-
 script: bash -e resources/travis/build.sh
-
+after_success: bash -e resources/travis/after_script.sh
+after_failure: bash -e resources/travis/after_script.sh
 before_deploy: bash -e resources/travis/before_deploy.sh
 
 cache:

--- a/resources/travis/after_script.sh
+++ b/resources/travis/after_script.sh
@@ -1,0 +1,32 @@
+#!/bin/bash -e
+
+if [[ "$TRAVIS_OS_NAME" = "osx" && "$TRAVIS_PULL_REQUEST" = "false" ]]; then
+
+  TMP=${TMPDIR:-/tmp}
+  SLUG_PLATFORM=$(uname -s || echo unknown)
+  ARCH=$(uname -m || echo unknown)
+  SLUG="ocaml-${OCAML_VERSION}_opam-${OPAM_VERSION}_${SLUG_PLATFORM}-${ARCH}"
+  CACHE_ROOT="$HOME/.flow_cache"
+  CACHE_TAR="$TMP/$SLUG.tar"
+  CACHE_TGZ="$CACHE_TAR.gz"
+
+  printf "travis_fold:start:cache.2\nstore build cache\n"
+  CHANGED=0
+  if [ -f "$CACHE_TAR" ]; then
+    tar --update -Pvf "$CACHE_TAR" "$CACHE_ROOT"
+    if ! shasum -c "$CACHE_TAR.sha1" >/dev/null; then
+      gzip "$CACHE_TAR"
+      CHANGED=1
+    fi
+  else
+    tar -Pczf "$CACHE_TGZ" "$CACHE_ROOT"
+    CHANGED=1
+  fi
+  if [ "$CHANGED" -eq 1 ]; then
+    echo "uploading $TRAVIS_BRANCH/$SLUG.tar.gz"
+    aws s3 cp --storage-class REDUCED_REDUNDANCY "$CACHE_TGZ" "s3://ci-cache.flowtype.org/$TRAVIS_BRANCH/$SLUG.tar.gz"
+  else
+    echo "nothing changed, not updating cache"
+  fi
+  printf "travis_fold:end:cache.2\n"
+fi

--- a/website/s3_website.yml
+++ b/website/s3_website.yml
@@ -1,5 +1,5 @@
-s3_id: <%= ENV['S3_ID'] %>
-s3_secret: <%= ENV['S3_SECRET'] %>
+s3_id: <%= ENV['AWS_ACCESS_KEY_ID'] %>
+s3_secret: <%= ENV['AWS_SECRET_ACCESS_KEY'] %>
 s3_bucket: flowtype.org
 
 exclude_from_upload:


### PR DESCRIPTION
Travis doesn't support caching in open-source Mac builds, so we'll do it ourselves.

this does basically what travis's [casher](https://github.com/travis-ci/casher) does; it downloads a tarball from S3, extracts it into the cache directory, runs the build, then updates the tarball with the new contents of the cache directory. if anything changed, it uploads the new tarball back to S3.

this cuts the mac build time by about 10 minutes!