### PR TITLE
Builtin support for requiring resource files (css, jpg, etc)

### DIFF
--- a/newtests/exact/prop_test.js
+++ b/newtests/exact/prop_test.js
@@ -1,6 +1,5 @@
 /***
  * Nonstrict prop testing and refinements on exact object types
- * @flow
  */
 
 //

--- a/newtests/exact/test.js
+++ b/newtests/exact/test.js
@@ -61,34 +61,34 @@ type ArityError = $Exact<number, number>; // error, 2 params expected 1
     addFile('per_prop_subtyping.js').noNewErrors(),
     addFile('prop_test.js').newErrors(
                              `
-                               prop_test.js:13
-                                13:   if (p.xxx) {     // error, prop existence test on inexact type
+                               prop_test.js:12
+                                12:   if (p.xxx) {     // error, prop existence test on inexact type
                                             ^^^ property \`xxx\`. Property not found in
-                                13:   if (p.xxx) {     // error, prop existence test on inexact type
+                                12:   if (p.xxx) {     // error, prop existence test on inexact type
                                           ^ object type
 
-                               prop_test.js:33
-                                33:   if (pc.first) {       // error, prop existence test on union of inexact types
+                               prop_test.js:32
+                                32:   if (pc.first) {       // error, prop existence test on union of inexact types
                                              ^^^^^ property \`first\`. Property not found in
-                                33:   if (pc.first) {       // error, prop existence test on union of inexact types
+                                32:   if (pc.first) {       // error, prop existence test on union of inexact types
                                           ^^ object type
 
-                               prop_test.js:34
-                                34:     return pc.last;     // error, last not found on Address
+                               prop_test.js:33
+                                33:     return pc.last;     // error, last not found on Address
                                                   ^^^^ property \`last\`. Property not found in
-                                34:     return pc.last;     // error, last not found on Address
+                                33:     return pc.last;     // error, last not found on Address
                                                ^^ object type
 
-                               prop_test.js:36
-                                36:   return pc.state;      // error, state not found on Person
+                               prop_test.js:35
+                                35:   return pc.state;      // error, state not found on Person
                                                 ^^^^^ property \`state\`. Property not found in
-                                36:   return pc.state;      // error, state not found on Person
+                                35:   return pc.state;      // error, state not found on Person
                                              ^^ object type
 
-                               prop_test.js:43
-                                43:   return pc.state;      // error, since (pc: \$Exact<Person>).first may be ""
+                               prop_test.js:42
+                                42:   return pc.state;      // error, since (pc: \$Exact<Person>).first may be ""
                                                 ^^^^^ property \`state\`. Property not found in
-                                43:   return pc.state;      // error, since (pc: \$Exact<Person>).first may be ""
+                                42:   return pc.state;      // error, since (pc: \$Exact<Person>).first may be ""
                                              ^^ object type
                              `,
                            ),

--- a/newtests/import_errors/importer.js
+++ b/newtests/import_errors/importer.js
@@ -1,3 +1,2 @@
-// @flow
 
 import {a} from "./exporter";

--- a/newtests/import_errors/test.js
+++ b/newtests/import_errors/test.js
@@ -6,10 +6,13 @@ import {suite, test} from '../../tsrc/test/Tester';
 export default suite(({addFile, addFiles, addCode}) => [
   test('Named import of default-only module', [
     addFile('exporter.js'),
-    addFile('importer.js').newErrors(`
-      importer.js:3
-        3: import {a} from "./exporter";
-                   ^ Named import from module ${"`./exporter`"}. This module only has a default export. Did you mean ${"`import a from ...`"}?
-    `),
+    addFile('importer.js')
+      .newErrors(
+        `
+          importer.js:2
+            2: import {a} from "./exporter";
+                       ^ Named import from module \`./exporter\`. This module only has a default export. Did you mean \`import a from ...\`?
+        `,
+      ),
   ]),
 ]);

--- a/newtests/resource_files/_flowconfig
+++ b/newtests/resource_files/_flowconfig
@@ -1,0 +1,8 @@
+[ignore]
+
+[include]
+
+[libs]
+
+[options]
+all=true

--- a/newtests/resource_files/_flowconfig_with_module_name_mapper
+++ b/newtests/resource_files/_flowconfig_with_module_name_mapper
@@ -1,0 +1,9 @@
+[ignore]
+
+[include]
+
+[libs]
+
+[options]
+all=true
+module.name_mapper='^\(.*\)\.css$' -> '<PROJECT_ROOT>\cssMock.js'

