### PR TITLE
Avoid killing Flow server on package.json changes

### DIFF
--- a/src/services/inference/module_js.mli
+++ b/src/services/inference/module_js.mli
@@ -84,6 +84,8 @@ val clear_infos: FilenameSet.t -> unit
 
 val add_package: string -> Spider_monkey_ast.program -> unit
 
+val package_incompatible: string -> Spider_monkey_ast.program -> bool
+
 (***************************************************)
 
 val clear_filename_cache: unit -> unit


### PR DESCRIPTION
Flow only cares about the `main` and `name` fields in `package.json`. However if any `package.json` changes at all, the Flow server dies. This is pretty frustrating and leads to a lot of lost time for Nuclide devs (since we have `package.json` files all over the place). This change makes it so the Flow server only dies if a relevant change is detected.

This works (I've tested it manually), but I'm not super confident that it's the right way to do it:

* I have to duplicate the options computation in order to call `reparse`. Is there somewhere a utility could live that would be like `reparse` except it grabs these options itself? Would that belong in `Parsing_service_js` or do you want to keep that from taking a dependency on `Options`?
* I'm not sure what the implications are of reparsing a file. Since it modifies global state it's hard to know. Is that a safe operation here?

Once we get the implementation strategy sorted out I'll look into adding automated tests.

CC @zertosh