### PR TITLE
Add Error.stackTraceLimit and Error.prepareStackTrace.

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -354,6 +354,24 @@ declare class Date {
     [key: $SymbolToPrimitive]: (hint: 'string' | 'default' | 'number') => string | number;
 }
 
+declare class CallSite {
+    getThis(): any;
+    getTypeName(): string;
+    getFunction(): ?Function;
+    getFunctionName(): string;
+    getMethodName(): string;
+    getFileName(): ?string;
+    getLineNumber(): ?number;
+    getColumnNumber(): ?number;
+    getEvalOrigin(): ?CallSite;
+    getScriptNameOrSourceURL(): ?string;
+    isToplevel(): bool;
+    isEval(): bool;
+    isNative(): bool;
+    isConstructor(): bool;
+    toString(): string;
+}
+
 declare class Error {
     static (message?:string):Error;
     name: string;
@@ -362,6 +380,9 @@ declare class Error {
 
     // note: v8 only (node/chrome)
     static captureStackTrace(target: Object, constructor?: Function): void;
+
+    static stackTraceLimit: number;
+    static prepareStackTrace: (err: Error, stack: CallSite[]) => any;
 }
 
 declare class EvalError extends Error {


### PR DESCRIPTION
This PR adds `Error.stackTraceLimit` and `Error.prepareStackTrace`, two very useful properties on `Error` that are exposed by v8/node.

`Error.prepareStackTrace` can be assigned a function that takes an error and an array of `CallSite`, so I also added the `CallSite` class.