### PR TITLE
Implement server-side coverage command

### DIFF
--- a/src/server/serverProt.ml
+++ b/src/server/serverProt.ml
@@ -33,6 +33,7 @@ let build_revision = match Build_id.build_revision with
 type command =
 | AUTOCOMPLETE of file_input
 | CHECK_FILE of file_input * int option (* verbose *)
+| COVERAGE of file_input
 | DUMP_TYPES of file_input * bool (* filename, include raw *)
 | ERROR_OUT_OF_DATE
 | FIND_MODULE of string * string
@@ -64,6 +65,11 @@ type autocomplete_response = (
 ) Utils_js.ok_or_err
 type dump_types_response = (
   (Loc.t * string * string * string option * Reason_js.t list) list,
+  Loc.t * string
+) Utils_js.ok_or_err
+
+type coverage_response = (
+  (Loc.t * bool) list,
   Loc.t * string
 ) Utils_js.ok_or_err
 

--- a/src/typing/query_types.ml
+++ b/src/typing/query_types.ml
@@ -73,6 +73,22 @@ let dump_types printer raw_printer cx =
     (a_loc, _, _, _, _) (b_loc, _, _, _, _) -> Loc.compare a_loc b_loc
   )
 
+let is_covered = function
+  | Type.AnyT _
+  | Type.EmptyT _ -> false
+  | _ -> true
+
+let covered_types cx =
+  Type_normalizer.suggested_type_cache := IMap.empty;
+  let lst = Hashtbl.fold (fun loc t list ->
+    let ground_t = Type_normalizer.normalize_type cx t in
+    (loc, is_covered ground_t)::list
+  ) (Context.type_table cx) [] in
+  lst |> List.sort (fun
+    (a_loc, _) (b_loc, _) -> Loc.compare a_loc b_loc
+  )
+
+
 (********)
 (* Fill *)
 (********)


### PR DESCRIPTION
Running `flow coverage` on the file below, in the Nuclide codebase, occupies the Flow server for two minutes on my machine:

`Nuclide/pkg/nuclide-reprint-js/lib/printers/complex/printLiteral.js`

This is because coverage is implemented using the `dump-types` server command, which forces all of the types to be stringified and sent across the process boundary. The file above, for whatever reason, has types that are ridiculously long when stringified. To solve this, I've added a new `coverage` command to the server, which simply returns a boolean depending on whether the region is covered or not. With this change, running `flow coverage` on the file above is basically instantaneous, and the output is identical to the output without this change.

I will follow up with another PR to add detailed coverage information to the JSON output, so Nuclide can switch from dump-types to coverage for its coverage display. Then we can get away from this pathological behavior.

Of course, this PR doesn't fix `dump-types`. But it solves my immediate problem and seems like the right long-term call for `coverage` anyway.