--- a/newtests/resource_files/_flowconfig_with_module_resource_ext
+++ b/newtests/resource_files/_flowconfig_with_module_resource_ext
@@ -1,0 +1,9 @@
+[ignore]
+
+[include]
+
+[libs]
+
+[options]
+all=true
+module.resource_ext=.gabe

--- a/newtests/resource_files/cssMock.js
+++ b/newtests/resource_files/cssMock.js
@@ -1,0 +1,2 @@
+// Let's pretend that require('blah.css') returns a boolean
+declare module.exports: boolean;

--- a/newtests/resource_files/test.js
+++ b/newtests/resource_files/test.js
@@ -1,0 +1,132 @@
+/* @flow */
+
+
+import {suite, test} from '../../tsrc/test/Tester';
+
+export default suite(({addFile, addFiles, addCode}) => [
+  test('Requiring a .css file', [
+    addFile('foo.css')
+      .addCode("import './foo.css'")
+      .noNewErrors(),
+  ]),
+
+  test('.css extension cannot be omitted', [
+    addFile('foo.css')
+      .addCode("import './foo'")
+      .newErrors(
+        `
+          test.js:3
+            3: import './foo'
+                      ^^^^^^^ ./foo. Required module not found
+        `,
+      ),
+  ]),
+
+  test('By default, .css files export the void type', [
+    addFile('foo.css')
+      .addCode("const css = require('./foo.css');")
+      .addCode("(css: string)")
+      .newErrors(
+        `
+          test.js:5
+            5: (css: string)
+                ^^^ undefined. This type is incompatible with
+            5: (css: string)
+                     ^^^^^^ string
+        `,
+      ),
+  ]),
+
+  test('Requiring a .png file', [
+    addFile('bar.png')
+      .addCode("import './bar.png'")
+      .noNewErrors(),
+  ]),
+
+  test('.png extension cannot be omitted', [
+    addFile('bar.png')
+      .addCode("import './bar'")
+      .newErrors(
+        `
+          test.js:3
+            3: import './bar'
+                      ^^^^^^^ ./bar. Required module not found
+        `,
+      ),
+  ]),
+
+  test('By default, .png files export the string type', [
+    addFile('bar.png')
+      .addCode("const png = require('./bar.png');")
+      .addCode("(png: number)")
+      .newErrors(
+        `
+          test.js:5
+            5: (png: number)
+                ^^^ string. This type is incompatible with
+            5: (png: number)
+                     ^^^^^^ number
+        `,
+      ),
+  ]),
+
+  test('Requiring a custom module.resource_ext file', [
+    addFile('baz.gabe')
+      .addCode('import "./baz.gabe";')
+      .noNewErrors(),
+  ]).flowConfig('_flowconfig_with_module_resource_ext'),
+
+  test('Custom module.resource_ext extensions cannot be omitted', [
+    addFile('baz.gabe')
+      .addCode("import './baz'")
+      .newErrors(
+        `
+          test.js:3
+            3: import './baz'
+                      ^^^^^^^ ./baz. Required module not found
+        `,
+      ),
+  ]).flowConfig('_flowconfig_with_module_resource_ext'),
+
+  test('By default, custom module.resource_ext files export the string type', [
+    addFile('baz.gabe')
+      .addCode("const gabe = require('./baz.gabe');")
+      .addCode("(gabe: number)")
+      .newErrors(
+        `
+          test.js:5
+            5: (gabe: number)
+                ^^^^ string. This type is incompatible with
+            5: (gabe: number)
+                      ^^^^^^ number
+        `,
+      )
+  ]).flowConfig('_flowconfig_with_module_resource_ext'),
+
+  test('Adding custom module.resource_ext extensions removes the defaults', [
+    addFile('foo.css')
+      .addCode('import "./foo.css"')
+      .newErrors(
+        `
+          test.js:3
+            3: import "./foo.css"
+                      ^^^^^^^^^^^ ./foo.css. Required module not found
+        `,
+      ),
+  ]).flowConfig('_flowconfig_with_module_resource_ext'),
+
+  test('module.name_mapper should still work', [
+    addFiles('foo.css', 'cssMock.js')
+      .addCode('const css = require("./foo.css");')
+      .addCode('(css: string)')
+      .newErrors(
+        `
+          test.js:5
+            5: (css: string)
+                ^^^ boolean. This type is incompatible with
+            5: (css: string)
+                     ^^^^^^ string
+        `,
+      ),
+  ]).flowConfig('_flowconfig_with_module_name_mapper'),
+]);

