### PR TITLE
Better error message on Windows for long paths

### DIFF
--- a/src/common/files.ml
+++ b/src/common/files.ml
@@ -73,7 +73,15 @@ let kind_of_path path = Unix.(
     end with Unix_error (ENOENT, _, _) -> Other)
   | S_DIR -> Dir (path, false)
   | _ -> Other
-  with Unix_error (e, _, _) ->
+  with 
+  | Unix_error (ENOENT, _, _) when Sys.win32 && String.length path >= 248 ->
+    Utils.prerr_endlinef 
+      "On Windows, paths must be less than 248 characters for directories \
+       and 260 characters for files. This path has %d characters. Skipping %s"
+      (String.length path)
+      path;
+    Other
+  | Unix_error (e, _, _) ->
     Printf.eprintf "Skipping %s: %s\n%!" path (Unix.error_message e);
     Other
 )


### PR DESCRIPTION
Windows doesn't allow long paths. Previously we'd just output a message saying that we were skipping the paths. This error message is a little more clear.

I ran into this when I used npm2 instead of npm3, which led to some really long file names. Since this is an OS restriction, it's probably better for the user to just avoid long file names than for us to do something clever.