### PR TITLE
markdown error: header was not rendered due to extraneous spacing

### DIFF
--- a/website/docs/ref/react.doc.js
+++ b/website/docs/ref/react.doc.js
@@ -119,9 +119,7 @@ const Counter = React.createClass({
 });
 
 /*
-
- ![animation](flow-state.gif)
- 
+  ![animation](flow-state.gif)
 
   ## Defining components as `React.Component` subclasses
 


### PR DESCRIPTION
markdown header not rendered correctly. before:

![image](https://cloud.githubusercontent.com/assets/51902/14881360/e6082d70-0d33-11e6-99de-051d21d77632.png)

after:

![image](https://cloud.githubusercontent.com/assets/51902/14881369/f1cd7d36-0d33-11e6-9e92-7388c9713b62.png)
