### PR TITLE
Support `this` pseudo-params in classes, and enforce subtyping on structural class statics

### DIFF
--- a/src/parser/estree_translator.ml
+++ b/src/parser/estree_translator.ml
@@ -869,6 +869,7 @@ end with type t = Impl.t) = struct
     | Any -> any_type loc
     | Void -> void_type loc
     | Null -> null_type loc
+    | This -> this_type loc
     | Number -> number_type loc
     | String -> string_type loc
     | Boolean -> boolean_type loc
@@ -892,6 +893,8 @@ end with type t = Impl.t) = struct
   and void_type loc = node "VoidTypeAnnotation" loc [||]
 
   and null_type loc = node "NullTypeAnnotation" loc [||]
+
+  and this_type loc = node "ThisTypeAnnotation" loc [||]
 
   and number_type loc = node "NumberTypeAnnotation" loc [||]
 

--- a/src/parser/lexer_flow.mll
+++ b/src/parser/lexer_flow.mll
@@ -525,6 +525,7 @@
       "false",   T_FALSE;
       "number",  T_NUMBER_TYPE;
       "string",  T_STRING_TYPE;
+      "this",    T_THIS;
       "void",    T_VOID_TYPE;
       "null",    T_NULL;
     ]

--- a/src/parser/loc.ml
+++ b/src/parser/loc.ml
@@ -67,6 +67,12 @@ let btwn loc1 loc2 = {
   _end = loc2._end;
 }
 
+let start loc = {
+  source = loc.source;
+  start = loc.start;
+  _end = loc.start;
+}
+
 let btwn_exclusive loc1 loc2 = {
   source = loc1.source;
   start = loc1._end;

--- a/src/parser/parse_error.ml
+++ b/src/parser/parse_error.ml
@@ -75,6 +75,7 @@ type t =
   | ExportNamelessFunction
   | UnsupportedDecorator
   | MissingTypeParamDefault
+  | CtorThisParam
 
 exception Error of (Loc.t * t) list
 
@@ -170,6 +171,7 @@ module PP =
       | UnsupportedDecorator -> "Found a decorator in an unsupported position."
       | MissingTypeParamDefault -> "Type parameter declaration needs a default, \
           since a preceding type parameter declaration has a default."
+      | CtorThisParam -> "Found a `this` pseudo-param on a constructor."
 
 
   end

--- a/src/parser/parser_flow.ml
+++ b/src/parser/parser_flow.ml
@@ -2444,9 +2444,6 @@ end = struct
                 | false, Type.Function.ThisParam.Explicit (loc, _) ->
                     error_at env (loc, Error.CtorThisParam);
                     Class.Method.Constructor
-(* TJP: Does this actually admit any errors.
-   I suspect that the explicit pseudoparam ought to be replaced with an implicit one here--or statements.ml could handle it?
-   Prove that it does before "fixing" anything. *)
                 | false, _ -> Class.Method.Constructor
                 | _ -> Class.Method.Method
               )

--- a/src/parser/parser_flow.ml
+++ b/src/parser/parser_flow.ml
@@ -238,12 +238,13 @@ end = struct
     val type_parameter_instantiation : env -> Ast.Type.ParameterInstantiation.t option
     val generic : env -> Loc.t * Ast.Type.Generic.t
     val _object : ?allow_static:bool -> env -> Loc.t * Type.Object.t
-    val function_param_list : env -> Type.Function.Param.t option * Type.Function.Param.t list
+    val function_this_param : env -> Ast.Type.Function.ThisParam.t
+    val function_param_list : env -> Type.Function.ThisParam.t * Type.Function.Param.t list * Type.Function.Param.t option
     val annotation : env -> Ast.Type.annotation
     val annotation_opt : env -> Ast.Type.annotation option
   end = struct
     type param_list_or_type =
-      | ParamList of (Type.Function.Param.t option * Type.Function.Param.t list)
+      | ParamList of (Type.Function.ThisParam.t * Type.Function.Param.t list * Type.Function.Param.t option)
       | Type of Type.t
 
     let rec _type env = union env
@@ -389,6 +390,7 @@ end = struct
       | T_STRING_TYPE  -> Some Type.String
       | T_VOID_TYPE    -> Some Type.Void
       | T_NULL         -> Some Type.Null
+      | T_THIS         -> Some Type.This
       | _ -> None
 
     and tuple =
@@ -425,33 +427,41 @@ end = struct
         optional;
       })
 
-    and function_param_list_without_parens =
+    and function_this_param env =
+      let name, _ = Parse.identifier_or_reserved_keyword env in
+      let param = function_param_with_id env name in
+      if Peek.token env <> T_RPAREN
+      then Expect.token env T_COMMA;
+      Type.Function.ThisParam.Explicit param
+
+    and function_param_list_without_parens env this params =
       let param env =
         let name, _ = Parse.identifier_or_reserved_keyword env in
         function_param_with_id env name
-
-      in let rec param_list env acc =
+      in
+      let rec param_list env acc =
         match Peek.token env with
         | T_EOF
-        | T_ELLIPSIS
-        | T_RPAREN as t ->
-            let rest = if t = T_ELLIPSIS
-            then begin
-              Expect.token env T_ELLIPSIS;
-              Some (param env)
-            end else None in
-            rest, List.rev acc
+        | T_RPAREN ->
+            this, List.rev acc, None
+        | T_ELLIPSIS ->
+            Expect.token env T_ELLIPSIS;
+            this, List.rev acc, Some (param env)
         | _ ->
           let acc = (param env)::acc in
           if Peek.token env <> T_RPAREN
           then Expect.token env T_COMMA;
           param_list env acc
-
-      in fun env -> param_list env
+      in
+      param_list env params
 
     and function_param_list env =
         Expect.token env T_LPAREN;
-        let ret = function_param_list_without_parens env [] in
+        let this = match Peek.token env with
+          | T_THIS -> function_this_param env
+          | _ -> Type.Function.ThisParam.Implicit (Loc.start (Peek.loc env))
+        in
+        let ret = function_param_list_without_parens env this [] in
         Expect.token env T_RPAREN;
         ret
 
@@ -461,11 +471,15 @@ end = struct
       | T_EOF
       | T_ELLIPSIS ->
           (* (... is definitely the beginning of a param list *)
-          ParamList (function_param_list_without_parens env [])
+          let loc = Loc.start (Peek.loc env) in
+          let this = Type.Function.ThisParam.Implicit loc in
+          ParamList (function_param_list_without_parens env this [])
       | T_RPAREN ->
-          (* () or is definitely a param list *)
-          ParamList (None, [])
-      | T_IDENTIFIER ->
+          (* () is definitely a param list *)
+          let loc = Loc.start (Peek.loc env) in
+          ParamList (Type.Function.ThisParam.Implicit loc, [], None)
+      | T_IDENTIFIER
+      | T_THIS ->
           (* This could be a function parameter or a generic type *)
           function_param_or_generic_type env
       | token ->
@@ -493,7 +507,9 @@ end = struct
                   typeAnnotation;
                   optional;
                 }) in
