### PR TITLE
Make MessageEvent inherit from Event

### DIFF
--- a/lib/bom.js
+++ b/lib/bom.js
@@ -236,7 +236,7 @@ declare class WebSocket extends EventTarget {
 declare class Worker extends EventTarget {
     constructor(stringUrl: string): void;
     onerror: (ev: Event) => any;
-    onmessage: (ev: Event) => any;
+    onmessage: (ev: MessageEvent) => any;
     postMessage(message: any, ports?: any): void;
     terminate(): void;
 }

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -186,7 +186,7 @@ declare class ProgressEvent extends Event {
 // http://www.w3.org/TR/2011/WD-websockets-20110419/
 // and
 // http://www.w3.org/TR/2008/WD-html5-20080610/comms.html
-declare class MessageEvent {
+declare class MessageEvent extends Event {
     data: string;
     origin: string;
     lastEventId: string;
@@ -1684,7 +1684,7 @@ declare function getComputedStyle(elt: Element, pseudoElt?: string): any;
 declare var localStorage: Storage;
 declare function focus(): void;
 declare function onfocus(ev: Event): any;
-declare function onmessage(ev: Event): any;
+declare function onmessage(ev: MessageEvent): any;
 declare function open(url?: string, target?: string, features?: string, replace?: boolean): any;
 declare var parent: any;
 declare function print(): void;

--- a/tests/dom/eventtarget.js
+++ b/tests/dom/eventtarget.js
@@ -16,4 +16,11 @@ let tests = [
     (target.detachEvent('foo', listener): void); // invalid, may be undefined
     (target.detachEvent && target.detachEvent('foo', listener): void); // valid
   },
+
+  function() {
+    window.onmessage = (event: MessageEvent) => {
+      invariant(event.target === window);
+      invariant(event.type === 'message');
+    };
+  },
 ];


### PR DESCRIPTION
Also make WebWorker `onmessage` handlers take a `MessageEvent`.

Fixed #1654.