### PR TITLE
Fixes for node's 'net', 'child_process' lib

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -778,8 +778,18 @@ declare class net$Server extends events$EventEmitter {
   unref():  net$Server;
 }
 
-declare module "net" {
 
+type net$connectOptions = {
+  port?: number,
+  host?: string,
+  localAddress?: string,
+  localPort?: number,
+  family?: number,
+  lookup?: string,
+  path?: string,
+};
+
+declare module "net" {
 
   declare class Server extends net$Server {}
   declare class Socket extends net$Socket {}
@@ -800,17 +810,16 @@ declare module "net" {
 
   declare type connectListener = () => any;
   declare function connect(
-    options?: {
-      port?: number,
-      host?: string,
-      localAddress?: string,
-      localPort?: number,
-      family?: number,
-      lookup?: string,
-      path?: string,
-    } | connectListener,
+    pathOrPortOrOptions:  string | number | net$connectOptions,
+    hostOrConnectListener?: string | connectListener,
     connectListener?: connectListener,
-  ) : Socket;
+  ): Socket;
+
+  declare function createConnection(
+    pathOrPortOrOptions:  string | number | net$connectOptions,
+    hostOrConnectListener?: string | connectListener,
+    connectListener?: connectListener,
+  ): Socket;
 }
 
 type os$CPU = {

--- a/lib/node.js
+++ b/lib/node.js
@@ -160,7 +160,7 @@ declare class child_process$ChildProcess extends events$EventEmitter {
 
   disconnect(): void;
   kill(signal?: string): void;
-  send(message: Object, sendHandle?: child_process$Handle): void;
+  send(message: Object, sendHandle?: child_process$Handle): boolean;
 }
 
 declare module "child_process" {
@@ -222,7 +222,7 @@ type cluster$Worker = {
 
   disconnect(): void;
   kill(signal?: string): void;
-  send(message: Object, sendHandle?: child_process$Handle): void;
+  send(message: Object, sendHandle?: child_process$Handle): boolean;
 }
 
 declare module "cluster" {


### PR DESCRIPTION
Add createConnection() as an alias to connect() and allow all three signatures:
  `net.connect(options[, connectListener])`
  `net.connect(path[, connectListener])`
  `net.connect(port[, host][, connectListener])`