### PR TITLE
Parser support for `declare module "foo" { declare export ... }`

### DIFF
--- a/src/parser/estree_translator.ml
+++ b/src/parser/estree_translator.ml
@@ -239,6 +239,11 @@ end with type t = Impl.t) = struct
         node "DeclareModule" loc [|
           "id", id;
           "body", block m.body;
+          "kind", (
+            match m.kind with
+            | DeclareModule.CommonJS _ -> string "CommonJS"
+            | DeclareModule.ES _ -> string "ES"
+          )
         |]
       )
     | loc, DeclareExportDeclaration export -> DeclareExportDeclaration.(
@@ -247,6 +252,8 @@ end with type t = Impl.t) = struct
         | Some (Function f) -> declare_function f
         | Some (Class c) -> declare_class c
         | Some (DefaultType t) -> _type t
+        | Some (NamedType t) -> type_alias t
+        | Some (Interface i) -> interface_declaration i
         | None -> null
         in
         node "DeclareExportDeclaration" loc [|

--- a/src/parser/parse_error.ml
+++ b/src/parser/parse_error.ml
@@ -76,6 +76,8 @@ type t =
   | ExportNamelessFunction
   | UnsupportedDecorator
   | MissingTypeParamDefault
+  | DuplicateDeclareModuleExports
+  | AmbiguousDeclareModuleKind
 
 exception Error of (Loc.t * t) list
 
@@ -172,6 +174,11 @@ module PP =
       | UnsupportedDecorator -> "Found a decorator in an unsupported position."
       | MissingTypeParamDefault -> "Type parameter declaration needs a default, \
           since a preceding type parameter declaration has a default."
+      | DuplicateDeclareModuleExports -> "Duplicate `declare module.exports` \
+          statement!"
+      | AmbiguousDeclareModuleKind -> "Found both `declare module.exports` and \
+          `declare export` in the same module. Modules can only have 1 since \
+          they are either an ES module xor they are a CommonJS module."
 
 
   end

--- a/src/parser/parser_flow.ml
+++ b/src/parser/parser_flow.ml
@@ -2512,7 +2512,7 @@ end = struct
     val continue: env -> Ast.Statement.t
     val debugger: env -> Ast.Statement.t
     val declare: ?in_module:bool -> env -> Ast.Statement.t
-    val declare_export_declaration: env -> Ast.Statement.t
+    val declare_export_declaration: ?allow_export_type:bool -> env -> Ast.Statement.t
     val do_while: env -> Ast.Statement.t
     val empty: env -> Ast.Statement.t
     val export_declaration: env -> Ast.Expression.t list -> Ast.Statement.t
@@ -3012,7 +3012,7 @@ end = struct
       else
         Parse.statement env
 
-    and interface =
+    and interface_helper =
       let rec supers env acc =
         let super = Type.generic env in
         let acc = super::acc in
@@ -3021,33 +3021,36 @@ end = struct
             Expect.token env T_COMMA;
             supers env acc
         | _ -> List.rev acc
-
-      in fun env ->
+      in
+      fun env ->
         let start_loc = Peek.loc env in
-        if Peek.identifier ~i:1 env
+        if not (should_parse_types env)
+        then error env Error.UnexpectedTypeInterface;
+        Expect.token env T_INTERFACE;
+        let id = Parse.identifier env in
+        let typeParameters = Type.type_parameter_declaration_with_defaults env in
+        let extends = if Peek.token env = T_EXTENDS
         then begin
-          if not (should_parse_types env)
-          then error env Error.UnexpectedTypeInterface;
-          Expect.token env T_INTERFACE;
-          let id = Parse.identifier env in
-          let typeParameters = Type.type_parameter_declaration_with_defaults env in
-          let extends = if Peek.token env = T_EXTENDS
-          then begin
-            Expect.token env T_EXTENDS;
-            supers env []
-          end else [] in
-          let body = Type._object ~allow_static:true env in
-          let loc = Loc.btwn start_loc (fst body) in
-          loc, Statement.(InterfaceDeclaration Interface.({
-            id;
-            typeParameters;
-            body;
-            extends;
-            mixins = [];
-          }))
-        end else begin
-          expression env
-        end
+          Expect.token env T_EXTENDS;
+          supers env []
+        end else [] in
+        let body = Type._object ~allow_static:true env in
+        let loc = Loc.btwn start_loc (fst body) in
+        loc, Statement.Interface.({
+          id;
+          typeParameters;
+          body;
+          extends;
+          mixins = [];
+        })
+
+
+    and interface env =
+      if Peek.identifier ~i:1 env
+      then
+        let loc, iface = interface_helper env in
+        loc, Statement.InterfaceDeclaration iface
+      else expression env
 
     and declare_class =
       let rec supers env acc =
@@ -3136,11 +3139,75 @@ end = struct
       loc, Statement.DeclareVariable var
 
     and declare_module =
-      let rec module_items env acc =
+      let rec module_items env ?(module_kind=None) acc =
         match Peek.token env with
         | T_EOF
-        | T_RCURLY -> List.rev acc
-        | _ -> module_items env (declare ~in_module:true env::acc)
+        | T_RCURLY -> (module_kind, List.rev acc)
+        | _ ->
+          let stmt = declare ~in_module:true env in
+          let module_kind = Statement.(
+            let (loc, stmt) = stmt in
+            match (module_kind, stmt) with
+            (**
+             * The first time we see either a `declare export` or a
+             * `declare module.exports`, we lock in the kind of the module.
+             *
+             * `declare export type` and `declare export interface` are the two
+             * exceptions to this rule because they are valid in both CommonJS
+             * and ES modules (and thus do not indicate an intent for either).
+             *)
+            | None, DeclareModuleExports _ -> Some (DeclareModule.CommonJS loc)
+            | None, DeclareExportDeclaration {
+                DeclareExportDeclaration.declaration;
+                _;
+              } ->
+              (match declaration with
+                | Some (DeclareExportDeclaration.NamedType _)
+                | Some (DeclareExportDeclaration.Interface _)
+                  -> module_kind
+                | _ -> Some (DeclareModule.ES loc)
+              )
+
+            (* It's ok to see multiple `declare export` statements *)
+            | Some (DeclareModule.ES _), DeclareExportDeclaration _ ->
+              module_kind
+
+            (**
+             * There should never be more than one `declare module.exports`
+             * statement *)
+            | Some (DeclareModule.CommonJS _), DeclareModuleExports _ ->
+              error env Parse_error.DuplicateDeclareModuleExports;
+              module_kind
+
+            (**
+             * CommonJS modules are allowed to have `declare export type` and
+             * `declare export interface`.
+             *)
+            | Some (DeclareModule.CommonJS _), DeclareExportDeclaration {
+                DeclareExportDeclaration.declaration = Some (
+                  DeclareExportDeclaration.NamedType _
+                  | DeclareExportDeclaration.Interface _
+                );
+                _;
+              } -> module_kind
+
+            (**
+             * It's never ok to mix and match `declare export` and
+             * `declare module.exports` in the same DeclareModule because this
+             * leaves the kind of the module ambiguous.
+             *
+             * TODO: It *is* ok to use `declare export type` in a CommonJS
+             *       module.
+             *)
+            | Some (DeclareModule.ES _), DeclareModuleExports _
+            | Some (DeclareModule.CommonJS _), DeclareExportDeclaration _
+              ->
+                error env Parse_error.AmbiguousDeclareModuleKind;
+                module_kind
+
+            | _ -> module_kind
+          ) in
+          module_items env ~module_kind (stmt::acc)
 
       in fun env start_loc ->
         let id = match Peek.token env with
@@ -3153,13 +3220,19 @@ end = struct
             Statement.DeclareModule.Identifier (Parse.identifier env) in
         let body_start_loc = Peek.loc env in
         Expect.token env T_LCURLY;
-        let body = module_items env [] in
+        let (module_kind, body) = module_items env [] in
         Expect.token env T_RCURLY;
         let body_end_loc = Peek.loc env in
         let body_loc = Loc.btwn body_start_loc body_end_loc in
         let body = body_loc, { Statement.Block.body; } in
-        Loc.btwn start_loc (fst body),
-        Statement.(DeclareModule DeclareModule.({ id; body; }))
+        let loc = Loc.btwn start_loc (fst body) in
+        let kind =
+          match module_kind with
+          | Some k -> k
+          | None -> Statement.DeclareModule.CommonJS loc
+        in
+        loc,
+        Statement.(DeclareModule DeclareModule.({ id; body; kind; }))
 
     and declare_module_exports env start_loc =
       Expect.token env T_PERIOD;
@@ -3200,6 +3273,8 @@ end = struct
             error env Error.DeclareAsync;
             Expect.token env T_ASYNC;
             declare_function_statement env start_loc
+        | T_EXPORT ->
+            declare_export_declaration ~allow_export_type:in_module env
         | T_IDENTIFIER when Peek.value ~i:1 env = "module" ->
             Expect.token env T_DECLARE;
             Expect.contextual env "module";
@@ -3215,7 +3290,7 @@ end = struct
             Parse.statement env
       )
 
-    let export_source env =
+    and export_source env =
       Expect.contextual env "from";
       match Peek.token env with
       | T_STRING (loc, value, raw, octal) ->
@@ -3231,7 +3306,7 @@ end = struct
           error_unexpected env;
           ret
 
-    let extract_pattern_binding_names =
+    and extract_pattern_binding_names =
       let rec fold acc = Pattern.(function
         | (_, Object {Object.properties; _;}) ->
           List.fold_left (fun acc prop ->
@@ -3255,9 +3330,9 @@ end = struct
       ) in
       List.fold_left fold
 
-    let extract_ident_name (_, {Identifier.name; _;}) = name
+    and extract_ident_name (_, {Identifier.name; _;}) = name
 
-    let rec export_specifiers_and_errs env specifiers errs =
+    and export_specifiers_and_errs env specifiers errs =
       match Peek.token env with
       | T_EOF
       | T_RCURLY ->
@@ -3287,7 +3362,7 @@ end = struct
           | None -> errs in
           export_specifiers_and_errs env (specifier::specifiers) errs
 
-    let export_declaration env decorators =
+    and export_declaration env decorators =
       let env = env |> with_strict true |> with_in_export true in
       let start_loc = Peek.loc env in
       Expect.token env T_EXPORT;
@@ -3466,7 +3541,7 @@ end = struct
           }
       )
 
