### PR TITLE
Explicitly specify AppVeyor clone dir

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,5 @@
 version: '{build}'
+clone_folder: C:\projects\flow
 os: Visual Studio 2015
 platform: x64
 environment:


### PR DESCRIPTION
I was assuming it would always clone into `C:\projects\flow`, but then it do this:

```Bash
git clone -q --branch=master https://github.com/facebook/flow.git C:\projects\flow-sv90g
```

> The format of the default directory on the build machine for cloning repository is c:\projects\<project-slug>.

And on my AppVeyor account, gabelevi/flow is "flow" and facebook/flow is "flow-sv90g". Huh.