### PR TITLE
add analytics in header directly

### DIFF
--- a/website/_assets/js/analytics.js
+++ b/website/_assets/js/analytics.js
@@ -1,6 +1,0 @@
-(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-ga('create', 'UA-49208336-4', 'auto');
-ga('send', 'pageview');

--- a/website/_assets/js/default.js.es6
+++ b/website/_assets/js/default.js.es6
@@ -1,5 +1,3 @@
-//= require analytics
-
 import * as docsearch from "docsearch"
 
 docsearch({

--- a/website/_includes/header.html
+++ b/website/_includes/header.html
@@ -23,6 +23,17 @@
     {% endif %}
     {% js prelude.js %}
     <link rel="alternate" type="application/rss+xml" title="{{ site.name }}" href="{{ site.url }}/blog/feed.xml">
+
+    <script>
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+
+      ga('create', 'UA-49208336-4', 'auto');
+      ga('send', 'pageview');
+
+    </script>
 </head>
 <body class="{{ page.bodyClass }}">
 


### PR DESCRIPTION
AFAICT analytics.js is not imported from anywhere and isn't getting run right now.

This PR installs Google Analytics in the way most similar to how Google recommends - by just pasting an opaque blog right before </head>.