### PR TITLE
Fix type of fs.readFileSync

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -630,10 +630,10 @@ declare module "fs" {
     options: { flag?: string },
     callback: (err: ?Error, data: Buffer) => void
   ): void;
-  declare function readFileSync(filename: string): Buffer;
+  declare function readFileSync(filename: string, _: void): Buffer;
   declare function readFileSync(filename: string, encoding: string): string;
   declare function readFileSync(filename: string, options: { encoding: string, flag?: string }): string;
-  declare function readFileSync(filename: string, options: { flag?: string }): Buffer;
+  declare function readFileSync(filename: string, options: { encoding?: void, flag?: string }): Buffer;
   declare function writeFile(
     filename: string,
     data: Buffer | string,

--- a/tests/node_tests/fs/fs.js
+++ b/tests/node_tests/fs/fs.js
@@ -21,9 +21,13 @@ fs.readFile("file.exp", {}, (_, data) => {
 /* readFileSync */
 
 (fs.readFileSync("file.exp") : Buffer);
+(fs.readFileSync("file.exp") : string); // error
 
 (fs.readFileSync("file.exp", "blah") : string);
+(fs.readFileSync("file.exp", "blah") : Buffer); // error
 
 (fs.readFileSync("file.exp", { encoding: "blah" }) : string);
+(fs.readFileSync("file.exp", { encoding: "blah" }) : Buffer); // error
 
 (fs.readFileSync("file.exp", {}) : Buffer);
+(fs.readFileSync("file.exp", {}) : string); // error

--- a/tests/node_tests/node_tests.exp
+++ b/tests/node_tests/node_tests.exp
@@ -16,6 +16,126 @@ child_process/execSync.js:8
                                  ^^^^^ string. This type is incompatible with
   number. See lib: node.js:104
 
+fs/fs.js:24
+ 24: (fs.readFileSync("file.exp") : string); // error
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^ call of method `readFileSync`. Function cannot be called on any member of intersection type
+intersection. See lib: node.js:633
+  Member 1:
+  function type. See lib: node.js:633
+  Error:
+   24: (fs.readFileSync("file.exp") : string); // error
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Buffer. This type is incompatible with
+   24: (fs.readFileSync("file.exp") : string); // error
+                                      ^^^^^^ string
+  Member 2:
+  function intersection. See lib: node.js:635
+  Error:
+   24: (fs.readFileSync("file.exp") : string); // error
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^ undefined (too few arguments, expected default/rest parameters). This type is incompatible with
+  union: object type | string. See lib: node.js:635
+    Member 1:
+    object type. See lib: node.js:635
+    Error:
+     24: (fs.readFileSync("file.exp") : string); // error
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^ undefined (too few arguments, expected default/rest parameters). This type is incompatible with
+    object type. See lib: node.js:635
+    Member 2:
+    string. See lib: node.js:634
+    Error:
+     24: (fs.readFileSync("file.exp") : string); // error
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^ undefined (too few arguments, expected default/rest parameters). This type is incompatible with
+    string. See lib: node.js:634
+  Member 3:
+  function type. See lib: node.js:636
+  Error:
+   24: (fs.readFileSync("file.exp") : string); // error
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^ undefined (too few arguments, expected default/rest parameters). This type is incompatible with
+  object type. See lib: node.js:636
+
+fs/fs.js:27
+ 27: (fs.readFileSync("file.exp", "blah") : Buffer); // error
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call of method `readFileSync`. Function cannot be called on any member of intersection type
+intersection. See lib: node.js:633
+  Member 1:
+  function type. See lib: node.js:633
+  Error:
+   27: (fs.readFileSync("file.exp", "blah") : Buffer); // error
+                                    ^^^^^^ string. This type is incompatible with
+  undefined. See lib: node.js:633
+  Member 2:
+  function intersection. See lib: node.js:635
+  Error:
+   27: (fs.readFileSync("file.exp", "blah") : Buffer); // error
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string. This type is incompatible with
+   27: (fs.readFileSync("file.exp", "blah") : Buffer); // error
+                                              ^^^^^^ Buffer
+  Member 3:
+  function type. See lib: node.js:636
+  Error:
+   27: (fs.readFileSync("file.exp", "blah") : Buffer); // error
+                                    ^^^^^^ string. This type is incompatible with
+  object type. See lib: node.js:636
+
+fs/fs.js:30
+ 30: (fs.readFileSync("file.exp", { encoding: "blah" }) : Buffer); // error
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call of method `readFileSync`. Function cannot be called on any member of intersection type
+intersection. See lib: node.js:633
+  Member 1:
+  function type. See lib: node.js:633
+  Error:
+   30: (fs.readFileSync("file.exp", { encoding: "blah" }) : Buffer); // error
+                                    ^^^^^^^^^^^^^^^^^^^^ object literal. This type is incompatible with
+  undefined. See lib: node.js:633
+  Member 2:
+  function intersection. See lib: node.js:635
+  Error:
+   30: (fs.readFileSync("file.exp", { encoding: "blah" }) : Buffer); // error
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string. This type is incompatible with
+   30: (fs.readFileSync("file.exp", { encoding: "blah" }) : Buffer); // error
+                                                            ^^^^^^ Buffer
+  Member 3:
+  function type. See lib: node.js:636
+  Error:
+  inconsistent use of library definitions
+  string. This type is incompatible with. See lib: node.js:635
+  undefined. See lib: node.js:636
+
+fs/fs.js:33
+ 33: (fs.readFileSync("file.exp", {}) : string); // error
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call of method `readFileSync`. Function cannot be called on any member of intersection type
+intersection. See lib: node.js:633
+  Member 1:
+  function type. See lib: node.js:633
+  Error:
+   33: (fs.readFileSync("file.exp", {}) : string); // error
+                                    ^^ object literal. This type is incompatible with
+  undefined. See lib: node.js:633
+  Member 2:
+  function intersection. See lib: node.js:635
+  Error:
+   33: (fs.readFileSync("file.exp", {}) : string); // error
+                                    ^^ object literal. This type is incompatible with
+  union: object type | string. See lib: node.js:635
+    Member 1:
+    object type. See lib: node.js:635
+    Error:
+    property `encoding`. Property not found in. See lib: node.js:635
+     33: (fs.readFileSync("file.exp", {}) : string); // error
+                                      ^^ object literal
+    Member 2:
+    string. See lib: node.js:634
+    Error:
+     33: (fs.readFileSync("file.exp", {}) : string); // error
+                                      ^^ object literal. This type is incompatible with
+    string. See lib: node.js:634
+  Member 3:
+  function type. See lib: node.js:636
+  Error:
+   33: (fs.readFileSync("file.exp", {}) : string); // error
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Buffer. This type is incompatible with
+   33: (fs.readFileSync("file.exp", {}) : string); // error
+                                          ^^^^^^ string
+
 invalid_package_file/package.json:1
   1: 
      ^ Unexpected end of input
@@ -103,4 +223,4 @@ json_file/test.js:22
                               ^^^^ undefined
 
 
-Found 16 errors
+Found 20 errors


### PR DESCRIPTION
Fixes https://github.com/facebook/flow/issues/1870

since the first override had fewer params, it would accept any of the latter branches when the latter branches' return types didn't match, rather than making the entire intersection fail.