### PR TITLE
Don't add unparsed files to search index

### DIFF
--- a/src/parsing/parsing_service_js.ml
+++ b/src/parsing/parsing_service_js.ml
@@ -33,16 +33,10 @@ module ParserHeap = SharedMem.WithCache (Loc.FilenameKey) (struct
     let prefix = Prefix.make()
   end)
 
-let (parser_hook: (filename -> Ast.program -> unit) list ref) = ref []
-let call_on_success f = parser_hook := f :: !parser_hook
+let (parser_hook: (filename -> Ast.program option -> unit) list ref) = ref []
+let register_hook f = parser_hook := f :: !parser_hook
 
 let execute_hook file ast =
-  let ast = match ast with
-  | None ->
-     let empty_ast, _ = Parser_flow.parse_program true (Some file) "" in
-     empty_ast
-  | Some ast -> ast
-  in
   try
     List.iter (fun callback -> callback file ast) !parser_hook
   with e ->

--- a/src/parsing/parsing_service_js.mli
+++ b/src/parsing/parsing_service_js.mli
@@ -56,10 +56,13 @@ val get_ast_and_info_unsafe:
 (* remove asts for given file set. *)
 val remove_asts: FilenameSet.t -> unit
 
-(* Adds a hook called every time a file has been successfully parsed.
- * When a file is deleted, the hook is called with an empty Ast.
+(* Adds a hook that is called every time a file has been processed.
+ * When a file fails to parse, is deleted or is skipped because it isn't a Flow
+ * file, the AST is None.
  *)
-val call_on_success: (filename -> Spider_monkey_ast.program -> unit) -> unit
+val register_hook:
+  (filename -> Spider_monkey_ast.program option -> unit) ->
+  unit
 
 (* parse contents of a file *)
 val do_parse:

--- a/src/server/server.ml
+++ b/src/server/server.ml
@@ -30,7 +30,11 @@ struct
     (* Do some initialization before creating workers, so that each worker is
      * forked with this information already available. *)
     ignore (Init_js.get_master_cx options);
-    Parsing_service_js.call_on_success SearchService_js.update
+    Parsing_service_js.register_hook (fun filename ast ->
+      match ast with
+      | Some ast -> SearchService_js.update filename ast
+      | None -> ()
+    )
 
   let init genv =
     (* write binary path and version to server log *)


### PR DESCRIPTION
When a file fails to parse or is skipped because it isn't @flow, we were generating an empty AST and passing it to the search service (which, AFAIK, nobody even uses yet 😿 ) which then stores a bunch of empty lists in shared mem.

This is unnecessary since the filenames are unused by the search service; they're only stored by filename to prevent workers from clobbering each other.

Additionally, if you have enough non-@flow files, you can fill up shared memory even though they're all otherwise skipped. Projects using babel-6 seem to do this easily.