### PR TITLE
Fix travis by runing Travis linux builds with smaller tables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,6 +107,7 @@ ALL_HEADER_FILES=$(addprefix _build/,$(shell find hack -name '*.h'))
 ################################################################################
 
 CC_FLAGS=-DNO_LZ4
+CC_FLAGS += $(EXTRA_CC_FLAGS)
 CC_OPTS=$(foreach flag, $(CC_FLAGS), -ccopt $(flag))
 INCLUDE_OPTS=$(foreach dir,$(MODULES),-I $(dir))
 LIB_OPTS=$(foreach lib,$(OCAML_LIBRARIES),-lib $(lib))

--- a/resources/travis/build.sh
+++ b/resources/travis/build.sh
@@ -1,10 +1,11 @@
 #!/bin/bash -e
 
+EXTRA_CC_FLAGS=""
 case "$TRAVIS_OS_NAME" in
   linux)
-    # For some reason the Linux containers start killing the tests if too many
-    # tests are run in parallel. Luckily we can easily configure that here
-    export FLOW_RUNTESTS_PARALLELISM=4
+    # The linux containers don't have much memory. Let's compile with 
+    # a smaller heap size
+    EXTRA_CC_FLAGS="EXTRA_CC_FLAGS=-DOSS_SMALL_HH_TABLE_POWS"
     ;;
 esac
 
@@ -20,7 +21,7 @@ printf "Using ocaml %s from %s\n  and opam %s from %s\n" \
   "$(opam --version)" "$(which opam)"
 
 printf "travis_fold:start:make\nBuilding flow\n"
-make
+make $EXTRA_CC_FLAGS
 printf "travis_fold:end:make\n"
 
 printf "travis_fold:start:make_js\nBuilding flow.js\n"


### PR DESCRIPTION
The shared hash table size was recently doubled, which started breaking travis tests on their Linux containers, since they don't have enough memory.

The easiest fix for now is to build the travis linux binaries with smaller tables. This also allows us to run more tests in parallel.

At some point we should probably revisit how large the default table size should be for the open source flow binaries.