### PR TITLE
Fix value of OscillatorNode.type

### DIFF
--- a/lib/bom.js
+++ b/lib/bom.js
@@ -605,7 +605,7 @@ declare class GainNode extends AudioNode {
 declare class OscillatorNode extends AudioNode {
   frequency: AudioParam;
   detune: AudioParam;
-  type: AudioParam;
+  type: 'sine'|'square'|'sawtooth'|'triangle'|'custom';
   start(when?: number): void;
   stop(when?: number): void;
   setPeriodicWave(periodicWave: PeriodicWave): void;


### PR DESCRIPTION
OscillatorNode.type should be a string enum, not an AudioParam. See https://webaudio.github.io/web-audio-api/#the-oscillatornode-interface for details.