### PR TITLE
[fix] require('events') isn't recognized as the 'EventEmitter' class

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -588,7 +588,11 @@ declare class events$EventEmitter {
 
 declare module "events" {
   // TODO: See the comment above the events$EventEmitter declaration
-  declare var EventEmitter: typeof events$EventEmitter;
+  declare class EventEmitter extends events$EventEmitter {
+    static EventEmitter: typeof EventEmitter;
+  }
+
+  declare var exports: typeof EventEmitter;
 }
 
 declare class domain$Domain extends events$EventEmitter {


### PR DESCRIPTION
Closes #604

--

```javascript
// Also this PR should fix the following issues if the type import is changed...

// From
import type { EventEmitter } from 'events';

// To
import type EventEmitter from 'events';
```

#1153, #2102, #2130