### PR TITLE
Fix Issue 2176 - Incorrect param signature on AudioContext.createMediaElementSource()

### DIFF
--- a/lib/bom.js
+++ b/lib/bom.js
@@ -385,7 +385,7 @@ declare class AudioContext {
   close(): void;
   createBuffer(numOfChannels: number, length: number, sampleRate: number): AudioBuffer;
   createBufferSource(myMediaElement?: HTMLMediaElement): AudioBufferSourceNode;
-  createMediaElementSource(stream?: MediaStream): MediaElementAudioSourceNode;
+  createMediaElementSource(myMediaElement: HTMLMediaElement): MediaElementAudioSourceNode;
   createMediaStreamSource(): MediaStreamAudioSourceNode;
   createMediaStreamDestination(): MediaStream;
   createScriptProcessor(bufferSize: number, numberOfInputChannels: number, numberOfOutputChannels: number): ScriptProcessorNode;


### PR DESCRIPTION
Flow types the parameter to AudioContext.createMediaElementSource() as a stream?: MediaStream, when according to the spec, it should be typed as myMediaElement: HTMLMediaElement. Submitting a pull request today.

flow:
https://github.com/facebook/flow/blob/0deefc1f4e01d0b20f2a168a6facfb09bc39c4c6/lib/bom.js#L388

spec:
https://webaudio.github.io/web-audio-api/#widl-AudioContext-createMediaElementSource-MediaElementAudioSourceNode-HTMLMediaElement-mediaElement