### PR TITLE
[parser] Allow `type` as an imported binding

### DIFF
--- a/src/parser/parser_flow.ml
+++ b/src/parser/parser_flow.ml
@@ -1782,7 +1782,14 @@ end = struct
       let lex_value = Peek.value env in
       let lex_loc = Peek.loc env in
       match lex_token with
-      | T_IDENTIFIER -> Parse.identifier env, None
+      (* Anything that is a special token in Flow but not in the ES6 spec
+         should be here. *)
+      | T_ASYNC
+      | T_DECLARE
+      | T_IDENTIFIER
+      | T_OF
+      | T_TYPE
+        -> Parse.identifier env, None
       | _ ->
         let err = match lex_token with
         | T_FUNCTION
@@ -1806,7 +1813,6 @@ end = struct
         | T_CASE
         | T_CATCH
         | T_CONTINUE
-        | T_DECLARE
         | T_DEFAULT
         | T_DO
         | T_FINALLY
@@ -1830,14 +1836,11 @@ end = struct
         | T_PROTECTED
         | T_PUBLIC
         | T_YIELD
-        | T_TYPE
-        | T_OF
         | T_ANY_TYPE
         | T_BOOLEAN_TYPE
         | T_NUMBER_TYPE
         | T_STRING_TYPE
         | T_VOID_TYPE
-        | T_ASYNC
         | T_AWAIT
         | T_DEBUGGER ->
             Some (lex_loc, get_unexpected_error (lex_token, lex_value))

--- a/src/parser/test/esprima_tests.js
+++ b/src/parser/test/esprima_tests.js
@@ -4866,10 +4866,20 @@ module.exports = {
         'import type from "MyModule"',
         'import type, {} from "MyModule"',
         'import type, * as namespace from "MyModule"',
+        'import {type} from "MyModule"',
+        'import {type as type} from "MyModule"',
 
         // Other pseudo keywords
         'import of from "MyModule"',
+        'import {of} from "MyModule"',
         'import declare from "MyModule"',
+        'import {declare} from "MyModule"',
+        'import async from "MyModule"',
+        'import {async} from "MyModule"',
+
+        'import {of as of} from "MyModule"',
+        'import {declare as declare} from "MyModule"',
+        'import {async as async} from "MyModule"',
       ],
     },
     'Import Type': {


### PR DESCRIPTION
This also fixes a number of other bugs around reserved words. Notably, both `static` and `implements` are disallowed in strict mode:

http://www.ecma-international.org/ecma-262/6.0/#sec-keywords