### PR TITLE
Update flow comments in getting starting page

### DIFF
--- a/website/docs/getting-started.doc.js
+++ b/website/docs/getting-started.doc.js
@@ -31,14 +31,14 @@ next: five-simple-examples.html
   **index.js**
 */
 
-// @flow
+/* @flow */
 
 // $DocIssue
 var str = 'hello world!';
 console.log(str);
 
 /*
-  Note that we've added `// @flow` to the top of our file. This indicates to Flow
+  Note that we've added `/* @flow */` to the top of our file. This indicates to Flow
   that we want this file to be checked. **If we don't add this flag to the top of
   the file, Flow will assume that the file isn't ready to be checked yet and
   Flow will not attempt to type check the file.**
@@ -61,7 +61,7 @@ console.log(str);
 */
 
 // $NoCliOutput
-// @flow
+/* @flow */
 
 // $ExpectError
 var str: number = 'hello world!';


### PR DESCRIPTION
As pointed out by https://flowtype.org/docs/new-project.html#typechecking-your-files all files should use `/* @flow */` comment at the top of the file, this PR updates getting starting guide to use `/* @flow */` comments