### PR TITLE
readme.md should be more focused on installing & usage.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,45 +13,9 @@ Flow works with:
 
 There are binary distributions for Mac OS X and many variants of Linux; you can also build it from source on almost any 64-bit Linux variant.
 
-## Building Flow
-
-Flow is written in OCaml (OCaml 4.01.0 or higher is required) and (on Linux) requires libelf. You can install OCaml on Mac OS X and Linux by following the instructions at [ocaml.org](https://ocaml.org/docs/install.html). 
-
-For example, on Ubuntu 14.04 and similar systems:
-
-```
-sudo apt-get install ocaml libelf-dev
-```
-
-On OSX, using the [brew package manager](http://brew.sh/):
-
-```
-brew install ocaml ocamlbuild libelf opam
-```
-
-Once you have these dependencies, building Flow just requires running
-
-```
-make
-```
-
-This produces a `bin` folder containing the `flow` binary. 
-
-*Note: at this time, the OCaml dependency prevents us from adding Flow to [npm](http://npmjs.org). Try [flow-bin](https://www.npmjs.org/package/flow-bin) if you need a npm binary wrapper.*
-
-## Running the tests
-
-To run the tests, first compile flow using `make`. Then run `bash ./runtests.sh bin/flow`
-
-There is a `make test` target that compiles and runs tests.
-
-To run a subset of the tests you can pass a second argument to the `runtests.sh` file.
-
-For example: `bash runtests.sh bin/flow class | grep -v 'SKIP'`
-
 ## Installing Flow
 
-Flow is simple to install: all you need is the `flow` binary on your PATH and you're good to go. 
+Flow is simple to install: all you need is the `flow` binary on your PATH and you're good to go.
 
 ### Using Homebrew
 
@@ -59,6 +23,12 @@ Installing Flow with [Homebrew](http://brew.sh/) package manager:
 
 ```
 brew install flow
+```
+
+To ensure you get the latest version of Flow, update your Homebrew with:
+
+```
+brew update
 ```
 
 ### Using OPAM
@@ -79,9 +49,62 @@ eval `opam config env`
 flow --help
 ```
 
-## Documentation
+## Getting started
 
-Check out http://flowtype.org for documentation and examples. 
+Getting started with flow is super easy.
+
+- Initialize Flow by running the following command in the root of your project
+```
+flow init
+```
+
+- Add the following to the top of all the files you want to typecheck
+``` javascript
+/* @flow */
+```
+
+- Run and see the magic happen
+```
+flow check
+```
+
+More thorough documentation and many examples can be found at http://flowtype.org.
+
+## Building Flow
+
+Flow is written in OCaml (OCaml 4.01.0 or higher is required) and (on Linux) requires libelf. You can install OCaml on Mac OS X and Linux by following the instructions at [ocaml.org](https://ocaml.org/docs/install.html).
+
+For example, on Ubuntu 14.04 and similar systems:
+
+```
+sudo apt-get install ocaml libelf-dev
+```
+
+On OSX, using the [brew package manager](http://brew.sh/):
+
+```
+brew install ocaml ocamlbuild libelf opam
+```
+
+Once you have these dependencies, building Flow just requires running
+
+```
+make
+```
+
+This produces a `bin` folder containing the `flow` binary.
+
+*Note: at this time, the OCaml dependency prevents us from adding Flow to [npm](http://npmjs.org). Try [flow-bin](https://www.npmjs.org/package/flow-bin) if you need a npm binary wrapper.*
+
+## Running the tests
+
+To run the tests, first compile flow using `make`. Then run `bash ./runtests.sh bin/flow`
+
+There is a `make test` target that compiles and runs tests.
+
+To run a subset of the tests you can pass a second argument to the `runtests.sh` file.
+
+For example: `bash runtests.sh bin/flow class | grep -v 'SKIP'`
 
 ## Join the Flow community
 * Website: [http://flowtype.org/](http://flowtype.org/)


### PR DESCRIPTION
I've decided to finally add Flow to our dev stack on the project I am currently working on. I had a bit of trouble getting started though, as I was a bit surprised that the first thing I saw in the readme is how to build Flow instead of how to actually install it and get up & running.

For me personally it was quiet stressful as I wasn't sure if I need to do the building or I can just install using brew (I'm pretty sure there's a diagnose for that).

I am not very good at writing stuff so just take this as a poke & point to the better (didn't want to use "right") direction.

Thanks,

Foxhoundn