### PR TITLE
Bump version in `flowConfig.ml` to 0.23.1

### DIFF
--- a/src/common/flowConfig.ml
+++ b/src/common/flowConfig.ml
@@ -10,7 +10,7 @@
 
 open Utils_js
 
-let version = "0.23.0"
+let version = "0.23.1"
 
 let map_add map (key, value) = SMap.add key value map
 

--- a/tests/version/version.exp
+++ b/tests/version/version.exp
@@ -1,1 +1,1 @@
-Wrong version of Flow. The config specifies version 0.1.0 but this is version 0.23.0
+Wrong version of Flow. The config specifies version 0.1.0 but this is version 0.23.1


### PR DESCRIPTION
I forgot to bump this version number when I shipped the `0.23.1` patch release.

Per https://github.com/facebook/flow/issues/1708, I'm just going to bump the number in master for now, we'll ship `0.24.0` later this week, and pretend like nothing happened...

![nothingtoseehere](https://cloud.githubusercontent.com/assets/498293/14797419/bfff9ea4-0b00-11e6-8134-f3a8bc571137.gif)