### PR TITLE
Update the type of OscillatorNode's type property

### DIFF
--- a/lib/bom.js
+++ b/lib/bom.js
@@ -558,7 +558,7 @@ declare class GainNode extends AudioNode {
 declare class OscillatorNode extends AudioNode {
   frequency: AudioParam;
   detune: AudioParam;
-  type: AudioParam;
+  type: 'sine' | 'square' | 'sawtooth' | 'triangle' | 'custom';
   start(when?: number): void;
   stop(when?: number): void;
   setPeriodicWave(periodicWave: PeriodicWave): void;


### PR DESCRIPTION
Per w3's spec (https://www.w3.org/TR/webaudio/#idl-def-OscillatorType) the type is one in five strings, not an AudioParam. Fix for issue #2146.