### PR TITLE
add better type for arr.filter(Boolean)

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -176,6 +176,9 @@ declare var Math: {
     trunc(x: number): number;
 };
 
+type _NonNull<T, N: ?T> = T;
+type $NonNull<N> = _NonNull<*, N>;
+
 declare class Array<T> {
     @@iterator(): Iterator<T>;
     toLocaleString(): string;
@@ -185,6 +188,7 @@ declare class Array<T> {
     entries(): Iterator<[number, T]>;
     every(callbackfn: (value: T, index: number, array: Array<T>) => any, thisArg?: any): boolean;
     fill(value: T, begin?: number, end?: number): Array<T>;
+    filter(callbackfn: typeof Boolean): Array<$NonNull<T>>;
     filter(callbackfn: (value: T, index: number, array: Array<T>) => any, thisArg?: any): Array<T>;
     find(callbackfn: (value: T, index: number, array: Array<T>) => any, thisArg?: any): T;
     findIndex(callbackfn: (value: T, index: number, array: Array<T>) => any, thisArg?: any): number;


### PR DESCRIPTION
This pull request simply adds an overload for the `Array.prototype.filter` method.

One code example that explains it all.

```typescript
function filterOutVoids<T> (arr: Array<?T>): Array<T> {
  return arr.filter(Boolean)
}

function filterOutSmall (arr: Array<?number>): Array<?number> {
  return arr.filter(num => num && num > 10)
}
```