### PR TITLE
Add code / signal attribute to child_process Error

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -123,7 +123,12 @@ type child_process$execOpts = {
   gid?: number;
 };
 
-type child_process$execCallback = (error: ?Error, stdout: Buffer, stderr: Buffer) => void;
+declare class child_process$Error extends Error {
+  code: number,
+  signal: ?string,
+}
+
+type child_process$execCallback = (error: ?child_process$Error, stdout: Buffer, stderr: Buffer) => void;
 
 type child_process$execSyncOpts = {
   cwd?: string;


### PR DESCRIPTION
As seen in the node documentation:

https://nodejs.org/api/child_process.html#child_process_child_process_exec_command_options_callback

```
...On error, error will be an instance of Error. The error.code property will be the exit code of the child process while error.signal will be set to the signal that terminated the process....
```

Also see the implementation:
https://github.com/nodejs/node/blob/master/lib/child_process.js#L213-L214