### PR TITLE
Use curl to download Travis cache

### DIFF
--- a/resources/travis/install_deps.sh
+++ b/resources/travis/install_deps.sh
@@ -36,7 +36,9 @@ case "$TRAVIS_OS_NAME" in
 
     printf "travis_fold:start:cache.1\nSetting up build cache\n"
     echo -n "downloading $TRAVIS_BRANCH/$SLUG.tar.gz:"
-    aws s3 cp --storage-class REDUCED_REDUNDANCY "s3://ci-cache.flowtype.org/$TRAVIS_BRANCH/$SLUG.tar.gz" "$TMP" >/dev/null 2>&1 || true
+    curl -sSL -o "$TMP/$SLUG.tar.gz" \
+      "https://ci-cache.flowtype.org.s3.amazonaws.com/$TRAVIS_BRANCH/$SLUG.tar.gz" \
+      || true
     if [ -f "$TMP/$SLUG.tar.gz" ]; then
       gzip -d "$TMP/$SLUG.tar.gz"
       shasum "$TMP/$SLUG.tar" > "$TMP/$SLUG.tar.sha1"

--- a/resources/travis/install_deps.sh
+++ b/resources/travis/install_deps.sh
@@ -37,7 +37,7 @@ case "$TRAVIS_OS_NAME" in
     printf "travis_fold:start:cache.1\nSetting up build cache\n"
     echo -n "downloading $TRAVIS_BRANCH/$SLUG.tar.gz:"
     curl -sSL -o "$TMP/$SLUG.tar.gz" \
-      "https://ci-cache.flowtype.org.s3.amazonaws.com/$TRAVIS_BRANCH/$SLUG.tar.gz" \
+      "https://s3.amazonaws.com/ci-cache.flowtype.org/$TRAVIS_BRANCH/$SLUG.tar.gz" \
       || true
     if [ -f "$TMP/$SLUG.tar.gz" ]; then
       gzip -d "$TMP/$SLUG.tar.gz"


### PR DESCRIPTION
the aws cli requires auth, even for anonymous/public downloads, and we don't want to use a token for PRs. https doesn't require auth, so use curl instead.