### PR TITLE
Better support for promises, WIP

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -494,29 +494,36 @@ declare class WeakSet<T: Object> {
    cf. https://github.com/borisyankov/DefinitelyTyped/blob/master/es6-promises/es6-promises.d.ts
 */
 
+interface $Thenable<+R> {
+  then<U>(
+    onFulfill?: (value: R) => $Thenable<U> | U,
+    onReject?: (error: any) => $Thenable<U> | U
+  ): $Thenable<U>;
+}
+
 declare class Promise<+R> {
     constructor(callback: (
-      resolve: (result: Promise<R> | R) => void,
+      resolve: (result: $Thenable<R> | R) => void,
       reject:  (error: any) => void
     ) => mixed): void;
 
     then<U>(
-      onFulfill?: (value: R) => Promise<U> | U,
-      onReject?: (error: any) => Promise<U> | U
+      onFulfill?: (value: R) => $Thenable<U> | U,
+      onReject?: (error: any) => $Thenable<U> | U
     ): Promise<U>;
 
     catch<U>(
-      onReject?: (error: any) => ?Promise<U> | U
+      onReject?: (error: any) => ?$Thenable<U> | U
     ): Promise<U>;
 
-    static resolve<T>(object: Promise<T> | T): Promise<T>;
+    static resolve<T>(object: $Thenable<T> | T): Promise<T>;
     static reject<T>(error?: any): Promise<T>;
     static all: Promise$All;
-    static race<T, Elem: Promise<T> | T>(promises: Array<Elem>): Promise<T>;
+    static race<T, Elem: $Thenable<T> | T>(promises: Array<Elem>): Promise<T>;
 }
 
 // we use this signature when typing await expressions
-declare function $await<T>(p: Promise<T> | T): T;
+declare function $await<T>(p: Promise<T> | $Thenable<T> | T): T; // TODO Promise<T> shouldn't be needed
 
 /* Binary data */
 

--- a/lib/core.js
+++ b/lib/core.js
@@ -434,6 +434,8 @@ interface $Iterable<Yield,Return,Next> {
 }
 type Iterable<T> = $Iterable<T,void,void>;
 
+declare function $iterate<T>(p: Iterable<T>): T;
+
 /* Generators */
 interface Generator<+Yield,+Return,-Next> {
     @@iterator(): $Iterator<Yield,Return,Next>;

--- a/src/typing/flow_js.ml
+++ b/src/typing/flow_js.ml
@@ -3702,6 +3702,15 @@ let rec __flow cx ((l: Type.t), (u: Type.use_t)) trace =
       ) in
       rec_flow_t cx trace (ArrT (reason, f t, List.map f ts), tout)
 
+    | _, TupleMapT (reason, funt, tout) ->
+      let iter = get_builtin cx ~trace "$iterate" reason in
+
+      let t = mk_tvar_where cx reason (fun t ->
+        rec_flow cx trace (iter, CallT (reason, mk_functiontype [l] t))
+      ) in
+
+      rec_flow cx trace (ArrT (reason, t, []), TupleMapT (reason, funt, tout))
+
     (***********************************************)
     (* functions may have their prototypes written *)
     (***********************************************)

--- a/tests/async/async.exp
+++ b/tests/async/async.exp
@@ -55,14 +55,20 @@ async_return_void.js:4
 async_return_void.js:8
   8:   return undefined;
               ^^^^^^^^^ undefined. This type is incompatible with
-union: type application of identifier `Promise` | type parameter `T` of async return. See lib: core.js:519
+union: type application of identifier `Promise` | type application of identifier `$Thenable` | type parameter `T` of async return. See lib: core.js:526
   Member 1:
-  type application of identifier `Promise`. See lib: core.js:519
+  type application of identifier `Promise`. See lib: core.js:526
   Error:
     8:   return undefined;
                 ^^^^^^^^^ undefined. This type is incompatible with
-  Promise. See lib: core.js:519
+  Promise. See lib: core.js:526
   Member 2:
+  type application of identifier `$Thenable`. See lib: core.js:526
+  Error:
+  property `then` of $Thenable. Property not found in possibly undefined value. See lib: core.js:526
+    8:   return undefined;
+                ^^^^^^^^^ undefined
+  Member 3:
     8:   return undefined;
                 ^^^^^^^^^ type parameter `T` of async return
   Error:

--- a/tests/async/async.exp
+++ b/tests/async/async.exp
@@ -55,17 +55,17 @@ async_return_void.js:4
 async_return_void.js:8
   8:   return undefined;
               ^^^^^^^^^ undefined. This type is incompatible with
-union: type application of identifier `Promise` | type application of identifier `$Thenable` | type parameter `T` of async return. See lib: core.js:526
+union: type application of identifier `Promise` | type application of identifier `$Thenable` | type parameter `T` of async return. See lib: core.js:528
   Member 1:
-  type application of identifier `Promise`. See lib: core.js:526
+  type application of identifier `Promise`. See lib: core.js:528
   Error:
     8:   return undefined;
                 ^^^^^^^^^ undefined. This type is incompatible with
-  Promise. See lib: core.js:526
+  Promise. See lib: core.js:528
   Member 2:
-  type application of identifier `$Thenable`. See lib: core.js:526
+  type application of identifier `$Thenable`. See lib: core.js:528
   Error:
-  property `then` of $Thenable. Property not found in possibly undefined value. See lib: core.js:526
+  property `then` of $Thenable. Property not found in possibly undefined value. See lib: core.js:528
     8:   return undefined;
                 ^^^^^^^^^ undefined
   Member 3:

--- a/tests/core_tests/core_tests.exp
+++ b/tests/core_tests/core_tests.exp
@@ -3,14 +3,14 @@ map.js:23
                  ^^^^^^^^^^^^^^^^^^^^^ constructor call
  23:     let x = new Map(['foo', 123]); // error
                           ^^^^^ string. This type is incompatible with
-tuple type. See lib: core.js:449
+tuple type. See lib: core.js:451
 
 map.js:23
  23:     let x = new Map(['foo', 123]); // error
                  ^^^^^^^^^^^^^^^^^^^^^ constructor call
  23:     let x = new Map(['foo', 123]); // error
                                  ^^^ number. This type is incompatible with
-tuple type. See lib: core.js:449
+tuple type. See lib: core.js:451
 
 map.js:24
  24:     let y: Map<number, string> = new Map([['foo', 123]]); // error
@@ -87,28 +87,28 @@ weakset.js:19
                ^^^^^^^^^^^^^^^^^^^^^^ constructor call
  19: let ws3 = new WeakSet([1, 2, 3]); // error, must be objects
                             ^ number. This type is incompatible with
-object type. See lib: core.js:486
+object type. See lib: core.js:488
 
 weakset.js:19
  19: let ws3 = new WeakSet([1, 2, 3]); // error, must be objects
                ^^^^^^^^^^^^^^^^^^^^^^ constructor call
  19: let ws3 = new WeakSet([1, 2, 3]); // error, must be objects
                                ^ number. This type is incompatible with
-object type. See lib: core.js:486
+object type. See lib: core.js:488
 
 weakset.js:19
  19: let ws3 = new WeakSet([1, 2, 3]); // error, must be objects
                ^^^^^^^^^^^^^^^^^^^^^^ constructor call
  19: let ws3 = new WeakSet([1, 2, 3]); // error, must be objects
                                   ^ number. This type is incompatible with
-object type. See lib: core.js:486
+object type. See lib: core.js:488
 
 weakset.js:36
  36: let ws5 = new WeakSet(numbers()); // error, must be objects
                ^^^^^^^^^^^^^^^^^^^^^^ constructor call
  29: function* numbers(): Iterable<number> {
                                    ^^^^^^ number. This type is incompatible with
-object type. See lib: core.js:486
+object type. See lib: core.js:488
 
 
 Found 15 errors

--- a/tests/iterable/iterable.exp
+++ b/tests/iterable/iterable.exp
@@ -35,7 +35,7 @@ boolean literal `true`. See lib: core.js:419
 map.js:13
  13: function mapTest4(map: Map<number, string>): Iterable<string> {
                                                            ^^^^^^ string. This type is incompatible with
-tuple type. See lib: core.js:448
+tuple type. See lib: core.js:450
 
 set.js:13
  13: function setTest4(set: Set<string>): Iterable<number> {

--- a/tests/promises/all.js
+++ b/tests/promises/all.js
@@ -28,3 +28,9 @@ Promise.all(0); // Error: expected array instead of number
 
 // Promise.all is a function
 (Promise.all : Function);
+
+// iterables
+
+function test(val: Iterable<Promise<number>>) {
+  const r: Promise<Array<number>> = Promise.all(val);
+}

--- a/tests/promises/promises.exp
+++ b/tests/promises/promises.exp
@@ -63,9 +63,9 @@ promise.js:30
                ^ constructor call
  30:   resolve(new Promise(function(resolve, reject) {
                ^ Promise. This type is incompatible with
-union: type application of identifier `Promise` | type parameter `R` of constructor call. See lib: core.js:499
+union: type application of polymorphic type: class type: $Thenable | type parameter `R` of constructor call. See lib: core.js:506
   Member 1:
-  type application of identifier `Promise`. See lib: core.js:499
+  type application of polymorphic type: class type: $Thenable. See lib: core.js:506
   Error:
    35:   var b: string = num; // Error: number ~> string
                          ^^^ number. This type is incompatible with
@@ -85,9 +85,9 @@ promise.js:41
                  ^ constructor call
  41:     resolve(new Promise(function(resolve, reject) {
                  ^ Promise. This type is incompatible with
-union: type application of identifier `Promise` | type parameter `R` of constructor call. See lib: core.js:499
+union: type application of polymorphic type: class type: $Thenable | type parameter `R` of constructor call. See lib: core.js:506
   Member 1:
-  type application of identifier `Promise`. See lib: core.js:499
+  type application of polymorphic type: class type: $Thenable. See lib: core.js:506
   Error:
    47:   var b: string = num; // Error: number ~> string
                          ^^^ number. This type is incompatible with
@@ -119,9 +119,9 @@ promise.js:121
                      ^^^^^^^^^^^^^^^^^^ call of method `resolve`
 121: Promise.resolve(Promise.resolve(0)).then(function(num) {
                      ^^^^^^^^^^^^^^^^^^ Promise. This type is incompatible with
-union: type application of identifier `Promise` | type parameter `T` of call of method `resolve`. See lib: core.js:512
+union: type application of polymorphic type: class type: $Thenable | type parameter `T` of call of method `resolve`. See lib: core.js:519
   Member 1:
-  type application of identifier `Promise`. See lib: core.js:512
+  type application of polymorphic type: class type: $Thenable. See lib: core.js:519
   Error:
   123:   var b: string = num; // Error: number ~> string
                          ^^^ number. This type is incompatible with
@@ -141,9 +141,9 @@ promise.js:127
                                      ^^^^^^^^^^^^^^^^^^ call of method `resolve`
 127: Promise.resolve(Promise.resolve(Promise.resolve(0))).then(function(num) {
                                      ^^^^^^^^^^^^^^^^^^ Promise. This type is incompatible with
-union: type application of identifier `Promise` | type parameter `T` of call of method `resolve`. See lib: core.js:512
+union: type application of polymorphic type: class type: $Thenable | type parameter `T` of call of method `resolve`. See lib: core.js:519
   Member 1:
-  type application of identifier `Promise`. See lib: core.js:512
+  type application of polymorphic type: class type: $Thenable. See lib: core.js:519
   Error:
   129:   var b: string = num; // Error: number ~> string
                          ^^^ number. This type is incompatible with
@@ -169,9 +169,9 @@ promise.js:166
                                     ^^^^^^^^^^^^^^^^^^^^^^^ call of method `resolve`
 166:   .then(function(num) { return Promise.resolve('asdf'); })
                                     ^^^^^^^^^^^^^^^^^^^^^^^ Promise. This type is incompatible with
-union: type application of identifier `Promise` | type parameter `U` of call of method `then`. See lib: core.js:504
+union: type application of polymorphic type: class type: $Thenable | type parameter `U` of call of method `then`. See lib: core.js:511
   Member 1:
-  type application of identifier `Promise`. See lib: core.js:504
+  type application of polymorphic type: class type: $Thenable. See lib: core.js:511
   Error:
   169:     var b: number = str; // Error: string ~> number
                            ^^^ string. This type is incompatible with
@@ -191,9 +191,9 @@ promise.js:174
                                                     ^^^^^^^^^^^^^^^^^^^^^^^ call of method `resolve`
 174:   .then(function(num) { return Promise.resolve(Promise.resolve('asdf')); })
                                                     ^^^^^^^^^^^^^^^^^^^^^^^ Promise. This type is incompatible with
-union: type application of identifier `Promise` | type parameter `T` of call of method `resolve`. See lib: core.js:512
+union: type application of polymorphic type: class type: $Thenable | type parameter `T` of call of method `resolve`. See lib: core.js:519
   Member 1:
-  type application of identifier `Promise`. See lib: core.js:512
+  type application of polymorphic type: class type: $Thenable. See lib: core.js:519
   Error:
   177:     var b: number = str; // Error: string ~> number
                            ^^^ string. This type is incompatible with
@@ -219,9 +219,9 @@ promise.js:206
                                      ^^^^^^^^^^^^^^^^^^^^^^^ call of method `resolve`
 206:   .catch(function(num) { return Promise.resolve('asdf'); })
                                      ^^^^^^^^^^^^^^^^^^^^^^^ Promise. This type is incompatible with
-union: ?type application of identifier `Promise` | type parameter `U` of call of method `catch`. See lib: core.js:509
+union: ?type application of polymorphic type: class type: $Thenable | type parameter `U` of call of method `catch`. See lib: core.js:516
   Member 1:
-  ?type application of identifier `Promise`. See lib: core.js:509
+  ?type application of polymorphic type: class type: $Thenable. See lib: core.js:516
   Error:
   209:     var b: number = str; // Error: string ~> number
                            ^^^ string. This type is incompatible with
@@ -241,9 +241,9 @@ promise.js:214
                                                      ^^^^^^^^^^^^^^^^^^^^^^^ call of method `resolve`
 214:   .catch(function(num) { return Promise.resolve(Promise.resolve('asdf')); })
                                                      ^^^^^^^^^^^^^^^^^^^^^^^ Promise. This type is incompatible with
-union: type application of identifier `Promise` | type parameter `T` of call of method `resolve`. See lib: core.js:512
+union: type application of polymorphic type: class type: $Thenable | type parameter `T` of call of method `resolve`. See lib: core.js:519
   Member 1:
-  type application of identifier `Promise`. See lib: core.js:512
+  type application of polymorphic type: class type: $Thenable. See lib: core.js:519
   Error:
   217:     var b: number = str; // Error: string ~> number
                            ^^^ string. This type is incompatible with
@@ -279,13 +279,13 @@ resolve_void.js:3
 resolve_void.js:5
   5: (Promise.resolve(undefined): Promise<number>); // error
                       ^^^^^^^^^ undefined. This type is incompatible with
-union: type application of identifier `Promise` | type parameter `T` of call of method `resolve`. See lib: core.js:512
+union: type application of polymorphic type: class type: $Thenable | type parameter `T` of call of method `resolve`. See lib: core.js:519
   Member 1:
-  type application of identifier `Promise`. See lib: core.js:512
+  type application of polymorphic type: class type: $Thenable. See lib: core.js:519
   Error:
+  property `then` of $Thenable. Property not found in possibly undefined value. See lib: core.js:519
     5: (Promise.resolve(undefined): Promise<number>); // error
-                        ^^^^^^^^^ undefined. This type is incompatible with
-  Promise. See lib: core.js:512
+                        ^^^^^^^^^ undefined
   Member 2:
     5: (Promise.resolve(undefined): Promise<number>); // error
         ^^^^^^^^^^^^^^^^^^^^^^^^^^ type parameter `T` of call of method `resolve`

--- a/tests/promises/promises.exp
+++ b/tests/promises/promises.exp
@@ -36,13 +36,17 @@ all.js:19
 
 all.js:24
  24: Promise.all(); // Error: expected array instead of undefined (too few arguments)
-     ^^^^^^^^^^^^^ call of method `all`. Expected array instead of possibly undefined value
+     ^^^^^^^^^^^^^ call of method `all`
+Library type error:. See lib: core.js:437
+property `@@iterator` of $Iterable. Property not found in possibly undefined value. See lib: core.js:437
  24: Promise.all(); // Error: expected array instead of undefined (too few arguments)
      ^^^^^^^^^^^^^ undefined (too few arguments)
 
 all.js:27
  27: Promise.all(0); // Error: expected array instead of number
-     ^^^^^^^^^^^^^^ call of method `all`. Expected array instead of
+     ^^^^^^^^^^^^^^ call of method `all`
+Library type error:. See lib: core.js:437
+property `@@iterator` of $Iterable. Property not found in. See lib: core.js:437
  27: Promise.all(0); // Error: expected array instead of number
                  ^ number
 
@@ -63,9 +67,9 @@ promise.js:30
                ^ constructor call
  30:   resolve(new Promise(function(resolve, reject) {
                ^ Promise. This type is incompatible with
-union: type application of polymorphic type: class type: $Thenable | type parameter `R` of constructor call. See lib: core.js:506
+union: type application of polymorphic type: class type: $Thenable | type parameter `R` of constructor call. See lib: core.js:508
   Member 1:
-  type application of polymorphic type: class type: $Thenable. See lib: core.js:506
+  type application of polymorphic type: class type: $Thenable. See lib: core.js:508
   Error:
    35:   var b: string = num; // Error: number ~> string
                          ^^^ number. This type is incompatible with
@@ -85,9 +89,9 @@ promise.js:41
                  ^ constructor call
  41:     resolve(new Promise(function(resolve, reject) {
                  ^ Promise. This type is incompatible with
-union: type application of polymorphic type: class type: $Thenable | type parameter `R` of constructor call. See lib: core.js:506
+union: type application of polymorphic type: class type: $Thenable | type parameter `R` of constructor call. See lib: core.js:508
   Member 1:
-  type application of polymorphic type: class type: $Thenable. See lib: core.js:506
+  type application of polymorphic type: class type: $Thenable. See lib: core.js:508
   Error:
    47:   var b: string = num; // Error: number ~> string
                          ^^^ number. This type is incompatible with
@@ -119,9 +123,9 @@ promise.js:121
                      ^^^^^^^^^^^^^^^^^^ call of method `resolve`
 121: Promise.resolve(Promise.resolve(0)).then(function(num) {
                      ^^^^^^^^^^^^^^^^^^ Promise. This type is incompatible with
-union: type application of polymorphic type: class type: $Thenable | type parameter `T` of call of method `resolve`. See lib: core.js:519
+union: type application of polymorphic type: class type: $Thenable | type parameter `T` of call of method `resolve`. See lib: core.js:521
   Member 1:
-  type application of polymorphic type: class type: $Thenable. See lib: core.js:519
+  type application of polymorphic type: class type: $Thenable. See lib: core.js:521
   Error:
   123:   var b: string = num; // Error: number ~> string
                          ^^^ number. This type is incompatible with
@@ -141,9 +145,9 @@ promise.js:127
                                      ^^^^^^^^^^^^^^^^^^ call of method `resolve`
 127: Promise.resolve(Promise.resolve(Promise.resolve(0))).then(function(num) {
                                      ^^^^^^^^^^^^^^^^^^ Promise. This type is incompatible with
-union: type application of polymorphic type: class type: $Thenable | type parameter `T` of call of method `resolve`. See lib: core.js:519
+union: type application of polymorphic type: class type: $Thenable | type parameter `T` of call of method `resolve`. See lib: core.js:521
   Member 1:
-  type application of polymorphic type: class type: $Thenable. See lib: core.js:519
+  type application of polymorphic type: class type: $Thenable. See lib: core.js:521
   Error:
   129:   var b: string = num; // Error: number ~> string
                          ^^^ number. This type is incompatible with
@@ -169,9 +173,9 @@ promise.js:166
                                     ^^^^^^^^^^^^^^^^^^^^^^^ call of method `resolve`
 166:   .then(function(num) { return Promise.resolve('asdf'); })
                                     ^^^^^^^^^^^^^^^^^^^^^^^ Promise. This type is incompatible with
-union: type application of polymorphic type: class type: $Thenable | type parameter `U` of call of method `then`. See lib: core.js:511
+union: type application of polymorphic type: class type: $Thenable | type parameter `U` of call of method `then`. See lib: core.js:513
   Member 1:
-  type application of polymorphic type: class type: $Thenable. See lib: core.js:511
+  type application of polymorphic type: class type: $Thenable. See lib: core.js:513
   Error:
   169:     var b: number = str; // Error: string ~> number
                            ^^^ string. This type is incompatible with
@@ -191,9 +195,9 @@ promise.js:174
                                                     ^^^^^^^^^^^^^^^^^^^^^^^ call of method `resolve`
 174:   .then(function(num) { return Promise.resolve(Promise.resolve('asdf')); })
                                                     ^^^^^^^^^^^^^^^^^^^^^^^ Promise. This type is incompatible with
-union: type application of polymorphic type: class type: $Thenable | type parameter `T` of call of method `resolve`. See lib: core.js:519
+union: type application of polymorphic type: class type: $Thenable | type parameter `T` of call of method `resolve`. See lib: core.js:521
   Member 1:
-  type application of polymorphic type: class type: $Thenable. See lib: core.js:519
+  type application of polymorphic type: class type: $Thenable. See lib: core.js:521
   Error:
   177:     var b: number = str; // Error: string ~> number
                            ^^^ string. This type is incompatible with
@@ -219,9 +223,9 @@ promise.js:206
                                      ^^^^^^^^^^^^^^^^^^^^^^^ call of method `resolve`
 206:   .catch(function(num) { return Promise.resolve('asdf'); })
                                      ^^^^^^^^^^^^^^^^^^^^^^^ Promise. This type is incompatible with
-union: ?type application of polymorphic type: class type: $Thenable | type parameter `U` of call of method `catch`. See lib: core.js:516
+union: ?type application of polymorphic type: class type: $Thenable | type parameter `U` of call of method `catch`. See lib: core.js:518
   Member 1:
-  ?type application of polymorphic type: class type: $Thenable. See lib: core.js:516
+  ?type application of polymorphic type: class type: $Thenable. See lib: core.js:518
   Error:
   209:     var b: number = str; // Error: string ~> number
                            ^^^ string. This type is incompatible with
@@ -241,9 +245,9 @@ promise.js:214
                                                      ^^^^^^^^^^^^^^^^^^^^^^^ call of method `resolve`
 214:   .catch(function(num) { return Promise.resolve(Promise.resolve('asdf')); })
                                                      ^^^^^^^^^^^^^^^^^^^^^^^ Promise. This type is incompatible with
-union: type application of polymorphic type: class type: $Thenable | type parameter `T` of call of method `resolve`. See lib: core.js:519
+union: type application of polymorphic type: class type: $Thenable | type parameter `T` of call of method `resolve`. See lib: core.js:521
   Member 1:
-  type application of polymorphic type: class type: $Thenable. See lib: core.js:519
+  type application of polymorphic type: class type: $Thenable. See lib: core.js:521
   Error:
   217:     var b: number = str; // Error: string ~> number
                            ^^^ string. This type is incompatible with
@@ -279,11 +283,11 @@ resolve_void.js:3
 resolve_void.js:5
   5: (Promise.resolve(undefined): Promise<number>); // error
                       ^^^^^^^^^ undefined. This type is incompatible with
-union: type application of polymorphic type: class type: $Thenable | type parameter `T` of call of method `resolve`. See lib: core.js:519
+union: type application of polymorphic type: class type: $Thenable | type parameter `T` of call of method `resolve`. See lib: core.js:521
   Member 1:
-  type application of polymorphic type: class type: $Thenable. See lib: core.js:519
+  type application of polymorphic type: class type: $Thenable. See lib: core.js:521
   Error:
-  property `then` of $Thenable. Property not found in possibly undefined value. See lib: core.js:519
+  property `then` of $Thenable. Property not found in possibly undefined value. See lib: core.js:521
     5: (Promise.resolve(undefined): Promise<number>); // error
                         ^^^^^^^^^ undefined
   Member 2:

--- a/tests/promises/thenable.js
+++ b/tests/promises/thenable.js
@@ -1,0 +1,28 @@
+// @flow
+
+declare class Thenable<+R> {
+  then<U>(
+    onFulfill?: (value: R) => $Thenable<U> | U,
+    onReject?: (error: any) => $Thenable<U> | U
+  ): Thenable<U>;
+}
+
+declare function createThenable<T>(val: T): Thenable<T>;
+
+const r0: $Thenable<number> = createThenable(1);
+const r1: $Thenable<number> = Promise.resolve(1);
+const r2: Promise<number> = Promise.resolve(createThenable(1));
+const r3: Promise<number> = new Promise(resolve => {
+  resolve(createThenable(1));
+});
+
+const r4: Promise<number> = Promise.resolve().then(() => createThenable(1));
+const r5: Promise<number> = Promise.resolve().then(() => createThenable(1), () => createThenable(1));
+
+const r6: Promise<number> = Promise.resolve().catch(() => createThenable(1));
+
+const r7: Promise<number> = Promise.race([createThenable(1), createThenable(1)]);
+
+async function test(val: $Thenable<number>) { // TODO
+  const r: number = await val;
+}

--- a/tests/promises/thenable.js
+++ b/tests/promises/thenable.js
@@ -26,3 +26,5 @@ const r7: Promise<number> = Promise.race([createThenable(1), createThenable(1)])
 async function test(val: $Thenable<number>) { // TODO
   const r: number = await val;
 }
+
+const r8: Promise<[number, string]> = Promise.all([createThenable(1), createThenable('foo')]);


### PR DESCRIPTION
General idea is to make promise type more permissive. The most common problem is using custom promise implementations (such as Bluebird), in particular with `async-await`.

Typedefs for popular promise libraries should probably be adjusted to properly implement `$Thenable`, for example, this won't work as is: https://github.com/marudor/flowInterfaces/blob/master/packages/iflow-bluebird/index.js.flow#L89

To-do list:

 - [x] - support `$Thenable` in `Promise.all`;
 - [x] - support iterables other than Array in `Promise.all`;
 - [ ] - support subclassing promises;
 - [ ] - figure out why `Promise<T> | $Thenable<T> | T` is required in `$await` (probably a bug in union type handling).


See: https://github.com/facebook/flow/issues/2219