### PR TITLE
[declarations.doc.js]  Add slash for directory

### DIFF
--- a/website/docs/ref/declarations.doc.js
+++ b/website/docs/ref/declarations.doc.js
@@ -49,7 +49,7 @@ next: react.html
 // $DocIssue{not a flow file}
 [libs]
 // $DocIssue{not a flow file}
-decls
+decls/
 
 /*
   ## Declaring definitions that should exist at run time


### PR DESCRIPTION
There should be a slash at the end of decls/ as it is a directory in the example.

Similar to "If we now add the interfaces/ directory to our flow config under a [libs] section:" in https://flowtype.org/docs/third-party.html