### PR TITLE
Fix accessing number literal properties on objects

### DIFF
--- a/src/typing/flow_js.ml
+++ b/src/typing/flow_js.ml
@@ -3636,7 +3636,8 @@ let rec __flow cx ((l: Type.t), (u: Type.use_t)) trace =
       ->
       rec_flow cx trace (key, ElemT(reason_op, l, tout, Read))
 
-    | (StrT (reason_x, Literal x), ElemT(reason_op, (ObjT _ as o), t, rw)) ->
+    | (StrT (reason_x, Literal x), ElemT(reason_op, (ObjT _ as o), t, rw))
+    | (NumT (reason_x, Literal (_, x)), ElemT(reason_op, (ObjT _ as o), t, rw)) ->
       let reason_x = replace_reason (spf "property `%s`" x) reason_x in
       let u = match rw with
       | Read -> GetPropT (reason_op, (reason_x, x), t)

--- a/src/typing/flow_js.ml
+++ b/src/typing/flow_js.ml
@@ -3636,8 +3636,16 @@ let rec __flow cx ((l: Type.t), (u: Type.use_t)) trace =
       ->
       rec_flow cx trace (key, ElemT(reason_op, l, tout, Read))
 
-    | (StrT (reason_x, Literal x), ElemT(reason_op, (ObjT _ as o), t, rw))
-    | (NumT (reason_x, Literal (_, x)), ElemT(reason_op, (ObjT _ as o), t, rw)) ->
+    | (StrT (reason_x, Literal x), ElemT(reason_op, (ObjT _ as o), t, rw)) ->
+      let reason_x = replace_reason (spf "property `%s`" x) reason_x in
+      let u = match rw with
+      | Read -> GetPropT (reason_op, (reason_x, x), t)
+      | Write -> SetPropT (reason_op, (reason_x, x), t)
+      in
+      rec_flow cx trace (o, u)
+
+    | (NumT (reason_x, Literal (n, _)), ElemT(reason_op, (ObjT _ as o), t, rw)) ->
+      let x = string_of_float_trunc n in
       let reason_x = replace_reason (spf "property `%s`" x) reason_x in
       let u = match rw with
       | Read -> GetPropT (reason_op, (reason_x, x), t)

--- a/tests/objects/objects.exp
+++ b/tests/objects/objects.exp
@@ -58,28 +58,28 @@ objects.js:11
   3: var x : {'123': string, bar: string} = {'123': 'val', bar: 'bar'};
                      ^^^^^^ string
 
-objects.js:14
- 14: (x[`foo`]: string);   // error, key doesn't exist
+objects.js:16
+ 16: (x[`foo`]: string);   // error, key doesn't exist
         ^^^^^ property `foo`. Property not found in
- 14: (x[`foo`]: string);   // error, key doesn't exist
+ 16: (x[`foo`]: string);   // error, key doesn't exist
       ^ object type
 
-objects.js:17
- 17: y['foo'] = 123; // error, number !~> string
+objects.js:19
+ 19: y['foo'] = 123; // error, number !~> string
                 ^^^ number. This type is incompatible with
- 16: var y : {foo: string} = {foo: 'bar'};
+ 18: var y : {foo: string} = {foo: 'bar'};
                    ^^^^^^ string
 
-objects.js:18
- 18: y['bar'] = 'abc'; // error, property not found
+objects.js:20
+ 20: y['bar'] = 'abc'; // error, property not found
        ^^^^^ property `bar`. Property not found in
- 18: y['bar'] = 'abc'; // error, property not found
+ 20: y['bar'] = 'abc'; // error, property not found
      ^ object type
 
-objects.js:20
- 20: (y['hasOwnProperty']: string); // error, prototype method is not a string
+objects.js:22
+ 22: (y['hasOwnProperty']: string); // error, prototype method is not a string
       ^^^^^^^^^^^^^^^^^^^ function type. This type is incompatible with
- 20: (y['hasOwnProperty']: string); // error, prototype method is not a string
+ 22: (y['hasOwnProperty']: string); // error, prototype method is not a string
                            ^^^^^^ string
 
 unaliased_assign.js:18

--- a/tests/objects/objects.exp
+++ b/tests/objects/objects.exp
@@ -22,46 +22,64 @@ objects.js:5
   5: (x['foo'] : string);  // error, key doesn't exist
       ^ object type
 
+objects.js:6
+  6: (x[345] : string);  // error, key doesn't exist
+        ^^^ property `345`. Property not found in
+  6: (x[345] : string);  // error, key doesn't exist
+      ^ object type
+
 objects.js:7
-  7: (x.bar: boolean);     // error, string !~> boolean
-      ^^^^^ string. This type is incompatible with
-  7: (x.bar: boolean);     // error, string !~> boolean
-             ^^^^^^^ boolean
+  7: (x[123] : boolean);   // error, string !~> boolean
+      ^^^^^^ string. This type is incompatible with
+  7: (x[123] : boolean);   // error, string !~> boolean
+               ^^^^^^^ boolean
 
 objects.js:8
