### PR TITLE
Use the 4.03.0 input_value workaround everywhere

### DIFF
--- a/hack/procs/worker.ml
+++ b/hack/procs/worker.ml
@@ -133,16 +133,7 @@ let slave_main ic oc =
     Daemon.output_string oc s;
     Daemon.flush oc in
   try
-    let Request do_process =
-      (* OCaml 4.03.0 changed the behavior of Marshal.from_channel to no longer
-       * throw End_of_file when the pipe has closed. We can simulate that
-       * behavior, however, by trying to read a byte afterwards, which WILL
-       * raise End_of_file if the pipe has closed *)
-      try Daemon.from_channel ic
-      with Failure msg as e when msg = "input_value: truncated object" ->
-        Daemon.input_char ic |> ignore;
-        raise e
-    in
+    let Request do_process = Daemon.from_channel ic in
     do_process { send = send_result };
     exit 0
   with


### PR DESCRIPTION
I noticed that some Travis runs ([like this one](https://travis-ci.org/gabelevi/flow/builds/134900465)) were failing due to this bug in 4.03.0. We had a workaround in one place, but I've moved it up into `Timeout.input_value`, which is used basically everywhere. Hopefully this should fix the race-condition bad behavior that the test was noticing.