### PR TITLE
Type parameter defaults

### DIFF
--- a/src/parser/estree_translator.ml
+++ b/src/parser/estree_translator.ml
@@ -1050,6 +1050,7 @@ end with type t = Impl.t) = struct
       "name", string tp.name;
       "bound", option type_annotation tp.bound;
       "variance", option variance tp.variance;
+      "default", option _type tp.default;
     |]
   )
 

--- a/src/parser/lexer_flow.mll
+++ b/src/parser/lexer_flow.mll
@@ -867,6 +867,8 @@ and type_token env = parse
   (* Generics *)
   | "<"                { env, T_LESS_THAN }
   | ">"                { env, T_GREATER_THAN }
+  (* Generic default *)
+  | "="                { env, T_ASSIGN }
   (* Optional or nullable *)
   | "?"                { env, T_PLING }
   (* Existential *)

--- a/src/parser/parse_error.ml
+++ b/src/parser/parse_error.ml
@@ -74,6 +74,7 @@ type t =
   | ExportNamelessClass
   | ExportNamelessFunction
   | UnsupportedDecorator
+  | MissingTypeParamDefault
 
 exception Error of (Loc.t * t) list
 
@@ -167,4 +168,8 @@ module PP =
           you must specify a function name. Did you mean \
           `export default function ...`?"
       | UnsupportedDecorator -> "Found a decorator in an unsupported position."
+      | MissingTypeParamDefault -> "Type parameter declaration needs a default, \
+          since a preceding type parameter declaration has a default."
+
+
   end

--- a/src/parser/parser_flow.ml
+++ b/src/parser/parser_flow.ml
@@ -234,6 +234,7 @@ end = struct
   module Type : sig
     val _type : env -> Ast.Type.t
     val type_parameter_declaration : env -> Ast.Type.ParameterDeclaration.t option
+    val type_parameter_declaration_with_defaults : env -> Ast.Type.ParameterDeclaration.t option
     val type_parameter_instantiation : env -> Ast.Type.ParameterInstantiation.t option
     val generic : env -> Loc.t * Ast.Type.Generic.t
     val _object : ?allow_static:bool -> env -> Loc.t * Type.Object.t
@@ -542,7 +543,7 @@ end = struct
 
     and _function env =
       let start_loc = Peek.loc env in
-      let typeParameters = type_parameter_declaration env in
+      let typeParameters = type_parameter_declaration ~allow_default:false env in
       let rest, params = function_param_list env in
       Expect.token env T_ARROW;
       let returnType = _type env in
@@ -556,7 +557,7 @@ end = struct
 
     and _object =
       let methodish env start_loc =
-        let typeParameters = type_parameter_declaration env in
+        let typeParameters = type_parameter_declaration ~allow_default:false env in
         let rest, params = function_param_list env in
         Expect.token env T_COLON;
         let returnType = _type env in
@@ -674,16 +675,26 @@ end = struct
         })
 
     and type_parameter_declaration =
