### PR TITLE
flow check --json --profile

### DIFF
--- a/src/common/errors_js.ml
+++ b/src/common/errors_js.ml
@@ -774,13 +774,17 @@ let json_of_errors errors =
 let json_of_errors_with_context ~root ~stdin_file errors =
   Hh_json.JSON_Array (List.map (json_of_error_with_context ~root ~stdin_file) errors)
 
-let print_error_json ~root ?(stdin_file=None) oc el =
+let print_error_json ~root ?(timing=None) ?(stdin_file=None) oc el =
   let open Hh_json in
-  let res = JSON_Object [
+  let props = [
     "flowVersion", JSON_String FlowConfig.version;
     "errors", json_of_errors_with_context ~root ~stdin_file el;
     "passed", JSON_Bool (el = []);
   ] in
+  let props = match timing with
+  | None -> props
+  | Some timing -> props @ [ "timing", Timing.to_json timing; ] in
+  let res = JSON_Object props in
   output_string oc (json_to_string res);
   flush oc
 

--- a/src/common/errors_js.mli
+++ b/src/common/errors_js.mli
@@ -90,6 +90,7 @@ val print_error_color_new:
 
 val print_error_json :
   root:Path.t ->
+  ?timing:Timing.t option ->
   ?stdin_file:stdin_file ->
   out_channel ->
   error list ->

--- a/src/common/timing.ml
+++ b/src/common/timing.ml
@@ -1,0 +1,67 @@
+(**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the "flow" directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ *)
+
+type result = {
+  start_wall_age: float;
+  wall_duration: float;
+}
+
+type t = {
+  running_timers: float SMap.t;
+  results: result SMap.t;
+}
+
+let create () = { running_timers = SMap.empty; results = SMap.empty }
+
+let start_timer ~timer { running_timers; results; } =
+  {
+    running_timers = SMap.add timer (Unix.gettimeofday ()) running_timers;
+    results;
+  }
+
+let flow_start_time = Unix.gettimeofday ()
+
+let stop_timer ~timer { running_timers; results; } =
+  match SMap.get timer running_timers with
+  | None -> { running_timers; results; }
+  | Some timer_start_time ->
+      let result = {
+	start_wall_age = timer_start_time -. flow_start_time;
+	wall_duration = Unix.gettimeofday () -. timer_start_time;
+      } in
+      {
+	running_timers = SMap.remove timer running_timers;
+	results = SMap.add timer result results;
+      }
+
+let get_finished_timer ~timer { results; _; } =
+  match SMap.get timer results with
+  | None -> None
+  | Some { start_wall_age; wall_duration; } ->
+      Some (start_wall_age, wall_duration)
+
+let json_of_result { start_wall_age; wall_duration; } =
+  let open Hh_json in
+  let open Utils_js in
+  JSON_Object [
+    "start_wall_age", JSON_Number (string_of_float_trunc start_wall_age);
+    "wall_duration", JSON_Number (string_of_float_trunc wall_duration);
+  ]
+
+let to_json { results; _; } =
+  let open Hh_json in
+  let results = results
+  |> SMap.map json_of_result
+  |> SMap.elements in
+  JSON_Object [
+    "results", JSON_Object results;
+  ]
+
+let to_string sample = to_json sample |> Hh_json.json_to_string

--- a/src/common/timing.mli
+++ b/src/common/timing.mli
@@ -1,0 +1,18 @@
+(**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the "flow" directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ *)
+
+type t
+
+val create: unit -> t
+val start_timer: timer:string -> t -> t
+val stop_timer: timer:string -> t -> t
+val get_finished_timer: timer:string -> t -> (float * float) option
+val to_json: t -> Hh_json.json
+val to_string: t -> string

--- a/src/server/serverFunctors.ml
+++ b/src/server/serverFunctors.ml
@@ -18,7 +18,7 @@ exception State_not_found
 
 module type SERVER_PROGRAM = sig
   val preinit : Options.t -> unit
-  val init : genv -> (FlowEventLogger.Timing.t * env)
+  val init : genv -> (Timing.t * env)
   val run_once_and_exit : env -> unit
   (* filter and relativize updated file paths *)
   val process_updates : genv -> env -> SSet.t -> FilenameSet.t

--- a/src/services/inference/types_js.ml
+++ b/src/services/inference/types_js.ml
@@ -129,14 +129,14 @@ let collate_errors =
       |> FilenameMap.fold collate !merge_errors
 
 let with_timer ?options timer timing f =
-  let timing = FlowEventLogger.Timing.start_timer ~timer timing in
+  let timing = Timing.start_timer ~timer timing in
   let ret = f () in
-  let timing = FlowEventLogger.Timing.stop_timer ~timer timing in
+  let timing = Timing.stop_timer ~timer timing in
 
   (* If we're profiling then output timing information to stderr *)
   (match options with
   | Some options when Options.should_profile options ->
-      (match FlowEventLogger.Timing.get_finished_timer ~timer timing with
+      (match Timing.get_finished_timer ~timer timing with
       | Some (start_wall_age, wall_duration) ->
           prerr_endlinef
             "TimingEvent `%s`: start_wall_age: %f; wall_duration: %f"
@@ -151,7 +151,7 @@ let with_timer ?options timer timing f =
 (* Another special case, similar assumptions as above. *)
 (** TODO: handle case when file+contents don't agree with file system state **)
 let typecheck_contents ~options ?verbose contents filename =
-  let timing = FlowEventLogger.Timing.create () in
+  let timing = Timing.create () in
 
   (* always enable types when checking an individual file *)
   let types_mode = Parsing_service_js.TypesAllowed in
@@ -359,7 +359,7 @@ let recheck genv env modified =
     else modified
   ) modified modified in
 
-  let timing = FlowEventLogger.Timing.create () in
+  let timing = Timing.create () in
 
   (* track deleted files, remove from modified set *)
   let deleted = FilenameSet.filter (fun f ->
@@ -505,7 +505,7 @@ let recheck genv env modified =
 
 (* full typecheck *)
 let full_check workers ~ordered_libs parse_next options =
-  let timing = FlowEventLogger.Timing.create () in
+  let timing = Timing.create () in
 
   (* force types when --all is set, but otherwise forbid them unless the file
      has @flow in it. *)
@@ -568,7 +568,7 @@ let full_check workers ~ordered_libs parse_next options =
   (timing, parsed)
 
 (* helper - print errors. used in check-and-die runs *)
-let print_errors options errors =
+let print_errors ~timing options errors =
   let strip_root = Options.should_strip_root options in
   let root = Options.root options in
 
@@ -578,8 +578,13 @@ let print_errors options errors =
   in
 
   if Options.should_output_json options
-  then Errors.print_error_json ~root stdout errors
-  else
+  then begin 
+    let timing = 
+      if options.Options.opt_profile
+      then Some timing
+      else None in
+    Errors.print_error_json ~root ~timing stdout errors
+  end else
     Errors.print_error_summary
       ~flags:(Options.error_flags options)
       ~strip_root
@@ -603,7 +608,7 @@ let server_init genv =
 
   let errors = get_errors () in
   if Options.is_check_mode options
-  then print_errors options errors;
+  then print_errors ~timing options errors;
 
   (* Return an env that initializes invariants required and maintained by
      recheck, namely that `files` contains files that parsed successfully, and

--- a/src/services/inference/types_js.mli
+++ b/src/services/inference/types_js.mli
@@ -15,14 +15,14 @@ val recheck: ServerEnv.genv -> ServerEnv.env -> FilenameSet.t -> ServerEnv.env
 
 (* hh_server initial (full) check *)
 val server_init:
-  ServerEnv.genv -> FlowEventLogger.Timing.t * ServerEnv.env
+  ServerEnv.genv -> Timing.t * ServerEnv.env
 
 val typecheck_contents:
   options: Options.t ->
   ?verbose: Verbose.t ->
   string ->               (* contents *)
   filename ->             (* fake file-/module name *)
-  FlowEventLogger.Timing.t *
+  Timing.t *
     Context.t option *
     Errors_js.ErrorSet.t *
     Docblock.t

--- a/src/stubs/flowEventLogger.ml
+++ b/src/stubs/flowEventLogger.ml
@@ -28,15 +28,6 @@ let set_command _ = ()
 let set_from _ = ()
 let set_root _ = ()
 
-module Timing = struct
-  type t = unit
-
-  let create _ = ()
-  let start_timer ~timer:_ _ = ()
-  let stop_timer ~timer:_ _ = ()
-  let get_finished_timer ~timer:_ _ = None
-end
-
 let status_response _ = ()
 let init_server _ = ()
 let init_done ~timing:_ = ()


### PR DESCRIPTION
Currently, `flow check --profile` will print out profiling info. It would be great if we could output that timing info as JSON, so profiling scripts could consume it in a more robust manner.

```Bash
./bin/flow check --json --profile \
| node -e "s=process.openStdin(); \
  d=[]; \
  s.on('data', function(c){ d.push(c); }); \
  s.on('end', function() { console.log(JSON.stringify(JSON.parse(d.join('')), null, 2)); });"
```

```JavaScript
{
  "flowVersion": "0.28.0",
  "errors": [
    {
      "kind": "infer",
      "level": "error",
      "message": [
        {
          "context": "  normalizeForFlowconfig(path) {",
          "descr": "parameter `path`",
          "type": "Blame",
          "loc": {
            "source": "/Users/glevi/projects/flow-gabe/tsrc/test/builder.js",
            "type": "SourceFile",
            "start": {
              "line": 57,
              "column": 26,   
              "offset": 1300  
            },
            "end": {
              "line": 57,
              "column": 29,   
              "offset": 1304  
            }
          },
          "path": "/Users/glevi/projects/flow-gabe/tsrc/test/builder.js",
          "line": 57,
          "endline": 57,
          "start": 26,
          "end": 29
        },
        {
          "context": null,
          "descr": "Missing annotation",
          "type": "Comment",
          "path": "",
          "line": 0,
          "endline": 0,
          "start": 1,
          "end": 0
        }
      ]
    }
  ],
  "passed": false,
  "timing": {
    "results": {
      "ResolveDirectDeps": {
        "start_wall_age": 8.02384591103,
        "wall_duration": 0.00000309944152832
      },
      "Parsing": {
        "start_wall_age": 0.0314590930939,
        "wall_duration": 5.02810001373
      },
      "PackageHeap": {
        "start_wall_age": 5.05956411362,
        "wall_duration": 0.107503890991
      },
      "Merge": {
        "start_wall_age": 8.0411939621,
        "wall_duration": 0.463415145874
      },
      "MakeMergeInput": {
        "start_wall_age": 8.02384209633,
        "wall_duration": 0
      },
      "InitLibs": {
        "start_wall_age": 5.16707110405,
        "wall_duration": 0.309567928314
      },
      "Infer": {
        "start_wall_age": 5.47664403915,
        "wall_duration": 0.210661888123
      },
      "CommitModules": {
        "start_wall_age": 5.98769307137,
        "wall_duration": 2.0361468792
      },
      "CalcDeps": {
        "start_wall_age": 8.02384901047,
        "wall_duration": 0.0124320983887
      }
    }
  }
}

```