### PR TITLE
Get gen_flow_files working on Windows

### DIFF
--- a/newtests/gen_flow_files_command/test.js
+++ b/newtests/gen_flow_files_command/test.js
@@ -205,7 +205,7 @@ export default suite(({addFile, addFiles, flowCmd}) => [
       'gen-flow-files',
       '--strip-root',
       './test_project/src/main.js',
-      '--out-dir=./test_project/dist/'
+      '--out-dir=./test_project/dist'
     ]).stderr('').stdout(`
       test_project/src/main.js -> test_project/dist/main.js.flow
     `),
@@ -221,7 +221,7 @@ export default suite(({addFile, addFiles, flowCmd}) => [
       'gen-flow-files',
       '--strip-root',
       './test_project/src/lib/utils.js',
-      '--out-dir=./test_project/dist/'
+      '--out-dir=./test_project/dist'
     ]).stderr('').stdout(`
       test_project/src/lib/utils.js -> test_project/dist/utils.js.flow
     `),

--- a/src/commands/genFlowFilesCommand.ml
+++ b/src/commands/genFlowFilesCommand.ml
@@ -165,10 +165,15 @@ let main option_values root error_flags strip_root ignore_flag include_flag src 
     results |> List.iter (fun (file_path, result) ->
       match result with
       | GenFlowFile_FlowFile content when src_is_dir ->
-        (* File path relative to the src dir *)
-        let dest_path = Files.relative_path src file_path in
-        (* Concatenated with the output dir *)
-        let dest_path = Filename.concat out_dir dest_path in
+        let dest_path = file_path
+          (* File path relative to the src dir *)
+          |> Files.relative_path src
+          (* Make the path OS specific *)
+          |> Str.split_delim (Str.regexp "/")
+          |> String.concat Filename.dir_sep
+          (* Concatenated with the output dir *)
+          |> Filename.concat out_dir in
+
         (* Replace file extension .js -> .js.flow *)
         let dest_path = dest_path ^ ".flow" in
 


### PR DESCRIPTION
`./tool test` was broken on Windows because `flow gen_flow_files` didn't work on Windows. Rather than just fixing the test, I decided to fix the command for Windows, since Windows isn't intended to be a second-class citizen.