### PR TITLE
remove duplicated `mediaDevices` declaration

### DIFF
--- a/lib/bom.js
+++ b/lib/bom.js
@@ -71,7 +71,6 @@ declare class Navigator mixins NavigatorCommon {
     mediaDevices?: Object;
     javaEnabled: Function;
     maxTouchPoints: number;
-    mediaDevices: Object;
     mimeTypes: MimeTypeArray;
     oscpu: string;
     permissions: any;


### PR DESCRIPTION
`Navigator` in `bom.js` had two declarations of `mediaDevices`, one optional - removed the required one, as older browsers could not have it