--- a/src/commands/findModuleCommand.ml
+++ b/src/commands/findModuleCommand.ml
@@ -50,7 +50,8 @@ let main option_values root json strip_root moduleref filename () =
   let result = match response with
     | Some Loc.LibFile file
     | Some Loc.SourceFile file
-    | Some Loc.JsonFile file ->
+    | Some Loc.JsonFile file
+    | Some Loc.ResourceFile file ->
         if strip_root then Files.relative_path (Path.to_string root) file
         else file
     | Some Loc.Builtins -> "(global)"

--- a/src/commands/lsCommand.ml
+++ b/src/commands/lsCommand.ml
@@ -102,6 +102,9 @@ let main strip_root ignore_flag include_flag root () =
     opt_module_file_exts = FlowConfig.(
       flowconfig.options.Opts.module_file_exts
     );
+    opt_module_resource_exts = FlowConfig.(
+      flowconfig.options.Opts.module_resource_exts
+    );
     opt_module_name_mappers = FlowConfig.(
       flowconfig.options.Opts.module_name_mappers
     );

--- a/src/commands/serverCommands.ml
+++ b/src/commands/serverCommands.ml
@@ -282,6 +282,9 @@ module OptionParser(Config : CONFIG) = struct
       opt_module_file_exts = FlowConfig.(
         flowconfig.options.Opts.module_file_exts
       );
+      opt_module_resource_exts = FlowConfig.(
+        flowconfig.options.Opts.module_resource_exts
+      );
       opt_module_name_mappers = FlowConfig.(
         flowconfig.options.Opts.module_name_mappers
       );

--- a/src/common/errors.ml
+++ b/src/common/errors.ml
@@ -208,7 +208,8 @@ let format_reason_color
   let source = match loc.source with
   | Some LibFile filename
   | Some SourceFile filename
-  | Some JsonFile filename -> [file_clr, filename]
+  | Some JsonFile filename
+  | Some ResourceFile filename -> [file_clr, filename]
   | None | Some Builtins -> []
   in
   let loc_format =
@@ -340,7 +341,8 @@ let file_of_source source =
           end else filename in
         Some filename
     | Some Loc.SourceFile filename
-    | Some Loc.JsonFile filename ->
+    | Some Loc.JsonFile filename
+    | Some Loc.ResourceFile filename ->
         Some filename
     | Some Loc.Builtins -> None
     | None -> None