-      let rec params env acc = Type.ParameterDeclaration.TypeParam.(
+      let rec params env ~allow_default ~require_default acc = Type.ParameterDeclaration.TypeParam.(
         let variance = match Peek.token env with
           | T_PLUS -> Eat.token env; Some Variance.Plus
           | T_MINUS -> Eat.token env; Some Variance.Minus
           | _ -> None in
         let loc, id = Parse.identifier_with_type env Error.StrictParamName in
+        let default, require_default = match allow_default, Peek.token env with
+        | false, _ -> None, false
+        | true, T_ASSIGN -> 
+            Eat.token env;
+            Some (_type env), true
+        | true, _ -> 
+            if require_default
+            then error_at env (loc, Error.MissingTypeParamDefault);
+            None, require_default in
         let param = loc, {
           name = id.Identifier.name;
           bound = id.Identifier.typeAnnotation;
           variance;
+          default;
         } in
         let acc = param::acc in
         match Peek.token env with
@@ -693,16 +704,16 @@ end = struct
           Expect.token env T_COMMA;
           if Peek.token env = T_GREATER_THAN
           then List.rev acc
-          else params env acc
+          else params env ~allow_default ~require_default acc
       )
-      in fun env ->
+      in fun ~allow_default env ->
           let start_loc = Peek.loc env in
           if Peek.token env = T_LESS_THAN
           then begin
             if not (should_parse_types env)
             then error env Error.UnexpectedTypeAnnotation;
             Expect.token env T_LESS_THAN;
-            let params = params env [] in
+            let params = params env ~allow_default ~require_default:false [] in
             let loc = Loc.btwn start_loc (Peek.loc env) in
             Expect.token env T_GREATER_THAN;
             Some (loc, Type.ParameterDeclaration.({
@@ -712,15 +723,14 @@ end = struct
 
     and type_parameter_instantiation =
       let rec params env acc =
-        let acc = (_type env)::acc in
         match Peek.token env with
         | T_EOF
         | T_GREATER_THAN -> List.rev acc
         | _ ->
-          Expect.token env T_COMMA;
-          if Peek.token env = T_GREATER_THAN
-          then List.rev acc
-          else params env acc
+          let acc = (_type env)::acc in
+          if Peek.token env <> T_GREATER_THAN
+          then Expect.token env T_COMMA;
+          params env acc
 
       in fun env ->
           let start_loc = Peek.loc env in
@@ -780,7 +790,10 @@ end = struct
       ret
 
     let _type = wrap _type
-    let type_parameter_declaration = wrap type_parameter_declaration
+    let type_parameter_declaration_with_defaults = 
+      wrap (type_parameter_declaration ~allow_default:true)
+    let type_parameter_declaration = 
+      wrap (type_parameter_declaration ~allow_default:false)
     let type_parameter_instantiation = wrap type_parameter_instantiation
     let _object ?(allow_static=false) env = wrap (_object ~allow_static) env
     let function_param_list = wrap function_param_list
@@ -2434,7 +2447,7 @@ end = struct
         | true, false -> None
         | _ -> Some(Parse.identifier tmp_env)
       ) in
-      let typeParameters = Type.type_parameter_declaration env in
+      let typeParameters = Type.type_parameter_declaration_with_defaults env in
       let body, superClass, superTypeParameters, implements = _class env in
       let loc = Loc.btwn start_loc (fst body) in
       loc, Ast.Statement.(ClassDeclaration Class.({
@@ -2457,7 +2470,7 @@ end = struct
         | T_LCURLY -> None, None
         | _ ->
             let id = Some (Parse.identifier env) in
-            let typeParameters = Type.type_parameter_declaration env in
+            let typeParameters = Type.type_parameter_declaration_with_defaults env in
             id, typeParameters in
       let body, superClass, superTypeParameters, implements = _class env in
       let loc = Loc.btwn start_loc (fst body) in
@@ -2961,7 +2974,7 @@ end = struct
       Expect.token env T_TYPE;
       Eat.push_lex_mode env TYPE_LEX;
       let id = Parse.identifier env in
-      let typeParameters = Type.type_parameter_declaration env in
+      let typeParameters = Type.type_parameter_declaration_with_defaults env in
       Expect.token env T_ASSIGN;
       (match Peek.token env with
       | T_BIT_OR | T_BIT_AND -> Eat.token env
@@ -3004,7 +3017,7 @@ end = struct
           then error env Error.UnexpectedTypeInterface;
           Expect.token env T_INTERFACE;
           let id = Parse.identifier env in
-          let typeParameters = Type.type_parameter_declaration env in
+          let typeParameters = Type.type_parameter_declaration_with_defaults env in
           let extends = if Peek.token env = T_EXTENDS
           then begin
             Expect.token env T_EXTENDS;
@@ -3038,7 +3051,7 @@ end = struct
         let env = env |> with_strict true in
         Expect.token env T_CLASS;
         let id = Parse.identifier env in
-        let typeParameters = Type.type_parameter_declaration env in
+        let typeParameters = Type.type_parameter_declaration_with_defaults env in
         let extends = if Peek.token env = T_EXTENDS
           then begin
             Expect.token env T_EXTENDS;

--- a/src/parser/spider_monkey_ast.ml
+++ b/src/parser/spider_monkey_ast.ml
@@ -174,6 +174,7 @@ and Type : sig
         name: string;
         bound: Type.annotation option;
         variance: Variance.t option;
+        default: Type.t option;
       }
     end
     type t = Loc.t * t'

--- a/src/parser/test/hardcoded_tests.js
+++ b/src/parser/test/hardcoded_tests.js
@@ -3494,6 +3494,67 @@ module.exports = {
           }
         }]
       }
-    }
+    },
+    'Type Parameter Defaults': {
+      'type A<T = string> = T': {},
+      'type A<T: ?string = string> = T': {},
+      'type A<S, T: ?string = string> = T': {},
+      'type A<S = number, T: ?string = string> = T': {},
+      'class A<T = string> {}': {},
+      'class A<T: ?string = string> {}': {},
+      'class A<S, T: ?string = string> {}': {},
+      'class A<S = number, T: ?string = string> {}': {},
+      '(class A<T = string> {})': {},
+      '(class A<T: ?string = string> {})': {},
+      '(class A<S, T: ?string = string> {})': {},
+      '(class A<S = number, T: ?string = string> {})': {},
+      'declare class A<T = string> {}': {},
+      'declare class A<T: ?string = string> {}': {},
+      'declare class A<S, T: ?string = string> {}': {},
+      'declare class A<S = number, T: ?string = string> {}': {},
+      'interface A<T = string> {}': {},
+      'interface A<T: ?string = string> {}': {},
+      'interface A<S, T: ?string = string> {}': {},
+      'interface A<S = number, T: ?string = string> {}': {},
+
+      // With defaults, this is now valid
+      'var x: Foo<>': {},
+      'class A extends B<> {}': {},
+    },
+    'Invalid Type Parameter Defaults': {
+      'type A<T = string : ?string> = T': {
+        'errors.0.message': 'Unexpected token :'
+      },
+      'type A<HasDefault = string, NoDefault> = T': {
+        'errors.0.message': 'Type parameter declaration needs a default, since a preceding type parameter declaration has a default.'
+      },
+      'class A extends B<T = number> {}': {
+        'errors.0.message': 'Unexpected token ='
+      },
+      'var x: Array<T = number>': {
+        'errors.0.message': 'Unexpected token ='
+      },
+      'function foo<T = string>() {}': {
+        'errors.0.message': 'Unexpected token ='
+      },
+      'declare function foo<T = string>() {}': {
+        'errors.0.message': 'Unexpected token ='
+      },
+      '({ foo<T = string>() {} })': {
+        'errors.0.message': 'Unexpected token ='
+      },
+      'class A { foo<T = string>() {} }': {
+        'errors.0.message': 'Unexpected token ='
+      },
+      '(class A { foo<T = string>() {} })': {
+        'errors.0.message': 'Unexpected token ='
+      },
+      'declare class A { foo<T = string>(): void }': {
+        'errors.0.message': 'Unexpected token ='
+      },
+      '<T = string>() => 123': {
+        'errors.0.message': 'Unexpected token ='
+      }
+    },
   }
 };

