### PR TITLE
fix Element.namespaceURI property

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -670,7 +670,7 @@ declare class Element extends Node {
   innerHTML: string;
   lastElementChild: ?Element;
   localName: string;
-  namespaceUri: ?string;
+  namespaceURI: ?string;
   nextElementSibling: ?Element;
   outerHTML: string;
   prefix: string;


### PR DESCRIPTION
0.25.0 regression - wrong case for `Element.namespaceURI`