### PR TITLE
Timeout should raise End_of_file instead of EPIPE

### DIFF
--- a/hack/utils/timeout.ml
+++ b/hack/utils/timeout.ml
@@ -188,7 +188,10 @@ module Select_timeout = struct
     match Unix.select [ tic.fd ] [] [] timeout with
     | [], _, _ -> raise Timeout
     | [_], _, _ ->
-        let read = Unix.read tic.fd tic.buf tic.max (buffer_size - tic.max) in
+        let read = try 
+          Unix.read tic.fd tic.buf tic.max (buffer_size - tic.max) 
+        with Unix.Unix_error (Unix.EPIPE, _, _) ->
+          raise End_of_file in
         tic.max <- tic.max + read;
         read
     | _ :: _, _, _-> assert false (* Should never happen *)


### PR DESCRIPTION
The Windows implementation of Timeout handles input byte by byte. This means we can end up with different exceptional behavior. One difference I noticed was when a pipe broke while we're waiting to read from that pipe. The built in `input_value` would raise `End_of_file`, but this implementation was raising `Unix.Unix_error (Unix.EPIPE, "read", "foo")`