### PR TITLE
ES6 class statics

### DIFF
--- a/src/typing/flow_js.ml
+++ b/src/typing/flow_js.ml
@@ -2475,8 +2475,8 @@ let rec __flow cx ((l: Type.t), (u: Type.use_t)) trace =
         "Ineligible value used in/as type annotation (did you forget 'typeof'?)"
         l u
 
-    | (ClassT(l), UseT (use_op, ClassT(u))) ->
-      rec_flow cx trace (l, UseT(use_op, u))
+    | (ClassT(l), UseT (_, ClassT(u))) ->
+      rec_flow_t cx trace (l, u)
 
     | FunT (_,static1,prototype,_),
       UseT (_, ClassT (InstanceT (_,static2,_, _) as u_)) ->

--- a/src/typing/flow_js.ml
+++ b/src/typing/flow_js.ml
@@ -2475,8 +2475,8 @@ let rec __flow cx ((l: Type.t), (u: Type.use_t)) trace =
         "Ineligible value used in/as type annotation (did you forget 'typeof'?)"
         l u
 
-    | (ClassT(l), UseT (_, ClassT(u))) ->
-      rec_unify cx trace l u
+    | (ClassT(l), UseT (use_op, ClassT(u))) ->
+      rec_flow cx trace (l, UseT(use_op, u))
 
     | FunT (_,static1,prototype,_),
       UseT (_, ClassT (InstanceT (_,static2,_, _) as u_)) ->

--- a/tests/class_statics/class_statics.exp
+++ b/tests/class_statics/class_statics.exp
@@ -1,9 +1,3 @@
-test.js:1
-  1: class A {
-           ^ A. This type is incompatible with
- 48: (B: typeof A);
-      ^ B
-
 test.js:2
   2:   static x: number;
                  ^^^^^^ number. This type is incompatible with
@@ -107,4 +101,4 @@ test.js:54
                      ^^^^^^ string
 
 
-Found 16 errors
+Found 15 errors


### PR DESCRIPTION
ES6 classes inherit static fields and methods, so subtyping should apply to statics too.