--- a/src/typing/debug_js.ml
+++ b/src/typing/debug_js.ml
@@ -512,12 +512,14 @@ and json_of_polarity_impl _json_cx polarity =
 
 and json_of_typeparam json_cx = check_depth json_of_typeparam_impl json_cx
 and json_of_typeparam_impl json_cx tparam = Hh_json.(
-  JSON_Object [
+  JSON_Object ([
     "reason", json_of_reason tparam.reason;
     "name", JSON_String tparam.name;
     "bound", _json_of_t json_cx tparam.bound;
     "polarity", json_of_polarity json_cx tparam.polarity;
-  ]
+  ] @ match tparam.default with
+    | None -> []
+    | Some t -> ["default", _json_of_t json_cx t])
 )
 
 and json_of_objtype json_cx = check_depth json_of_objtype_impl json_cx

--- a/src/typing/gc_js.ml
+++ b/src/typing/gc_js.ml
@@ -400,7 +400,10 @@ and gc_id cx state id =
   state#mark root_id |> ignore
 
 and gc_typeparam cx state typeparam =
-  gc cx state typeparam.bound
+  gc cx state typeparam.bound;
+  match typeparam.default with 
+  | None -> ()
+  | Some t -> gc cx state t
 
 and gc_selector cx state = function
   | Prop _ -> ()

