### PR TITLE
Update node.js

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -137,7 +137,7 @@ declare class child_process$Error extends Error {
   signal: ?string,
 }
 
-type child_process$execCallback = (error: ?child_process$Error, stdout: Buffer, stderr: Buffer) => void;
+type child_process$execCallback = (error: ?child_process$Error, stdout: string | Buffer, stderr: string | Buffer) => void;
 
 type child_process$execSyncOpts = {
   cwd?: string;


### PR DESCRIPTION
According to https://nodejs.org/api/child_process.html#child_process_child_process_exec_command_options_callback

the `childprocess.exec` callback is a string by default and can also be a buffer depending on args.