### PR TITLE
Relax console.assert's first argument

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -702,7 +702,7 @@ declare var exports: any;
 
 /* Commonly available, shared between node and dom */
 declare var console: {
-  assert(condition: boolean, ...data: Array<any>): void;
+  assert(condition: mixed, ...data: Array<any>): void;
   clear(): void;
   count(label: string): void;
   debug(...data: Array<any>): void;


### PR DESCRIPTION
It accepts truthy/falsey values, rather than a simple boolean.

We have quite a few instances of `console.assert(someObjectThatMightBeNull, 'msg')` in our codebase, which flow 0.30 started warning about.  Am I using console.assert wrong, or would this PR be an appropriate fix?