### PR TITLE
Complete node's EventEmitter API definition

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -573,21 +573,19 @@ declare module "dns" {
   ): void;
 }
 
-// TODO: This is copypasta of the EventEmitter class signature exported from the
-//       `events` module. The only reason this exists is because other module
-//       interface definitions need to reference this type structure -- but
-//       referencing type structures defined in other modules isn't possible at
-//       the time of this writing.
 declare class events$EventEmitter {
   // deprecated
   static listenerCount(emitter: events$EventEmitter, event: string): number;
 
   addListener(event: string, listener: Function): events$EventEmitter;
   emit(event: string, ...args:Array<any>): boolean;
+  eventNames(): Array<string>;
   listeners(event: string): Array<Function>;
   listenerCount(event: string): number;
   on(event: string, listener: Function): events$EventEmitter;
   once(event: string, listener: Function): events$EventEmitter;
+  prependListener(event: string, listener: Function): events$EventEmitter;
+  prependOnceListener(event: string, listener: Function): events$EventEmitter;
   removeAllListeners(event?: string): events$EventEmitter;
   removeListener(event: string, listener: Function): events$EventEmitter;
   setMaxListeners(n: number): void;


### PR DESCRIPTION
Also remove a comment about copypasta that no longer applies, since `events.EventEmitter` is defined as `typeof events$EventEmitter`, avoiding copypasta.