### PR TITLE
Fix http$IncomingMessage typing for node libdef 

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -769,7 +769,7 @@ declare class http$IncomingMessage extends stream$Readable {
   setTimeout(msecs: number, callback: Function): void;
   socket: net$Socket;
   statusCode: number;
-  url: String;
+  url: string;
 }
 
 declare class http$ClientRequest extends stream$Writable {


### PR DESCRIPTION
- change http$IncomingMessage.url to be 'string' not 'String'