### PR TITLE
Fix type declaration for require

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -694,7 +694,10 @@ declare var module: {
     parent: any;
     children: Array<any>;
 };
-declare function require(id: string): any;
+declare var require: (id: string) => any & {
+  resolve: (id: string) => string;
+  cache: any;
+};
 declare var exports: any;
 
 /* Commonly available, shared between node and dom */


### PR DESCRIPTION
Closes #1963 

Change the type declaration from function to a union type adhering to [the node.js api docs](https://nodejs.org/api/globals.html#globals_require).
Didn't add `require.extensions` since it's been deprecated from [0.10.6 and forwards](https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V010.md#20130514-version-0106-stable)
