### PR TITLE
Add some missing Buffer declarations.

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -34,7 +34,7 @@ declare class Buffer {
   includes(value: string | Buffer | number, offset?: number, encoding?: string): boolean;
   indexOf(value: string | Buffer | number, offset?: number, encoding?: string): number;
   inspect(): string;
-  keys(): Iterator,
+  keys(): Iterator<number>,
   lastIndexOf(value: string | Buffer | number, offset?: number, encoding?: string): number;
   readDoubleBE(offset: number, noAssert?: boolean): number;
   readDoubleLE(offset: number, noAssert?: boolean): number;

--- a/lib/node.js
+++ b/lib/node.js
@@ -86,7 +86,7 @@ declare class Buffer {
   static byteLength(string: string, encoding?: buffer$Encoding): number;
   static compare(buf1: Buffer, buf2: Buffer): number;
   static concat(list: Array<Buffer>, totalLength?: number): Buffer;
-  static from(value: Array<number> | number | string | Buffer, encoding?: buffer$Encoding): Buffer
+  static from(value: Array<number> | number | string | Buffer, encoding?: buffer$Encoding): Buffer;
   static isBuffer(obj: any): boolean;
   static isEncoding(encoding: string): boolean;
 }

--- a/lib/node.js
+++ b/lib/node.js
@@ -59,7 +59,7 @@ declare class Buffer {
   swap32(): Buffer;
   toJSON(): Array<number>;
   toString(encoding?: buffer$Encoding, start?: number, end?: number): string;
-  values(): Iterator,
+  values(): Iterator<number>;
   write(string: string, offset?: number, length?: number, encoding?: buffer$Encoding): void;
   writeDoubleBE(value: number, offset: number, noAssert?: boolean): number;
   writeDoubleLE(value: number, offset: number, noAssert?: boolean): number;

--- a/lib/node.js
+++ b/lib/node.js
@@ -25,64 +25,70 @@ declare class Buffer {
   ): void;
   [i: number]: number;
   length: number;
-  write(
-    string: string,
-    offset?: number,
-    length?: number,
-    encoding?: buffer$Encoding
-  ): void;
-  copy(targetBuffer: Buffer, targetStart?: number, sourceStart?: number, sourceEnd?: number): number;
-  equals(otherBuffer: Buffer): boolean;
-  compare(otherBuffer: Buffer): number;
-  slice(start?: number, end?: number): Buffer;
-  fill(value: string | number, offset?: number, end?: number): void;
-  inspect(): string;
-  toString(encoding?: buffer$Encoding, start?: number, end?: number): string;
-  toJSON(): Array<number>;
 
-  readUInt8(offset: number, noAssert?: boolean): number;
-  readUInt16LE(offset: number, noAssert?: boolean): number;
-  readUInt16BE(offset: number, noAssert?: boolean): number;
-  readUInt32LE(offset: number, noAssert?: boolean): number;
-  readUInt32BE(offset: number, noAssert?: boolean): number;
-  readUIntLE(offset: number, byteLength: number, noAssert?: boolean): number;
-  readUIntBE(offset: number, byteLength: number, noAssert?: boolean): number;
-  readInt8(offset: number, noAssert?: boolean): number;
-  readInt16LE(offset: number, noAssert?: boolean): number;
-  readInt16BE(offset: number, noAssert?: boolean): number;
-  readInt32LE(offset: number, noAssert?: boolean): number;
-  readInt32BE(offset: number, noAssert?: boolean): number;
-  readIntLE(offset: number, byteLength: number, noAssert?: boolean): number;
-  readIntBE(offset: number, byteLength: number, noAssert?: boolean): number;
-  readFloatLE(offset: number, noAssert?: boolean): number;
-  readFloatBE(offset: number, noAssert?: boolean): number;
-  readDoubleLE(offset: number, noAssert?: boolean): number;
+  compare(otherBuffer: Buffer): number;
+  copy(targetBuffer: Buffer, targetStart?: number, sourceStart?: number, sourceEnd?: number): number;
+  entries(): Iterator<[number, number]>;
+  equals(otherBuffer: Buffer): boolean;
+  fill(value: string | number, offset?: number, end?: number): void;
+  includes(value: string | Buffer | number, offset?: number, encoding?: string): boolean;
+  indexOf(value: string | Buffer | number, offset?: number, encoding?: string): number;
+  inspect(): string;
+  keys(): Iterator,
+  lastIndexOf(value: string | Buffer | number, offset?: number, encoding?: string): number;
   readDoubleBE(offset: number, noAssert?: boolean): number;
-  writeUInt8(value: number, offset: number, noAssert?: boolean): number;
-  writeUInt16LE(value: number, offset: number, noAssert?: boolean): number;
-  writeUInt16BE(value: number, offset: number, noAssert?: boolean): number;
-  writeUInt32LE(value: number, offset: number, noAssert?: boolean): number;
-  writeUInt32BE(value: number, offset: number, noAssert?: boolean): number;
-  writeUIntLE(value: number, offset: number, byteLength: number, noAssert?: boolean): number;
-  writeUIntBE(value: number, offset: number, byteLength: number, noAssert?: boolean): number;
-  writeInt8(value: number, offset: number, noAssert?: boolean): number;
-  writeInt16LE(value: number, offset: number, noAssert?: boolean): number;
-  writeInt16BE(value: number, offset: number, noAssert?: boolean): number;
-  writeInt32LE(value: number, offset: number, noAssert?: boolean): number;
-  writeInt32BE(value: number, offset: number, noAssert?: boolean): number;
-  writeIntLE(value: number, offset: number, byteLength: number, noAssert?: boolean): number;
-  writeIntBE(value: number, offset: number, byteLength: number, noAssert?: boolean): number;
-  writeFloatLE(value: number, offset: number, noAssert?: boolean): number;
-  writeFloatBE(value: number, offset: number, noAssert?: boolean): number;
-  writeDoubleLE(value: number, offset: number, noAssert?: boolean): number;
+  readDoubleLE(offset: number, noAssert?: boolean): number;
+  readFloatBE(offset: number, noAssert?: boolean): number;
+  readFloatLE(offset: number, noAssert?: boolean): number;
+  readInt16BE(offset: number, noAssert?: boolean): number;
+  readInt16LE(offset: number, noAssert?: boolean): number;
+  readInt32BE(offset: number, noAssert?: boolean): number;
+  readInt32LE(offset: number, noAssert?: boolean): number;
+  readInt8(offset: number, noAssert?: boolean): number;
+  readIntBE(offset: number, byteLength: number, noAssert?: boolean): number;
+  readIntLE(offset: number, byteLength: number, noAssert?: boolean): number;
+  readUInt16BE(offset: number, noAssert?: boolean): number;
+  readUInt16LE(offset: number, noAssert?: boolean): number;
+  readUInt32BE(offset: number, noAssert?: boolean): number;
+  readUInt32LE(offset: number, noAssert?: boolean): number;
+  readUInt8(offset: number, noAssert?: boolean): number;
+  readUIntBE(offset: number, byteLength: number, noAssert?: boolean): number;
+  readUIntLE(offset: number, byteLength: number, noAssert?: boolean): number;
+  slice(start?: number, end?: number): Buffer;
+  swap16(): Buffer;
+  swap32(): Buffer;
+  toJSON(): Array<number>;
+  toString(encoding?: buffer$Encoding, start?: number, end?: number): string;
+  values(): Iterator,
+  write(string: string, offset?: number, length?: number, encoding?: buffer$Encoding): void;
   writeDoubleBE(value: number, offset: number, noAssert?: boolean): number;
+  writeDoubleLE(value: number, offset: number, noAssert?: boolean): number;
+  writeFloatBE(value: number, offset: number, noAssert?: boolean): number;
+  writeFloatLE(value: number, offset: number, noAssert?: boolean): number;
+  writeInt16BE(value: number, offset: number, noAssert?: boolean): number;
+  writeInt16LE(value: number, offset: number, noAssert?: boolean): number;
+  writeInt32BE(value: number, offset: number, noAssert?: boolean): number;
+  writeInt32LE(value: number, offset: number, noAssert?: boolean): number;
+  writeInt8(value: number, offset: number, noAssert?: boolean): number;
+  writeIntBE(value: number, offset: number, byteLength: number, noAssert?: boolean): number;
+  writeIntLE(value: number, offset: number, byteLength: number, noAssert?: boolean): number;
+  writeUInt16BE(value: number, offset: number, noAssert?: boolean): number;
+  writeUInt16LE(value: number, offset: number, noAssert?: boolean): number;
+  writeUInt32BE(value: number, offset: number, noAssert?: boolean): number;
+  writeUInt32LE(value: number, offset: number, noAssert?: boolean): number;
+  writeUInt8(value: number, offset: number, noAssert?: boolean): number;
+  writeUIntBE(value: number, offset: number, byteLength: number, noAssert?: boolean): number;
+  writeUIntLE(value: number, offset: number, byteLength: number, noAssert?: boolean): number;
 
   static alloc(size: number, fill?: string | number, encoding?: buffer$Encoding): Buffer;
-  static isEncoding(encoding: string): boolean;
-  static isBuffer(obj: any): boolean;
+  static allocUnsafe(size: number): Buffer;
+  static allocUnsafeSlow(size: number): Buffer;
   static byteLength(string: string, encoding?: buffer$Encoding): number;
-  static concat(list: Array<Buffer>, totalLength?: number): Buffer;
   static compare(buf1: Buffer, buf2: Buffer): number;
+  static concat(list: Array<Buffer>, totalLength?: number): Buffer;
+  static from(value: Array<number> | number | string | Buffer, encoding?: buffer$Encoding): Buffer
+  static isBuffer(obj: any): boolean;
+  static isEncoding(encoding: string): boolean;
 }
 
 declare module "buffer" {

--- a/tests/node_tests/node_tests.exp
+++ b/tests/node_tests/node_tests.exp
@@ -4,26 +4,26 @@ child_process/execSync.js:8
   8: (execSync('ls', {timeout: '250'})); // error, no signatures match
       ^^^^^^^^ intersection
   Member 1:
-  function type. See lib: node.js:184
+  function type. See lib: node.js:190
   Error:
   property `encoding`. Property not found in. See lib: node.js:186
     8: (execSync('ls', {timeout: '250'})); // error, no signatures match
                        ^^^^^^^^^^^^^^^^ object literal
   Member 2:
-  function type. See lib: node.js:189
+  function type. See lib: node.js:195
   Error:
     8: (execSync('ls', {timeout: '250'})); // error, no signatures match
                                  ^^^^^ string. This type is incompatible with
-  number. See lib: node.js:113
+  number. See lib: node.js:119
 
 fs/fs.js:13
  13: fs.readFile("file.exp", { encoding: "blah" }, (_, data) => {
      ^ call of method `readFile`. Could not decide which case to select
-intersection type. See lib: node.js:623
+intersection type. See lib: node.js:629
   Case 3 may work:
-  function type. See lib: node.js:632
+  function type. See lib: node.js:638
   But if it doesn't, case 4 looks promising too:
-  function type. See lib: node.js:637
+  function type. See lib: node.js:643
   Please provide additional annotation(s) to determine whether case 3 works (or consider merging it with case 4):
    13: fs.readFile("file.exp", { encoding: "blah" }, (_, data) => {
                                                          ^^^^ parameter `data`
@@ -53,7 +53,7 @@ fs/fs.js:33
                                         ^^^^^^ string
 
 invalid_package_file/package.json:1
-  1: 
+  1:
      ^ Unexpected end of input
 
 json_file/json_invalid.json:1

--- a/tests/node_tests/node_tests.exp
+++ b/tests/node_tests/node_tests.exp
@@ -6,7 +6,7 @@ child_process/execSync.js:8
   Member 1:
   function type. See lib: node.js:190
   Error:
-  property `encoding`. Property not found in. See lib: node.js:186
+  property `encoding`. Property not found in. See lib: node.js:192
     8: (execSync('ls', {timeout: '250'})); // error, no signatures match
                        ^^^^^^^^^^^^^^^^ object literal
   Member 2:
@@ -53,7 +53,7 @@ fs/fs.js:33
                                         ^^^^^^ string
 
 invalid_package_file/package.json:1
-  1:
+  1: 
      ^ Unexpected end of input
 
 json_file/json_invalid.json:1


### PR DESCRIPTION
By reading the [Buffer documentation](https://nodejs.org/api/buffer.html) I found that some methods were missing.

Added: 
- entries(): Iterator<[number, number]>
- includes(value: string | Buffer | number, offset?: number, encoding?: string): boolean
- indexOf(value: string | Buffer | number, offset?: number, encoding?: string): number
- keys(): Iterator<number>
- lastIndexOf(value: string | Buffer | number, offset?: number, encoding?: string): number
- swap16(): Buffer
- swap32(): Buffer
- values(): Iterator<number>
- static allocUnsafe(size: number): Buffer
- static allocUnsafeSlow(size: number): Buffer
- static from(value: Array<number> | number | string | Buffer, encoding?: buffer$Encoding): Buffer

Fixes: #1932