-    and declare_export_declaration env =
+    and declare_export_declaration ?(allow_export_type=false) env =
       if not (should_parse_types env)
       then error env Error.UnexpectedTypeDeclaration;
       let start_loc = Peek.loc env in
@@ -3564,6 +3639,26 @@ end = struct
             specifiers;
             source;
           }
+      | T_TYPE when allow_export_type ->
+          (* declare export type = ... *)
+          let (alias_loc, alias) = type_alias_helper env in
+          let loc = Loc.btwn start_loc alias_loc in
+          (loc, Statement.DeclareExportDeclaration {
+            default = false;
+            declaration = Some (NamedType (alias_loc, alias));
+            specifiers = None;
+            source = None;
+          })
+      | T_INTERFACE when allow_export_type ->
+          (* declare export interface ... *)
+          let (iface_loc, iface) = interface_helper env in
+          let loc = Loc.btwn start_loc iface_loc in
+          (loc, Statement.DeclareExportDeclaration {
+            default = false;
+            declaration = Some (Interface (iface_loc, iface));
+            specifiers = None;
+            source = None;
+          })
       | _ ->
           (match Peek.token env with
             | T_TYPE -> error env Error.DeclareExportType

--- a/src/parser/spider_monkey_ast.ml
+++ b/src/parser/spider_monkey_ast.ml
@@ -363,9 +363,15 @@ and Statement : sig
     type id =
       | Identifier of Identifier.t
       | Literal of (Loc.t * Literal.t)
+
+    type module_kind =
+      | CommonJS of Loc.t
+      | ES of Loc.t
+
     type t = {
       id: id;
       body: Loc.t * Block.t;
+      kind: module_kind;
     }
   end
   module ExportDeclaration : sig
@@ -405,6 +411,10 @@ and Statement : sig
        * this corresponds to things like
        * export default 1+1; *)
       | DefaultType of Type.t