@@ -377,7 +379,8 @@ let print_file_at_location ~strip_root ~root stdin_file main_file loc s = Loc.(
       | None, Some Loc.LibFile filename -> filename,true
       | Some filename, _
       | None, Some Loc.SourceFile filename
-      | None, Some Loc.JsonFile filename -> filename, false
+      | None, Some Loc.JsonFile filename
+      | None, Some Loc.ResourceFile filename -> filename, false
       | None, Some Loc.Builtins
       | None, None -> failwith "Should only have lib and source files at this point" in
       [comment_style s] @
@@ -805,7 +808,8 @@ let string_of_loc_deprecated loc = Loc.(
     | Some Builtins -> ""
     | Some LibFile file
     | Some SourceFile file
-    | Some JsonFile file ->
+    | Some JsonFile file
+    | Some ResourceFile file ->
       let line = loc.start.line in
       let start = loc.start.column + 1 in
       let end_ = loc._end.column in

--- a/src/common/files.mli
+++ b/src/common/files.mli
@@ -58,4 +58,4 @@ val is_prefix: string -> string -> bool
 
 val get_flowtyped_path: Path.t -> Path.t
 
-val filename_from_string: string -> Loc.filename
+val filename_from_string: options: Options.t -> string -> Loc.filename

--- a/src/common/flowConfig.ml
+++ b/src/common/flowConfig.ml
@@ -56,6 +56,7 @@ module Opts = struct
     node_resolver_dirnames: string list;
     munge_underscores: bool;
     module_file_exts: SSet.t;
+    module_resource_exts: SSet.t;
     modules_are_use_strict: bool;
     suppress_comments: Str.regexp list;
     suppress_types: SSet.t;
@@ -118,9 +119,22 @@ module Opts = struct
     config
 
   let module_file_exts = SSet.empty
-        |> SSet.add ".js"
-        |> SSet.add ".jsx"
-        |> SSet.add ".json"
+    |> SSet.add ".js"
+    |> SSet.add ".jsx"
+    |> SSet.add ".json"
+
+  let module_resource_exts = SSet.empty
+    |> SSet.add ".css"
+    |> SSet.add ".jpg"
+    |> SSet.add ".png"
+    |> SSet.add ".gif"
+    |> SSet.add ".eot"
+    |> SSet.add ".svg"
+    |> SSet.add ".ttf"
+    |> SSet.add ".woff"
+    |> SSet.add ".woff2"
+    |> SSet.add ".mp4"
+    |> SSet.add ".webm"
 
   let default_options = {
     enable_const_params = false;
@@ -137,6 +151,7 @@ module Opts = struct
     node_resolver_dirnames = ["node_modules"];
     munge_underscores = false;
     module_file_exts;
+    module_resource_exts;
     modules_are_use_strict = false;
     suppress_comments = [];
     suppress_types = SSet.empty;
@@ -460,6 +475,18 @@ let parse_options config lines =
         ));
         let module_file_exts = SSet.add v opts.module_file_exts in
         {opts with module_file_exts;}
+      );
+    }
+
+    |> define_opt "module.resource_ext" {
+      _initializer = INIT_FN (fun opts -> {
+        opts with module_resource_exts = SSet.empty;
+      });
+      flags = [ALLOW_DUPLICATE];
+      optparser = optparse_string;
+      setter = (fun opts v ->
+        let module_resource_exts = SSet.add v opts.module_resource_exts in
+        {opts with module_resource_exts;}
       );
     }
 

--- a/src/common/flowConfig.mli
+++ b/src/common/flowConfig.mli
@@ -25,6 +25,7 @@ module Opts : sig
     node_resolver_dirnames: string list;
     munge_underscores: bool;
     module_file_exts: SSet.t;
+    module_resource_exts: SSet.t;
     modules_are_use_strict: bool;
     suppress_comments: Str.regexp list;
     suppress_types: SSet.t;

