### PR TITLE
Fix coverage percentage calculation

### DIFF
--- a/src/commands/coverageCommand.ml
+++ b/src/commands/coverageCommand.ml
@@ -164,7 +164,7 @@ let handle_response ~json ~color ~debug (types : (Loc.t * bool) list) content =
   end;
 
   let covered, total = List.fold_left accum_coverage (0, 0) types in
-  let percent = (float_of_int covered /. float_of_int total) *. 100. in
+  let percent = if total = 0 then 100. else (float_of_int covered /. float_of_int total) *. 100. in
 
   if json then
     let uncovered_locs = types


### PR DESCRIPTION
Fixes the case, when file contains no expressions.

Before:

```
Covered: nan% (0 of 0 expressions)
```

After:

```
Covered: 100.00% (0 of 0 expressions)
```