### PR TITLE
./tool test --watch

### DIFF
--- a/flow-typed/sane.js
+++ b/flow-typed/sane.js
@@ -1,0 +1,16 @@
+import type {Stats} from 'fs';
+declare module 'sane' {
+  declare type Sane$Options = {
+    glob?: Array<string>,
+    poll?: boolean,
+    watchman?: boolean,
+    dot?: boolean,
+  };
+  declare class Sane$Watcher {
+    on(event: 'ready', callback: () => mixed): void;
+    on(event: 'change', callback: (filepath: string, root: string, stat: Stats) => mixed): void;
+    on(event: 'add', callback: (filepath: string, root: string, stat: Stats) => mixed): void;
+    on(event: 'delete', callback: (filepath: string, root: string) => mixed): void;
+  }
+  declare module.exports: (path: string, options?: Sane$Options) => Sane$Watcher;
+}

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "mkdirp": "^0.5.1",
     "ncp": "~2.0.0",
     "rimraf": "^2.5.2",
+    "sane": "^1.4.0",
     "source-map-support": "~0.4.0"
   }
 }

--- a/tsrc/main.js
+++ b/tsrc/main.js
@@ -12,8 +12,8 @@ function cleanUp() {
   process.exit(1);
 }
 
-process.on('unhandledRejection', function (err) {
-  process.stderr.write(format("uncaught rejection", err, err.stack, "\n"));
+process.on('unhandledRejection', function (err, p) {
+  process.stderr.write(format("uncaught rejection\n%s\n%s\n", err, err.stack));
   cleanUp();
 });
 

--- a/tsrc/test/TestStep.js
+++ b/tsrc/test/TestStep.js
@@ -17,6 +17,7 @@ type Action = (builder: TestBuilder, envWrite: StepEnvWriteable) => Promise<void
 export type StepResult = {
   passed: boolean,
   assertionResults: Array<ErrorAssertionResult>,
+  exception?: Error,
 }
 
 /**

--- a/tsrc/test/testCommand.js
+++ b/tsrc/test/testCommand.js
@@ -13,6 +13,7 @@ export type Args = {
   errorCheckCommand: "check" | "status",
   rerun: ?string,
   failedOnly: boolean,
+  watch: boolean,
 };
 
 export default class TestCommand extends Base<Args> {
@@ -30,6 +31,7 @@ export default class TestCommand extends Base<Args> {
       errorCheckCommand: argv.check,
       rerun: argv.rerun || argv["rerun-failed"],
       failedOnly: !!argv["rerun-failed"],
+      watch: Boolean(argv.watch),
     };
   }
 
@@ -75,6 +77,11 @@ SUITE
         name: "rerun-failed",
         argName: "RUN",
         description: "Rerun failed tests from a previous test run",
+      },
+      {
+        type: "boolean",
+        name: "watch",
+        description: "Automatically rerun tests when they change",
       },
     ];
   }


### PR DESCRIPTION
Works just like `./tool test`, except it just sits around. When a test changes, it reruns that test. If the Flow binary changes, it reruns all the tests