### PR TITLE
Add definitions for console methods

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -669,4 +669,20 @@ declare function require(id: string): any;
 declare var exports: any;
 
 /* Commonly available, shared between node and dom */
-declare var console: any;
+declare var console: {
+  clear(): void;
+  log(...data: Array<any>): void;
+  info(...data: Array<any>): void;
+  warn(...data: Array<any>): void;
+  error(...data: Array<any>): void;
+  debug(...data: Array<any>): void;
+  trace(...data: Array<any>): void;
+  count(label: string): void;
+  group(...data: Array<any>): void;
+  groupCollapse(...data: Array<any>): void;
+  groupEnd(): void;
+  time(label: string): void;
+  timeEnd(label: string): void;
+  assert(condition: boolean, ...data: Array<any>): void;
+  table(tabularData: { [key: string]: any } | Array<Array<any>>): void;
+};


### PR DESCRIPTION
This is based on the WhatWG Console Standard (https://console.spec.whatwg.org/).

Obviously not all these methods are available in every environment. So the handling of this comes down to how Flow typically handles standards that aren't implemented everywhere at the current time.