### PR TITLE
Update KeyboardEvent.code to be a a string

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -202,7 +202,7 @@ declare class MessageEvent extends Event {
 
 declare class KeyboardEvent extends UIEvent {
   altKey: boolean;
-  code: number;
+  code: string;
   ctrlKey: boolean;
   isComposing: boolean;
   key: string;


### PR DESCRIPTION
KeyboardEvent.code is defined as a DomString whose

> unitialized value must be "" (empty string)

so this changes KeyboardEvent.code from `number` to `string`.

see also [mdn's `KeyboardEvent.code` page](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/code)