--- a/src/typing/type.ml
+++ b/src/typing/type.ml
@@ -506,7 +506,8 @@ module rec TypeTerm : sig
     reason: reason;
     name: string;
     bound: t;
-    polarity: polarity
+    polarity: polarity;
+    default: t option;
   }
 
   and selector =
@@ -1151,8 +1152,8 @@ let rec mod_reason_of_t f = function
   | FunProtoCallT (reason) -> FunProtoCallT (f reason)
   | PolyT (plist, t) -> PolyT (plist, mod_reason_of_t f t)
   | ThisClassT t -> ThisClassT (mod_reason_of_t f t)
-  | BoundT { reason; name; bound; polarity } ->
-    BoundT { reason = f reason; name; bound; polarity }
+  | BoundT { reason; name; bound; polarity; default; } ->
+    BoundT { reason = f reason; name; bound; polarity; default; }
   | ExistsT reason -> ExistsT (f reason)
   | ObjT (reason, ot) -> ObjT (f reason, ot)
   | ArrT (reason, t, ts) -> ArrT (f reason, t, ts)

--- a/src/typing/type_annotation.mli
+++ b/src/typing/type_annotation.mli
@@ -37,7 +37,7 @@ val mk_nominal_type: ?for_type:bool ->
   Context.t ->
   Reason_js.t ->
   Type.t SMap.t ->
-  (Type.t * Spider_monkey_ast.Type.t list) ->
+  (Type.t * Spider_monkey_ast.Type.t list option) ->
   Type.t
 
 val mk_type_param_declarations: Context.t ->
@@ -47,4 +47,4 @@ val mk_type_param_declarations: Context.t ->
 
 val extract_type_param_instantiations:
   Spider_monkey_ast.Type.ParameterInstantiation.t option ->
-  Spider_monkey_ast.Type.t list
+  Spider_monkey_ast.Type.t list option

