### PR TITLE
Fix Makefile rebuilding of object files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -198,7 +198,7 @@ test: build-flow copy-flow-files
 test-ocp: build-flow-with-ocp copy-flow-files-ocp
 	${MAKE} do-test
 
-js: $(NATIVE_OBJECT_FILES)
+js: $(BUILT_OBJECT_FILES)
 	mkdir -p bin
 	ocamlbuild -use-ocamlfind \
 		-pkgs js_of_ocaml \
@@ -214,7 +214,7 @@ js: $(NATIVE_OBJECT_FILES)
 			-o bin/flow.js \
 			$(JS_STUBS) _build/src/flow_dot_js.byte \
 			2>_build/js_of_ocaml.err; \
-	ret=$?; \
+	ret=$$?; \
 	if [ ! $$ret ]; then \
 		exit $$ret; \
 	elif [ -s _build/js_of_ocaml.err ]; then \


### PR DESCRIPTION
I was having problems with `make` not picking up changes to `.c` files. I think the problem is that `build-flow` depends on `build-flow-native-deps` which does not actually depend on the `.c` files, so that step was getting skipped.

As I started tweaking stuff, I eventually just replaced the target that runs `ocamlbuild` on all `.o` files with a rule that directly runs `ocamlopt` on each `.c` file, letting `make` instead of `ocamlbuild` decide when it's dirty. this is faster.

Test Plan: changed hh_shared.c, ran `make`. before, it wasn't picking up my changes unless I deleted `_build/`. after, it works. running `make` again doesn't rebuild things that are clean.