### PR TITLE
Change `MessageEvent::source` to `any`

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -197,7 +197,7 @@ declare class MessageEvent extends Event {
   data: string | Blob | ArrayBuffer;
   origin: string;
   lastEventId: string;
-  source: Document;
+  source: WindowProxy;
 }
 
 declare class KeyboardEvent extends UIEvent {
@@ -1777,6 +1777,7 @@ declare class TreeWalker<RootNodeT, WhatToShowT> {
 
 /* window */
 
+declare type WindowProxy = any;
 declare function alert(message?: any): void;
 declare function prompt(message?: any, value?: any): string;
 declare function close(): void;
@@ -1788,10 +1789,10 @@ declare function focus(): void;
 declare function onfocus(ev: Event): any;
 declare function onmessage(ev: MessageEvent): any;
 declare function open(url?: string, target?: string, features?: string, replace?: boolean): any;
-declare var parent: any;
+declare var parent: WindowProxy;
 declare function print(): void;
 declare var self: any;
 declare var sessionStorage: Storage;
 declare var status: string;
-declare var top: any;
+declare var top: WindowProxy;
 declare function getSelection(): Selection | null;


### PR DESCRIPTION
The `.source` property on a `MessageEvent` is a `WindowProxy` or a `MessagePort` not a `Document`
See: https://html.spec.whatwg.org/multipage/comms.html#the-messageevent-interfaces