### PR TITLE
Buffer lenght not only for strings

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -95,7 +95,7 @@ declare class Buffer {
   static alloc(size: number, fill?: string | number, encoding?: buffer$Encoding): Buffer;
   static allocUnsafe(size: number): Buffer;
   static allocUnsafeSlow(size: number): Buffer;
-  static byteLength(string: string, encoding?: buffer$Encoding): number;
+  static byteLength(string: string | Buffer | $TypedArray | DataView | ArrayBuffer, encoding?: buffer$Encoding): number;
   static compare(buf1: Buffer, buf2: Buffer): number;
   static concat(list: Array<Buffer>, totalLength?: number): Buffer;
   // `UNUSED` argument strictly enforces arity to enable overloading this


### PR DESCRIPTION
Adding byteLenght for actual buffers, plus some other types (straight from the documentation)