### PR TITLE
Fix ./tool new-test path/to/test

### DIFF
--- a/tsrc/new-test/new-testRunner.js
+++ b/tsrc/new-test/new-testRunner.js
@@ -25,13 +25,14 @@ async function newTest(bin: string, suiteName: string): Promise<void> {
   await mkdirp(dest);
 
   const testFile = join(dest, 'test.js');
+  const testerLoc = relative(dest, resolve(__dirname, "../test/Tester"));
 
   await writeFile(
     join(dest, 'test.js'),
 `/* @flow */
 
 
-import {suite, test} from '../../tsrc/test/Tester';
+import {suite, test} from '${testerLoc}';
 
 export default suite(({addFile, addFiles, addCode}) => [
   test('TestName', [


### PR DESCRIPTION
You can run `./tool new-test path/to/test` which will create `newtests/path/to/test/test.js`. The single import statement had a hardcoded relative path which assumed that `test.js` was at `newtests/foo/test.js`. This fixes