--- a/src/common/options.ml
+++ b/src/common/options.ml
@@ -44,6 +44,7 @@ type t = {
   opt_module: string;
   opt_module_file_exts: SSet.t;
   opt_module_name_mappers: (Str.regexp * string) list;
+  opt_module_resource_exts: SSet.t;
   opt_modules_are_use_strict: bool;
   opt_munge_underscores: bool;
   opt_node_resolver_dirnames: string list;
@@ -102,6 +103,7 @@ let max_trace_depth opts = opts.opt_traces
 let max_workers opts = opts.opt_max_workers
 let module_file_exts opts = opts.opt_module_file_exts
 let module_name_mappers opts = opts.opt_module_name_mappers
+let module_resource_exts opts = opts.opt_module_resource_exts
 let module_system opts = opts.opt_module
 let modules_are_use_strict opts = opts.opt_modules_are_use_strict
 let node_resolver_dirnames opts = opts.opt_node_resolver_dirnames

--- a/src/common/reason.ml
+++ b/src/common/reason.ml
@@ -121,7 +121,8 @@ let string_of_loc loc = Loc.(
   | Some Builtins -> ""
   | Some LibFile file
   | Some SourceFile file
-  | Some JsonFile file ->
+  | Some JsonFile file
+  | Some ResourceFile file ->
     let line = loc.start.line in
     let start = loc.start.column + 1 in
     let end_ = loc._end.column in
@@ -146,13 +147,9 @@ let strip_root_from_loc root loc = Loc.(
     then Some (LibFile (spf "[LIB] %s" (Files.relative_path root_str file)))
     else Some (LibFile (spf "[LIB] %s" (Filename.basename file)))
 
-  | Some SourceFile file ->
+  | Some (SourceFile _ | JsonFile _ | ResourceFile _ as filename) ->
     let root_str = spf "%s%s" (Path.to_string root) Filename.dir_sep in
-    Some (SourceFile (Files.relative_path root_str file))
-
-  | Some JsonFile file ->
-    let root_str = spf "%s%s" (Path.to_string root) Filename.dir_sep in
-    Some (JsonFile (Files.relative_path root_str file))
+    Some (Loc.filename_map (Files.relative_path root_str) filename)
   in
   { loc with source }
 )
@@ -173,6 +170,7 @@ let json_of_loc ?(strip_root=None) loc = Hh_json.(Loc.(
     | Some LibFile _ -> JSON_String "LibFile"
     | Some SourceFile _ -> JSON_String "SourceFile"
     | Some JsonFile _ -> JSON_String "JsonFile"
+    | Some ResourceFile _ -> JSON_String "ResourceFile"
     | Some Builtins -> JSON_String "Builtins"
     | None -> JSON_Null);
     "start", JSON_Object [
@@ -320,6 +318,7 @@ let is_lib_reason r =
   | Some Builtins -> true
   | Some SourceFile _ -> false
   | Some JsonFile _ -> false
+  | Some ResourceFile _ -> false
   | None -> false)
 
 let is_blamable_reason r =

--- a/src/common/utils_js.ml
+++ b/src/common/utils_js.ml
@@ -198,3 +198,9 @@ let count_calls ~counter ~default f =
     decr counter;
     f ()
   end
+
+let extension_of_filename filename =
+  try
+    let idx = String.rindex filename '.' in
+    Some (String.sub filename idx (String.length filename - idx))
+  with Not_found -> None

--- a/src/parser/estree_translator.ml
+++ b/src/parser/estree_translator.ml
@@ -50,7 +50,8 @@ end with type t = Impl.t) = struct
     let source = match Loc.source location with
     | Some Loc.LibFile src
     | Some Loc.SourceFile src
-    | Some Loc.JsonFile src -> string src
+    | Some Loc.JsonFile src
+    | Some Loc.ResourceFile src -> string src
     | Some Loc.Builtins -> string "(global)"
     | None -> null
     in

--- a/src/parser/parser_env.ml
+++ b/src/parser/parser_env.ml
@@ -210,7 +210,8 @@ let init_env ?(token_sink=None) ?(parse_options=None) source content =
     | Some Loc.Builtins -> ()
     | Some Loc.LibFile fn
     | Some Loc.SourceFile fn
-    | Some Loc.JsonFile fn ->
+    | Some Loc.JsonFile fn
+    | Some Loc.ResourceFile fn ->
       lb.Lexing.lex_curr_p <- {
         lb.Lexing.lex_curr_p with Lexing.pos_fname = fn
       });

--- a/src/parsing/parsing_service_js.ml
+++ b/src/parsing/parsing_service_js.ml
@@ -15,14 +15,28 @@ module Ast = Spider_monkey_ast
 type result =
   | Parse_ok of Spider_monkey_ast.program
   | Parse_err of Errors.ErrorSet.t
-  | Parse_skip
+  | Parse_skip of parse_skip_reason
+
+and parse_skip_reason =
+  | Skip_resource_file
+  | Skip_non_flow_file
 
 (* results of parse job, returned by parse and reparse *)
-type results =
-  FilenameSet.t *                (* successfully parsed files *)
-  (filename * Docblock.t) list * (* list of skipped files *)
-  (filename * Docblock.t) list * (* list of failed files *)
-  Errors.ErrorSet.t list      (* parallel list of error sets *)
+type results = {
+  parse_ok: FilenameSet.t;                   (* successfully parsed files *)
+  parse_skips: (filename * Docblock.t) list; (* list of skipped files *)
+  parse_fails: (filename * Docblock.t) list; (* list of failed files *)
+  parse_errors: Errors.ErrorSet.t list;      (* parallel list of error sets *)
+  parse_resource_files: FilenameSet.t;       (* resource files *)
+}
+
+let empty_result = {
+  parse_ok = FilenameSet.empty;
+  parse_skips = [];
+  parse_fails = [];
+  parse_errors = [];
+  parse_resource_files = FilenameSet.empty;
+}
 
 (**************************** internal *********************************)
 
@@ -129,6 +143,7 @@ let get_docblock
   ~max_tokens file content
 : Errors.ErrorSet.t option * Docblock.t =
   match file with
+  | Loc.ResourceFile _
   | Loc.JsonFile _ -> None, Docblock.default_info
   | _ ->
     let errors, docblock = Docblock.extract ~max_tokens file content in
@@ -148,6 +163,8 @@ let do_parse ?(fail=true) ~types_mode ~use_strict ~info content file =
     match file with
     | Loc.JsonFile _ ->
       Parse_ok (parse_json_file ~fail content file)
+    | Loc.ResourceFile _ ->
+      Parse_skip Skip_resource_file
     | _ ->
       (* Allow types based on `types_mode`, using the @flow annotation in the
        file header if possible. *)
@@ -165,7 +182,7 @@ let do_parse ?(fail=true) ~types_mode ~use_strict ~info content file =
       (* don't bother to parse if types are disabled *)
       if types
       then Parse_ok (parse_source_file ~fail ~types ~use_strict content file)
-      else Parse_skip
+      else Parse_skip Skip_non_flow_file
   )
   with
   | Parse_error.Error (first_parse_error::_) ->
@@ -182,7 +199,7 @@ let do_parse ?(fail=true) ~types_mode ~use_strict ~info content file =
  * Add success/error info to passed accumulator. *)
 let reducer
   ~types_mode ~use_strict ~max_header_tokens
