### PR TITLE
Add React.PureComponent to lib/react.js

### DIFF
--- a/lib/react.js
+++ b/lib/react.js
@@ -49,6 +49,16 @@ declare class React$Component<DefaultProps, Props, State> {
   static propTypes: $Subtype<{[_: $Keys<Props>]: any}>; //object whose keys are in PropTypes
 }
 
+declare class React$PureComponent<DefaultProps, Props, State> extends React$Component<DefaultProps, Props, State> {
+  // TODO: Due to bugs in Flow's handling of React.createClass, some fields
+  // already declared in the base class need to be redeclared below. Ideally
+  // they should simply be inherited.
+
+  static defaultProps: DefaultProps;
+  props: Props;
+  state: State;
+}
+
 /**
  * Base class of legacy React classes, which extends the base class of ES6 React
  * classes and supports additional methods.
@@ -212,6 +222,7 @@ declare module react {
   declare function withContext(context: any, callback: () => void): any;
 
   declare var Component: typeof React$Component;
+  declare var PureComponent: typeof React$PureComponent;
   declare var Element: typeof React$Element;
 }
 


### PR DESCRIPTION
We're adding this to React soon.

Test Plan:

```
/* @flow */

var React = require('react');
var ReactDOM = require('react-dom');

class K extends React.PureComponent {
}

K.displayName;
K.contextTypes;
K.childContextTypes;
K.propTypes;

ReactDOM.render(<K />, document.createElement('div'));

K.foo;
```

only complains about K.foo being missing.