### PR TITLE
Add gif to .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 * text=auto
 * text eol=lf
 *.png binary
+*.gif binary


### PR DESCRIPTION
I noticed a fresh clone of the Flow repo on Windows led to `website/docs/flow-state.gif` appearing changed. The fix is to add `.gif` files to the `.gitattributes` file, so that the `eol=lf` stuff doesn't mess with them