### PR TITLE
Limit length of type hints

### DIFF
--- a/src/common/utils_js.ml
+++ b/src/common/utils_js.ml
@@ -173,3 +173,9 @@ let typo_suggestions =
       | _ -> 3
     in
     fst (List.fold_left (fold_results limit name) ([], max_int) possible_names)
+
+let truncate_string str max_len =
+  if (String.length str) <= max_len then
+    str
+  else
+    String.sub str 0 max_len

--- a/src/server/server.ml
+++ b/src/server/server.ml
@@ -159,6 +159,7 @@ module FlowProgram : Server.SERVER_PROGRAM = struct
     }
 
   let infer_type ~options (file_input, line, col, verbose, include_raw) oc =
+    let max_str_len = 5000 in
     let file = ServerProt.file_input_get_filename file_input in
     let file = Loc.SourceFile file in
     let response = (try
@@ -171,10 +172,12 @@ module FlowProgram : Server.SERVER_PROGRAM = struct
       let ty, raw_type = match ground_t with
         | None -> None, None
         | Some t ->
-            let ty = Some (Type_printer.string_of_t cx t) in
+            let ty_string = Type_printer.string_of_t cx t in
+            let ty = Some (Utils_js.truncate_string ty_string max_str_len) in
             let raw_type =
               if include_raw then
-                Some (Debug_js.jstr_of_t ~depth:10 cx t)
+                let json_string = Debug_js.jstr_of_t ~depth:10 cx t in
+                Some (Utils_js.truncate_string json_string max_str_len)
               else
                 None
             in


### PR DESCRIPTION
Run on this file here:
https://github.com/facebook/nuclide/blob/e679970e6a20af834e9862fb83e49a4abaf6549c/pkg/nuclide-reprint-js/lib/printers/complex/printBinaryExpression.js

`flow type-at-pos printBinaryExpression.js 43 13`

Before this change, Flow printed so much text that my tmux session was
overwhelmed for a couple minutes. When Nuclide called it, Atom would crash. Now,
it still takes 15 seconds to run but the output is smaller and Atom doesn't
crash when Nuclide calls `type-at-pos`. Flow features are unavailable while the
type is being computed, but that's better than the entire editor crashing.