### PR TITLE
Add method signature annotation for class example

### DIFF
--- a/website/docs/ref/react.doc.js
+++ b/website/docs/ref/react.doc.js
@@ -130,13 +130,14 @@ const Counter = React.createClass({
   and more. With class-based components, you can specify the components'
   props, default props, and state using Flow's annotation syntax.
 */
+type Props = {
+  title: string,
+  visited: boolean,
+  onClick: () => void,
+};
 
 class Button extends React.Component {
-  props: {
-    title: string,
-    visited: boolean,
-    onClick: () => void,
-  };
+  props: Props;
 
   state: {
     display: 'static' | 'hover' | 'active';
@@ -148,7 +149,7 @@ class Button extends React.Component {
   onMouseLeave: () => void;
   onMouseDown: () => void;
 
-  constructor(props) {
+  constructor(props: Props) {
     super(props);
     this.state = {
       display: 'static',


### PR DESCRIPTION
Addresses the confusion created by the current `React.Component` subclass example and described in #1694 

Could also create a type for `state` as well to keep it consistent. If this isn’t desired and it’s preferred to keep the example with the inline type declaration for the `props` instance property, I can instead add a note after the example warning users that any exported component will require this kind of annotation.

When I was trying to figure this out in my own project, I had hoped that there would be a way to reference the inline `props` annotation in the `constructor` method signature, but couldn’t figure it out. If that’s possible in a nice way, I think changing this example to use that technique would be best.