### PR TITLE
Nullable check with class fields lost after first expression

### DIFF
--- a/tests/class_fields/nullable.js
+++ b/tests/class_fields/nullable.js
@@ -1,0 +1,15 @@
+class NullableCheck {
+
+  obj:?{ call: Function, apply: Function };
+
+  constructor(obj:?{ call: Function, apply: Function }) {
+    this.obj = obj;
+  }
+
+  apply() {
+    if(this.obj) {
+      this.obj.call();
+      this.obj.apply();
+    }
+  }
+}


### PR DESCRIPTION
When doing a nullable check on a class field from within the class like `if(this.field) {}`, the field is only considered to be not null in the first expression within the checked scope (the `if`). All subsequent usages of the field are considered to be potentially null again.

```js
if(this.obj) {
  this.obj.call(); // < works
  this.obj.apply(); // < fails "this.obj might be null/undefined"
}
```

At first I thought it might have to do that within `call()` I could set the field to null, but then the same thing should also not work for simple variables, but it does:

```js
var x:?{ call: Function, apply: Function } = null;

if (x) {
  x.call();
  x.apply();
}
```
Because here I could also potentially set x to null within x.call().

So I'm not sure if this is a bug, but to me it seems it should work as it is pretty common to do this kind of checks.

Added a failing test case.