-  (ok, skips, fails, errors)
+  parse_results
   file
 : results =
   (* It turns out that sometimes files appear and disappear very quickly. Just
@@ -212,31 +229,50 @@ let reducer
              * implementation file was also added. *)
             if not (Loc.check_suffix file Files.flow_ext)
               && ParserHeap.get_old file = Some (ast, info)
-            then (ok, skips, fails, errors)
+            then parse_results
             else begin
               ParserHeap.add file (ast, info);
               execute_hook file (Some ast);
-              (FilenameSet.add file ok, skips, fails, errors)
+              let parse_ok = FilenameSet.add file parse_results.parse_ok in
+              { parse_results with parse_ok; }
             end
         | Parse_err converted ->
             execute_hook file None;
-            (ok, skips, (file, info) :: fails, converted :: errors)
-        | Parse_skip ->
+            let parse_fails = (file, info) :: parse_results.parse_fails in
+            let parse_errors = converted :: parse_results.parse_errors in
+            { parse_results with parse_fails; parse_errors; }
+        | Parse_skip Skip_non_flow_file ->
             execute_hook file None;
-            (ok, (file, info) :: skips, fails, errors)
+            let parse_skips = (file, info) :: parse_results.parse_skips in
+            { parse_results with parse_skips; }
+        | Parse_skip Skip_resource_file ->
+            execute_hook file None;
+            let parse_resource_files =
+              FilenameSet.add file parse_results.parse_resource_files in
+            { parse_results with parse_resource_files; }
         end
       | Some docblock_errors, info ->
         execute_hook file None;
-        (ok, skips, (file, info) :: fails, docblock_errors :: errors)
+        let parse_fails = (file, info) :: parse_results.parse_fails in
+        let parse_errors = docblock_errors :: parse_results.parse_errors in
+        { parse_results with parse_fails; parse_errors; }
       end
   | None ->
       execute_hook file None;
       let info = Docblock.default_info in
-      (ok, (file, info) :: skips, fails, errors)
+      let parse_skips = (file, info) :: parse_results.parse_skips in
+      { parse_results with parse_skips; }
 
 (* merge is just memberwise union/concat of results *)
-let merge (ok1, skip1, fail1, errors1) (ok2, skip2, fail2, errors2) =
-  (FilenameSet.union ok1 ok2, skip1 @ skip2, fail1 @ fail2, errors1 @ errors2)
+let merge r1 r2 =
+  {
+    parse_ok = FilenameSet.union r1.parse_ok r2.parse_ok;
+    parse_skips = r1.parse_skips @ r2.parse_skips;
+    parse_fails = r1.parse_fails @ r2.parse_fails;
+    parse_errors = r1.parse_errors @ r2.parse_errors;
+    parse_resource_files =
+      FilenameSet.union r1.parse_resource_files r2.parse_resource_files;
+  }
 
 (***************************** public ********************************)
 
@@ -245,45 +281,49 @@ let parse
   workers next
 : results =
   let t = Unix.gettimeofday () in
-  let ok, skip, fail, errors = MultiWorker.call
+  let results = MultiWorker.call
     workers
     ~job: (List.fold_left (reducer ~types_mode ~use_strict ~max_header_tokens))