--- a/src/typing/type_visitor.ml
+++ b/src/typing/type_visitor.ml
@@ -235,8 +235,9 @@ class ['a] t = object(self)
     | None -> acc
     | Some t -> self#type_ cx acc t
 
-  method private type_param cx acc { bound; _ } =
-    self#type_ cx acc bound
+  method private type_param cx acc { bound; default; _ } =
+    let acc = self#type_ cx acc bound in
+    self#opt (self#type_ cx) acc default
 
   method fun_type cx acc { this_t; params_tlist; return_t; _ } =
     let acc = self#type_ cx acc this_t in

--- a/tests/type_param_defaults/.flowconfig
+++ b/tests/type_param_defaults/.flowconfig
@@ -1,0 +1,7 @@
+[ignore]
+
+[include]
+
+[libs]
+
+[options]

--- a/tests/type_param_defaults/classes.js
+++ b/tests/type_param_defaults/classes.js
@@ -1,0 +1,54 @@
+/* @flow */
+
+class A<T> {
+  p: T;
+  constructor(p: T) {
+    this.p = p;
+  }
+}
+
+// Test out simple defaults
+class B<T = string> extends A<T> {}
+
+var b_number: B<number> = new B(123);
+var b_void: B<void> = new B();
+var b_default: B<> = new B('hello');
+var b_any: B = new B(10);
+
+(b_number.p: boolean); // Error number ~> boolean
+(b_void.p: boolean); // Error void ~> boolean
+(b_default.p: boolean); // Error string ~> boolean
+(b_any.p: boolean); // This is fine due to any
+
+class C<T: ?string = string> extends A<T> {}
+
+var c_number: C<number> = new C(123); // Error number ~> ?string
+var c_void: C<void> = new C();
+var c_default: C<> = new C('hello');
+var c_any: C = new C('hello');
+
+(c_void.p: boolean); // Error void ~> boolean
+(c_default.p: boolean); // Error string ~> boolean
+(c_any.p: boolean); // This is fine due to any
+
+class D<S, T = string> extends A<T> {}
+var d_number: D<mixed, number> = new D(123);
+var d_void: D<mixed, void> = new D();
+var d_default: D<mixed> = new D('hello');
+var d_too_few_args: D<> = new D('hello'); // Error too few tparams
+var d_too_many: D<mixed, string, string> = new D('hello'); // Error too many tparams
+var d_any: D = new D(10);
+
+(d_number.p: boolean); // Error number ~> boolean
+(d_void.p: boolean); // Error void ~> boolean
+(d_default.p: boolean); // Error string ~> boolean
+(d_any.p: boolean); // This is fine due to any
+
+class E<S: string, T: number = S> {} // Error: string ~> number
+class F<S: string, T: S = number> {} // Error: number ~> string
+
+class G<S: string, T = S> extends A<T> {}
+
+var g_default: G<string> = new G('hello');
+
+(g_default.p: boolean); // Error string ~> boolean

--- a/tests/type_param_defaults/type_param_defaults.exp
+++ b/tests/type_param_defaults/type_param_defaults.exp
@@ -1,0 +1,106 @@
+classes.js:18
+ 18: (b_number.p: boolean); // Error number ~> boolean
+      ^^^^^^^^^^ number. This type is incompatible with
+ 18: (b_number.p: boolean); // Error number ~> boolean
+                  ^^^^^^^ boolean
+
+classes.js:19
+ 19: (b_void.p: boolean); // Error void ~> boolean
+      ^^^^^^^^ undefined. This type is incompatible with
+ 19: (b_void.p: boolean); // Error void ~> boolean
+                ^^^^^^^ boolean
+
+classes.js:20
+ 20: (b_default.p: boolean); // Error string ~> boolean
+      ^^^^^^^^^^^ string. This type is incompatible with
+ 20: (b_default.p: boolean); // Error string ~> boolean
+                   ^^^^^^^ boolean
+
+classes.js:25
+ 25: var c_number: C<number> = new C(123); // Error number ~> ?string
+                     ^^^^^^ number. This type is incompatible with
+ 23: class C<T: ?string = string> extends A<T> {}
+                 ^^^^^^ string
+
+classes.js:25
+ 25: var c_number: C<number> = new C(123); // Error number ~> ?string
+                               ^^^^^^^^^^ constructor call
+ 25: var c_number: C<number> = new C(123); // Error number ~> ?string
+                                     ^^^ number. This type is incompatible with
+ 23: class C<T: ?string = string> extends A<T> {}
+                 ^^^^^^ string
+
+classes.js:30
+ 30: (c_void.p: boolean); // Error void ~> boolean
+      ^^^^^^^^ undefined. This type is incompatible with
+ 30: (c_void.p: boolean); // Error void ~> boolean
+                ^^^^^^^ boolean
+
+classes.js:31
+ 31: (c_default.p: boolean); // Error string ~> boolean
+      ^^^^^^^^^^^ string. This type is incompatible with
+ 31: (c_default.p: boolean); // Error string ~> boolean
+                   ^^^^^^^ boolean
+
+classes.js:38
+ 38: var d_too_few_args: D<> = new D('hello'); // Error too few tparams
+                         ^^^ D. Too few type arguments. Expected at least 1
+
+classes.js:38
+ 38: var d_too_few_args: D<> = new D('hello'); // Error too few tparams
+                         ^^^ type application of identifier `D`. Too few type arguments. Expected at least 1
+
+classes.js:38
+ 38: var d_too_few_args: D<> = new D('hello'); // Error too few tparams
+                               ^^^^^^^^^^^^^^ D. Too few type arguments. Expected at least 1
+
+classes.js:39
+ 39: var d_too_many: D<mixed, string, string> = new D('hello'); // Error too many tparams
+                     ^^^^^^^^^^^^^^^^^^^^^^^^ D. Too many type arguments. Expected at most 2
+
+classes.js:39
+ 39: var d_too_many: D<mixed, string, string> = new D('hello'); // Error too many tparams
+                     ^^^^^^^^^^^^^^^^^^^^^^^^ type application of identifier `D`. Too many type arguments. Expected at most 2
+
+classes.js:39
+ 39: var d_too_many: D<mixed, string, string> = new D('hello'); // Error too many tparams
+                                                ^^^^^^^^^^^^^^ D. Too many type arguments. Expected at most 2
+
+classes.js:42
+ 42: (d_number.p: boolean); // Error number ~> boolean
+      ^^^^^^^^^^ number. This type is incompatible with
+ 42: (d_number.p: boolean); // Error number ~> boolean
+                  ^^^^^^^ boolean
+
+classes.js:43
+ 43: (d_void.p: boolean); // Error void ~> boolean
+      ^^^^^^^^ undefined. This type is incompatible with
+ 43: (d_void.p: boolean); // Error void ~> boolean
+                ^^^^^^^ boolean
+
+classes.js:44
+ 44: (d_default.p: boolean); // Error string ~> boolean
+      ^^^^^^^^^^^ string. This type is incompatible with
+ 44: (d_default.p: boolean); // Error string ~> boolean
+                   ^^^^^^^ boolean
+
+classes.js:47
+ 47: class E<S: string, T: number = S> {} // Error: string ~> number
+                ^^^^^^ string. This type is incompatible with
+ 47: class E<S: string, T: number = S> {} // Error: string ~> number
+                           ^^^^^^ number
+
+classes.js:48
+ 48: class F<S: string, T: S = number> {} // Error: number ~> string
+                               ^^^^^^ number. This type is incompatible with
+ 48: class F<S: string, T: S = number> {} // Error: number ~> string
+                ^^^^^^ string
+
+classes.js:54
+ 54: (g_default.p: boolean); // Error string ~> boolean
+      ^^^^^^^^^^^ string. This type is incompatible with
+ 54: (g_default.p: boolean); // Error string ~> boolean
+                   ^^^^^^^ boolean
+
+
+Found 19 errors


### PR DESCRIPTION
Motivation:

Currently we have some code like

```JavaScript
interface $Iterator<Yield,Return,Next> { ... }
type Iterator<T> = $Iterator<T,void,void>;
```

It would be nice to instead be able to write

```JavaScript
interface Iterator<Yield,Return=void,Next=void> { ... }
```

General idea:

  * Type parameter declarations for classes, interfaces, types, etc can now include defaults
  * Type parameter declarations for methods, functions, etc are unaffected
  * Type parameter instantiation can now take 0 args (`Foo<>`)

Status quo:

  * A generic type with N type parameters can be instantiated with 0 or N type arguments
  * When you instantiate with 0 type arguments, we use `any` for all the type params

Change:

  * If a generic type with N type parameters has defaults and is instantiated with less than N type arguments, then we use the defaults