### PR TITLE
Correcting fetch's `json()`

### DIFF
--- a/lib/bom.js
+++ b/lib/bom.js
@@ -651,7 +651,7 @@ declare class Response {
     arrayBuffer(): Promise<ArrayBuffer>;
     blob(): Promise<Blob>;
     formData(): Promise<FormData>;
-    json(): Promise<Object>;
+    json(): Promise<any>;
     text(): Promise<string>;
 }
 
@@ -677,7 +677,7 @@ declare class Request {
     arrayBuffer(): Promise<ArrayBuffer>;
     blob(): Promise<Blob>;
     formData(): Promise<FormData>;
-    json(): Promise<Object>;
+    json(): Promise<any>;
     text(): Promise<string>;
 }
 


### PR DESCRIPTION
Fetch's json() should use `Promise<any>`, not `Promise<Object>`, since `any` is what `JSON.parse()` returns, and `json()` just gets text and runs `JSON.parse()` on it.