-    ~neutral: (FilenameSet.empty, [], [], [])
+    ~neutral: empty_result
     ~merge: merge
     ~next: next in
 
   if profile then
     let t2 = Unix.gettimeofday () in
-    let ok_count = FilenameSet.cardinal ok in
-    let skip_count = List.length skip in
-    let fail_count = List.length fail in
-    prerr_endlinef "parsed %d files (%d ok, %d skipped, %d failed) in %f"
+    let ok_count = FilenameSet.cardinal results.parse_ok in
+    let skip_count = List.length results.parse_skips in
+    let fail_count = List.length results.parse_fails in
+    let resource_file_count =
+      FilenameSet.cardinal results.parse_resource_files in
+    prerr_endlinef "parsed %d files (%d ok, %d skipped, %d failed, %d resource files) in %f"
       (ok_count + skip_count + fail_count)
-      ok_count skip_count fail_count
+      ok_count skip_count fail_count resource_file_count
       (t2 -. t)
   else ();
 
-  (ok, skip, fail, errors)
+  results
 
 let reparse ~types_mode ~use_strict ~profile ~max_header_tokens workers files =
   (* save old parsing info for files *)
   ParserHeap.oldify_batch files;
   let next = MultiWorker.next workers (FilenameSet.elements files) in
-  let ok, skips, fails, errors =
+  let results =
     parse ~types_mode ~use_strict ~profile ~max_header_tokens workers next in
