### PR TITLE
Adjusted callback error types for many methods in the fs module decla…

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -8,6 +8,14 @@
  *
  */
 
+type ErrnoError extends Error {
+  errno?: number;
+  code?: string;
+  path?: string;
+  syscall?: string;
+  stack?: string;
+}
+
 type buffer$NonBufferEncoding =
   'hex' | 'HEX' |
   'utf8' | 'UTF8' | 'utf-8' | 'UTF-8' |
@@ -649,58 +657,60 @@ declare module "fs" {
     close(): void
   }
 
-  declare function rename(oldPath: string, newPath: string, callback?: (err: ?Error) => void): void;
+  declare function rename(oldPath: string, newPath: string, callback?: (err: ?ErrnoError) => void): void;
   declare function renameSync(oldPath: string, newPath: string): void;
-  declare function ftruncate(fd: number, len: number, callback?: (err: ?Error) => void): void;
+  declare function ftruncate(fd: number, len: number, callback?: (err: ?ErrnoError) => void): void;
   declare function ftruncateSync(fd: number, len: number): void;
-  declare function truncate(path: string, len: number, callback?: (err: ?Error) => void): void;
+  declare function truncate(path: string, len: number, callback?: (err: ?ErrnoError) => void): void;
   declare function truncateSync(path: string, len: number): void;
-  declare function chown(path: string, uid: number, gid: number, callback?: (err: ?Error) => void): void;
+  declare function chown(path: string, uid: number, gid: number, callback?: (err: ?ErrnoError) => void): void;
   declare function chownSync(path: string, uid: number, gid: number): void;
-  declare function fchown(fd: number, uid: number, gid: number, callback?: (err: ?Error) => void): void;
+  declare function fchown(fd: number, uid: number, gid: number, callback?: (err: ?ErrnoError) => void): void;
   declare function fchownSync(fd: number, uid: number, gid: number): void;
-  declare function lchown(path: string, uid: number, gid: number, callback?: (err: ?Error) => void): void;
+  declare function lchown(path: string, uid: number, gid: number, callback?: (err: ?ErrnoError) => void): void;
   declare function lchownSync(path: string, uid: number, gid: number): void;
-  declare function chmod(path: string, mode: number | string, callback?: (err: ?Error) => void): void;
+  declare function chmod(path: string, mode: number | string, callback?: (err: ?ErrnoError) => void): void;
   declare function chmodSync(path: string, mode: number | string): void;
-  declare function fchmod(fd: number, mode: number | string, callback?: (err: ?Error) => void): void;
+  declare function fchmod(fd: number, mode: number | string, callback?: (err: ?ErrnoError) => void): void;
   declare function fchmodSync(fd: number, mode: number | string): void;
-  declare function lchmod(path: string, mode: number | string, callback?: (err: ?Error) => void): void;
+  declare function lchmod(path: string, mode: number | string, callback?: (err: ?ErrnoError) => void): void;
   declare function lchmodSync(path: string, mode: number | string): void;
-  declare function stat(path: string, callback?: (err: ?Error, stats: Stats) => any): void;
+  declare function stat(path: string, callback?: (err: ?ErrnoError, stats: Stats) => any): void;
   declare function statSync(path: string): Stats;
-  declare function fstat(fd: number, callback?: (err: ?Error, stats: Stats) => any): void;
+  declare function fstat(fd: number, callback?: (err: ?ErrnoError, stats: Stats) => any): void;
   declare function fstatSync(fd: number): Stats;
-  declare function lstat(path: string, callback?: (err: ?Error, stats: Stats) => any): void;
+  declare function lstat(path: string, callback?: (err: ?ErrnoError, stats: Stats) => any): void;
   declare function lstatSync(path: string): Stats;
-  declare function link(srcpath: string, dstpath: string, callback?: (err: ?Error) => void): void;
+  declare function link(srcpath: string, dstpath: string, callback?: (err: ?ErrnoError) => void): void;
   declare function linkSync(srcpath: string, dstpath: string): void;
-  declare function symlink(srcpath: string, dtspath: string, type?: string, callback?: (err: ?Error) => void): void;
+  declare function symlink(srcpath: string, dtspath: string, type?: string, callback?: (err: ?ErrnoError) => void): void;
   declare function symlinkSync(srcpath: string, dstpath: string, type: string): void;
-  declare function readlink(path: string, callback: (err: ?Error, linkString: string) => void): void;
+  declare function readlink(path: string, callback: (err: ?ErrnoError, linkString: string) => void): void;
   declare function readlinkSync(path: string): string;
-  declare function realpath(path: string, cache?: Object, callback?: (err: ?Error, resolvedPath: string) => void): void;
+  declare function realpath(path: string, cache?: Object, callback?: (err: ?ErrnoError, resolvedPath: string) => void): void;
   declare function realpathSync(path: string, cache?: Object): string;
-  declare function unlink(path: string, callback?: (err: ?Error) => void): void;
+  declare function unlink(path: string, callback?: (err: ?ErrnoError) => void): void;
   declare function unlinkSync(path: string): void;
-  declare function rmdir(path: string, callback?: (err: ?Error) => void): void;
+  declare function rmdir(path: string, callback?: (err: ?ErrnoError) => void): void;
   declare function rmdirSync(path: string): void;
-  declare function mkdir(path: string, mode?: number, callback?: (err: ?Error) => void): void;
+  declare function mkdir(path: string, mode?: number, callback?: (err: ?ErrnoError) => void): void;
   declare function mkdirSync(path: string, mode?: number): void;
