### PR TITLE
Adds reference to flow-remove-types

### DIFF
--- a/website/docs/02-running.md
+++ b/website/docs/02-running.md
@@ -34,3 +34,27 @@ $> babel --watch=./src --out-dir=./build
 This will run in the background, pick up any changes to files in `src/`, and create their pure JavaScript version in `build/`.
 
 For more detailed documentation on the `babel` CLI utility, check out it's own [docs](https://babeljs.io/docs/usage/cli/).
+
+## flow-remove-types Quick Start
+
+While Babel is the recommended way of running Flow code, [`flow-remove-types`](https://github.com/leebyron/flow-remove-types) is a limited but simpler alternative.
+
+First, install `flow-remove-types`:
+
+```bash
+$> npm install -g flow-remove-types
+```
+
+Then run your code through to remove the types, creating a pure JavaScript version in `build/`.
+
+```bash
+$> flow-remove-types src/ --out-dir build/
+```
+
+Or run the code directly by substituting `flow-node` for `node`.
+
+```bash
+$> flow-node main.js
+```
+
+For more detailed documentation on `flow-remove-types`, check out it's own [docs](https://github.com/leebyron/flow-remove-types).


### PR DESCRIPTION
As suggested by @hzoo in https://github.com/leebyron/flow-remove-types/issues/8, this adds a short getting started guide for flow-remove-types as a limited but simpler alternative to Babel.

Open to suggestions on the explanation!