### PR TITLE
[console.table] Support arrays of objects

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -714,7 +714,7 @@ declare var console: {
   log(...data: Array<any>): void;
   profile(name: string): void;
   profileEnd(): void;
-  table(tabularData: { [key: string]: any } | Array<Array<any>>): void;
+  table(tabularData: { [key: string]: any } | Array<{ [key: string]: any }> | Array<Array<any>>): void;
   time(label: string): void;
   timeEnd(label: string): void;
   timeStamp(label?: string): void;


### PR DESCRIPTION
Right now it fails: https://flowtype.org/try/#0PQKgBAAgZgNg9gdzCYAoVBjOA7AznGAUwDoAXAQwCMiAKAbQG9yAuMARgF8AaMJ1gJg4BdAJQBuVEA

But

```js
console.table([{a: 1}, {a: 2}]);
```

is working correctly in Chrome:

<img width="572" alt="screen shot 2016-08-27 at 12 01 13 pm" src="https://cloud.githubusercontent.com/assets/197597/18029505/8d4de8c6-6c4e-11e6-84ed-022b8f610de7.png">


We're using it inside of React: https://github.com/facebook/react/blob/master/src/renderers/shared/ReactPerf.js#L332-L341