### PR TITLE
use Uint8ClampedArray in canvas ImageData

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -1035,7 +1035,7 @@ declare class Path2D {
 declare class ImageData {
   width: number;
   height: number;
-  data: Array<number>;
+  data: Uint8ClampedArray;
 };
 
 declare class CanvasRenderingContext2D {


### PR DESCRIPTION
I was having a problem with data field in ImageData class because its defined as `Array<number>` instead of `Uint8ClampedArray`. With `Array<number>` I can't use various methods defined on the typed array.

### Error example
```
imageData.data.set(buffer);
               ^^^ property `set`. Property not found in
imageData.data.set(buffer);
^^^^^^^^^^^^^^^^^^^^^^^^^^ Array
```

reference: https://developer.mozilla.org/en-US/docs/Web/API/ImageData