### PR TITLE
[try] Store last edit in localStorage for next load

### DIFF
--- a/website/_assets/js/tryFlow.js.es6
+++ b/website/_assets/js/tryFlow.js.es6
@@ -135,7 +135,8 @@ function getAnnotations(text, callback, options, editor) {
 }
 getAnnotations.async = true;
 
-const defaultValue = `/* @flow */
+const lastEditorValue = localStorage.getItem('tryFlowLastContent');
+const defaultValue = (lastEditorValue && getHashedValue(lastEditorValue)) || `/* @flow */
 
 function foo(x: ?number): string {
   if (x) {
@@ -271,6 +272,7 @@ exports.createEditor = function createEditor(
       const value = editor.getValue();
       const encoded = LZString.compressToEncodedURIComponent(value);
       history.replaceState(undefined, undefined, `#0${encoded}`);
+      localStorage.setItem('tryFlowLastContent', location.hash);
     });
 
     versionTabNode.addEventListener('change', function(evt) {


### PR DESCRIPTION
It always mildly irked me that /try doesn't remember the thing I wrote last time, so here we go.

(Note that I made this diff in the GitHub browser editor, so I have not tested it at all yet. I'll do that and follow up with confirmation in a little bit when I get to the office)