### PR TITLE
[doc] Fix CSSModule example documentation

### DIFF
--- a/website/docs/ref/modules.doc.js
+++ b/website/docs/ref/modules.doc.js
@@ -265,6 +265,7 @@ ES_DefaultExport.default();
   ```
   [options]
   module.name_mapper='^\(.*\)\.css$' -> '<PROJECT_ROOT>/CSSModule.js.flow'
+  module.system=haste
   ```
 
   **NOTE: You do not need to manually substitue anything for


### PR DESCRIPTION
Currently, the documentation is not enough, or not clear.

By following it, I (and I think [I am](http://stackoverflow.com/questions/34921185/required-module-not-found-for-module-that-exists-in-node-modules) [not](https://github.com/facebook/flow/issues/51#issuecomment-143923503) [alone](https://gist.github.com/lambdahands/d19e0da96285b749f0ef)) get a `Required module not found` error for css file references.

Example

```
web_modules/ReactFunction/index.js:4
  4: import styles from "./index.css"
                        ^^^^^^^^^^^^^ ./index.css. Required module not found
```

I just following this gist https://gist.github.com/lambdahands/d19e0da96285b749f0ef#gistcomment-1703455 to find a solution.

I am new to flow so this workaround is probably bad, but I wanted to start a discussion about it, since [no issue is opened about cssmodule](https://github.com/facebook/flow/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+cssmodule).