### PR TITLE
Remove "bottom type" reference from `mixed` docs

### DIFF
--- a/website/docs/ref/builtins.doc.js
+++ b/website/docs/ref/builtins.doc.js
@@ -240,7 +240,9 @@ unsafe.foo.bar.baz;
   ## mixed
 
   Like `any`, `mixed` is a supertype of all types. Unlike `any`, however,
-  `mixed` is not a bottom type.
+  `mixed` is not a subtype of all types. This means `mixed` is like a safe 
+  but somewhat annoying version of `any`. It should be preferred over `any`
+  whenever possible.
 */
 
 function takes_mixed(x: mixed): void {}


### PR DESCRIPTION
Most people probably don't know what a [bottom type](https://en.wikipedia.org/wiki/Bottom_type) is.