### PR TITLE
Fix parser makefile for 4.03.0

### DIFF
--- a/_tags
+++ b/_tags
@@ -5,5 +5,6 @@
 <src/commands/shellCompleteCommand.ml>: warn(-3)
 <src/flow.ml>: warn(-3)
 <src/services/inference/module_js.ml>: warn(-3)
+<src/typing/flow_error.ml>: warn(-3)
 <src/typing/statement.ml>: warn(-3)
 <**/node_modules/**>: -traverse

--- a/src/parser/Makefile
+++ b/src/parser/Makefile
@@ -2,7 +2,8 @@
 # All rights reserved.
 
 DIR:=$(dir $(abspath $(lastword $(MAKEFILE_LIST))))
-TOP=$(DIR)../..
+TOP=$(DIR)/../..
+REL_DIR=src/parser
 
 NATIVE_OBJECT_FILES=\
 	hack/heap/hh_shared.o\
@@ -25,42 +26,47 @@ RUNNER_DEPS=\
 all: build-parser
 
 clean:
-	ocamlbuild -clean
-	rm -f flow_parser.js tools/native_test_files
+	cd $(TOP); \
+	ocamlbuild -clean; \
+	rm -f $(REL_DIR)/flow_parser.js $(REL_DIR)/tools/native_test_files
 
 build-parser:
-	ocamlbuild -no-links parser_flow.cmxa
+	cd $(TOP); \
+	ocamlbuild -no-links $(REL_DIR)/parser_flow.cmxa
 
 js:
-	ocamlbuild -use-ocamlfind -pkgs js_of_ocaml -build-dir _build flow_parser_js.byte
-	js_of_ocaml --opt 3 -o flow_parser.js _build/flow_parser_js.byte
-	rm _build/flow_parser_js.byte
+	cd $(TOP); \
+	ocamlbuild -use-ocamlfind -pkgs js_of_ocaml $(REL_DIR)/flow_parser_js.byte; \
+	js_of_ocaml --opt 3 -o $(REL_DIR)/flow_parser.js $(TOP)/js/caml_hexstring_of_float.js _build/$(REL_DIR)/flow_parser_js.byte; \
+	rm flow_parser_js.byte
 
 test-js: build-parser js
 	npm test
 
-_build/src/parser/test/run_hardcoded_tests.native: build-parser
+../../_build/$(REL_DIR)/test/run_hardcoded_tests.native: build-parser
 	cd $(TOP); \
-	ocamlbuild -build-dir src/parser/_build \
+	ocamlbuild \
 		-ocamlc "ocamlopt -ccopt -DNO_LZ4" \
 		$(NATIVE_OBJECT_FILES); \
 	ocamlbuild \
-		-build-dir src/parser/_build \
 		$(foreach dir,$(RUNNER_DEPS),-I $(dir)) \
 	 	-lib unix -lib str \
 	 	-lflags "$(NATIVE_OBJECT_FILES)" \
-		src/parser/test/run_hardcoded_tests.native
+		$(REL_DIR)/test/run_hardcoded_tests.native; \
+	rm run_hardcoded_tests.native
 
-test-ocaml: _build/src/parser/test/run_hardcoded_tests.native
-	$< test/hardcoded_tests.js
+test-ocaml: ../../_build/$(REL_DIR)/test/run_hardcoded_tests.native
+	cd $(TOP); \
+	_build/$(REL_DIR)/test/run_hardcoded_tests.native $(REL_DIR)/test/hardcoded_tests.js
 
 test: test-js test-ocaml
 
 tools: native_test_files
 
 native_test_files:
-	ocamlbuild tools/native_test_files.native
-	mv native_test_files.native tools/native_test_files
+	cd $(TOP); \
+	ocamlbuild $(REL_DIR)/tools/native_test_files.native; \
+	mv native_test_files.native $(REL_DIR)/tools/native_test_files
 
 npm-publish:
 	mv README.md README-backup.md


### PR DESCRIPTION
4.03.0's `ocamlbuild` was not happy about `_build/` dir sanitization. The easiest fix is to always use the top level `_build/` dir.