### PR TITLE
Infer munged instance members.

### DIFF
--- a/newtests/munged_class_member_inference/_flowconfig
+++ b/newtests/munged_class_member_inference/_flowconfig
@@ -1,0 +1,10 @@
+[ignore]
+
+[include]
+
+[libs]
+
+[options]
+all=true
+esproposal.class_instance_fields=enable
+munge_underscores=true

--- a/newtests/munged_class_member_inference/test.js
+++ b/newtests/munged_class_member_inference/test.js
@@ -1,0 +1,17 @@
+/* @flow */
+
+
+import {suite, test} from '../../tsrc/test/Tester';
+
+export default suite(({addFile, addFiles, addCode}) => [
+  test('Munged instance fields does not require annotation within init values', [
+    addCode('export class Foo { _a = (p) => 42; }')
+      .noNewErrors(''),
+  ]),
+
+  test('Munged instance methods does not require annotation', [
+    addCode('export class Foo { _a(p) {} }')
+      .noNewErrors(''),
+  ]),
+
+]);

--- a/src/typing/flow_js.ml
+++ b/src/typing/flow_js.ml
@@ -7279,11 +7279,11 @@ let rec assert_ground ?(infer=false) cx skip ids t =
   | TaintT _ ->
     ()
 
-  | FunT (_, static, prototype, { this_t; params_tlist; return_t; _ }) ->
+  | FunT (reason, static, prototype, { this_t; params_tlist; return_t; _ }) ->
     unify cx static AnyT.t;
     unify cx prototype AnyT.t;
     unify cx this_t AnyT.t;
-    List.iter recurse params_tlist;
+    List.iter (recurse ~infer:(is_derivable_reason reason)) params_tlist;
     recurse ~infer:true return_t
 
   | PolyT (_, t)
@@ -7304,10 +7304,16 @@ let rec assert_ground ?(infer=false) cx skip ids t =
 
   | InstanceT (_, static, super, instance) ->
     let process_element ?(is_field=false) name t =
-      let infer =
-        is_munged_prop_name cx name
-        || (is_field && SSet.mem name instance.initialized_field_names)
+      let munged = is_munged_prop_name cx name in
+      let initialized = SSet.mem name instance.initialized_field_names in
+      let infer = munged || is_field && initialized in
+
+      let t =
+        if munged && (not is_field || initialized)
+        then mod_reason_of_t (fun r -> derivable_reason r) t
+        else t
       in
+
       recurse ~infer t
     in
     iter_props cx instance.fields_tmap (process_element ~is_field:true);


### PR DESCRIPTION
The doc says that flow should be able to infer all types within a module. If `munge_underscores` is enabled, then private methods' params annotation should not be required I guess.

I find myself writing a lot on annotations instead of allowing flow to infer types like this:

```js
export default class Comp extends React.Component {
  render() {
    return this._render('hi');
  }

  _render(msg) {
    return <Button onClick={this._handleClick}>{msg}</Button>;
  }

  _handleClick = (event) => {};
}
```

I'm only starting to dive into flow. So this PR is just my best guess how to fix the problem :)