### PR TITLE
Fix Tail for Windows

### DIFF
--- a/src/commands/commandConnect.ml
+++ b/src/commands/commandConnect.ml
@@ -246,12 +246,7 @@ let rec connect env retries start_time tail_env =
       connect env retries start_time tail_env
 
 let connect env =
-  let link_file = env.log_file in
-  let log_file =
-    if Sys.win32 && Sys.file_exists link_file then
-      Sys_utils.cat link_file
-    else
-      link_file in
+  let log_file = env.log_file in
   let start_time = Unix.time () in
   let tail_env = Tail.create_env log_file in
   let retries = {


### PR DESCRIPTION
I'm not sure what this code was supposed to do, but reading the log file and using those contents as the name of the log file doesn't make much sense. Removing this special case seems to work, so let's go with that.