### PR TITLE
adjust MutationRecord lib definition

### DIFF
--- a/lib/bom.js
+++ b/lib/bom.js
@@ -177,15 +177,15 @@ declare class FormData {
 }
 
 declare class MutationRecord {
-    oldValue: string;
-    previousSibling: Node;
-    addedNodes: NodeList<any>;
-    attributeName: string;
-    removedNodes: NodeList<any>;
+    type: 'attributes' | 'characterData' | 'childList';
     target: Node;
-    nextSibling: Node;
-    attributeNamespace: string;
-    type: string;
+    addedNodes: NodeList<Node>;
+    removedNodes: NodeList<Node>;
+    previousSibling: ?Node;
+    nextSibling: ?Node;
+    attributeName: ?string;
+    attributeNamespace: ?string;
+    oldValue: ?string;
 }
 
 declare class MutationObserver {


### PR DESCRIPTION
Was recently using MutationObserver with flow and noticed that MutationRecord does not quite match the spec. https://dom.spec.whatwg.org/#mutationrecord

- `type` can only be one of three strings
- `previousSibling`, `nextSibling`, `attributeName`, `attributeNamespace`, `oldValue` should all be nullable
- for readability changed order of properties to be the same as in spec
