### PR TITLE
Add parser support for access modifiers

### DIFF
--- a/src/parser/lexer_flow.mll
+++ b/src/parser/lexer_flow.mll
@@ -43,6 +43,9 @@
     | T_VAR
     | T_WHILE
     | T_WITH
+    | T_READWRITE
+    | T_READONLY
+    | T_WRITEONLY
     | T_CONST
     | T_LET
     | T_NULL
@@ -177,6 +180,9 @@
     | T_VAR -> "T_VAR"
     | T_WHILE -> "T_WHILE"
     | T_WITH -> "T_WITH"
+    | T_READWRITE -> "T_READWRITE"
+    | T_READONLY -> "T_READONLY"
+    | T_WRITEONLY -> "T_WRITEONLY"
     | T_CONST -> "T_CONST"
     | T_LET  -> "T_LET"
     | T_NULL -> "T_NULL"
@@ -491,6 +497,9 @@
       "class", T_CLASS;
       "extends", T_EXTENDS;
       "static", T_STATIC;
+      "readwrite", T_READWRITE;
+      "readonly", T_READONLY;
+      "writeonly", T_WRITEONLY;
       "else", T_ELSE;
       "new", T_NEW;
       "delete", T_DELETE;
@@ -517,6 +526,9 @@
   let _ = List.iter (fun (key, token) -> Hashtbl.add type_keywords key token)
     [
       "static",  T_STATIC;
+      "readwrite", T_READWRITE;
+      "readonly", T_READONLY;
+      "writeonly", T_WRITEONLY;
       "typeof",  T_TYPEOF;
       "any",     T_ANY_TYPE;
       "bool",    T_BOOLEAN_TYPE;

--- a/src/parser/parse_error.ml
+++ b/src/parser/parse_error.ml
@@ -16,6 +16,7 @@ type t =
   | UnexpectedString
   | UnexpectedIdentifier
   | UnexpectedReserved
+  | UnexpectedModifier
   | UnexpectedEOS
   | UnexpectedTypeAlias
   | UnexpectedTypeAnnotation
@@ -94,6 +95,7 @@ module PP =
       | UnexpectedString ->  "Unexpected string"
       | UnexpectedIdentifier ->  "Unexpected identifier"
       | UnexpectedReserved ->  "Unexpected reserved word"
+      | UnexpectedModifier -> "Unexpected modifier"
       | UnexpectedEOS ->  "Unexpected end of input"
       | UnexpectedTypeAlias -> "Type aliases are not allowed in untyped mode"
       | UnexpectedTypeAnnotation -> "Type annotations are not allowed in untyped mode"

--- a/src/parser/spider_monkey_ast.ml
+++ b/src/parser/spider_monkey_ast.ml
@@ -13,6 +13,11 @@
  * https://developer.mozilla.org/en-US/docs/SpiderMonkey/Parser_API
  *)
 
+type access =
+  | ReadWrite
+  | ReadOnly
+  | WriteOnly
+
 module rec Identifier : sig
   type t = Loc.t * t'
   and t' = {
@@ -69,6 +74,7 @@ and Type : sig
         value: Type.t;
         optional: bool;
         static: bool;
+        access: access option;
         _method: bool;
       }
       type t = Loc.t * t'
@@ -79,6 +85,7 @@ and Type : sig
         key: Type.t;
         value: Type.t;
         static: bool;
+        access: access option;
       }
       and t = Loc.t * t'
     end
@@ -555,6 +562,7 @@ and Expression : sig
         key: key;
         value: Expression.t;
         kind: kind;
+        access: access option;
         _method: bool;
         shorthand: bool;
       }
@@ -969,6 +977,7 @@ and Class : sig
       key: Expression.Object.Property.key;
       value: Loc.t * Expression.Function.t;
       static: bool;
+      access: access option;
       decorators: Expression.t list;
     }
   end
@@ -979,6 +988,7 @@ and Class : sig
       value: Expression.t option;
       typeAnnotation: Type.annotation option;
       static: bool;
+      access: access option;
     }
   end
   module Implements : sig

--- a/src/parser/test/hardcoded_tests.js
+++ b/src/parser/test/hardcoded_tests.js
@@ -3556,5 +3556,233 @@ module.exports = {
         'errors.0.message': 'Unexpected token ='
       }
     },
