### PR TITLE
Add path to filesystem streams in lib/node.js

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -642,11 +642,15 @@ declare module "fs" {
   }
 
   declare class ReadStream extends stream$Readable {
-    close(): void
+    path: string | Buffer;
+
+    close(): void;
   }
 
   declare class WriteStream extends stream$Writable {
-    close(): void
+    path: string | Buffer;
+
+    close(): void;
   }
 
   declare function rename(oldPath: string, newPath: string, callback?: (err: ?Error) => void): void;


### PR DESCRIPTION
According to Node documentation this has been there since version 0.1.93.

https://nodejs.org/api/fs.html#fs_readstream_path