### PR TITLE
add http/https ServerResponse types

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -780,6 +780,22 @@ declare class http$ClientRequest extends stream$Writable {
   setSocketKeepAlive(enable?: boolean, initialDelay?: number): void;
 }
 
+declare class http$ServerResponse extends stream$Writable {
+  addTrailers(headers: {[key: string] : string}): void;
+  finished: boolean;
+  getHeader(name: string): void;
+  headersSent: boolean;
+  removeHeader(name: string): void;
+  sendDate: boolean;
+  setHeader(name: string, value: string | Array<string>): void;
+  setTimeout(msecs: number, callback?: Function): http$ServerResponse;
+  statusCode: number;
+  statusMessage: string;
+  writeContinue(): void;
+  writeHead(status: number, statusMessage?: string, headers?: {[key: string] : string}): void;
+  writeHead(status: number, headers?: {[key: string] : string}): void;
+}
+
 declare module "http" {
   declare class Server extends net$Server {
     listen(port: number, hostname?: string, backlog?: number, callback?: Function): Server;
@@ -793,8 +809,11 @@ declare module "http" {
 
   declare class ClientRequest extends http$ClientRequest {}
   declare class IncomingMessage extends http$IncomingMessage {}
+  declare class ServerResponse extends http$ServerResponse {}
 
-  declare function createServer(listener?: Function): Server;
+  declare function createServer(
+    requestListener?: (request: IncomingMessage, response: ServerResponse) => void
+  ): Server;
   declare function request(
     options: Object | string,
     callback?: (response: IncomingMessage) => void
@@ -817,8 +836,12 @@ declare module "https" {
 
   declare class ClientRequest extends http$ClientRequest {}
   declare class IncomingMessage extends http$IncomingMessage {}
+  declare class ServerResponse extends http$ServerResponse {}
 
-  declare function createServer(options: Object, secureConnectionListener?: function): Server;
+  declare function createServer(
+    options: Object,
+    requestListener?: (request: IncomingMessage, response: ServerResponse) => void
+  ): Server;
   declare function request(
     options: Object | string,
     callback?: (response: IncomingMessage) => void


### PR DESCRIPTION
Source: https://nodejs.org/api/http.html#http_class_http_serverresponse and https://nodejs.org/api/https.html#https_https_createserver_options_requestlistener