+    'Object type property modifiers': {
+      'type X = {p:T}': {
+        'errors.length': 0,
+        'body.0.right.properties.0': {
+          'static': false,
+          'access': null
+        }
+      },
+      'type X = {readwrite p:T}': {
+        'errors.length': 0,
+        'body.0.right.properties.0': {
+          'static': false,
+          'access': 'ReadWrite'
+        }
+      },
+      'type X = {readonly p:T}': {
+        'errors.length': 0,
+        'body.0.right.properties.0': {
+          'static': false,
+          'access': 'ReadOnly'
+        }
+      },
+      'type X = {writeonly p:T}': {
+        'errors.length': 0,
+        'body.0.right.properties.0': {
+          'static': false,
+          'access': 'WriteOnly'
+        }
+      },
+      'type X = {static p:T}': {
+        'errors.0': {
+          'loc.start.column': 10,
+          'loc.end.column': 16,
+          'message': 'Unexpected modifier'
+        }
+      },
+      'type X = {readwrite:T}': {
+        'errors.length': 0,
+        'body.0.right.properties.0': {
+          'key.name': 'readwrite',
+          'access': null
+        }
+      },
+      'type X = {readwrite readonly:T}': {
+        'errors.length': 0,
+        'body.0.right.properties.0': {
+          'key.name': 'readonly',
+          'access': 'ReadWrite'
+        }
+      },
+      'type X = {readonly readwrite p:T}': {
+        'errors.0': {
+          'loc.start.column': 19,
+          'loc.end.column': 28,
+          'message': 'Unexpected modifier'
+        }
+      }
+    },
+    'Object literal property modifiers': {
+      '({p:T})': {
+        'errors.length': 0,
+        'body.0.expression.properties.0': {
+          'access': null
+        }
+      },
+      '({readwrite p:e})': {
+        'errors.length': 0,
+        'body.0.expression.properties.0': {
+          'access': 'ReadWrite'
+        }
+      },
+      '({readonly p:e})': {
+        'errors.length': 0,
+        'body.0.expression.properties.0': {
+          'access': 'ReadOnly'
+        }
+      },
+      '({writeonly p:e})': {
+        'errors.length': 0,
+        'body.0.expression.properties.0': {
+          'access': 'WriteOnly'
+        }
+      },
+      '({static p:e})': {
+        'errors.0': {
+          'loc.start.column': 2,
+          'loc.end.column': 8,
+          'message': 'Unexpected modifier'
+        }
+      },
+      '({readwrite:e})': {
+        'errors.length': 0,
+        'body.0.expression.properties.0': {
+          'key.name': 'readwrite',
+          'access': null
+        }
+      },
+      '({readwrite readonly:e})': {
+        'errors.length': 0,
+        'body.0.expression.properties.0': {
+          'key.name': 'readonly',
+          'access': 'ReadWrite'
+        }
+      },
+      '({readonly readwrite p:e})': {
+        'errors.0': {
+          'loc.start.column': 11,
+          'loc.end.column': 20,
+          'message': 'Unexpected modifier'
+        }
+      }
+    },
+    'Class property modifiers': {
+      'class C {p:T;}': {
+        'errors.length': 0,
+        'body.0.body.body.0': {
+          'static': false,
+          'access': null
+        }
+      },
+      'class C {readwrite p:T;}': {
+        'errors.length': 0,
+        'body.0.body.body.0': {
+          'static': false,
+          'access': 'ReadWrite'
+        }
+      },
+      'class C {readonly p:T;}': {
+        'errors.length': 0,
+        'body.0.body.body.0': {
+          'static': false,
+          'access': 'ReadOnly'
+        }
+      },
+      'class C {writeonly p:T;}': {
+        'errors.length': 0,
+        'body.0.body.body.0': {
+          'static': false,
+          'access': 'WriteOnly'
+        }
+      },
+      'class C {static p:T;}': {
+        'errors.length': 0,
+        'body.0.body.body.0': {
+          'static': true,
+          'access': null
+        }
+      },
+      'class C {readwrite:T;}': {
+        'errors.length': 0,
+        'body.0.body.body.0': {
+          'key.name': 'readwrite',
+          'access': null
+        }
+      },
+      'class C {readwrite readonly:T;}': {
+        'errors.length': 0,
+        'body.0.body.body.0': {
+          'key.name': 'readonly',
+          'access': 'ReadWrite'
+        }
+      },
+      'class C {readonly readwrite p:T;}': {
+        'errors.0': {
+          'loc.start.column': 18,
+          'loc.end.column': 27,
+          'message': 'Unexpected modifier'
+        }
+      }
+    },
+    'Interface modifiers': {
+      'interface C {p:T;}': {
+        'errors.length': 0,
+        'body.0.body.properties.0': {
+          'static': false,
+          'access': null
+        }
+      },
+      'interface C {readwrite p:T;}': {
+        'errors.length': 0,
+        'body.0.body.properties.0': {
+          'static': false,
+          'access': 'ReadWrite'
+        }
+      },
+      'interface C {readonly p:T;}': {
+        'errors.length': 0,
+        'body.0.body.properties.0': {
+          'static': false,
+          'access': 'ReadOnly'
+        }
+      },
+      'interface C {writeonly p:T;}': {
+        'errors.length': 0,
+        'body.0.body.properties.0': {
+          'static': false,
+          'access': 'WriteOnly'
+        }
+      },
+      'interface C {static p:T;}': {
+        'errors.length': 0,
+        'body.0.body.properties.0': {
+          'static': true,
+          'access': null
+        }
+      },
+      'interface C {readwrite:T;}': {
+        'errors.length': 0,
+        'body.0.body.properties.0': {
+          'key.name': 'readwrite',
+          'access': null
+        }
+      },
+      'interface C {readwrite readonly:T;}': {
+        'errors.length': 0,
+        'body.0.body.properties.0': {
+          'key.name': 'readonly',
+          'access': 'ReadWrite'
+        }
+      },
+      'interface C {readonly readwrite p:T;}': {
+        'errors.0': {
+          'loc.start.column': 22,
+          'loc.end.column': 31,
+          'message': 'Unexpected modifier'
+        }
+      }
+    }
   }
 };

