### PR TITLE
Fixing typo in docs/cli.html

### DIFF
--- a/website/docs/04-cli.md
+++ b/website/docs/04-cli.md
@@ -11,7 +11,7 @@ The flow command line tool is made to be easy-to-use for the simple case.
 Just using the command `flow` will type-check your current directory if the `.flowconfig` file is present.
 A flow server will automatically be started if needed.
 
-The CLI tool also provides several other options and commands that allow you to control the server and build tools that integrate with Flow. For example, this is how the [Nuclide](http://nuclide.io) editor integrates with Flow to provide autocompletion, type errors, etc. in it's UI.
+The CLI tool also provides several other options and commands that allow you to control the server and build tools that integrate with Flow. For example, this is how the [Nuclide](http://nuclide.io) editor integrates with Flow to provide autocompletion, type errors, etc. in its UI.
 
 To find out more about the CLI just type:
 


### PR DESCRIPTION
"it's" should be "its".