-  8: (x['123'] : boolean); // error, string !~> boolean
-      ^^^^^^^^ string. This type is incompatible with
-  8: (x['123'] : boolean); // error, string !~> boolean
-                 ^^^^^^^ boolean
+  8: (x.bar: boolean);     // error, string !~> boolean
+      ^^^^^ string. This type is incompatible with
+  8: (x.bar: boolean);     // error, string !~> boolean
+             ^^^^^^^ boolean
 
 objects.js:9
-  9: x['123'] = false;     // error, boolean !~> string
+  9: (x['123'] : boolean); // error, string !~> boolean
+      ^^^^^^^^ string. This type is incompatible with
+  9: (x['123'] : boolean); // error, string !~> boolean
+                 ^^^^^^^ boolean
+
+objects.js:10
+ 10: x['123'] = false;     // error, boolean !~> string
                 ^^^^^ boolean. This type is incompatible with
   3: var x : {'123': string, bar: string} = {'123': 'val', bar: 'bar'};
                      ^^^^^^ string
 
-objects.js:12
- 12: (x[`foo`]: string);   // error, key doesn't exist
+objects.js:11
+ 11: x[123] = false;       // error, boolean !~> string
+              ^^^^^ boolean. This type is incompatible with
+  3: var x : {'123': string, bar: string} = {'123': 'val', bar: 'bar'};
+                     ^^^^^^ string
+
+objects.js:14
+ 14: (x[`foo`]: string);   // error, key doesn't exist
         ^^^^^ property `foo`. Property not found in
- 12: (x[`foo`]: string);   // error, key doesn't exist
+ 14: (x[`foo`]: string);   // error, key doesn't exist
       ^ object type
 
-objects.js:15
- 15: y['foo'] = 123; // error, number !~> string
+objects.js:17
+ 17: y['foo'] = 123; // error, number !~> string
                 ^^^ number. This type is incompatible with
- 14: var y : {foo: string} = {foo: 'bar'};
+ 16: var y : {foo: string} = {foo: 'bar'};
                    ^^^^^^ string
 
-objects.js:16
- 16: y['bar'] = 'abc'; // error, property not found
+objects.js:18
+ 18: y['bar'] = 'abc'; // error, property not found
        ^^^^^ property `bar`. Property not found in
- 16: y['bar'] = 'abc'; // error, property not found
+ 18: y['bar'] = 'abc'; // error, property not found
      ^ object type
 
-objects.js:18
- 18: (y['hasOwnProperty']: string); // error, prototype method is not a string
+objects.js:20
+ 20: (y['hasOwnProperty']: string); // error, prototype method is not a string
       ^^^^^^^^^^^^^^^^^^^ function type. This type is incompatible with
- 18: (y['hasOwnProperty']: string); // error, prototype method is not a string
+ 20: (y['hasOwnProperty']: string); // error, prototype method is not a string
                            ^^^^^^ string
 
 unaliased_assign.js:18
@@ -71,4 +89,4 @@ unaliased_assign.js:18
                     ^^^^^^ string
 
 
-Found 12 errors
+Found 15 errors

--- a/tests/objects/objects.js
+++ b/tests/objects/objects.js
@@ -11,6 +11,8 @@ x['123'] = false;     // error, boolean !~> string
 x[123] = false;       // error, boolean !~> string
 x['foo'+'bar'] = 'derp'; // ok since we can't tell
 x[123] = 'foo'; // ok
+x[123.0] = 'foo'; // ok
+x[1.23e2] = 'foo'; // ok
 (x[`foo`]: string);   // error, key doesn't exist
 
 var y : {foo: string} = {foo: 'bar'};

--- a/tests/objects/objects.js
+++ b/tests/objects/objects.js
@@ -3,12 +3,14 @@
 var x : {'123': string, bar: string} = {'123': 'val', bar: 'bar'};
 (x.foo : string);     // error, key doesn't exist
 (x['foo'] : string);  // error, key doesn't exist
-(x[123] : boolean);   // TODO: use the number's value to error here
+(x[345] : string);  // error, key doesn't exist
+(x[123] : boolean);   // error, string !~> boolean
 (x.bar: boolean);     // error, string !~> boolean
 (x['123'] : boolean); // error, string !~> boolean
 x['123'] = false;     // error, boolean !~> string
-x[123] = false;       // TODO: use the number's value to error here
+x[123] = false;       // error, boolean !~> string
 x['foo'+'bar'] = 'derp'; // ok since we can't tell
+x[123] = 'foo'; // ok
 (x[`foo`]: string);   // error, key doesn't exist
 
 var y : {foo: string} = {foo: 'bar'};


### PR DESCRIPTION
This uses `raw` value as string representation of number literal. This is an oversimplification, but better than nothing.

The correct way is to implement this part of the spec: http://www.ecma-international.org/ecma-262/6.0/index.html#sec-tostring-applied-to-the-number-type

Fixes: https://github.com/facebook/flow/issues/1512
