### PR TITLE
Make flow automatically load libs from `flow-typed`

### DIFF
--- a/src/common/flowConfig.ml
+++ b/src/common/flowConfig.ml
@@ -333,7 +333,7 @@ let parse_includes config lines =
   { config with includes; }
 
 let parse_libs config lines =
-  let libs = trim_lines lines in
+  let libs = "flow-typed" :: (trim_lines lines) in
   { config with libs; }
 
 let parse_ignores config lines =

--- a/tests/libflow-typed/.flowconfig
+++ b/tests/libflow-typed/.flowconfig
@@ -1,0 +1,7 @@
+[ignore]
+
+[include]
+
+[libs]
+
+[options]

--- a/tests/libflow-typed/flow-typed/dino.js
+++ b/tests/libflow-typed/flow-typed/dino.js
@@ -1,0 +1,1 @@
+declare type Dinosaur = "T-Rex" | "Apatosaurus";

--- a/tests/libflow-typed/libflow-typed.exp
+++ b/tests/libflow-typed/libflow-typed.exp
@@ -1,0 +1,8 @@
+libtest.js:1
+  1: const dino : Dinosaur = "Stegosaurus"
+                             ^^^^^^^^^^^^^ string. This type is incompatible with
+  1: const dino : Dinosaur = "Stegosaurus"
+                  ^^^^^^^^ string enum
+
+
+Found 1 error

--- a/tests/libflow-typed/libtest.js
+++ b/tests/libflow-typed/libtest.js
@@ -1,0 +1,1 @@
+const dino : Dinosaur = "Stegosaurus"


### PR DESCRIPTION
We've been organizing an effort over at https://github.com/flowtype/flow-typed to build a repository of 3rd party library definitions.

As part of this effort, @jeffmo and I thought it'd be a good idea to have flow automatically load any definitions from the `flow-typed` folder if it exists.