+      (* declare export type *)
+      | NamedType of (Loc.t * TypeAlias.t)
+      (* declare export interface *)
+      | Interface of (Loc.t * Interface.t)
 
     type t = {
       default: bool;

--- a/src/parser/test/custom_ast_types.js
+++ b/src/parser/test/custom_ast_types.js
@@ -14,6 +14,24 @@ def("DeclareModuleExports")
   .build("typeAnnotation")
   .field("typeAnnotation", def("TypeAnnotation"));
 
+def("DeclareModule")
+  .bases("Statement")
+  .build("id", "body", "kind")
+  .field("id", or(def("Identifier"), def("Literal")))
+  .field("body", def("BlockStatement"))
+  .field("kind", or("CommonJS", "ES"));
+
+def("DeclareExportDeclaration")
+  .field("declaration", or(
+    def("DeclareVariable"),
+    def("DeclareFunction"),
+    def("DeclareClass"),
+    def("Type"), // Implies default type
+    def("TypeAlias"), // Implies named type
+    def("InterfaceDeclaration"),
+    null
+  ))
+
 def("ExistsTypeAnnotation")
   .bases("Type")
   .build();

--- a/src/parser/test/esprima_ast_types.js
+++ b/src/parser/test/esprima_ast_types.js
@@ -8,7 +8,6 @@ require("ast-types/def/core");
 
 // Feel free to add to or remove from this list of extension modules to
 // configure the precise type hierarchy that you need.
-require('./custom_ast_types');
 require("ast-types/def/e4x");
 require("ast-types/def/es6");
 require("ast-types/def/es7");
@@ -16,6 +15,7 @@ require("ast-types/def/esprima");
 require("ast-types/def/flow");
 require("ast-types/def/jsx");
 require("ast-types/def/mozilla");
+require('./custom_ast_types');
 
 types.finalize();
 

--- a/src/parser/test/esprima_tests.js
+++ b/src/parser/test/esprima_tests.js
@@ -4934,13 +4934,6 @@ module.exports = {
       'declare function foo();',
       'declare function foo(x): void',
     ],
-    'Declare Module': [
-      'declare module A {}',
-      'declare module "./a/b.js" {}',
-      'declare module A { declare var x: number; }',
-      'declare module A { declare function foo(): number; }',
-      'declare module A { declare class B { foo(): number; } }',
-    ],
     'Invalid Declare Module': [
       'declare Module A {}',
       'declare module {}',

--- a/src/parser/test/hardcoded_tests.js
+++ b/src/parser/test/hardcoded_tests.js
@@ -1632,8 +1632,209 @@ module.exports = {
         },
       },
     },
