### PR TITLE
domain reimplemented as class

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -485,7 +485,7 @@ declare class events$EventEmitter {
 
 declare module "events" {
   // TODO: See the comment above the events$EventEmitter declaration
-  declare class EventEmitter extends events$EventEmitter {}
+  declare var EventEmitter: typeof events$EventEmitter;
 }
 
 declare class domain$Domain extends events$EventEmitter {

--- a/lib/node.js
+++ b/lib/node.js
@@ -482,15 +482,15 @@ declare class events$EventEmitter {
   setMaxListeners(n: number): void;
 }
 
-declare class EventEmitter extends events$EventEmitter {};
 
 declare module "events" {
   // TODO: See the comment above the events$EventEmitter declaration
-  declare var EventEmitter : typeof events$EventEmitter;
+  declare class EventEmitter extends events$EventEmitter {}
 }
 
-declare class domain$Domain extends EventEmitter {
+declare class domain$Domain extends events$EventEmitter {
   members: Array<any>;
+
   add(emitter: events$EventEmitter): void;
   bind(callback: Function): Function;
   dispose(): void;

--- a/lib/node.js
+++ b/lib/node.js
@@ -462,23 +462,6 @@ declare module "dns" {
   ): void;
 }
 
-type domain$Domain = {
-  members: Array<any>;
-
-  add(emitter: events$EventEmitter): void;
-  bind(callback: Function): Function;
-  dispose(): void;
-  enter(): void;
-  exit(): void;
-  intercept(callback: Function): Function;
-  remove(emitter: events$EventEmitter): void;
-  run(fn: Function): void;
-};
-
-declare module "domain" {
-  declare function create(): domain$Domain;
-}
-
 // TODO: This is copypasta of the EventEmitter class signature exported from the
 //       `events` module. The only reason this exists is because other module
 //       interface definitions need to reference this type structure -- but
@@ -499,9 +482,28 @@ declare class events$EventEmitter {
   setMaxListeners(n: number): void;
 }
 
+declare class EventEmitter extends events$EventEmitter {};
+
 declare module "events" {
   // TODO: See the comment above the events$EventEmitter declaration
-  declare class EventEmitter extends events$EventEmitter {}
+  declare var EventEmitter : typeof events$EventEmitter;
+}
+
+declare class domain$Domain extends EventEmitter {
+  members: Array<any>;
+
+  add(emitter: events$EventEmitter): void;
+  bind(callback: Function): Function;
+  dispose(): void;
+  enter(): void;
+  exit(): void;
+  intercept(callback: Function): Function;
+  remove(emitter: events$EventEmitter): void;
+  run(fn: Function): void;
+}
+
+declare module "domain" {
+  declare function create(): domain$Domain;
 }
 
 declare module "fs" {

--- a/lib/node.js
+++ b/lib/node.js
@@ -491,7 +491,6 @@ declare module "events" {
 
 declare class domain$Domain extends EventEmitter {
   members: Array<any>;
-
   add(emitter: events$EventEmitter): void;
   bind(callback: Function): Function;
   dispose(): void;


### PR DESCRIPTION
domain$Domain changed from type declaration to class definition as suggested in this issue:
https://github.com/facebook/flow/issues/1454

domain definition moved down so it would be able to extend eventEmmiter definition