### PR TITLE
Update the declaration of cloneNode to use self instead of Node

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -236,7 +236,7 @@ declare class Node extends EventTarget {
   rootNode: Node;
   textContent: string;
   appendChild(newChild: Node): Node;
-  cloneNode(deep?: boolean): Node;
+  cloneNode(deep?: boolean): self;
   compareDocumentPosition(other: Node): number;
   contains(other: ?Node): boolean;
   hasChildNodes(): boolean;


### PR DESCRIPTION
This fixes #749 - the original solution presented in the issue replaced more signatures of `Node`, but from looking at it I don't think it'd be right to assume that any of the other types are `self` rather than `node`.