### PR TITLE
fix ocaml 4.03.0 compile

### DIFF
--- a/_tags
+++ b/_tags
@@ -1,4 +1,4 @@
-<**/*.ml*>: ocaml, warn_A, warn(-4-6-29-35-44-48-50), warn_error_A
+<**/*.ml*>: ocaml, warn_A, warn(-4-6-29-35-44-48-50), warn_error_A, warn_error_d
 <hack/heap/*.ml*>: warn(-27-34)
 <hack/third-party/core/result.ml>: warn(-41)
 <hack/utils/*.ml*>: warn(-3-27)


### PR DESCRIPTION
I've add the warn_error_d tag - this removes deprecations as fatal warning.
Quite some deprecations were added in one of the latest commits, breaking compile for newer ocaml versions.
This way the warnings will still show up but will not prevent compilation.