### PR TITLE
Fix log rotating on Windows

### DIFF
--- a/src/commands/commandConnect.ml
+++ b/src/commands/commandConnect.ml
@@ -181,6 +181,10 @@ let rec connect env retries start_time tail_env =
   | Result.Ok (ic, oc) -> (ic, oc)
   | Result.Error CCS.Server_missing ->
       if env.autostart then begin
+        (* Windows doesn't let us move open files, and flow start
+         * tries to move the log file, so let's close our tail for
+         * now. It will be reopened when we next call connect *)
+        Tail.close_env tail_env;
         let retries =
           if start_flow_server env
           then begin
@@ -196,7 +200,6 @@ let rec connect env retries start_time tail_env =
               (Tty.spinner());
             consume_retry retries
           end in
-        Tail.close_env tail_env;
         connect env retries start_time tail_env
       end else begin
         let msg = Utils_js.spf

--- a/src/server/serverFunctors.ml
+++ b/src/server/serverFunctors.ml
@@ -207,8 +207,24 @@ end = struct
     env
 
   let open_log_file options =
+    (* When opening a new foo.log file, if foo.log already exists, we move it to
+     * foo.log.old. On Linux/OSX this is easy, we just call rename. On Windows,
+     * the rename can fail if foo.log is open or if foo.log.old already exists.
+     * Not a huge problem, we just need to be more intentional *)
     let file = Path.to_string (Options.log_file options) in
-    (try Sys.rename file (file ^ ".old") with _ -> ());
+    let old_file = file ^ ".old" in
+
+    (try 
+      if Sys.file_exists old_file
+      then Sys.remove old_file;
+      Sys.rename file old_file
+    with e -> 
+      Utils.prerr_endlinef 
+        "Log rotate: failed to move '%s' to '%s'\n%s" 
+        file 
+        old_file
+        (Printexc.to_string e)
+    );
     Unix.openfile file [Unix.O_WRONLY; Unix.O_CREAT; Unix.O_APPEND] 0o666
 
   (* The main entry point of the daemon


### PR DESCRIPTION
When we create a new log file `foo.log`, we move the existing `foo.log` to `foo.log.old`. This wasn't quite working on Windows. The problems were

1. On Windows, `Sys.rename` fails if `foo.log.old` already exists. Easy to fix - we just explicitly delete it.
2. `Sys.rename` would fail if someone had `foo.log` open. If the server is starting up because you ran `flow status`, the status command still had `foo.log` open to tail the log messages. This was easy to fix - we just stop tailing the log file before we start the new server.

Either way, if the log rotation fails, we soldier on.