+  let modified =
+    FilenameSet.union results.parse_ok results.parse_resource_files in
   let modified = List.fold_left (fun acc (fail, _) ->
     FilenameSet.add fail acc
-  ) ok fails in
+  ) modified results.parse_fails in
   let modified = List.fold_left (fun acc (skip, _) ->
     FilenameSet.add skip acc
-  ) modified skips in
+  ) modified results.parse_skips in
   (* discard old parsing info for modified files *)
   ParserHeap.remove_old_batch modified;
   let unchanged = FilenameSet.diff files modified in
   (* restore old parsing info for unchanged files *)
   ParserHeap.revive_batch unchanged;
   SharedMem.collect `gentle;
-  modified, (ok, skips, fails, errors)
+  modified, results
 
 let has_ast file =
   ParserHeap.mem file

--- a/src/parsing/parsing_service_js.mli
+++ b/src/parsing/parsing_service_js.mli
@@ -18,14 +18,20 @@ type types_mode =
 type result =
   | Parse_ok of Spider_monkey_ast.program
   | Parse_err of Errors.ErrorSet.t
-  | Parse_skip
+  | Parse_skip of parse_skip_reason
+
+and parse_skip_reason =
+  | Skip_resource_file
+  | Skip_non_flow_file
 
 (* results of parse job, returned by parse and reparse *)
-type results =
-  FilenameSet.t *                 (* successfully parsed files *)
-  (filename * Docblock.t) list *  (* list of skipped files *)
-  (filename * Docblock.t) list *  (* list of failed files *)
-  Errors.ErrorSet.t list       (* parallel list of error sets *)
+type results = {
+  parse_ok: FilenameSet.t;                   (* successfully parsed files *)
+  parse_skips: (filename * Docblock.t) list; (* list of skipped files *)
+  parse_fails: (filename * Docblock.t) list; (* list of failed files *)
+  parse_errors: Errors.ErrorSet.t list;      (* parallel list of error sets *)
+  parse_resource_files: FilenameSet.t;       (* resource files *)
+}
 
 (* initial parsing pass: success/failure info is returned,
  * asts are made available via get_ast_unsafe. *)

--- a/src/server/server.ml
+++ b/src/server/server.ml
@@ -447,7 +447,7 @@ module FlowProgram : Server.SERVER_PROGRAM = struct
         (* removes excluded and lib files. the latter are already filtered *)
         want f
       then
-        let filename = Files.filename_from_string f in
+        let filename = Files.filename_from_string ~options f in
         FilenameSet.add filename acc
       else acc
     ) updates FilenameSet.empty

--- a/src/services/inference/infer_service.ml
+++ b/src/services/inference/infer_service.ml
@@ -33,6 +33,18 @@ let apply_docblock_overrides metadata docblock_info =
   | Some value -> { metadata with munge_underscores = not value; }
   | None -> metadata
 
+let infer_resource_file ~options filename =
+  let info = Docblock.default_info in
+  let module_name = Module_js.exported_module ~options filename info in
+  let metadata = Context.metadata_of_options options in
+  let metadata = { metadata with Context.checked = true; } in
+  let cx = Type_inference_js.infer_resource_file ~metadata ~filename ~module_name in
+
+  (* register module info *)
+  Module_js.add_module_info ~options cx;
+  Context_cache.add cx
+
+
 (* Given a filename, retrieve the parsed AST, derive a module name,
    and invoke the local (infer) pass. This will build and return a
    fresh context object for the module. *)

--- a/src/services/inference/infer_service.mli
+++ b/src/services/inference/infer_service.mli
@@ -22,3 +22,8 @@ val apply_docblock_overrides:
  Context.metadata ->
  Docblock.t ->
  Context.metadata
+
+val infer_resource_file:
+  options: Options.t ->
+  Loc.filename ->
+  unit

--- a/src/services/inference/init_js.ml
+++ b/src/services/inference/init_js.ml
@@ -107,7 +107,8 @@ let load_lib_files files ~options save_errors save_suppressions =
         save_errors lib_file errors;
         exclude_syms, ((lib_file, false) :: result)
 
-      | Parsing.Parse_skip ->
+      | Parsing.Parse_skip
+          (Parsing.Skip_non_flow_file | Parsing.Skip_resource_file) ->
         (* should never happen *)
         exclude_syms, ((lib_file, false) :: result)
 

--- a/src/typing/type_inference_js.ml
+++ b/src/typing/type_inference_js.ml
@@ -168,3 +168,39 @@ let infer_lib_file ~metadata ~exclude_syms file statements comments =
   ));
 
   cx, SMap.keys Scope.(module_scope.entries)
+
+let infer_resource_file ~metadata ~filename ~module_name =
+  Flow_js.Cache.clear();
+
+  let cx = Flow_js.fresh_context metadata filename module_name in
+  let exported_module_name = Modulename.to_string module_name in
+
+  let reason_exports_module =
+    Reason.reason_of_string (
+      Utils.spf "exports of module `%s`" exported_module_name) in
+  let reason_loc = Loc.({ none with source = Some filename }) in
+
+  let filename = Loc.(match filename with
+  | ResourceFile filename -> filename
+  | SourceFile _
+  | LibFile _
+  | Builtins
+  | JsonFile _ -> failwith "Resource file is not a resource file?!") in
+  let reason, exports_t = match Utils.extension_of_filename filename with
+  | Some ".css" ->
+      let reason = Reason.mk_reason
+        "Flow assumes requiring a .css file returns undefined"
+        reason_loc in
+      reason, Type.VoidT.why reason
+  | Some ext ->
+      let reason = Reason.mk_reason
+        (Utils.spf "Flow assumes that requiring a %s file returns a string" ext)
+        reason_loc in
+      reason, Type.StrT.why reason
+  | None -> failwith "How did we find a resource file without an extension?!"
+  in
+
+  let module_t = ImpExp.mk_commonjs_module_t cx reason_exports_module
+    reason exports_t in
+  Flow_js.flow_t cx (module_t, ImpExp.exports cx);
+  cx

--- a/src/typing/type_inference_js.mli
+++ b/src/typing/type_inference_js.mli
@@ -22,3 +22,9 @@ val infer_lib_file:
   Spider_monkey_ast.Statement.t list ->
   Spider_monkey_ast.Comment.t list ->
   Context.t * string list
+
+val infer_resource_file:
+  metadata: Context.metadata ->
+  filename: Loc.filename ->
+  module_name: Modulename.t ->
+  Context.t


### PR DESCRIPTION
Often, people require resource files from their JavaScript. Until now, this has
mainly been handled by using the `module.name_mapper` option in the
`./flowconfig` like so:

```
module.name_mapper='^(.*).css$' -> 'flow/css'
module.name_mapper='^(.*).(jpg\|png\|gif\|eot\|svg\|ttf\|woff\|woff2\|mp4\|webm)$' -> 'flow/file'
```

Where `flow/css.js` would export a css mock and `flow/file.js` would export
`string`. This would let you write

```
const myCSS = require('./myCSS.css');
const myJPG = require('./myJPG.jpg');
```

This change teaches Flow that it's ok to import and require these resource
files. By default, requiring a resource file returns a `string`, except for css
which returns `void`. This hopefully will let code that requires resource files
to work with Flow without the need for configuration.