+    '`declare module {}` with exports': {
+      'declare module "foo" { declare export * from "bar"; }': {
+        'body.0': {
+          'type': 'DeclareModule',
+          'body.body.0': {
+            'type': 'DeclareExportDeclaration',
+            'declaration': null,
+            'specifiers': [{
+              'type': 'ExportBatchSpecifier',
+              'name': null,
+            }],
+            'source': {
+              'type': 'Literal',
+              'value': 'bar',
+            },
+          },
+          'kind': 'ES',
+        },
+      },
+
+      'declare module "foo" { declare export {a,} from "bar"; }': {
+        'body.0': {
+          'type': 'DeclareModule',
+          'body.body.0': {
+            'type': 'DeclareExportDeclaration',
+            'declaration': null,
+            'specifiers': [{
+              'type': 'ExportSpecifier',
+              'id': {
+                'type': 'Identifier',
+                'name': 'a',
+                'typeAnnotation': null,
+              },
+            }],
+            'source': {
+              'type': 'Literal',
+              'value': 'bar',
+            },
+          },
+          'kind': 'ES',
+        },
+      },
+
+      'declare module "foo" { declare export {a,}; }': {
+        'body.0': {
+          'type': 'DeclareModule',
+          'body.body.0': {
+            'type': 'DeclareExportDeclaration',
+            'declaration': null,
+            'specifiers': [{
+              'type': 'ExportSpecifier',
+              'id': {
+                'type': 'Identifier',
+                'name': 'a',
+                'typeAnnotation': null,
+              },
+            }],
+            'source': null,
+          },
+          'kind': 'ES',
+        },
+      },
+
+      'declare module "foo" { declare export var a: number; }': {
+        'body.0': {
+          'type': 'DeclareModule',
+          'body.body.0': {
+            'type': 'DeclareExportDeclaration',
+            'declaration.id': {
+              'type': 'Identifier',
+              'name': 'a',
+              'typeAnnotation.typeAnnotation.type': 'NumberTypeAnnotation',
+            },
+            'specifiers.length': 0,
+            'source': null,
+          },
+        },
+      },
+
+      'declare module "foo" { declare export function bar(p1: number): string; }': {
+        'body.0': {
+          'type': 'DeclareModule',
+          'body.body.0': {
+            'type': 'DeclareExportDeclaration',
+            'declaration': {
+              'type': 'DeclareFunction',
+              'id': {
+                'name': 'bar',
+                'typeAnnotation.typeAnnotation': {
+                  'type': 'FunctionTypeAnnotation',
+                  'params': [{
+                    'type': 'FunctionTypeParam',
+                    'name.name': 'p1',
+                    'typeAnnotation.type': 'NumberTypeAnnotation',
+                  }],
+                  'returnType.type': 'StringTypeAnnotation',
+                },
+              },
+            },
+            'specifiers.length': 0,
+            'source': null,
+          },
+          'kind': 'ES',
+        },
+      },
+
+      'declare module "foo" { declare export class Foo { meth(p1: number): void; } }': {
+        'body.0': {
+          'type': 'DeclareModule',
+          'body.body.0': {
+            'type': 'DeclareExportDeclaration',
+            'declaration': {
+              'type': 'DeclareClass',
+              'id': {'name': 'Foo', 'typeAnnotation': null},
+              'body.properties': [{
+                'type': 'ObjectTypeProperty',
+                'key': {'type': 'Identifier', 'name': 'meth'},
+                'value': {
+                  'type': 'FunctionTypeAnnotation',
+                  'params': [{
+                    'type': 'FunctionTypeParam',
+                    'name': {'type': 'Identifier', 'name': 'p1'},
+                    'typeAnnotation.type': 'NumberTypeAnnotation',
+                  }],
+                  'returnType.type': 'VoidTypeAnnotation',
+                },
+              }],
+            },
+            'specifiers.length': 0,
+            'source': null,
+          },
+          'kind': 'ES',
+        },
+      },
+
+      'declare module "foo" { declare export type bar = number; }': {
+        'body.0': {
+          'type': 'DeclareModule',
+          'body.body.0': {
+            'type': 'DeclareExportDeclaration',
+            'declaration': {
+              'type': 'TypeAlias',
+              'id': {'type': 'Identifier', 'name': 'bar'},
+              'right.type': 'NumberTypeAnnotation',
+            },
+            'specifiers.length': 0,
+            'source': null,
+          },
+          'kind': 'CommonJS',
+        },
+      },
+
+      'declare module "foo" { declare export type bar = number; declare export var baz: number; }': {
+        'body.0': {
+          'type': 'DeclareModule',
+          'body.body.length': 2,
+          'kind': 'ES',
+        },
+      },
+
+      'declare module "foo" { declare export type bar = number; declare module.exports: number; }': {
+        'body.0': {
+          'type': 'DeclareModule',
+          'body.body.length': 2,
+          'kind': 'CommonJS',
+        },
+      },
+
+      'declare module "foo" { declare export interface bar {} }': {
+        'body.0': {
+          'type': 'DeclareModule',
+          'body.body.0': {
+            'type': 'DeclareExportDeclaration',
+            'declaration': {
+              'type': 'InterfaceDeclaration',
+              'id': {'type': 'Identifier', 'name': 'bar'},
+            },
+            'specifiers.length': 0,
+            'source': null,
+          },
+          'kind': 'CommonJS',
+        },
+      },
+
+      'declare module "foo" { declare export interface bar {} declare export var baz: number; }': {
+        'body.0': {
+          'type': 'DeclareModule',
+          'body.body.length': 2,
+          'kind': 'ES',
+        },
+      },
+
+      'declare module "foo" { declare export interface bar {} declare module.exports: number; }': {
+        'body.0': {
+          'type': 'DeclareModule',
+          'body.body.length': 2,
+          'kind': 'CommonJS',
+        },
+      },
+    },
     'Invalid Declare Export': {
-      // declare export type is not supported since export type is identical
+      // declare export type is not supported at the toplevel since export type
+			// is identical there.
       'declare export type foo = number;': {
         'errors.0.message': '`declare export type` is not supported. Use `export type` instead.',
       },
@@ -2444,6 +2645,11 @@ module.exports = {
       'declare module A { export default function foo() {} }': {
         'errors': {
           '0.message': 'Unexpected token export',
+        }
+      },
+      'declare module "foo" { declare export var a: number; declare module.exports: number; }': {
+        'errors': {
+          '0.message': 'Found both `declare module.exports` and `declare export` in the same module. Modules can only have 1 since they are either an ES module xor they are a CommonJS module.'
         }
       },
     },

--- a/src/typing/statement.ml
+++ b/src/typing/statement.ml
@@ -327,6 +327,10 @@ and statement_decl cx type_params_map = Ast.Statement.(
         | Some (Class (loc, c)) ->
             statement_decl cx type_params_map (loc, DeclareClass c)
         | Some (DefaultType _) -> ()
+        | Some (NamedType (loc, t)) ->
+            statement_decl cx type_params_map (loc, TypeAlias t)
+        | Some (Interface (loc, i)) ->
+            statement_decl cx type_params_map (loc, InterfaceDeclaration i)
         | None ->
             if not default
             then ()
@@ -1468,7 +1472,7 @@ and statement cx type_params_map = Ast.Statement.(
   | (loc, InterfaceDeclaration decl) ->
     interface cx loc true decl
 
-  | (loc, DeclareModule { DeclareModule.id; body; }) ->
+  | (loc, DeclareModule { DeclareModule.id; body; kind=_; }) ->
     let name = match id with
     | DeclareModule.Identifier ident -> ident_name ident
     | DeclareModule.Literal (_, { Ast.Literal.value = Ast.Literal.String str; _; }) ->
@@ -1581,6 +1585,19 @@ and statement cx type_params_map = Ast.Statement.(
       | Some (DefaultType (loc, t)) ->
           let _type = Anno.convert cx type_params_map (loc, t) in
           [( "<<type>>", loc, "default", Some _type)]
+      | Some (NamedType (_, {
+          TypeAlias.
+          id = (name_loc, {Ast.Identifier.name; _;});
+          right;
+          _;
+        })) ->
+          (* TODO: This is wrong. Should just delegate to `statement cx ...` *)
+          let _type = Anno.convert cx type_params_map right in
+          [(spf "type %s = ..." name, name_loc, name, Some _type)]
+      | Some (Interface (loc, i)) ->
+          let {Interface.id = (name_loc, {Ast.Identifier.name; _;}); _;} = i in
+          statement cx type_params_map (loc, InterfaceDeclaration i);
+          [(spf "interface %s {}" name, name_loc, name, None)]
       | None ->
           [] in
 


### PR DESCRIPTION
Adds parser support for `declare export` statements inside `declare module` bodies.
Inference support will follow

(see https://github.com/facebook/flow/issues/1806 for why this is important)