-                ParamList (function_param_list_without_parens env [param])
+                let loc = Loc.start (fst name) in
+                let this = Type.Function.ThisParam.Implicit loc in
+                ParamList (function_param_list_without_parens env this [param])
             | _ ->
                 (* Ok this is definitely a type *)
                 (* Note; what we really want here (absent 2-token LA :) is
@@ -513,13 +529,20 @@ end = struct
       ret
 
     and function_param_or_generic_type env =
+      let token = Peek.token env in
       let id = Parse.identifier env in
       match Peek.token env with
       | T_PLING (* optional param *)
       | T_COLON ->
           let param = function_param_with_id env id in
           ignore (Expect.maybe env T_COMMA);
-          ParamList (function_param_list_without_parens env [param])
+          let this, params = match token with
+            | T_THIS -> Type.Function.ThisParam.Explicit param, []
+            | _ ->
+                let loc = Loc.start (fst param) in
+                Type.Function.ThisParam.Implicit loc, [param]
+          in
+          ParamList (function_param_list_without_parens env this params)
       | _ ->
           Type (union_with env
                   (intersection_with env
@@ -529,11 +552,12 @@ end = struct
     and function_or_group env =
       let start_loc = Peek.loc env in
       match param_list_or_type env with
-      | ParamList (rest, params) ->
+      | ParamList (this, params, rest) ->
         Expect.token env T_ARROW;
         let returnType = _type env in
         let end_loc = fst returnType in
         Loc.btwn start_loc end_loc, Type.(Function Function.({
+          this;
           params;
           returnType;
           rest;
@@ -544,11 +568,12 @@ end = struct
     and _function env =
       let start_loc = Peek.loc env in
       let typeParameters = type_parameter_declaration ~allow_default:false env in
-      let rest, params = function_param_list env in
+      let this, params, rest = function_param_list env in
       Expect.token env T_ARROW;
       let returnType = _type env in
       let end_loc = fst returnType in
       Loc.btwn start_loc end_loc, Type.(Function Function.({
+        this;
         params;
         returnType;
         rest;
@@ -558,11 +583,12 @@ end = struct
     and _object =
       let methodish env start_loc =
         let typeParameters = type_parameter_declaration ~allow_default:false env in
-        let rest, params = function_param_list env in
+        let this, params, rest = function_param_list env in
         Expect.token env T_COLON;
         let returnType = _type env in
         let loc = Loc.btwn start_loc (fst returnType) in
         loc, Type.Function.({
+          this;
           params;
           returnType;
           rest;
@@ -796,6 +822,7 @@ end = struct
       wrap (type_parameter_declaration ~allow_default:false)
     let type_parameter_instantiation = wrap type_parameter_instantiation
     let _object ?(allow_static=false) env = wrap (_object ~allow_static) env
+    let function_this_param = wrap function_this_param
     let function_param_list = wrap function_param_list
     let annotation = wrap annotation
     let annotation_opt = wrap annotation_opt
@@ -915,9 +942,13 @@ end = struct
 
       in fun env ->
         Expect.token env T_LPAREN;
+        let this = match Peek.token env with
+          | T_THIS -> Type.function_this_param env
+          | _ -> Ast.Type.Function.ThisParam.Implicit (Loc.start (Peek.loc env))
+        in
         let params, defaults, rest = param_list env ([], [], false) in
         Expect.token env T_RPAREN;
-        params, defaults, rest
+        this, params, defaults, rest
 
     let function_body env ~async ~generator =
       let env = enter_function env ~async ~generator in
@@ -972,7 +1003,7 @@ end = struct
           in
           (Type.type_parameter_declaration env, Some id)
       ) in
-      let params, defaults, rest = function_params env in
+      let this, params, defaults, rest = function_params env in
       let returnType = Type.annotation_opt env in
       let _, body, strict = function_body env ~async ~generator in
       let simple = is_simple_function_params params defaults rest in
@@ -983,6 +1014,7 @@ end = struct
         | BodyExpression (loc, _) -> loc, true) in
       Loc.btwn start_loc end_loc, Statement.(FunctionDeclaration Function.({
         id;
+        this;
         params;
         defaults;
         rest;
@@ -1609,7 +1641,7 @@ end = struct
             | _ -> Some (Parse.identifier ~restricted_error:Error.StrictFunctionName env) in
           id, Type.type_parameter_declaration env
         end in
-      let params, defaults, rest = Declaration.function_params env in
+      let this, params, defaults, rest = Declaration.function_params env in
       let returnType = Type.annotation_opt env in
       let end_loc, body, strict =
         Declaration.function_body env ~async ~generator in
@@ -1621,6 +1653,7 @@ end = struct
         | BodyExpression _ -> true) in
       Loc.btwn start_loc end_loc, Expression.(Function Function.({
         id;
+        this;
         params;
         defaults;
         rest;
@@ -1844,17 +1877,22 @@ end = struct
          * that it's an async function *)
         let async = Peek.token ~i:1 env <> T_ARROW && Declaration.async env in
         let typeParameters = Type.type_parameter_declaration env in
-        let params, defaults, rest, returnType =
+        let this, params, defaults, rest, returnType =
           (* Disallow all fancy features for identifier => body *)
           if Peek.identifier env && typeParameters = None
           then
             let id =
               Parse.identifier ~restricted_error:Error.StrictParamName env in
             let param = fst id, Pattern.Identifier id in
-            [param], [], None, None
+            let this =
+              Ast.Type.Function.ThisParam.Implicit (Loc.start (fst id))
+            in
+            this, [param], [], None, None
           else
-            let params, defaults, rest = Declaration.function_params env in
-            params, defaults, rest, Type.annotation_opt env in
+            let
+              this, params, defaults, rest = Declaration.function_params env
+            in
+            this, params, defaults, rest, Type.annotation_opt env in
 
         (* It's hard to tell if an invalid expression was intended to be an
          * arrow function before we see the =>. If there are no params, that
@@ -1888,6 +1926,7 @@ end = struct
         let loc = Loc.btwn start_loc end_loc in
         loc, Expression.(ArrowFunction Function.({
           id = None;
+          this;
           params;
           defaults;
           rest;
@@ -2054,6 +2093,10 @@ end = struct
       | Get | Set -> None
       | _ -> Type.type_parameter_declaration env) in
       Expect.token env T_LPAREN;
+      let this = match Peek.token env with
+        | T_THIS -> Type.function_this_param env
+        | _ -> Ast.Type.Function.ThisParam.Implicit (Loc.start (Peek.loc env))
+      in
       let params = Ast.Expression.Object.Property.(match kind with
       | Get -> []
       | Set ->
@@ -2074,6 +2117,7 @@ end = struct
         | BodyExpression (loc, _) -> loc, true) in
       let value = end_loc, Function.({
         id = None;
+        this;
         params;
         defaults;
         rest;
@@ -2159,7 +2203,9 @@ end = struct
             | T_LESS_THAN
             | T_LPAREN ->
                 let typeParameters = Type.type_parameter_declaration env in
-                let params, defaults, rest = Declaration.function_params env in
+                let
+                  this, params, defaults, rest = Declaration.function_params env
+                in
                 let returnType = Type.annotation_opt env in
                 let _, body, strict =
                   Declaration.function_body env ~async ~generator in
@@ -2171,6 +2217,7 @@ end = struct
                   | BodyExpression (loc, _) -> loc, true) in
                 let value = end_loc, Ast.Expression.(Function Function.({
                   id = None;
+                  this;
                   params;
                   defaults;
                   rest;
@@ -2360,7 +2407,7 @@ end = struct
           })))
         | _ ->
           let typeParameters = Type.type_parameter_declaration env in
-          let params, defaults, rest = Declaration.function_params env in
+          let this, params, defaults, rest = Declaration.function_params env in
           let returnType = Type.annotation_opt env in
           let _, body, strict =
             Declaration.function_body env ~async ~generator in
@@ -2373,6 +2420,7 @@ end = struct
             | BodyExpression (loc, _) -> loc, true) in
           let value = end_loc, Function.({
             id = None;
+            this;
             params;
             defaults;
             rest;
@@ -3081,12 +3129,13 @@ end = struct
       let id = Parse.identifier env in
       let start_sig_loc = Peek.loc env in
       let typeParameters = Type.type_parameter_declaration env in
-      let rest, params = Type.function_param_list env in
+      let this, params, rest = Type.function_param_list env in
       Expect.token env T_COLON;
       let returnType = Type._type env in
       let end_loc = fst returnType in
       let loc = Loc.btwn start_sig_loc end_loc in
       let value = loc, Ast.Type.(Function {Function.
+        this;
         params;
         returnType;
         rest;

--- a/src/parser/parser_flow.ml
+++ b/src/parser/parser_flow.ml
@@ -2439,8 +2439,17 @@ end = struct
             | Expression.Object.Property.Literal (_, {
                 Literal.value = Literal.String "constructor";
                 _;
-              }) ->
-              Class.Method.Constructor
+              }) -> (
+                match static, this with
+                | false, Type.Function.ThisParam.Explicit (loc, _) ->
+                    error_at env (loc, Error.CtorThisParam);
+                    Class.Method.Constructor
+(* TJP: Does this actually admit any errors.
+   I suspect that the explicit pseudoparam ought to be replaced with an implicit one here--or statements.ml could handle it?
+   Prove that it does before "fixing" anything. *)
+                | false, _ -> Class.Method.Constructor
+                | _ -> Class.Method.Method
+              )
             | _ ->
               Class.Method.Method) in
           Ast.Class.(Body.Method (Loc.btwn start_loc end_loc, Method.({

--- a/src/parser/spider_monkey_ast.ml
+++ b/src/parser/spider_monkey_ast.ml
@@ -54,7 +54,14 @@ and Type : sig
       }
     end
 
+    module ThisParam : sig
+      type t =
+      | Implicit of Loc.t
+      | Explicit of Param.t
+    end
+
     type t = {
+      this: ThisParam.t;
       params: Param.t list;
       returnType: Type.t;
       rest: Param.t option;
@@ -141,6 +148,7 @@ and Type : sig
     | Any
     | Void
     | Null
+    | This
     | Number
     | String
     | Boolean
@@ -969,6 +977,7 @@ and Function : sig
     | BodyExpression of Expression.t
   type t = {
     id: Identifier.t option;
+    this: Type.Function.ThisParam.t;
     params: Pattern.t list;
     defaults: Expression.t option list;
     rest: Identifier.t option;

--- a/src/typing/flow_js.ml
+++ b/src/typing/flow_js.ml
@@ -928,7 +928,8 @@ let rec __flow cx ((l: Type.t), (u: Type.use_t)) trace =
     (* The sink component of an annotation constrains values flowing
        into the annotated site. *)
 
-    | _, UseT (use_op, AnnotT (sink_t, _)) ->
+    | l, UseT (use_op, AnnotT (sink_t, _))
+    | ClassT (l), UseT (use_op, ClassT (AnnotT (sink_t, _))) ->
       let reason = reason_of_t sink_t in
       rec_flow cx trace (ReposUpperT (reason, l), UseT (use_op, sink_t))
 
@@ -2043,7 +2044,7 @@ let rec __flow cx ((l: Type.t), (u: Type.use_t)) trace =
     (* TODO: ideally we'd do the same when lower bounds flow to a
        this-abstracted class, but fixing the class is easier; might need to
        revisit *)
-    | (_, UseT (use_op, ThisClassT i)) ->
+    | (_, UseT (use_op, ThisClassT i)) -> (*TJP: x ~> Class<this> case? Or has the `this` already been fixed? *)
       let r = reason_of_t l in
       rec_flow cx trace (l, UseT (use_op, fix_this_class cx trace r i))
 

--- a/src/typing/flow_js.ml
+++ b/src/typing/flow_js.ml
@@ -3930,7 +3930,7 @@ and subst cx ?(force=true) (map: Type.t SMap.t) t =
     ) ([], map) xs in
     PolyT (List.rev xs, subst cx ~force:false map t)
 
-  | ThisClassT t ->
+  | ThisClassT t ->(*TJP: Figure out the syntactic origin of this*)
     let map = SMap.remove "this" map in
     ThisClassT (subst cx ~force map t)
 
@@ -3997,7 +3997,7 @@ and subst cx ?(force=true) (map: Type.t SMap.t) t =
       let ts = List.map (subst cx ~force map) ts in
       TypeAppT(c, ts)
 
-  | ThisTypeAppT(c, this, ts) ->
+  | ThisTypeAppT(c, this, ts) -> (*TJP: Grep to figure out the syntactic origin of these*)
       let c = subst cx ~force map c in
       let this = subst cx ~force map this in
       let ts = List.map (subst cx ~force map) ts in

--- a/src/typing/func_params.ml
+++ b/src/typing/func_params.ml
@@ -13,91 +13,111 @@ type param =
   | Complex of Type.t * binding list
   | Rest of Type.t * binding
 type t = {
-  list: param list;
+  this: Type.t;
+  rev_list: param list;
   defaults: Ast.Expression.t Default.t SMap.t;
 }
 
-let empty = {
-  list = [];
+let empty this = {
+  this;
+  rev_list = [];
   defaults = SMap.empty
 }
 
-let add cx type_params_map params pattern default =
-  Ast.Pattern.(match pattern with
-  | loc, Identifier (_, { Ast.Identifier.name; typeAnnotation; optional }) ->
-    let reason = mk_reason (Utils.spf "parameter `%s`" name) loc in
-    let t = Anno.mk_type_annotation cx type_params_map reason typeAnnotation
-    in (match default with
-    | None ->
-      let t =
-        if optional
-        then OptionalT t
-        else t
+let mk cx type_params_map {Ast.Function.this; params; defaults; rest; _} implicit_this =
+  let add_param params pattern default =
+    Ast.Pattern.(match pattern with
+    | loc, Identifier (_, { Ast.Identifier.name; typeAnnotation; optional }) ->
+      let reason = mk_reason (Utils.spf "parameter `%s`" name) loc in
+      let t = Anno.mk_type_annotation cx type_params_map reason typeAnnotation
+      in (match default with
+      | None ->
+        let t =
+          if optional
+          then OptionalT t
+          else t
+        in
+        Hashtbl.replace (Context.type_table cx) loc t;
+        let binding = name, t, loc in
+        let rev_list = Simple (t, binding) :: params.rev_list in
+        { params with rev_list }
+      | Some expr ->
+        (* TODO: assert (not optional) *)
+        let binding = name, t, loc in
+        { this = params.this;
+          rev_list = Simple (OptionalT t, binding) :: params.rev_list;
+          defaults = SMap.add name (Default.Expr expr) params.defaults })
+    | loc, _ ->
+      let reason = mk_reason "destructuring" loc in
+      let t = type_of_pattern pattern
+        |> Anno.mk_type_annotation cx type_params_map reason in
+      let default = Option.map default Default.expr in
+      let bindings = ref [] in
+      let defaults = ref params.defaults in
+      pattern |> destructuring cx t None default (fun _ loc name default t ->
+        Hashtbl.replace (Context.type_table cx) loc t;
+        bindings := (name, t, loc) :: !bindings;
+        Option.iter default ~f:(fun default ->
+          defaults := SMap.add name default !defaults
+        )
+      );
+      let t = match default with
+        | Some _ -> OptionalT t
+        | None -> t (* TODO: assert (not optional) *)
       in
-      Hashtbl.replace (Context.type_table cx) loc t;
-      let binding = name, t, loc in
-      let list = Simple (t, binding) :: params.list in
-      { params with list }
-    | Some expr ->
-      (* TODO: assert (not optional) *)
-      let binding = name, t, loc in
-      { list = Simple (OptionalT t, binding) :: params.list;
-        defaults = SMap.add name (Default.Expr expr) params.defaults })
-  | loc, _ ->
-    let reason = mk_reason "destructuring" loc in
-    let t = type_of_pattern pattern
-      |> Anno.mk_type_annotation cx type_params_map reason in
-    let default = Option.map default Default.expr in
-    let bindings = ref [] in
-    let defaults = ref params.defaults in
-    pattern |> destructuring cx t None default (fun _ loc name default t ->
-      Hashtbl.replace (Context.type_table cx) loc t;
-      bindings := (name, t, loc) :: !bindings;
-      Option.iter default ~f:(fun default ->
-        defaults := SMap.add name default !defaults
-      )
-    );
-    let t = match default with
-      | Some _ -> OptionalT t
-      | None -> t (* TODO: assert (not optional) *)
-    in
-    { list = Complex (t, !bindings) :: params.list;
-      defaults = !defaults })
-
-let add_rest cx type_params_map params =
-  function loc, { Ast.Identifier.name; typeAnnotation; _ } ->
-    let reason = mk_reason (Utils.spf "rest parameter `%s`" name) loc in
-    let t = Anno.mk_type_annotation cx type_params_map reason typeAnnotation
-    in { params with
-      list = Rest (Anno.mk_rest cx t, (name, t, loc)) :: params.list
-    }
-
-let mk cx type_params_map {Ast.Function.params; defaults; rest; _} =
+      { this = params.this;
+        rev_list = Complex (t, !bindings) :: params.rev_list;
+        defaults = !defaults })
+  in
+  let add_rest params =
+    function loc, { Ast.Identifier.name; typeAnnotation; _ } ->
+      let reason = mk_reason (Utils.spf "rest parameter `%s`" name) loc in
+      let t = Anno.mk_type_annotation cx type_params_map reason typeAnnotation
+      in { params with
+        rev_list = Rest (Anno.mk_rest cx t, (name, t, loc)) :: params.rev_list
+      }
+  in
   let defaults =
     if defaults = [] && params <> []
     then List.map (fun _ -> None) params
     else defaults
   in
-  let params = List.fold_left2 (add cx type_params_map) empty params defaults in
+  let this =
+    let desc = "pseudo-param `this`" in
+    Ast.Type.Function.ThisParam.(match this with
+      | Implicit loc -> Flow_js.reposition cx (mk_reason desc loc) implicit_this
+      | Explicit (loc, { Ast.Type.Function.Param.typeAnnotation; _ }) ->
+          let reason = mk_reason desc loc in (*TJP: Should I be using just the type's loc?*)
+          let anno = Some (loc, typeAnnotation) in
+          Anno.mk_type_annotation cx type_params_map reason anno
+    )
+  in
+  let func_params = {
+    this;
+    rev_list = [];
+    defaults = SMap.empty
+  } in
+  let func_params = List.fold_left2 add_param func_params params defaults in
   match rest with
-  | Some ident -> add_rest cx type_params_map params ident
-  | None -> params
+  | Some ident -> add_rest func_params ident
+  | None -> func_params
 
+let this params = params.this
 
 let names params =
-  params.list |> List.rev |> List.map (function
+  params.rev_list |> List.rev |> List.map (function
     | Simple (_, (name, _, _))
     | Rest (_, (name, _, _)) -> name
   | Complex _ -> "_")
 
 let tlist params =
-  params.list |> List.rev |> List.map (function
+  params.rev_list |> List.rev |> List.map (function
     | Simple (t, _)
     | Complex (t, _)
     | Rest (t, _) -> t)
 
 let iter f params =
-  params.list |> List.rev |> List.iter (function
+  params.rev_list |> List.rev |> List.iter (function
     | Simple (_, b)
     | Rest (_, b) -> f b
     | Complex (_, bs) -> List.iter f bs)
@@ -110,11 +130,12 @@ let with_default name f params =
 let subst_binding cx map (name, t, loc) = (name, Flow.subst cx map t, loc)
 
 let subst cx map params =
-  let list = params.list |> List.map (function
+  let this = Flow.subst cx map params.this in
+  let rev_list = params.rev_list |> List.map (function
     | Simple (t, b) ->
       Simple (Flow.subst cx map t, subst_binding cx map b)
     | Complex (t, bs) ->
       Complex (Flow.subst cx map t, List.map (subst_binding cx map) bs)
     | Rest (t, b) ->
       Rest (Flow.subst cx map t, subst_binding cx map b)) in
-  { params with list }
+  { params with this; rev_list }

--- a/src/typing/func_params.ml
+++ b/src/typing/func_params.ml
@@ -82,16 +82,13 @@ let mk cx type_params_map {Ast.Function.this; params; defaults; rest; _} implici
     then List.map (fun _ -> None) params
     else defaults
   in
-  let this =
-    let desc = "pseudo-param `this`" in
-    Ast.Type.Function.ThisParam.(match this with
-      | Implicit loc -> Flow_js.reposition cx (mk_reason desc loc) implicit_this
-      | Explicit (loc, { Ast.Type.Function.Param.typeAnnotation; _ }) ->
-          let reason = mk_reason desc loc in (*TJP: Should I be using just the type's loc?*)
-          let anno = Some (loc, typeAnnotation) in
-          Anno.mk_type_annotation cx type_params_map reason anno
-    )
-  in
+  let this = Ast.Type.Function.ThisParam.(match this with
+    | Implicit _ -> implicit_this
+    | Explicit (loc, { Ast.Type.Function.Param.typeAnnotation; _ }) ->
+        let reason = mk_reason "pseudo-param `this`" loc in
+        let anno = Some (loc, typeAnnotation) in
+        Anno.mk_type_annotation cx type_params_map reason anno
+  ) in
   let func_params = {
     this;
     rev_list = [];

--- a/src/typing/func_params.mli
+++ b/src/typing/func_params.mli
@@ -1,23 +1,15 @@
 type t
 
 (* build up a params value *)
-val empty: t
-val add: Context.t ->
-  (Type.t SMap.t) -> (* type params map *)
-  t ->
-  Spider_monkey_ast.Pattern.t ->
-  Spider_monkey_ast.Expression.t option -> (* default expr *)
-  t
-val add_rest: Context.t ->
-  (Type.t SMap.t) -> (* type params map *)
-  t ->
-  Spider_monkey_ast.Identifier.t ->
-  t
-
+val empty: Type.t -> t
 val mk: Context.t ->
   (Type.t SMap.t) -> (* type params map *)
   Spider_monkey_ast.Function.t ->
+  Type.t -> (* implicit `this` pseudoparameter *)
   t
+
+(* type of the this pseudoparameter*)
+val this: t -> Type.t
 
 (* name of each param, in order *)
 (* destructured params will be "_" *)

--- a/src/typing/statement.ml
+++ b/src/typing/statement.ml
@@ -4645,7 +4645,7 @@ and mk_class_signature cx reason_c type_params_map is_derived body = Ast.Class.(
       let typeparams, type_params_map =
         Anno.mk_type_param_declarations cx type_params_map typeParameters in
 
-      let implicit_this = if static then ThisClassT this else this in
+      let implicit_this = if static then ClassT this else this in
       let meth_params = Func_params.mk cx type_params_map func implicit_this in
 (*TJP: Ocaml method to warn on statics with `this: this` and nonstatics with `this: Class<this>` *)
       let meth_return_type = mk_return_type cx type_params_map func in

--- a/src/typing/statement.ml
+++ b/src/typing/statement.ml
@@ -2726,7 +2726,7 @@ and expression_ ~is_cond cx type_params_map loc e = Ast.Expression.(match e with
       let reason = mk_reason (spf "super.%s(...)" name) loc in
       let reason_prop = mk_reason (spf "property `%s`" name) ploc in
       let super = super_ cx (mk_reason "super" super_loc) in
-      let this = this_ cx (mk_reason "this" super_loc) in (*TJP: Bad loc?  Cause an error and check it out.*)
+      let this = this_ cx (mk_reason "this" super_loc) in
       let argts = List.map (expression_or_spread cx type_params_map) arguments in
       Type_inference_hooks_js.dispatch_call_hook cx name ploc super;
       Flow.mk_tvar_where cx reason (fun t ->
@@ -4648,7 +4648,6 @@ and mk_class_signature cx reason_c type_params_map is_derived body = Ast.Class.(
 
       let implicit_this = if static then ClassT this else this in
       let meth_params = Func_params.mk cx type_params_map func implicit_this in
-(*TJP: Ocaml method to warn on statics with `this: this` and nonstatics with `this: Class<this>` *)
       let meth_return_type = mk_return_type cx type_params_map func in
       let reason_desc = (match kind with
       | Method.Method -> spf "method `%s`" name
@@ -4661,8 +4660,6 @@ and mk_class_signature cx reason_c type_params_map is_derived body = Ast.Class.(
         meth_tparams = typeparams;
         meth_tparams_map = type_params_map;
         meth_params;
-(* TJP: `static fn(this: this)` should yield a warning (because the `this` type
-   is not `Class<>` qualified) *)
         meth_return_type;
       } in
 
@@ -5031,7 +5028,7 @@ and mk_class = Ast.Class.(
         SMap.map (Flow.subst cx map_) method_sig.meth_tparams_map;
 
       (* params = (x: Y), ret = T *)
-      meth_params = Func_params.subst cx map_ method_sig.meth_params; (*TJP: Verify semantics for `this` substitution*)
+      meth_params = Func_params.subst cx map_ method_sig.meth_params;
       meth_return_type = Flow.subst cx map_ method_sig.meth_return_type;
     } in
 

--- a/src/typing/statement.ml
+++ b/src/typing/statement.ml
@@ -2726,10 +2726,11 @@ and expression_ ~is_cond cx type_params_map loc e = Ast.Expression.(match e with
       let reason = mk_reason (spf "super.%s(...)" name) loc in
       let reason_prop = mk_reason (spf "property `%s`" name) ploc in
       let super = super_ cx (mk_reason "super" super_loc) in
+      let this = this_ cx (mk_reason "this" super_loc) in (*TJP: Bad loc?  Cause an error and check it out.*)
       let argts = List.map (expression_or_spread cx type_params_map) arguments in
       Type_inference_hooks_js.dispatch_call_hook cx name ploc super;
       Flow.mk_tvar_where cx reason (fun t ->
-        let funtype = Flow.mk_methodtype super argts t in
+        let funtype = Flow.mk_methodtype this argts t in
         Flow.flow cx (super, MethodT (reason, (reason_prop, name), funtype))
       )
 

--- a/src/typing/type_annotation.ml
+++ b/src/typing/type_annotation.ml
@@ -58,6 +58,19 @@ let rec convert cx type_params_map = Ast.Type.(function
 
 | loc, Null -> NullT.at loc
 
+| loc, This ->
+    if SMap.mem "this" type_params_map then
+      (* We model a this type like a type parameter. The bound on a this
+         type reflects the interface of `this` exposed in the current
+         environment. Currently, we only support this types in a class
+         environment: a this type in class C is bounded by C. *)
+      let reason = mk_reason "`this` type" loc in
+      Flow_js.reposition cx reason (SMap.find_unsafe "this" type_params_map)
+    else (
+      FlowError.add_warning cx (loc, ["Unexpected use of `this` type"]);
+      AnyT.t
+    )
+
 | loc, Number -> NumT.at loc
 
 | loc, String -> StrT.at loc
@@ -235,21 +248,6 @@ let rec convert cx type_params_map = Ast.Type.(function
       AbstractT t
     )
 
-  | "this" ->
-    if SMap.mem "this" type_params_map then
-      (* We model a this type like a type parameter. The bound on a this
-         type reflects the interface of `this` exposed in the current
-         environment. Currently, we only support this types in a class
-         environment: a this type in class C is bounded by C. *)
-      check_type_param_arity cx loc typeParameters 0 (fun () ->
-        let reason = mk_reason "`this` type" loc in
-        Flow_js.reposition cx reason (SMap.find_unsafe "this" type_params_map)
-      )
-    else (
-      FlowError.add_warning cx (loc, ["Unexpected use of `this` type"]);
-      AnyT.t
-    )
-
   (* Class<T> is the type of the class whose instances are of type T *)
   | "Class" ->
     check_type_param_arity cx loc typeParameters 1 (fun () ->
@@ -348,7 +346,12 @@ let rec convert cx type_params_map = Ast.Type.(function
 
   end
 
-| loc, Function { Function.params; returnType; rest; typeParameters } ->
+| _, Function { Function.this = Function.ThisParam.Explicit (loc, _); _ } ->
+  let msg = "Unsupported explicit this pseudoparameter found in function type" in
+  FlowError.add_error cx (loc, [msg]);
+  AnyT.t
+
+| loc, Function { Function.this = Function.ThisParam.Implicit _; params; returnType; rest; typeParameters } ->
   let typeparams, type_params_map =
     mk_type_param_declarations cx type_params_map typeParameters in
 

--- a/tests/class_type/class_type.exp
+++ b/tests/class_type/class_type.exp
@@ -1,2 +1,8 @@
+test2.js:23
+ 23:   static gn(): Class<Z> {
+                          ^ Z. This type is incompatible with
+ 17:   static gn(): Class<this> {
+                          ^^^^ some incompatible instantiation of `this`
 
-Found 0 errors
+
+Found 1 error

--- a/tests/class_type/class_type.exp
+++ b/tests/class_type/class_type.exp
@@ -1,7 +1,7 @@
-test2.js:23
- 23:   static gn(): Class<Z> {
-                          ^ Z. This type is incompatible with
- 17:   static gn(): Class<this> {
+test2.js:35
+ 35:   static gn(): Class<Y> {
+                          ^ Y. This type is incompatible with
+ 29:   static gn(): Class<this> {
                           ^^^^ some incompatible instantiation of `this`
 
 

--- a/tests/class_type/test2.js
+++ b/tests/class_type/test2.js
@@ -1,0 +1,28 @@
+class A {}
+class B extends A {}
+
+class X {
+  fn(): Class<A> {
+    return B;
+  }
+  static fn(): Class<A> {
+    return B;
+  }
+  static gn(): Class<X> {
+    return X;
+  }
+}
+
+class Y extends X {
+  static gn(): Class<this> {
+    return this;
+  }
+}
+
+class Z extends Y {
+  static gn(): Class<Z> {
+    return Z;
+  }
+}
+
+var K: Class<X> = Y.gn();

--- a/tests/class_type/test2.js
+++ b/tests/class_type/test2.js
@@ -1,28 +1,40 @@
 class A {}
 class B extends A {}
 
-class X {
+class K {
+  static gn() {
+    return this;
+  }
+}
+
+class L extends K {
+  static gn() { // Bug: False positive.  This is a NG.
+    return L;
+  }
+}
+
+class W {
   fn(): Class<A> {
     return B;
   }
   static fn(): Class<A> {
     return B;
   }
-  static gn(): Class<X> {
-    return X;
+  static gn(): Class<W> {
+    return W;
   }
 }
 
-class Y extends X {
+class X extends W {
   static gn(): Class<this> {
     return this;
   }
 }
 
-class Z extends Y {
-  static gn(): Class<Z> {
-    return Z;
+class Y extends X {
+  static gn(): Class<Y> {
+    return Y;
   }
 }
 
-var K: Class<X> = Y.gn();
+var a: Class<W> = X.gn();

--- a/tests/interface/interface.exp
+++ b/tests/interface/interface.exp
@@ -108,5 +108,41 @@ test3.js:6
   6:   (k.y: number); // error: y is string in I
              ^^^^^^ number
 
+test4.js:8
+  8: var p: A & I = a; // NG
+                ^ property `fn` of I. Property not found in
+  8: var p: A & I = a; // NG
+                    ^ A
 
-Found 19 errors
+test4.js:8
+  8: var p: A & I = a; // NG
+                ^ property `gn` of statics of I. Property not found in
+  8: var p: A & I = a; // NG
+                    ^ statics of A
+
+test4.js:9
+  9: var P: Class<A> & Class<I> = A; // NG
+                             ^ property `gn` of statics of I. Property not found in
+  6: class A {}
+           ^ statics of A
+
+test4.js:9
+  9: var P: Class<A> & Class<I> = A; // NG
+                             ^ property `fn` of I. Property not found in
+  9: var P: Class<A> & Class<I> = A; // NG
+                                  ^ A
+
+test4.js:20
+ 20: var q: A & I = b; // OK
+                ^ property `gn` of statics of I. Property not found in
+ 20: var q: A & I = b; // OK
+                    ^ statics of B
+
+test4.js:21
+ 21: var Q: Class<A> & Class<I> = B; // OK
+                             ^ property `gn` of statics of I. Property not found in
+ 11: class B extends A {
+           ^ statics of B
+
+
+Found 25 errors

--- a/tests/interface/test4.js
+++ b/tests/interface/test4.js
@@ -1,0 +1,21 @@
+interface I {
+  fn(): number;
+  static gn(): number;
+}
+
+class A {}
+var a = new A();
+var p: A & I = a; // NG
+var P: Class<A> & Class<I> = A; // NG
+
+class B extends A {
+  fn(): number {
+    return 1;
+  }
+  gn(): number {
+    return 2;
+  }
+}
+var b = new B();
+var q: A & I = b; // OK
+var Q: Class<A> & Class<I> = B; // OK

--- a/tests/this_param/ctor.js
+++ b/tests/this_param/ctor.js
@@ -1,0 +1,3 @@
+class A {
+  constructor(this: this) {}
+}

--- a/tests/this_param/explicit.js
+++ b/tests/this_param/explicit.js
@@ -1,10 +1,10 @@
-//@flow
-
 class A {
   method(this: Class<this>) {}
   static staticMethod(this: this) {}
 }
 
-var a = new A(); // NG
-a.method();
+var a = new A();
+a.method(); // NG
+
+// False positive.  Most likely a problem with the "knot" of `fix_this_class`.
 A.staticMethod(); // NG

--- a/tests/this_param/explicit.js
+++ b/tests/this_param/explicit.js
@@ -1,0 +1,10 @@
+//@flow
+
+class A {
+  method(this: Class<this>) {}
+  static staticMethod(this: this) {}
+}
+
+var a = new A(); // NG
+a.method();
+A.staticMethod(); // NG

--- a/tests/this_param/function.js
+++ b/tests/this_param/function.js
@@ -1,0 +1,14 @@
+function fn(this: { x: number }, x: string): string {
+  return x + this.x;
+}
+
+class A {
+  method(): number {
+    function k(this: any): number {
+      return 5;
+    }
+    return k();
+  }
+}
+
+var k = (this: any) => 5;

--- a/tests/this_param/interface.js
+++ b/tests/this_param/interface.js
@@ -5,13 +5,14 @@ interface I {
 
 class A {
   x: number;
-  static x: number; 
+  static x: number;
   method(this: this & I): number {
     return this.x + this.anotherMethod();
   }
   static staticMethod(this: Class<I> & Class<this>): number {
     // TODO:  There's a commutativity problem here.
-    // `Class<this> & I != I & Class<this>`
+    // `Class<this> & I != I & Class<this>`.  Add tests for intersections that
+    // include `ThisClassT`s.
     return this.x + this.anotherStaticMethod();
   }
 }
@@ -80,10 +81,9 @@ var n5: number = k.method(); // NG: `k` doesn't satisfy the requirements of `I`
 var n6: number = k.methodCaller();
 
 var ell = {
-  anotherMethod(): number {
-    return 3;
-  },
   fn: K.prototype.method
 };
+var n7: number = ell.fn(); // NG
 
-var n7: number = ell.fn(); // OK
+var fn = K.prototype.method;
+var n8: number = fn(); // NG

--- a/tests/this_param/interface.js
+++ b/tests/this_param/interface.js
@@ -1,0 +1,89 @@
+interface I {
+  anotherMethod(): number;
+  static anotherStaticMethod(): number;
+}
+
+class A {
+  x: number;
+  static x: number; 
+  method(this: this & I): number {
+    return this.x + this.anotherMethod();
+  }
+  static staticMethod(this: Class<I> & Class<this>): number {
+    // TODO:  There's a commutativity problem here.
+    // `Class<this> & I != I & Class<this>`
+    return this.x + this.anotherStaticMethod();
+  }
+}
+A.x = 1
+
+var a = new A();                   // OK
+var n1: number = a.method();       // NG
+var n2: number = A.staticMethod(); // NG
+
+class B extends A {
+  anotherMethod(): string {
+    // NGish: Incompatible with the `this` constraint on `method`.
+    return "another method";
+  }
+  static anotherStaticMethod(): string {
+    // NGish: Incompatible with the `this` constraint on `staticMethod`.
+    return "another static method";
+  }
+}
+
+var b = new B();
+var s1: string = b.anotherMethod(); // OK: Breaks a type requirement on
+                                    // `method`'s `this` pseudo-param, but
+                                    // that's okay on a `B` instance.
+var n3: number = b.method(); // NG: The return type on `anotherMethod` of `B`
+                             // breaks the constraint on `method`'s `this`
+                             // pseudo-param.
+var s2: string = B.anotherStaticMethod(); // OK: Analogous to `s1`.
+
+// False positive.  Flow ignores the following error, unless I comment out `n3`
+// above. If I move the `s3` above `n3`, then `s3` errors and the `n3` error is
+// ignored. Is this a bug or a feature?  If bug, it traces to an `Ops.peek`
+// call in `typecheck_error`, where the call yields the prior function call's
+// loc.
+var s3: number = B.staticMethod(); // NG: The return type on
+                                   // `anotherStaticMethod` of `B` breaks the
+                                   // constraint on `staticMethod`'s `this`
+                                   // pseudo-param.
+
+class C extends A {
+  anotherMethod() {
+    return 5;
+  }
+  static anotherStaticMethod() {
+    return 2;
+  }
+}
+
+var c = new C();
+var n3: number = c.method();       // OK
+var n4: number = C.staticMethod(); // OK
+
+// TJP TODO: In tests, generalize the following to a generic so that #1369 can be closed. Remove this note.
+class K {
+  method(this: I): number {
+    return this.anotherMethod(); // OK
+  }
+  methodCaller(): number {
+    return this.method(); // NG: The implicit pseudo-param of `methodCaller`,
+                          // i.e. `this`, doesn't satisfy the `I` interface.
+  }
+}
+
+var k = new K();             // OK
+var n5: number = k.method(); // NG: `k` doesn't satisfy the requirements of `I`
+var n6: number = k.methodCaller();
+
+var ell = {
+  anotherMethod(): number {
+    return 3;
+  },
+  fn: K.prototype.method
+};
+
+var n7: number = ell.fn(); // OK

--- a/tests/this_param/object.js
+++ b/tests/this_param/object.js
@@ -1,0 +1,92 @@
+type I = {
+  anotherMethod(): number;
+};
+
+type J = {
+  anotherStaticMethod(): number;
+};
+
+class A {
+  x: number;
+  static x: number; 
+  method(this: this & I): number {
+    return this.anotherMethod();
+  }
+  static staticMethod(this: J & Class<this>): number {
+    // NG AnnotT ~> ClassT flow necessary to capture statics.  Should this use case be supported (a class with only static methods is kinda an object, but then I guess somebody might want to inherit from such a data structure).
+    return this.anotherStaticMethod();
+  }
+}
+A.x = 1
+
+var a = new A();
+var n1: number = a.method(); // NG
+var n2: number = A.staticMethod(); // NG
+
+class B extends A {
+  anotherMethod(): string {
+    // NG: Incompatible with the `this` constraint on `method`.
+    return "another method";
+  }
+  static anotherStaticMethod(): string {
+    // NG: Incompatible with the `this` constraint on `staticMethod`.
+    return "another static method";
+  }
+}
+
+var b = new B();
+var s1: string = b.anotherMethod();
+var n3: number = b.method(); // NG
+var s2: string = B.anotherStaticMethod();
+var s3: number = B.staticMethod(); // NG: This line triggers an extra negative :(
+
+class C extends A {
+  anotherMethod() {
+    return 5;
+  }
+  static anotherStaticMethod() {
+    return 2;
+  }
+}
+
+var c = new C();
+var n3: number = c.method();
+var n4: number = C.staticMethod(); // OK! False Negative!
+
+class K {
+  method(this: I): number {
+    return this.anotherMethod();
+  }
+  methodCaller(): number {
+    return this.method(); // NG
+  }
+}
+
+var k = new K();
+var n5: number = k.method(); // NG
+var n6: number = k.methodCaller();
+
+var ell = {
+  anotherMethod(): number {
+    return 3;
+  },
+  fn: K.prototype.method
+};
+
+var n7: number = ell.fn();
+
+class Issue1369<T> {
+  _x: T;
+  getXMultBy(this: Issue1369<number>, y: number): number {
+    return this._x * y;
+  }
+}
+
+var s = new Issue1369();
+s._x = 5;
+s.getXMultBy(3);
+
+var t = new Issue1369();
+t._x = "a string";
+t.getXMultBy(4); // NG
+

--- a/tests/this_param/this_param.exp
+++ b/tests/this_param/this_param.exp
@@ -2,6 +2,14 @@ ctor.js:2
   2:   constructor(this: this) {}
                    ^^^^^^^^^^ Found a `this` pseudo-param on a constructor.
 
+explicit.js:7
+  7: a.method(); // NG
+     ^^^^^^^^^^ call of method `method`
+  7: a.method(); // NG
+     ^ A. This type is incompatible with
+  2:   method(this: Class<this>) {}
+                          ^^^^ class type: `this` type
+
 function.js:1
   1: function fn(this: { x: number }, x: string): string {
                  ^^^^^^^^^^^^^^^^^^^ explicit this pseudo-parameters are not allowed on functions
@@ -14,132 +22,145 @@ function.js:14
  14: var k = (this: any) => 5;
               ^^^^^^^^^ explicit this pseudo-parameters are not allowed on functions
 
-interface.js:21
- 21: var n1: number = a.method();       // NG
+interface.js:22
+ 22: var n1: number = a.method();       // NG
                       ^^^^^^^^^^ call of method `method`
   9:   method(this: this & I): number {
                            ^ property `anotherMethod` of I. Property not found in
- 21: var n1: number = a.method();       // NG
+ 22: var n1: number = a.method();       // NG
                       ^ A
 
-interface.js:21
- 21: var n1: number = a.method();       // NG
+interface.js:22
+ 22: var n1: number = a.method();       // NG
                       ^^^^^^^^^^ call of method `method`
   9:   method(this: this & I): number {
                            ^ property `anotherStaticMethod` of statics of I. Property not found in
- 21: var n1: number = a.method();       // NG
+ 22: var n1: number = a.method();       // NG
                       ^ statics of A
 
-interface.js:22
- 22: var n2: number = A.staticMethod(); // NG
+interface.js:23
+ 23: var n2: number = A.staticMethod(); // NG
                       ^^^^^^^^^^^^^^^^ call of method `staticMethod`
  12:   static staticMethod(this: Class<I> & Class<this>): number {
                                        ^ property `anotherStaticMethod` of statics of I. Property not found in
   6: class A {
            ^ statics of A
 
-interface.js:22
- 22: var n2: number = A.staticMethod(); // NG
+interface.js:23
+ 23: var n2: number = A.staticMethod(); // NG
                       ^^^^^^^^^^^^^^^^ call of method `staticMethod`
  12:   static staticMethod(this: Class<I> & Class<this>): number {
                                        ^ property `anotherMethod` of I. Property not found in
- 22: var n2: number = A.staticMethod(); // NG
+ 23: var n2: number = A.staticMethod(); // NG
                       ^ A
 
-interface.js:39
- 39: var n3: number = b.method(); // NG: The return type on `anotherMethod` of `B`
+interface.js:40
+ 40: var n3: number = b.method(); // NG: The return type on `anotherMethod` of `B`
                       ^^^^^^^^^^ call of method `method`
- 25:   anotherMethod(): string {
+ 26:   anotherMethod(): string {
                         ^^^^^^ string. This type is incompatible with
   2:   anotherMethod(): number;
                         ^^^^^^ number
 
-interface.js:39
- 39: var n3: number = b.method(); // NG: The return type on `anotherMethod` of `B`
+interface.js:40
+ 40: var n3: number = b.method(); // NG: The return type on `anotherMethod` of `B`
                       ^^^^^^^^^^ call of method `method`
- 29:   static anotherStaticMethod(): string {
+ 30:   static anotherStaticMethod(): string {
                                      ^^^^^^ string. This type is incompatible with
   3:   static anotherStaticMethod(): number;
                                      ^^^^^^ number
 
-interface.js:73
- 73:     return this.method(); // NG: The implicit pseudo-param of `methodCaller`,
-                ^^^^^^^^^^^^^ call of method `method`
- 69:   method(this: I): number {
+interface.js:70
+ 70:   method(this: I): number {
                     ^ property `anotherMethod` of I. Property not found in
- 68: class K {
+ 86: var n7: number = ell.fn(); // NG
+                      ^^^ object literal
+
+interface.js:74
+ 74:     return this.method(); // NG: The implicit pseudo-param of `methodCaller`,
+                ^^^^^^^^^^^^^ call of method `method`
+ 70:   method(this: I): number {
+                    ^ property `anotherMethod` of I. Property not found in
+ 69: class K {
            ^ K
 
-interface.js:73
- 73:     return this.method(); // NG: The implicit pseudo-param of `methodCaller`,
+interface.js:74
+ 74:     return this.method(); // NG: The implicit pseudo-param of `methodCaller`,
                 ^^^^^^^^^^^^^ call of method `method`
- 69:   method(this: I): number {
+ 70:   method(this: I): number {
                     ^ property `anotherStaticMethod` of statics of I. Property not found in
- 68: class K {
+ 69: class K {
            ^ statics of K
 
-interface.js:79
- 79: var n5: number = k.method(); // NG: `k` doesn't satisfy the requirements of `I`
+interface.js:80
+ 80: var n5: number = k.method(); // NG: `k` doesn't satisfy the requirements of `I`
                       ^^^^^^^^^^ call of method `method`
- 69:   method(this: I): number {
+ 70:   method(this: I): number {
                     ^ property `anotherMethod` of I. Property not found in
- 79: var n5: number = k.method(); // NG: `k` doesn't satisfy the requirements of `I`
+ 80: var n5: number = k.method(); // NG: `k` doesn't satisfy the requirements of `I`
                       ^ K
 
-interface.js:79
- 79: var n5: number = k.method(); // NG: `k` doesn't satisfy the requirements of `I`
+interface.js:80
+ 80: var n5: number = k.method(); // NG: `k` doesn't satisfy the requirements of `I`
                       ^^^^^^^^^^ call of method `method`
- 69:   method(this: I): number {
+ 70:   method(this: I): number {
                     ^ property `anotherStaticMethod` of statics of I. Property not found in
- 79: var n5: number = k.method(); // NG: `k` doesn't satisfy the requirements of `I`
+ 80: var n5: number = k.method(); // NG: `k` doesn't satisfy the requirements of `I`
                       ^ statics of K
 
-object.js:23
- 23: var n1: number = a.method(); // NG
+interface.js:89
+ 89: var n8: number = fn(); // NG
+                      ^^^^ function call
+ 70:   method(this: I): number {
+                    ^ property `anotherMethod` of I. Property not found in
+global object
+
+object.js:22
+ 22: var n1: number = a.method(); // NG
                       ^^^^^^^^^^ call of method `method`
  12:   method(this: this & I): number {
                            ^ property `anotherMethod`. Property not found in
- 23: var n1: number = a.method(); // NG
+ 22: var n1: number = a.method(); // NG
                       ^ A
 
-object.js:24
- 24: var n2: number = A.staticMethod(); // NG
+object.js:23
+ 23: var n2: number = A.staticMethod(); // NG
                       ^^^^^^^^^^^^^^^^ call of method `staticMethod`
  15:   static staticMethod(this: J & Class<this>): number {
                                  ^ property `anotherStaticMethod`. Property not found in
- 24: var n2: number = A.staticMethod(); // NG
+ 23: var n2: number = A.staticMethod(); // NG
                       ^ statics of A
 
-object.js:39
- 39: var n3: number = b.method(); // NG
+object.js:38
+ 38: var n3: number = b.method(); // NG
                       ^^^^^^^^^^ call of method `method`
   2:   anotherMethod(): number;
                         ^^^^^^ number. This type is incompatible with
- 27:   anotherMethod(): string {
+ 26:   anotherMethod(): string {
                         ^^^^^^ string
 
-object.js:39
- 39: var n3: number = b.method(); // NG
+object.js:38
+ 38: var n3: number = b.method(); // NG
                       ^^^^^^^^^^ call of method `method`
- 27:   anotherMethod(): string {
+ 26:   anotherMethod(): string {
                         ^^^^^^ string. This type is incompatible with
   2:   anotherMethod(): number;
                         ^^^^^^ number
 
-object.js:41
- 41: var s3: number = B.staticMethod(); // NG: This line triggers an extra negative :(
+object.js:46
+ 46: var s3: number = B.staticMethod(); // NG
                       ^^^^^^^^^^^^^^^^ call of method `staticMethod`
   6:   anotherStaticMethod(): number;
                               ^^^^^^ number. This type is incompatible with
- 31:   static anotherStaticMethod(): string {
+ 30:   static anotherStaticMethod(): string {
                                      ^^^^^^ string
 
-object.js:41
- 41: var s3: number = B.staticMethod(); // NG: This line triggers an extra negative :(
+object.js:46
+ 46: var s3: number = B.staticMethod(); // NG
                       ^^^^^^^^^^^^^^^^ call of method `staticMethod`
  15:   static staticMethod(this: J & Class<this>): number {
                                  ^^^^^^^^^^^^^^^ intersection. This type is incompatible with
- 26: class B extends A {
+ 25: class B extends A {
            ^ class type: `this` type
   Member 1:
     5: type J = {
@@ -147,64 +168,56 @@ object.js:41
   Error:
     5: type J = {
                 ^ object type. This type is incompatible with
-   26: class B extends A {
+   25: class B extends A {
              ^ class type: `this` type
   Member 2:
    15:   static staticMethod(this: J & Class<this>): number {
                                              ^^^^ class type: some incompatible instantiation of `this`
   Error:
-   26: class B extends A {
+   25: class B extends A {
              ^ B. This type is incompatible with
    15:   static staticMethod(this: J & Class<this>): number {
                                              ^^^^ some incompatible instantiation of `this`
 
-object.js:41
- 41: var s3: number = B.staticMethod(); // NG: This line triggers an extra negative :(
+object.js:46
+ 46: var s3: number = B.staticMethod(); // NG
                       ^^^^^^^^^^^^^^^^ call of method `staticMethod`
- 31:   static anotherStaticMethod(): string {
+ 30:   static anotherStaticMethod(): string {
                                      ^^^^^^ string. This type is incompatible with
   6:   anotherStaticMethod(): number;
                               ^^^^^^ number
 
-object.js:54
- 54: var n4: number = C.staticMethod(); // OK! False Negative!
+object.js:61
+ 61: var n4: number = C.staticMethod(); // OK
                       ^^^^^^^^^^^^^^^^ call of method `staticMethod`
- 43: class C extends A {
+ 48: class C extends A {
            ^ C. This type is incompatible with
  15:   static staticMethod(this: J & Class<this>): number {
                                            ^^^^ some incompatible instantiation of `this`
 
-object.js:61
- 61:     return this.method(); // NG
+object.js:68
+ 68:     return this.method(); // NG
                 ^^^^^^^^^^^^^ call of method `method`
- 57:   method(this: I): number {
+ 64:   method(this: I): number {
                     ^ property `anotherMethod`. Property not found in
- 56: class K {
+ 63: class K {
            ^ K
 
-object.js:66
- 66: var n5: number = k.method(); // NG
+object.js:73
+ 73: var n5: number = k.method(); // NG
                       ^^^^^^^^^^ call of method `method`
- 57:   method(this: I): number {
+ 64:   method(this: I): number {
                     ^ property `anotherMethod`. Property not found in
- 66: var n5: number = k.method(); // NG
+ 73: var n5: number = k.method(); // NG
                       ^ K
 
-object.js:91
- 91: t.getXMultBy(4); // NG
+object.js:98
+ 98: t.getXMultBy(4); // NG
      ^^^^^^^^^^^^^^^ call of method `getXMultBy`
- 90: t._x = "a string";
+ 97: t._x = "a string";
             ^^^^^^^^^^ string. This type is incompatible with
- 80:   getXMultBy(this: Issue1369<number>, y: number): number {
+ 87:   getXMultBy(this: Issue1369<number>, y: number): number {
                                   ^^^^^^ number
 
-test.js:9
-  9: a.method();
-     ^^^^^^^^^^ call of method `method`
-  9: a.method();
-     ^ A. This type is incompatible with
-  4:   method(this: Class<this>) {}
-                          ^^^^ class type: `this` type
 
-
-Found 26 errors
+Found 28 errors

--- a/tests/this_param/this_param.exp
+++ b/tests/this_param/this_param.exp
@@ -1,0 +1,210 @@
+ctor.js:2
+  2:   constructor(this: this) {}
+                   ^^^^^^^^^^ Found a `this` pseudo-param on a constructor.
+
+function.js:1
+  1: function fn(this: { x: number }, x: string): string {
+                 ^^^^^^^^^^^^^^^^^^^ explicit this pseudo-parameters are not allowed on functions
+
+function.js:7
+  7:     function k(this: any): number {
+                    ^^^^^^^^^ explicit this pseudo-parameters are not allowed on functions
+
+function.js:14
+ 14: var k = (this: any) => 5;
+              ^^^^^^^^^ explicit this pseudo-parameters are not allowed on functions
+
+interface.js:21
+ 21: var n1: number = a.method();       // NG
+                      ^^^^^^^^^^ call of method `method`
+  9:   method(this: this & I): number {
+                           ^ property `anotherMethod` of I. Property not found in
+ 21: var n1: number = a.method();       // NG
+                      ^ A
+
+interface.js:21
+ 21: var n1: number = a.method();       // NG
+                      ^^^^^^^^^^ call of method `method`
+  9:   method(this: this & I): number {
+                           ^ property `anotherStaticMethod` of statics of I. Property not found in
+ 21: var n1: number = a.method();       // NG
+                      ^ statics of A
+
+interface.js:22
+ 22: var n2: number = A.staticMethod(); // NG
+                      ^^^^^^^^^^^^^^^^ call of method `staticMethod`
+ 12:   static staticMethod(this: Class<I> & Class<this>): number {
+                                       ^ property `anotherStaticMethod` of statics of I. Property not found in
+  6: class A {
+           ^ statics of A
+
+interface.js:22
+ 22: var n2: number = A.staticMethod(); // NG
+                      ^^^^^^^^^^^^^^^^ call of method `staticMethod`
+ 12:   static staticMethod(this: Class<I> & Class<this>): number {
+                                       ^ property `anotherMethod` of I. Property not found in
+ 22: var n2: number = A.staticMethod(); // NG
+                      ^ A
+
+interface.js:39
+ 39: var n3: number = b.method(); // NG: The return type on `anotherMethod` of `B`
+                      ^^^^^^^^^^ call of method `method`
+ 25:   anotherMethod(): string {
+                        ^^^^^^ string. This type is incompatible with
+  2:   anotherMethod(): number;
+                        ^^^^^^ number
+
+interface.js:39
+ 39: var n3: number = b.method(); // NG: The return type on `anotherMethod` of `B`
+                      ^^^^^^^^^^ call of method `method`
+ 29:   static anotherStaticMethod(): string {
+                                     ^^^^^^ string. This type is incompatible with
+  3:   static anotherStaticMethod(): number;
+                                     ^^^^^^ number
+
+interface.js:73
+ 73:     return this.method(); // NG: The implicit pseudo-param of `methodCaller`,
+                ^^^^^^^^^^^^^ call of method `method`
+ 69:   method(this: I): number {
+                    ^ property `anotherMethod` of I. Property not found in
+ 68: class K {
+           ^ K
+
+interface.js:73
+ 73:     return this.method(); // NG: The implicit pseudo-param of `methodCaller`,
+                ^^^^^^^^^^^^^ call of method `method`
+ 69:   method(this: I): number {
+                    ^ property `anotherStaticMethod` of statics of I. Property not found in
+ 68: class K {
+           ^ statics of K
+
+interface.js:79
+ 79: var n5: number = k.method(); // NG: `k` doesn't satisfy the requirements of `I`
+                      ^^^^^^^^^^ call of method `method`
+ 69:   method(this: I): number {
+                    ^ property `anotherMethod` of I. Property not found in
+ 79: var n5: number = k.method(); // NG: `k` doesn't satisfy the requirements of `I`
+                      ^ K
+
+interface.js:79
+ 79: var n5: number = k.method(); // NG: `k` doesn't satisfy the requirements of `I`
+                      ^^^^^^^^^^ call of method `method`
+ 69:   method(this: I): number {
+                    ^ property `anotherStaticMethod` of statics of I. Property not found in
+ 79: var n5: number = k.method(); // NG: `k` doesn't satisfy the requirements of `I`
+                      ^ statics of K
+
+object.js:23
+ 23: var n1: number = a.method(); // NG
+                      ^^^^^^^^^^ call of method `method`
+ 12:   method(this: this & I): number {
+                           ^ property `anotherMethod`. Property not found in
+ 23: var n1: number = a.method(); // NG
+                      ^ A
+
+object.js:24
+ 24: var n2: number = A.staticMethod(); // NG
+                      ^^^^^^^^^^^^^^^^ call of method `staticMethod`
+ 15:   static staticMethod(this: J & Class<this>): number {
+                                 ^ property `anotherStaticMethod`. Property not found in
+ 24: var n2: number = A.staticMethod(); // NG
+                      ^ statics of A
+
+object.js:39
+ 39: var n3: number = b.method(); // NG
+                      ^^^^^^^^^^ call of method `method`
+  2:   anotherMethod(): number;
+                        ^^^^^^ number. This type is incompatible with
+ 27:   anotherMethod(): string {
+                        ^^^^^^ string
+
+object.js:39
+ 39: var n3: number = b.method(); // NG
+                      ^^^^^^^^^^ call of method `method`
+ 27:   anotherMethod(): string {
+                        ^^^^^^ string. This type is incompatible with
+  2:   anotherMethod(): number;
+                        ^^^^^^ number
+
+object.js:41
+ 41: var s3: number = B.staticMethod(); // NG: This line triggers an extra negative :(
+                      ^^^^^^^^^^^^^^^^ call of method `staticMethod`
+  6:   anotherStaticMethod(): number;
+                              ^^^^^^ number. This type is incompatible with
+ 31:   static anotherStaticMethod(): string {
+                                     ^^^^^^ string
+
+object.js:41
+ 41: var s3: number = B.staticMethod(); // NG: This line triggers an extra negative :(
+                      ^^^^^^^^^^^^^^^^ call of method `staticMethod`
+ 15:   static staticMethod(this: J & Class<this>): number {
+                                 ^^^^^^^^^^^^^^^ intersection. This type is incompatible with
+ 26: class B extends A {
+           ^ class type: `this` type
+  Member 1:
+    5: type J = {
+                ^ object type
+  Error:
+    5: type J = {
+                ^ object type. This type is incompatible with
+   26: class B extends A {
+             ^ class type: `this` type
+  Member 2:
+   15:   static staticMethod(this: J & Class<this>): number {
+                                             ^^^^ class type: some incompatible instantiation of `this`
+  Error:
+   26: class B extends A {
+             ^ B. This type is incompatible with
+   15:   static staticMethod(this: J & Class<this>): number {
+                                             ^^^^ some incompatible instantiation of `this`
+
+object.js:41
+ 41: var s3: number = B.staticMethod(); // NG: This line triggers an extra negative :(
+                      ^^^^^^^^^^^^^^^^ call of method `staticMethod`
+ 31:   static anotherStaticMethod(): string {
+                                     ^^^^^^ string. This type is incompatible with
+  6:   anotherStaticMethod(): number;
+                              ^^^^^^ number
+
+object.js:54
+ 54: var n4: number = C.staticMethod(); // OK! False Negative!
+                      ^^^^^^^^^^^^^^^^ call of method `staticMethod`
+ 43: class C extends A {
+           ^ C. This type is incompatible with
+ 15:   static staticMethod(this: J & Class<this>): number {
+                                           ^^^^ some incompatible instantiation of `this`
+
+object.js:61
+ 61:     return this.method(); // NG
+                ^^^^^^^^^^^^^ call of method `method`
+ 57:   method(this: I): number {
+                    ^ property `anotherMethod`. Property not found in
+ 56: class K {
+           ^ K
+
+object.js:66
+ 66: var n5: number = k.method(); // NG
+                      ^^^^^^^^^^ call of method `method`
+ 57:   method(this: I): number {
+                    ^ property `anotherMethod`. Property not found in
+ 66: var n5: number = k.method(); // NG
+                      ^ K
+
+object.js:91
+ 91: t.getXMultBy(4); // NG
+     ^^^^^^^^^^^^^^^ call of method `getXMultBy`
+ 90: t._x = "a string";
+            ^^^^^^^^^^ string. This type is incompatible with
+ 80:   getXMultBy(this: Issue1369<number>, y: number): number {
+                                  ^^^^^^ number
+
+test.js:9
+  9: a.method();
+     ^^^^^^^^^^ call of method `method`
+  9: a.method();
+     ^ A. This type is incompatible with
+  4:   method(this: Class<this>) {}
+                          ^^^^ class type: `this` type
+
+
+Found 26 errors

--- a/tests/this_type/generics.js
+++ b/tests/this_type/generics.js
@@ -6,3 +6,46 @@ class Implicit<X> { arg: X; val: X; }
 class ImplicitNumber extends Implicit { arg: number; }
 
 (new ImplicitNumber().val: string) // error: number ~> string
+
+class A {}
+
+class B<T> extends A {
+  x: T;
+  constructor(x: T) {
+    super();
+    this.x = x;
+  }
+  method(): this {
+    return new this.constructor(this.x);
+  }
+  static staticMethod(x: T): this {
+    return new this(x);
+  }
+}
+
+class C extends B<number> {
+/* Demo bugs in calls on `super`
+  method() {
+    var t = super.method();
+    t.x += 5;
+    return t;
+  }
+  static staticMethod(x) {
+    var t = super.staticMethod(x);
+    t.x += 6;
+    return t;
+  }
+*/
+}
+
+var a = new A();
+var b1 = new B(1);
+var b2 = new B("a string");
+var b3 = new B(null);
+var c1: C = new C(2);
+var c2 = new C("another string"); // NG
+var c3 = new C(null); // NG
+
+c1 = b1.method(); // NG
+c1 = b2.method(); // NG
+c1 = b3.method(); // NG

--- a/tests/this_type/super.js
+++ b/tests/this_type/super.js
@@ -1,0 +1,20 @@
+// @flow
+class A {
+  method(): this {
+    return new this.constructor();
+  }
+  static staticMethod(): this {
+    return new this();
+  }
+}
+
+class B extends A {
+/* Demo bugs in calls on `super`
+  method() {
+    return super.method();
+  }
+  static staticMethod(x) {
+    return super.staticMethod(x);
+  }
+*/
+}

--- a/tests/this_type/this_type.exp
+++ b/tests/this_type/this_type.exp
@@ -92,6 +92,40 @@ generics.js:8
   8: (new ImplicitNumber().val: string) // error: number ~> string
                                 ^^^^^^ string
 
+generics.js:46
+ 46: var c2 = new C("another string"); // NG
+              ^^^^^^^^^^^^^^^^^^^^^^^ constructor call
+ 46: var c2 = new C("another string"); // NG
+                    ^^^^^^^^^^^^^^^^ string. This type is incompatible with
+ 26: class C extends B<number> {
+                       ^^^^^^ number
+
+generics.js:47
+ 47: var c3 = new C(null); // NG
+              ^^^^^^^^^^^ constructor call
+ 47: var c3 = new C(null); // NG
+                    ^^^^ null. This type is incompatible with
+ 26: class C extends B<number> {
+                       ^^^^^^ number
+
+generics.js:49
+ 49: c1 = b1.method(); // NG
+          ^^^^^^^^^^^ B. This type is incompatible with
+ 45: var c1: C = new C(2);
+             ^ C
+
+generics.js:50
+ 50: c1 = b2.method(); // NG
+          ^^^^^^^^^^^ B. This type is incompatible with
+ 45: var c1: C = new C(2);
+             ^ C
+
+generics.js:51
+ 51: c1 = b3.method(); // NG
+          ^^^^^^^^^^^ B. This type is incompatible with
+ 45: var c1: C = new C(2);
+             ^ C
+
 import.js:8
   8:   foo(): B1 { return new B1(); } // error
               ^^ B1. This type is incompatible with
@@ -205,4 +239,4 @@ test.js:56
                     ^^^^ `this` type. contravariant position (expected `this` to occur only covariantly)
 
 
-Found 41 errors
+Found 46 errors


### PR DESCRIPTION
This patch adds support for a `this` pseudo-param on class methods (static and non-static).  With the syntax `someMethod(this: this & I,...` users can impose requirement beyond "is subtype of the enclosing class," the current behavior.  Some goofiness becomes admissible too, e.g. `someMethod(this: {})`--just don't be goofy (maybe a warning is warranted if the pseudo-param's type is not a subtype of the enclosing class).  I have a use case where the value in this extension lies in chaining of static methods, not non-statics, so I've extended class subtyping to structural class statics (InstanceT ~> SuperT still ignores subtyping of statics).  I feel like I'm on solid ground after a chat with @jeffmo  and @avikchaudhuri  on IRC, although during that discussion I forgot to contrast ES5 and Node inheritance against ES6 inheritance.  I recall in the past that @samwgoldman  and I disagreed on whether class statics should subtype.

Node's inheritance (`util.inherit`) and the ad hoc inheritance of ES5 (`SomeClass.prototype = Object.create(ParentClass.prototype, {...})` *without* SomeClass.\__proto__ = ParentClass) do not chain class statics.  Subtyping statics is biased toward ES6 inheritance, whereas the status quo is biased toward Node and ad hoc inheritance.

Closes #807, #1369, #1704, #1705