### PR TITLE
Missing .exp file error should indicate the file's intended name

### DIFF
--- a/runtests.sh
+++ b/runtests.sh
@@ -351,7 +351,9 @@ while (( next_test_to_reap < ${#dirs[@]} )); do
       $RUNTEST_MISSING_FILES )
         (( failed++ ))
         print_failure "$testname"
-        printf "Missing %s.exp file or .flowconfig file\n" "$testname" ;;
+        name=${testname%*/}
+        name=${name##*/}
+        printf "Missing %s.exp file or .flowconfig file\n" "$name" ;;
     esac
 
     ((next_test_to_reap++))


### PR DESCRIPTION
This has been driving me nuts for the last few days (not because of the goof itself, but because I authored the goof).  When a test directory's .exp file is missing, the error message looks like "Missing tests/some_test/.exp or .flowconfig...."  This is slightly unclear to a new dev and it looks like hell.