-  declare function readdir(path: string, callback?: (err: ?Error, files: Array<string>) => void): void;
+  declare function mkdtemp(prefix: string, callback: (err: ?ErrnoError, folderPath: string)): void;
+  declare function mkdtempSync(prefix: string): string;
+  declare function readdir(path: string, callback?: (err: ?ErrnoError, files: Array<string>) => void): void;
   declare function readdirSync(path: string): Array<string>;
-  declare function close(fd: number, callback?: (err: ?Error) => void): void;
+  declare function close(fd: number, callback?: (err: ?ErrnoError) => void): void;
   declare function closeSync(fd: number): void;
-  declare function open(path: string, flags: string, mode?: number, callback?: (err: ?Error, fd: number) => void): void;
-  declare function openSync(path: string, flags: string, mode?: number): number;
-  declare function utimes(path: string, atime: number, mtime: number, callback?: (err: ?Error) => void): void;
+  declare function open(path: string | Buffer, flags: string | number, mode?: number, callback?: (err: ?ErrnoError, fd: number) => void): void;
+  declare function openSync(path: string | Buffer, flags: string | number, mode?: number): number;
+  declare function utimes(path: string, atime: number, mtime: number, callback?: (err: ?ErrnoError) => void): void;
   declare function utimesSync(path: string, atime: number, mtime: number): void;
-  declare function futimes(fd: number, atime: number, mtime: number, callback?: (err: ?Error) => void): void;
+  declare function futimes(fd: number, atime: number, mtime: number, callback?: (err: ?ErrnoError) => void): void;
   declare function futimesSync(fd: number, atime: number, mtime: number): void;
-  declare function fsync(fd: number, callback?: (err: ?Error) => void): void;
+  declare function fsync(fd: number, callback?: (err: ?ErrnoError) => void): void;
   declare function fsyncSync(fd: number): void;
-  declare var write: (fd: number, buffer: Buffer, offset: number, length: number, position?: mixed, callback?: (err: ?Error, write: number, str: string) => void) => void
-                   | (fd: number, data: mixed, position?: mixed, encoding?: string, callback?: (err: ?Error, write: number, str: string) => void) => void;
+  declare var write: (fd: number, buffer: Buffer, offset: number, length: number, position?: mixed, callback?: (err: ?ErrnoError, write: number, str: string) => void) => void
+                   | (fd: number, data: mixed, position?: mixed, encoding?: string, callback?: (err: ?ErrnoError, write: number, str: string) => void) => void;
   declare var writeSync: (fd: number, buffer: Buffer, offset: number, length: number, position?: number) => number
                        | (fd: number, data: mixed, position?: mixed, encoding?: string) => number;
   declare function read(
@@ -709,7 +719,7 @@ declare module "fs" {
     offset: number,
     length: number,
     position: ?number,
-    callback?: (err: ?Error, bytesRead: number, buffer: Buffer) => void
+    callback?: (err: ?ErrnoError, bytesRead: number, buffer: Buffer) => void
   ): void;
   declare function readSync(
     fd: number,
@@ -720,22 +730,22 @@ declare module "fs" {
   ): number;
   declare function readFile(
     filename: string,
-    callback: (err: ?Error, data: Buffer) => void
+    callback: (err: ?ErrnoError, data: Buffer) => void
   ): void;
   declare function readFile(
     filename: string,
     encoding: string,
-    callback: (err: ?Error, data: string) => void
+    callback: (err: ?ErrnoError, data: string) => void
   ): void;
   declare function readFile(
     filename: string,
     options: { encoding: string; flag?: string },
-    callback: (err: ?Error, data: string) => void
+    callback: (err: ?ErrnoError, data: string) => void
   ): void;
   declare function readFile(
     filename: string,
     options: { flag?: string },
-    callback: (err: ?Error, data: Buffer) => void
+    callback: (err: ?ErrnoError, data: Buffer) => void
   ): void;
   declare function readFileSync(filename: string, _: void): Buffer;
   declare function readFileSync(filename: string, encoding: string): string;
@@ -745,21 +755,21 @@ declare module "fs" {
     filename: string,
     data: Buffer | string,
     options?: Object | string,
-    callback?: (err: ?Error) => void
+    callback?: (err: ?ErrnoError) => void
   ): void;
   declare function writeFileSync(
     filename: string,
     data: Buffer | string,
     options?: Object | string
   ): void;
-  declare function appendFile(filename: string, data: string | Buffer, options?: Object, callback?: (err: ?Error) => void): void;
+  declare function appendFile(filename: string, data: string | Buffer, options?: Object, callback?: (err: ?ErrnoError) => void): void;
   declare function appendFileSync(filename: string, data: string | Buffer, options?: Object): void;
   declare function watchFile(filename: string, options?: Object, listener?: (curr: Stats, prev: Stats) => void): void;
   declare function unwatchFile(filename: string, listener?: (curr: Stats, prev: Stats) => void): void;
   declare function watch(filename: string, options?: Object, listener?: (event: string, filename: string) => void): FSWatcher;
   declare function exists(path: string, callback?: (exists: boolean) => void): void;
   declare function existsSync(path: string): boolean;
-  declare function access(path: string, mode?: any, callback?: (err: ?Error) => void): void;
+  declare function access(path: string, mode?: any, callback?: (err: ?ErrnoError) => void): void;
   declare function accessSync(path: string, mode?: any): void;
   declare function createReadStream(path: string, options?: Object): ReadStream;
   declare function createWriteStream(path: string, options?: Object): WriteStream;


### PR DESCRIPTION
…rations for Node. Added declarations for mkdtemp and mkdtempSync. Fixes #1946 

The new error definition was used based on the TypeScript definition [here](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/324169800cb792855a96272f5d58f646e7b1d56d/node/node.d.ts#L235-L241).