### PR TITLE
Introduce intersection operator in docs with object types

### DIFF
--- a/website/_data/nav_docs.yml
+++ b/website/_data/nav_docs.yml
@@ -44,10 +44,10 @@
     title: Maybe Types
   - id: destructuring
     title: Destructuring
-  - id: union-intersection-types
-    title: Union and Intersection Types
   - id: type-aliases
     title: Type Aliases
+  - id: union-intersection-types
+    title: Union and Intersection Types
   - id: typeof
     title: Typeof types
   - id: dynamic-type-tests

--- a/website/docs/01-destructuring.md
+++ b/website/docs/01-destructuring.md
@@ -3,7 +3,7 @@ id: destructuring
 title: Destructuring
 permalink: /docs/destructuring.html
 prev: nullable-types.html
-next: union-intersection-types.html
+next: type-aliases.html
 ---
 
 Flow supports the JavaScript construct of destructuring, which allows 

--- a/website/docs/01-type-aliases.md
+++ b/website/docs/01-type-aliases.md
@@ -2,8 +2,8 @@
 id: type-aliases
 title: Type Aliases
 permalink: /docs/type-aliases.html
-prev: union-intersection-types.html
-next: typeof.html
+prev: destructuring.html
+next: union-intersection-types.html
 ---
 
 Flow supports type aliasing. 

--- a/website/docs/01-union-intersection-types.md
+++ b/website/docs/01-union-intersection-types.md
@@ -7,7 +7,7 @@ next: type-aliases.html
 ---
 
 Flow adds support for both union and intersection types. A union type requires
-for a value to be one of the input types:
+a value to be one of the input types:
 
 {% highlight javascript linenos=table %}
 /* @flow */

--- a/website/docs/01-union-intersection-types.md
+++ b/website/docs/01-union-intersection-types.md
@@ -26,7 +26,7 @@ x = {a: 1, b: 2, c: "three"};
 {% endhighlight %}
 
 The value `{a: 1, b: 2, c: "three"}` is admissible here because the
-`Intersection` type only constrains keys `a` and `b`.
+`Intersection` type only constrains properties `a` and `b`.
 
 > NOTE
 >

--- a/website/docs/01-union-intersection-types.md
+++ b/website/docs/01-union-intersection-types.md
@@ -26,7 +26,7 @@ x = {a: 1, b: 2, c: "three"};
 {% endhighlight %}
 
 The value `{a: 1, b: 2, c: "three"}` is admissible here because the
-`Intersection` type only constrains properties `a` and `b`.
+`I` type only constrains properties `a` and `b`.
 
 > NOTE
 >

--- a/website/docs/01-union-intersection-types.md
+++ b/website/docs/01-union-intersection-types.md
@@ -11,8 +11,8 @@ a value to be one of the input types:
 
 {% highlight javascript linenos=table %}
 /* @flow */
-type Union = number | string
-var x: Union = 1;
+type U = number | string
+var x: U = 1;
 x = "two";
 {% endhighlight %}
 
@@ -20,8 +20,8 @@ An intersection type requires a value to be all of the input types:
 
 {% highlight javascript linenos=table %}
 /* @flow */
-type Intersection = {a: number} & {b: number}
-var x: Intersection = {a: 1, b: 2};
+type I = {a: number} & {b: number}
+var x: I = {a: 1, b: 2};
 x = {a: 1, b: 2, c: "three"};
 {% endhighlight %}
 

--- a/website/docs/01-union-intersection-types.md
+++ b/website/docs/01-union-intersection-types.md
@@ -6,36 +6,33 @@ prev: destructuring.html
 next: type-aliases.html
 ---
 
-Flow adds support for both union and intersection types. A union type allows 
-for a value to be one of the input types.
+Flow adds support for both union and intersection types. A union type requires
+for a value to be one of the input types:
 
 {% highlight javascript linenos=table %}
 /* @flow */
-var x: number | string = 0;
+type Union = number | string
+var x: Union = 1;
+x = "two";
 {% endhighlight %}
 
-`x` can be either a `number` or a `string`. A default value can even be 
-provided of one of those two types.
+An intersection type requires a value to be all of the input types:
 
 {% highlight javascript linenos=table %}
 /* @flow */
-declare var f: ((x: number) => void) & ((x: string) => void);
-f('');
+type Intersection = {a: number} & {b: number}
+var x: Intersection = {a: 1, b: 2};
+x = {a: 1, b: 2, c: "three"};
 {% endhighlight %}
 
-> NOTE
-> 
-> Parentheses are important. Flow will not type-check correctly if you leave 
-> out the outer parenthesis on each of the function declarations on `f`.
-
-
-We are intersecting `function` here. A call to `f` has to be with a `number` 
-or `string`. Intersections are well-suited to mimic function overloading.
+The value `{a: 1, b: 2, c: "three"}` is admissible here because the
+`Intersection` type only constrains keys `a` and `b`.
 
 > NOTE
-> 
-> Not all intersection types make sense. For example, no value has type 
-`number & string` since there is no value that can have both of those types.
+>
+> Intersection typing interacts with function types to yield union types over
+> the parameters, e.g. `((x: A) => T) & ((x: B) => U)` is equivalent to
+> `(x: A | B) => (T & U)`.
 
 
 ## Syntax

--- a/website/docs/01-union-intersection-types.md
+++ b/website/docs/01-union-intersection-types.md
@@ -2,8 +2,8 @@
 id: union-intersection-types
 title: Union and Intersection Types
 permalink: /docs/union-intersection-types.html
-prev: destructuring.html
-next: type-aliases.html
+prev: type-aliases.html
+next: typeof.html
 ---
 
 Flow adds support for both union and intersection types. A union type requires

--- a/website/docs/ref/objects.doc.js
+++ b/website/docs/ref/objects.doc.js
@@ -69,6 +69,10 @@ sayHello(mySampleData);
 sayHello({message: 'Hi', isAwesome: false});
 
 /*
+These types can be added together with the intersection operator, `&`. See
+[union and intersection types](http://flowtype.org/docs/union-intersection-types.html#_)
+for details.
+
 ## Optional properties
 
 Object types can have optional properties. The following code shows how


### PR DESCRIPTION
This comes up kinda frequently in IRC....

* The intersection operator's docs have focused on a function declaration case. I feel that this is a 10%-or-less use case, so I've refocused the intersection's first introduction on two object types (IMO the 90%-or-more use case). The function case is left as an example, and the operator's interaction with functions is relegated to a note (no variations of the word "contravariance" are used).
* The Objects documentation contains a section titled "Reusable Object Types." I've mentioned there that object types can be added by intersection, linking to the "Union and Intersection Types" page.
* The type alias concept makes the exposition cleaner, separating the union type's definition from its use. I've moved the type alias introduction prior to the intersection and union type introduction so that the type alias is a familiar concept to the reader.