### PR TITLE
Fix the the ocaml parser test for TravisCI

### DIFF
--- a/src/parser/Makefile
+++ b/src/parser/Makefile
@@ -6,7 +6,6 @@ TOP=$(DIR)/../..
 REL_DIR=src/parser
 
 NATIVE_OBJECT_FILES=\
-	hack/heap/hh_shared.o\
 	hack/utils/files.o\
 	hack/utils/nproc.o\
 	hack/utils/realpath.o\


### PR DESCRIPTION
Travis was failing since 

* Parser ocaml test was linking with hh_shared.c
* hh_shared.c uses `BuildInfo_kRevision'
* We don't run the get_build_id step for the parser ocaml test