### PR TITLE
./tool remove-comments

### DIFF
--- a/tsrc/comment/add-commentsRunner.js
+++ b/tsrc/comment/add-commentsRunner.js
@@ -5,7 +5,7 @@ import {format} from 'util';
 
 import * as blessed from 'blessed'
 
-import {exec, execManual, readFile, writeFile} from '../async';
+import {exec, readFile, writeFile} from '../async';
 import {
   mainLocOfError,
   prettyPrintError,
@@ -13,9 +13,10 @@ import {
   prettyPrintMessageOfError,
 } from '../flowResult';
 import getPathToLoc from './getPathToLoc';
+import getFlowErrors from './getFlowErrors';
 
 import type {Args} from './add-commentsCommand';
-import type {FlowLoc, FlowResult, FlowError, FlowMessage} from '../flowResult';
+import type {FlowLoc, FlowError, FlowMessage} from '../flowResult';
 
 const unselectedBox = "[ ]";
 const selectedBox = "[✓]";
@@ -115,36 +116,6 @@ class BlessedError {
   isSelected() {
     return this.selected === selectedBox;
   }
-}
-
-async function getFlowErrors(
-  bin: string,
-  errorCheckCommand,
-  root: string,
-): Promise<FlowResult> {
-  const cmd = errorCheckCommand === 'check'
-  ? format(
-      "%s check --strip-root --json %s",
-      bin,
-      root,
-    )
-  : format(
-      "%s status --no-auto-start --strip-root --json %s",
-      bin,
-      root,
-    )
-  const [err, stdout, stderr] = await execManual(
-    cmd,
-    {cwd: root, maxBuffer: 16 * 1024 * 1024}
-  );
-
-  // 0 - no errors
-  // 2 - Some errors
-  if (err == null || err.code === 2) {
-    return JSON.parse(stdout.toString());
-  }
-
-  throw new Error(format('Flow check failed!', err, stdout, stderr));
 }
 
 export default async function(args: Args): Promise<void> {

--- a/tsrc/comment/getFlowErrors.js
+++ b/tsrc/comment/getFlowErrors.js
@@ -1,0 +1,37 @@
+/* @flow */
+
+import {format} from 'util';
+import {execManual} from '../async';
+
+import type {FlowResult} from '../flowResult';
+
+export default async function(
+  bin: string,
+  errorCheckCommand: 'check' | 'status',
+  root: string,
+): Promise<FlowResult> {
+  const cmd = errorCheckCommand === 'check'
+  ? format(
+      "%s check --strip-root --json %s",
+      bin,
+      root,
+    )
+  : format(
+      "%s status --no-auto-start --strip-root --json %s",
+      bin,
+      root,
+    )
+  const [err, stdout, stderr] = await execManual(
+    cmd,
+    {cwd: root, maxBuffer: 16 * 1024 * 1024}
+  );
+
+  // 0 - no errors
+  // 2 - Some errors
+  if (err == null || err.code === 2) {
+    return JSON.parse(stdout.toString());
+  }
+
+  throw new Error(format('Flow check failed!', err, stdout, stderr));
+}
+

--- a/tsrc/comment/remove-commentsCommand.js
+++ b/tsrc/comment/remove-commentsCommand.js
@@ -1,0 +1,49 @@
+/* @flow */
+
+import {format} from 'util';
+import {resolve} from 'path';
+
+import Base, {commonFlags} from '../command/Base';
+import findFlowBin from '../command/findFlowBin';
+
+export type Args = {
+  bin: string,
+  errorCheckCommand: 'check' | 'status',
+  root: string,
+};
+
+export default class RemoveCommentsCommand extends Base<Args> {
+  static processArgv(argv: Object): Args {
+    if (argv._.length !== 1) {
+      this.showUsage(this.BAD_ARGS);
+    }
+    return {
+      bin: findFlowBin(argv.bin),
+      errorCheckCommand: argv.check,
+      root: resolve(process.cwd(), argv._[0]),
+    };
+  }
+
+  static async run(args: Args): Promise<void> {
+    require('./remove-commentsRunner').default(args);
+  }
+
+  static description(): string {
+    return "Removes unused flow comments";
+  }
+
+  static async usage(): Promise<string> {
+return `usage: ${process.argv[1]} remove-comments [OPTION]... ROOT
+
+Queries Flow for the unused error suppressions for ROOT. Then removes them from the code.
+`;
+  }
+
+  static getFlags() {
+    return [
+      commonFlags.bin,
+      commonFlags.errorCheckCommand,
+    ];
+  }
+}
+

--- a/tsrc/comment/remove-commentsRunner.js
+++ b/tsrc/comment/remove-commentsRunner.js
@@ -1,0 +1,111 @@
+/* @flow */
+
+import getFlowErrors from './getFlowErrors';
+
+import {readFile, writeFile} from '../async';
+
+import type {Args} from './remove-commentsCommand';
+import type {FlowLoc, FlowResult, FlowError, FlowMessage} from '../flowResult';
+
+type Loc = {
+  start: number,
+  end: number,
+};
+
+async function getErrors(args: Args): Promise<Map<string, Array<Loc>>> {
+  const result = await getFlowErrors(
+    args.bin,
+    args.errorCheckCommand,
+    args.root,
+  );
+
+  const errors = result.errors.filter(error =>
+    error.message[0].descr === "Error suppressing comment" &&
+    error.message[1].descr === "Unused suppression"
+  );
+
+  const errorsByFile = new Map();;
+  for (const error of errors) {
+    if (error.message[0].loc && error.message[0].loc.source) {
+      const file = error.message[0].loc.source;
+      const start = error.message[0].loc.start.offset;
+      const end = error.message[0].loc.end.offset;
+      const fileErrors = errorsByFile.get(file) || [];
+      fileErrors.push({start, end});
+      errorsByFile.set(file, fileErrors);
+    }
+  }
+
+  // Group errors by file and sort by reverse location in the file
+  for (const file of errorsByFile.keys()) {
+    const fileErrors = errorsByFile.get(file);
+    fileErrors && fileErrors.sort((e1, e2) => e2.start - e1.start);
+  }
+  return errorsByFile;
+}
+
+async function removeUnusedErrorSuppressions(
+  [filename, errors]: [string, Array<Loc>],
+): Promise<void> {
+  let contents = await readFile(filename);
+
+  /* This is the most confusing part of this command. A simple version of this
+   * code would just remove exact characters of a comment. This might leave
+   * extra whitespace and blank lines. So this code tries to expand the range
+   * we remove to cover the following cases
+   *
+   * /* Comment with nothing before or after it * /
+   * var foo; /* Comment with something before it * /
+   * /* Comment with something after it * / var foo;
+   * var foo; /* Comment with something before and after it * / var bar;
+   *
+   * The TL;DR is that we only want to expand the range and remove the newline
+   * in the case where there is nothing before or after it
+   */
+  const edible = /[\t ]/;
+  for (let {start: origStart, end: origEnd} of errors) {
+    const length = contents.length;
+    origEnd--;
+    let start = origStart;
+    let end = origEnd;
+    while (start > 0) {
+      // Eat whitespace towards the start of the line
+      if (contents[start-1].match(edible)) {
+        start--;
+      } else if (contents[start-1] === "\n") {
+        // If we make it to the beginning of the line, awesome! Let's try and
+        // expand the end too!
+        while (end < length - 1) {
+          // Eat whitespace towards the end of the line
+          if (contents[end+1].match(edible)) {
+            end++;
+          } else if (contents[end+1] === "\n") {
+            // If we make it to both the beginning and the end of the line,
+            // then we can totally remove a newline!
+            end++;
+            break;
+          } else {
+            // Otherwise we can't, undo the expansion
+            start = origStart;
+            end = origEnd;
+            break;
+          }
+        }
+        break;
+      } else {
+        // If we hit something else, then undo the start expansion
+        start = origStart;
+        break;
+      }
+    }
+    contents = contents.slice(0, start) + contents.slice(end+1);
+  }
+  await writeFile(filename, contents);
+}
+
+export default async function(args: Args): Promise<void> {
+  const errors = await getErrors(args);
+  await Promise.all(
+    Array.from(errors.entries()).map(removeUnusedErrorSuppressions)
+  );
+}


### PR DESCRIPTION
We had a janky bash script to remove unused error suppression comments. This is a more robust attempt. It removes entire lines when there's nothing before or after a comment. Otherwise it just removes the comment.

```diff
-{ /* $FlowFixMe */ }
+{ }
 
-/* $FlowFixMe
- * And stuff
- */
-
-{ /* $FlowFixMe
-
-   */
-}
+{ }
 
 {
-  /* $FlowFixMe
-
-   */ }
+  }
 
-// $FlowFixMe
```