### PR TITLE
Fix hardcoded parser tests and get travis to run them

### DIFF
--- a/resources/travis/build.sh
+++ b/resources/travis/build.sh
@@ -31,3 +31,7 @@ printf "travis_fold:end:make_js\n"
 printf "travis_fold:start:runtests\nRunning flow tests\n"
 ./runtests.sh bin/flow
 printf "travis_fold:end:runtests\n"
+
+printf "travis_fold:start:runparsertests\nRunning ocaml parser tests\n"
+(cd src/parser && make test-ocaml)
+printf "travis_fold:end:runparsertests\n"

--- a/src/parser/Makefile
+++ b/src/parser/Makefile
@@ -39,7 +39,7 @@ js:
 test-js: build-parser js
 	npm test
 
-_build/src/parser/test/run_hardcoded_tests.native:
+_build/src/parser/test/run_hardcoded_tests.native: build-parser
 	cd $(TOP); \
 	ocamlbuild -build-dir src/parser/_build \
 		-ocamlc "ocamlopt -ccopt -DNO_LZ4" \

--- a/src/parser/parser_flow.ml
+++ b/src/parser/parser_flow.ml
@@ -2343,11 +2343,13 @@ end = struct
           let typeAnnotation = Type.annotation_opt env in
           let options = parse_options env in
           let value =
-            if Expect.maybe env T_ASSIGN then (
+            if Peek.token env = T_ASSIGN then (
               if static && options.esproposal_class_static_fields
                  || (not static) && options.esproposal_class_instance_fields
-              then Some (Parse.expression env)
-              else None
+              then begin 
+                Expect.token env T_ASSIGN;
+                Some (Parse.expression env)
+              end else None
             ) else None in
           let end_loc = Peek.loc env in
           if Expect.maybe env T_SEMICOLON then () else begin

--- a/src/parser/test/hardcoded_tests.js
+++ b/src/parser/test/hardcoded_tests.js
@@ -2914,12 +2914,12 @@ module.exports = {
           'computed': false,
         }]
       },
-      'class Properties { x = "hello"; }': {
+      'class Properties { x = "hi mom"; }': {
         '%parse_options%': {
           'esproposal_class_instance_fields': false,
         },
         'errors': {
-          '0.message': 'Unexpected string',
+          '0.message': 'Unexpected token =',
         },
       },
       'class Properties { x: string = "hello"; }': {
@@ -2968,11 +2968,11 @@ module.exports = {
           'computed': false,
         }]
       },
-      'class Properties { static x = "hello"; }': {
+      'class Properties { static x = "hi mom"; }': {
         '%parse_options%': {
           'esproposal_class_static_fields': false,
         },
-        'errors.0.message': 'Unexpected string',
+        'errors.0.message': 'Unexpected token =',
       },
       'class Properties { static x: string = "hello"; }': {
         '%parse_options%': {


### PR DESCRIPTION
Tests recently broke, partially because they were testing some broken behavior.

We run these tests on our internal CI, but Travis should run them too, so we can see when PRs break tests.