### PR TITLE
Avoid frozen build when `git` or `.git/`+`hg` are unavailable

### DIFF
--- a/scripts/gen_build_id.ml
+++ b/scripts/gen_build_id.ml
@@ -13,24 +13,26 @@
 let () =
   let out_file = Sys.argv.(1) in
   let rev =
-    try read_process_output "git" [|"git"; "rev-parse"; "HEAD"|]
+    try read_process_output "git rev-parse HEAD"
     with Failure _ ->
-      try read_process_output "hg" [|"hg"; "id"; "-i"|]
+      try read_process_output "hg id -i"
       with Failure _ -> ""
   in
   let time =
-    try read_process_output "git" [|"git"; "log"; "-1"; "--pretty=tformat:%ct"|]
+    try read_process_output "git log -1 --pretty=tformat:%ct"
     with Failure _ ->
       try
-        let raw = read_process_output "hg" [|"hg"; "log"; "-r"; "."; "-T"; "{date|hgdate}\\n"|] in
+        let raw = read_process_output "hg log -r . -T \"{date|hgdate}\\n\"" in
         String.sub raw 0 (String.index raw ' ')
       with
       | Failure _ -> "0"
       | Not_found -> "0"
   in
-  let content = Printf.sprintf
-    "const char* const BuildInfo_kRevision = %S;\nconst unsigned long BuildInfo_kRevisionCommitTimeUnix = %sul;\n"
-    rev time in
+  let content =
+    let spf = Printf.sprintf in
+    (spf "const char* const BuildInfo_kRevision = %S;\n" rev) ^
+    (spf "const unsigned long BuildInfo_kRevisionCommitTimeUnix = %sul;\n" time)
+  in
   let do_dump =
     not (Sys.file_exists out_file) || string_of_file out_file <> content in
   if do_dump then

--- a/scripts/utils.ml
+++ b/scripts/utils.ml
@@ -8,18 +8,6 @@
  *
  *)
 
-let with_pipe f =
-  let fd_r, fd_w = Unix.pipe () in
-  try
-    let res = f fd_r fd_w in
-    Unix.close fd_r;
-    Unix.close fd_w;
-    res
-  with exn ->
-    Unix.close fd_r;
-    Unix.close fd_w;
-    raise exn
-
 let with_in_channel filename f =
   let ic = open_in_bin filename in
   try let res = f ic in close_in ic; res
@@ -31,15 +19,20 @@ let with_out_channel filename f =
   with exn -> close_out oc; raise exn
 
 (* Read the first line in stdout or stderr of an external command. *)
-let read_process_output name args =
-  with_pipe @@ fun in_r in_w ->
-  with_pipe @@ fun out_r out_w ->
-  let pid = Unix.create_process name args in_r out_w out_w in
-  let out_inch = Unix.in_channel_of_descr out_r in
-  let line = input_line out_inch in
-  match Unix.waitpid [] pid with
-  | _, Unix.WEXITED 0 -> line
-  | _ -> raise (Failure line)
+let read_process_output cmd =
+  let channels = Unix.open_process_full cmd (Unix.environment ()) in
+  let (out_c, _, err_c) = channels in
+  let out = try Some (input_line out_c) with | End_of_file -> None in
+  let err = try Some (input_line err_c) with | End_of_file -> None in
+  let msg = match out, err with
+    | Some o, Some e -> o ^ "\n" ^ e
+    | Some o, None -> o
+    | None, Some e -> e
+    | _ -> ""
+  in
+  match Unix.close_process_full channels with
+  | Unix.WEXITED 0 -> msg
+  | _ -> raise (Failure msg)
 
 let string_of_file filename =
   with_in_channel filename @@ fun ic ->


### PR DESCRIPTION
This came up in IRC earlier. An [unofficial package](https://aur.archlinux.org/packages/flow/) maintainer for Archlinux had his/her build freezing at `ocaml -I scripts -w -3 unix.cma scripts/gen_build_id.ml _build/hack/utils/get_build_id.gen.c`. The build is from a tarball, so the `.git/` directory is unavailable.

The user didn't have Mercurial installed. After the `git` case under `gen_build_id.ml` failed, a read under the `hg` case from stdout/stderr would not stop blocking. It looks like `create_process` doesn't recognize exit 127 when `hg` isn't found, so an `input_line` call doesn't break. This PR substitutes the `open_process_full` function which recognizes that the command doesn't exist and interrupts the `input_line` call. I suspect that the same problem arises in environments without `git` installed regardless of whether `hg` is installed.