### PR TITLE
Use relative path in gen_build_id.ml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -155,7 +155,7 @@ $(BUILT_OBJECT_FILES): %.o: %.c $(ALL_HEADER_FILES)
 	cd $(dir $@) && ocamlopt $(EXTRA_INCLUDE_OPTS) $(CC_OPTS) -c $(notdir $<)
 
 _build/hack/utils/get_build_id.gen.c: FORCE scripts/utils.ml scripts/gen_build_id.ml
-	ocaml -w -3 unix.cma scripts/gen_build_id.ml $@
+	ocaml -w -3 unix.cma -I scripts scripts/gen_build_id.ml $@
 
 # We only rebuild the flowlib archive if any of the libs have changed. If the
 # archive has changed, then the incremental build needs to re-embed it into the

--- a/scripts/gen_build_id.ml
+++ b/scripts/gen_build_id.ml
@@ -8,7 +8,7 @@
  *
  *)
 
-#use "scripts/utils.ml"
+#use "utils.ml"
 
 let () =
   let out_file = Sys.argv.(1) in


### PR DESCRIPTION
`#use "scripts/utils.ml"` works on 4.02.1 but not 4.03.0
`#use "utils.ml"` works on 4.03.0 but not 4.02.1

Le sigh.