### PR TITLE
Fix Windows process ID/HANDLE mess

### DIFF
--- a/hack/utils/daemon.ml
+++ b/hack/utils/daemon.ml
@@ -59,6 +59,7 @@ module Entry : sig
      interface. *)
 
   type ('param, 'input, 'output) t
+  val get_name: ('param, 'input, 'output) t -> string
   val register:
     string -> ('param -> ('input, 'output) channel_pair -> unit) ->
     ('param, 'input, 'output) t
@@ -77,6 +78,8 @@ module Entry : sig
 end = struct
 
   type ('param, 'input, 'output) t = string
+
+  let get_name name = name
 
   (* Store functions as 'Obj.t' *)
   let entry_points : (string, Obj.t) Hashtbl.t = Hashtbl.create 23
@@ -239,6 +242,10 @@ let spawn
   if log_stderr <> Unix.stderr && log_stderr <> log_stdout then
     Unix.close log_stderr;
   Unix.close in_fd;
+  PidLog.log 
+    ~reason:(Entry.get_name entry) 
+    ~no_fail:true
+    pid;
   { channels = Timeout.in_channel_of_descr parent_in,
                Unix.out_channel_of_descr parent_out;
     pid }

--- a/hack/utils/pidLog.ml
+++ b/hack/utils/pidLog.ml
@@ -25,13 +25,15 @@ let init pids_file =
     Unix.(set_close_on_exec (descr_of_out_channel oc))
   end
 
-let log ?reason pid =
+let log ?reason ?(no_fail=false) pid =
   if !enabled
   then
+    let pid = Sys_utils.pid_of_handle pid in
     let reason = match reason with
       | None -> "unknown"
       | Some s -> s in
     match !log_oc with
+      | None when no_fail -> ()
       | None -> failwith "Can't write pid to uninitialized pids log"
       | Some oc -> Printf.fprintf oc "%d\t%s\n%!" pid reason
 

--- a/hack/utils/sys_utils.ml
+++ b/hack/utils/sys_utils.ml
@@ -374,6 +374,10 @@ external set_priorities : cpu_priority:int -> io_priority:int -> unit =
 
 external win_terminate_process: int -> bool = "win_terminate_process"
 
+external pid_of_handle: int -> int = "pid_of_handle"
+external handle_of_pid_for_termination: int -> int = 
+  "handle_of_pid_for_termination"
+
 let terminate_process pid =
   try Unix.kill pid Sys.sigkill
   with exn when Sys.win32 ->

--- a/hack/utils/sysinfo.c
+++ b/hack/utils/sysinfo.c
@@ -19,6 +19,10 @@
 #endif
 #endif
 
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
 value hh_sysinfo_totalram(void) {
   CAMLparam0();
 #ifdef __linux__
@@ -42,5 +46,38 @@ value hh_sysinfo_uptime(void) {
 #else
   /* Not implemented */
   CAMLreturn(Val_long(0));
+#endif
+}
+
+/**
+ * There are a bunch of functions that you expect to return a pid,
+ * like Unix.getpid() and Unix.create_process(). However, on
+ * Windows, instead of returning the process ID, they return a
+ * process handle.
+ *
+ * Process handles seem act like pointers to a process. You can have
+ * more than one handle that points to a single process (unliked
+ * pids, where there is a single pid for a process).
+ *
+ * This isn't a problem normally, since functons like Unix.waitpid()
+ * will take the process handle on Windows. But if you want to print
+ * or log the pid, then you need to dereference the handle and get
+ * the pid. And that's what this function does.
+ */
+value pid_of_handle(value handle) {
+  CAMLparam1(handle);
+#ifdef _WIN32
+  CAMLreturn(Val_int(GetProcessId((HANDLE)Long_val(handle))));
+#else
+  CAMLreturn(handle);
+#endif
+}
+
+value handle_of_pid_for_termination(value pid) {
+  CAMLparam1(pid);
+#ifdef _WIN32
+  CAMLreturn(Val_int(OpenProcess(PROCESS_TERMINATE, FALSE, Int_val(pid))));
+#else
+  CAMLreturn(pid);
 #endif
 }

--- a/hack/utils/win32_support.c
+++ b/hack/utils/win32_support.c
@@ -8,6 +8,7 @@
  *
  */
 
+#include <caml/memory.h>
 #include <caml/mlvalues.h>
 
 #ifdef _WIN32
@@ -20,8 +21,9 @@
 // Can be removed once support for ocaml-4.01 is dropped
 value win_terminate_process(value v_pid)
 {
+  CAMLparam1(v_pid);
 #ifdef _WIN32
-  return (Val_bool(TerminateProcess((HANDLE) Long_val(v_pid), 0)));
+  CAMLreturn(Val_bool(TerminateProcess((HANDLE) Long_val(v_pid), 0)));
 #else
   char error_msg[100];
   snprintf(

--- a/src/commands/stopCommand.ml
+++ b/src/commands/stopCommand.ml
@@ -75,7 +75,10 @@ let mean_kill ~tmp_dir root =
       raise FailedToKill
   in
   List.iter (fun (pid, _) ->
-    try Sys_utils.terminate_process pid
+    try 
+      pid
+      |> Sys_utils.handle_of_pid_for_termination
+      |> Sys_utils.terminate_process
     with Unix.Unix_error (Unix.ESRCH, "kill", _) ->
       (* no such process *)
       ()

--- a/src/server/serverFunctors.ml
+++ b/src/server/serverFunctors.ml
@@ -376,17 +376,18 @@ end = struct
     (* detach ourselves from the parent process *)
     Daemon.close_out waiting_channel_oc;
     (* let original parent exit *)
-
+    let pretty_pid = Sys_utils.pid_of_handle pid in
     if Options.should_output_json options
     then begin
       let open Hh_json in
       let json = json_to_string (JSON_Object [
-        "pid", JSON_String (string_of_int pid);
+        "pid", JSON_String (string_of_int pretty_pid);
         "log_file", JSON_String log_file;
       ]) in
       print_string json
     end else begin
-      Printf.eprintf "Spawned %s (child pid=%d)\n" (Program.name) pid;
+      Printf.eprintf 
+        "Spawned %s (pid=%d)\n" (Program.name) pretty_pid;
       Printf.eprintf
         "Logs will go to %s\n%!" log_file
     end;


### PR DESCRIPTION
This was pretty frustrating to debug. But I think I figured out what's going on.

Coming from Linux & OS X, I'm used to referring to processes by the "Process ID" (pid). Many functions return a pid, like `Unix.getpid()` and `Unix.create_process()`, and many processes take a pid, like `Unix.waitpid` and `Unix.kill`.

Windows also has Process IDs. Each Process has a pid. But in addition to this, there are also Process Handles. They feel a little bit like file descriptors. For example, you can get a Process Handle with a call like `OpenProcess(pid)`. Process handles look similar to pids (also a relatively small number), but are not portable. So if you want to refer to a process definitively, you need to use the pid.

For some reason that isn't clear to me, functions like `Unix.getpid()` and `Unix.create_process()` return Process Handles on Windows, and not always the same process handles. This is mostly ok, since functions like `Unix.waitpid` expect process handles, so it's mostly opaque. However, if you want to output a pid to stdout or a log, then you need to dereference the handle first.