### PR TITLE
Add respect-pragma flag to check-contents

### DIFF
--- a/src/commands/checkContentsCommand.ml
+++ b/src/commands/checkContentsCommand.ml
@@ -35,11 +35,13 @@ let spec = {
     |> strip_root_flag
     |> json_flags
     |> verbose_flags
+    |> flag "--respect-pragma" no_arg
+        ~doc:"Respect the presence or absence of an @flow pragma"
     |> anon "filename" (optional string) ~doc:"Filename"
   )
 }
 
-let main option_values root error_flags strip_root use_json verbose file () =
+let main option_values root error_flags strip_root use_json verbose respect_pragma file () =
   let file = get_file_from_filename_or_stdin file None in
   let root = guess_root (
     match root with
@@ -54,7 +56,7 @@ let main option_values root error_flags strip_root use_json verbose file () =
   if not use_json && (verbose <> None)
   then prerr_endline "NOTE: --verbose writes to the server log file";
 
-  ServerProt.cmd_to_channel oc (ServerProt.CHECK_FILE (file, verbose));
+  ServerProt.cmd_to_channel oc (ServerProt.CHECK_FILE (file, verbose, respect_pragma));
   let response = ServerProt.response_from_channel ic in
   let stdin_file = match file with
     | ServerProt.FileContent (None, contents) ->

--- a/src/server/serverProt.ml
+++ b/src/server/serverProt.ml
@@ -34,7 +34,8 @@ type command =
 | AUTOCOMPLETE of file_input
 | CHECK_FILE of
     file_input *
-    Verbose.t option
+    Verbose.t option *
+    bool (* respect_pragma *)
 | COVERAGE of file_input
 | DUMP_TYPES of file_input * bool (* filename, include raw *) * (Path.t option) (* strip_root *)
 | ERROR_OUT_OF_DATE


### PR DESCRIPTION
This behavior makes more sense for an IDE since the user isn't explicitly asking Flow to check the contents of the file.

See https://github.com/facebook/nuclide/issues/604