--- a/src/services/port/comments_js.ml
+++ b/src/services/port/comments_js.ml
@@ -293,7 +293,7 @@ and meta_statement cmap = Ast.Statement.(function
             value = _, { Ast.Expression.Function.params; body; _ };
             kind = Method.Method | Method.Constructor;
             static = false;
-            decorators = _;
+            _;
           }) ->
             meta_fbody cmap loc params body
         | _ -> cmap, []

--- a/src/typing/type_annotation.ml
+++ b/src/typing/type_annotation.ml
@@ -392,7 +392,11 @@ let rec convert cx type_params_map = Ast.Type.(function
 
 | loc, Object { Object.properties; indexers; callProperties; } ->
   let props_map = List.fold_left (
-    fun props_map (loc, { Object.Property.key; value; optional; _ }) ->
+    fun props_map (loc, { Object.Property.key; value; optional; access; _ }) ->
+      Option.iter access ~f:(fun _ ->
+        let msg = "access modifiers not yet supported" in
+        FlowError.add_error cx (loc, [msg])
+      );
       (match key with
         | Ast.Expression.Object.Property.Literal
             (_, { Ast.Literal.value = Ast.Literal.String name; _ })
@@ -410,7 +414,7 @@ let rec convert cx type_params_map = Ast.Type.(function
           let msg = "Unsupported key in object type" in
           FlowError.add_error cx (loc, [msg]);
           props_map
-    )
+      )
   ) SMap.empty properties
   in
   let props_map = match callProperties with

--- a/tests/readwrite/.flowconfig
+++ b/tests/readwrite/.flowconfig
@@ -1,0 +1,2 @@
+[options]
+unsafe.enable_getters_and_setters=true

--- a/tests/readwrite/readwrite.exp
+++ b/tests/readwrite/readwrite.exp
@@ -1,0 +1,38 @@
+readwrite.js:6
+  6:   readwrite p: number, // access modifiers not yet supported
+       ^^^^^^^^^^^^^^^^^^^ access modifiers not yet supported
+
+readwrite.js:10
+ 10:   readwrite [x]: 0, // access modifiers not yet supported
+       ^^^^^^^^^^^^^^^^ access modifiers not yet supported
+
+readwrite.js:11
+ 11:   readwrite p: 0,   // access modifiers not yet supported
+       ^^^^^^^^^^^^^^ access modifiers not yet supported
+
+readwrite.js:15
+ 15:   readwrite p;      // access modifiers not yet supported
+       ^^^^^^^^^^^^ access modifiers not yet supported
+
+readwrite.js:16
+ 16:   readwrite m() {}; // access modifiers not yet supported
+       ^^^^^^^^^^^^^^^^ access modifiers not yet supported
+
+readwrite.js:20
+ 20:   readwrite p: number; // access modifiers not yet supported
+       ^^^^^^^^^^^^^^^^^^^ access modifiers not yet supported
+
+readwrite.js:21
+ 21:   readwrite m(): void; // access modifiers not yet supported
+       ^^^^^^^^^^^^^^^^^^^ access modifiers not yet supported
+
+readwrite.js:25
+ 25:   readwrite p: number; // access modifiers not yet supported
+       ^^^^^^^^^^^^^^^^^^^ access modifiers not yet supported
+
+readwrite.js:26
+ 26:   readwrite m(): void; // access modifiers not yet supported
+       ^^^^^^^^^^^^^^^^^^^ access modifiers not yet supported
+
+
+Found 9 errors

--- a/tests/readwrite/readwrite.js
+++ b/tests/readwrite/readwrite.js
@@ -1,0 +1,27 @@
+/* @flow */
+
+declare var x: string;
+
+type O = {
+  readwrite p: number, // access modifiers not yet supported
+}
+
+var o = {
+  readwrite [x]: 0, // access modifiers not yet supported
+  readwrite p: 0,   // access modifiers not yet supported
+};
+
+class C {
+  readwrite p;      // access modifiers not yet supported
+  readwrite m() {}; // access modifiers not yet supported
+}
+
+interface I {
+  readwrite p: number; // access modifiers not yet supported
+  readwrite m(): void; // access modifiers not yet supported
+}
+
+declare class D {
+  readwrite p: number; // access modifiers not yet supported
+  readwrite m(): void; // access modifiers not yet supported
+}


### PR DESCRIPTION
This commit generalizes parsing the static modifier to also parse access
modifiers (readwrite, readonly, writeonly).

Access modifiers are supported in object types, object literals,
classes, interfaces, and declared classes.

This commit only adds parsing support. Type checking support will be
added in subsequent commits.