### PR TITLE
Use `Array.isArray` to refine `Array<mixed>`

### DIFF
--- a/src/typing/flow_js.ml
+++ b/src/typing/flow_js.ml
@@ -6396,8 +6396,7 @@ and predicate cx trace t (l,p) = match (l,p) with
   (*******************)
 
   | (MixedT (r, _), ArrP) ->
-    (* TODO: should use MixedT instead of AnyT, like we do with objects *)
-    let filtered_l = ArrT (replace_reason "array" r, AnyT.why r, []) in
+    let filtered_l = ArrT (replace_reason "array" r, MixedT (r, Mixed_everything), []) in
     rec_flow_t cx trace (filtered_l, t)
 
   | (_, ArrP) ->

--- a/tests/refinements/mixed.js
+++ b/tests/refinements/mixed.js
@@ -113,3 +113,9 @@ function obj2(x: mixed) {
     (x: Object);
   }
 }
+
+function arr0(x: mixed) {
+  if (Array.isArray(x)) {
+    takesString(x[0]); // error
+  }
+}

--- a/tests/refinements/refinements.exp
+++ b/tests/refinements/refinements.exp
@@ -282,6 +282,14 @@ mixed.js:97
  97:       (x['foo']: string); // error, mixed
                       ^^^^^^ string
 
+mixed.js:119
+119:     takesString(x[0]); // error
+         ^^^^^^^^^^^^^^^^^ function call
+119:     takesString(x[0]); // error
+                     ^^^^ mixed. This type is incompatible with
+  4: function takesString(x: string) {}
+                             ^^^^^^ string
+
 not.js:5
   5:     x++; // should error for null, void and bool (false)
          ^ boolean. This type is incompatible with
@@ -866,4 +874,4 @@ void.js:85
            ^^^^^^^^^^^^^ number
 
 
-Found 141 errors
+Found 142 errors


### PR DESCRIPTION
Fixes: https://github.com/facebook/flow/issues/2190