### PR TITLE
Typings for the Web Components spec (and other stuff)

### DIFF
--- a/lib/bom.js
+++ b/lib/bom.js
@@ -54,13 +54,13 @@ type Gamepad = {
 
 type BatteryManager = {
     charging: boolean;
-	chargingTime: number;
-	dischargingTime: number;
-	level: number;
-	onchargingchange: ?Function;
-	onchargingtimechange: ?Function;
-	ondischargingtimechange: ?Function;
-	onlevelchange: ?Function;
+    chargingTime: number;
+    dischargingTime: number;
+    level: number;
+    onchargingchange: ?Function;
+    onchargingtimechange: ?Function;
+    ondischargingtimechange: ?Function;
+    onlevelchange: ?Function;
 }
 
 declare class NavigatorCommon {
@@ -112,8 +112,8 @@ declare class Navigator mixins NavigatorCommon {
     msGetUserMedia?: Function;
     taintEnabled?: Function;
     vibrate?: (pattern: number|number[]) => bool;
-	mozVibrate?: (pattern: number|number[]) => bool;
-	webkitVibrate?: (pattern: number|number[]) => bool;
+    mozVibrate?: (pattern: number|number[]) => bool;
+    webkitVibrate?: (pattern: number|number[]) => bool;
 }
 
 declare var navigator: Navigator;

--- a/lib/bom.js
+++ b/lib/bom.js
@@ -51,6 +51,18 @@ type Gamepad = {
   mapping: string;
   timestamp: number;
 }
+
+type BatteryManager = {
+	charging: boolean;
+	chargingTime: number;
+	dischargingTime: number;
+	level: number;
+	onchargingchange: ?Function;
+	onchargingtimechange: ?Function;
+	ondischargingtimechange: ?Function;
+	onlevelchange: ?Function;
+}
+
 declare class NavigatorCommon {
     appName: 'Netscape';
     appVersion: string;
@@ -81,7 +93,8 @@ declare class Navigator mixins NavigatorCommon {
     serviceWorker?: Object;
     vendor: '' | 'Google Inc.' | 'Apple Computer, Inc';
     vendorSub: '';
-    getBattery?: () => Promise<Gamepad>;
+    getBattery?: () => Promise<BatteryManager>;
+		mozGetBattery?: () => Promise<BatteryManager>;
     getGamepads?: () => Object[];
     webkitGetGamepads?: Function;
     mozGetGamepads?: Function;
@@ -99,6 +112,8 @@ declare class Navigator mixins NavigatorCommon {
     msGetUserMedia?: Function;
     taintEnabled?: Function;
     vibrate?: (pattern: number|number[]) => bool;
+		mozVibrate?: (pattern: number|number[]) => bool;
+		webkitVibrate?: (pattern: number|number[]) => bool;
 }
 
 declare var navigator: Navigator;

--- a/lib/bom.js
+++ b/lib/bom.js
@@ -53,7 +53,7 @@ type Gamepad = {
 }
 
 type BatteryManager = {
-	charging: boolean;
+    charging: boolean;
 	chargingTime: number;
 	dischargingTime: number;
 	level: number;
@@ -94,7 +94,7 @@ declare class Navigator mixins NavigatorCommon {
     vendor: '' | 'Google Inc.' | 'Apple Computer, Inc';
     vendorSub: '';
     getBattery?: () => Promise<BatteryManager>;
-		mozGetBattery?: () => Promise<BatteryManager>;
+    mozGetBattery?: () => Promise<BatteryManager>;
     getGamepads?: () => Object[];
     webkitGetGamepads?: Function;
     mozGetGamepads?: Function;
@@ -112,8 +112,8 @@ declare class Navigator mixins NavigatorCommon {
     msGetUserMedia?: Function;
     taintEnabled?: Function;
     vibrate?: (pattern: number|number[]) => bool;
-		mozVibrate?: (pattern: number|number[]) => bool;
-		webkitVibrate?: (pattern: number|number[]) => bool;
+	mozVibrate?: (pattern: number|number[]) => bool;
+	webkitVibrate?: (pattern: number|number[]) => bool;
 }
 
 declare var navigator: Navigator;

--- a/lib/cssom.js
+++ b/lib/cssom.js
@@ -82,8 +82,8 @@ declare class CSSStyleDeclaration {
   animationName: string;
   animationPlayState: string;
   animationTimingFunction: string;
-	backdropFilter: string;
-	webkitBackdropFilter: string;
+  backdropFilter: string;
+  webkitBackdropFilter: string;
   backfaceVisibility: string;
   background: string;
   backgroundAttachment: string;
@@ -167,7 +167,7 @@ declare class CSSStyleDeclaration {
   columnRuleWidth: string;
   columnSpan: string;
   columnWidth: string;
-	contain: string;
+  contain: string;
   content: string;
   counterIncrement: string;
   counterReset: string;
@@ -260,11 +260,11 @@ declare class CSSStyleDeclaration {
   minWidth: string;
   mixBlendMode: string;
   mozTransform: string;
-	mozTransformOrigin: string;
-	mozTransitionDelay: string;
-	mozTransitionDuration: string;
-	mozTransitionProperty: string;
-	mozTransitionTimingFunction: string;
+  mozTransformOrigin: string;
+  mozTransitionDelay: string;
+  mozTransitionDuration: string;
+  mozTransitionProperty: string;
+  mozTransitionTimingFunction: string;
   objectFit: string;
   objectPosition: string;
   offsetBlockEnd: string;
@@ -346,13 +346,13 @@ declare class CSSStyleDeclaration {
   unicodeRange: string;
   verticalAlign: string;
   visibility: string;
-	webkitOverflowScrolling: string;
+  webkitOverflowScrolling: string;
   webkitTransform: string;
-	webkitTransformOrigin: string;
-	webkitTransitionDelay: string;
-	webkitTransitionDuration: string;
-	webkitTransitionProperty: string;
-	webkitTransitionTimingFunction: string;
+  webkitTransformOrigin: string;
+  webkitTransitionDelay: string;
+  webkitTransitionDuration: string;
+  webkitTransitionProperty: string;
+  webkitTransitionTimingFunction: string;
   whiteSpace: string;
   widows: string;
   width: string;
@@ -362,6 +362,7 @@ declare class CSSStyleDeclaration {
   wordWrap: string;
   writingMode: string;
   zIndex: string;
+  
   cssFloat: string;
   cssText: string;
   getPropertyPriority(property: string): string;

--- a/lib/cssom.js
+++ b/lib/cssom.js
@@ -82,6 +82,8 @@ declare class CSSStyleDeclaration {
   animationName: string;
   animationPlayState: string;
   animationTimingFunction: string;
+	backdropFilter: string;
+	webkitBackdropFilter: string;
   backfaceVisibility: string;
   background: string;
   backgroundAttachment: string;
@@ -165,6 +167,7 @@ declare class CSSStyleDeclaration {
   columnRuleWidth: string;
   columnSpan: string;
   columnWidth: string;
+	contain: string;
   content: string;
   counterIncrement: string;
   counterReset: string;
@@ -256,6 +259,12 @@ declare class CSSStyleDeclaration {
   minInlineSize: string;
   minWidth: string;
   mixBlendMode: string;
+  mozTransform: string;
+	mozTransformOrigin: string;
+	mozTransitionDelay: string;
+	mozTransitionDuration: string;
+	mozTransitionProperty: string;
+	mozTransitionTimingFunction: string;
   objectFit: string;
   objectPosition: string;
   offsetBlockEnd: string;
@@ -337,7 +346,13 @@ declare class CSSStyleDeclaration {
   unicodeRange: string;
   verticalAlign: string;
   visibility: string;
+	webkitOverflowScrolling: string;
   webkitTransform: string;
+	webkitTransformOrigin: string;
+	webkitTransitionDelay: string;
+	webkitTransitionDuration: string;
+	webkitTransitionProperty: string;
+	webkitTransitionTimingFunction: string;
   whiteSpace: string;
   widows: string;
   width: string;
@@ -347,7 +362,6 @@ declare class CSSStyleDeclaration {
   wordWrap: string;
   writingMode: string;
   zIndex: string;
-
   cssFloat: string;
   cssText: string;
   getPropertyPriority(property: string): string;

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -88,6 +88,28 @@ declare class DOMError {
   name: string;
 }
 
+declare type ElementDefinitionOptions = {
+	extends?: string;
+}
+
+declare interface CustomElementRegistry {
+	define(name: string, ctor: Class<Element>, options?: ElementDefinitionOptions): void;
+	get(name: string): any;
+	whenDefined(name: string): Promise<void>;
+} 
+
+declare interface ShadowRoot extends DocumentFragment {
+	host: Element;
+	innerHTML: string;
+}
+
+declare type ShadowRootMode = 'open'|'closed';
+
+declare type ShadowRootInit {
+	delegatesFocus?: boolean;
+	mode: ShadowRootMode;
+}
+
 type EventHandler = (event: Event) => mixed
 type EventListener = {handleEvent: EventHandler} | EventHandler
 type MouseEventHandler = (event: MouseEvent) => mixed
@@ -127,6 +149,7 @@ type Event$Init = {
   bubbles?: boolean,
   cancelable?: boolean,
   composed?: boolean,
+	scoped?: boolean
 }
 
 declare class Event {
@@ -134,9 +157,11 @@ declare class Event {
   bubbles: boolean;
   cancelable: boolean;
   currentTarget: EventTarget;
+	deepPath?: () => EventTarget[];
   defaultPrevented: boolean;
   eventPhase: number;
   isTrusted: boolean;
+	scoped: boolean;
   srcElement: Element;
   target: EventTarget;
   timeStamp: number;
@@ -756,6 +781,8 @@ declare class DOMTokenList {
 
 
 declare class Element extends Node {
+	assignedSlot: ?HTMLSlotElement;
+	attachShadow: (shadowRootInitDict: ShadowRootInit): ShadowRoot;
   attributes: NamedNodeMap;
   childElementCount: number;
   children: HTMLCollection<HTMLElement>;
@@ -859,6 +886,8 @@ declare class Element extends Node {
   setAttributeNode(newAttr: Attr): Attr;
   setAttributeNodeNS(newAttr: Attr): Attr;
   setPointerCapture(pointerId: string): void;
+	shadowRoot?: ShadowRoot;
+	slot?: string;
 }
 
 declare class HTMLElement extends Element {
@@ -947,6 +976,12 @@ declare class HTMLElement extends Element {
   tabIndex: number;
   title: string;
   translate: boolean;
+}
+
+
+declare class HTMLSlotElement extends HTMLElement {
+	name: string;
+	assignedNodes: (options?: {flatten: boolean}): Node[];
 }
 
 declare class HTMLTableCellElement extends HTMLElement {
@@ -1772,6 +1807,7 @@ declare class CharacterData extends Node {
 }
 
 declare class Text extends CharacterData {
+	assignedSlot?: HTMLSlotElement;
   wholeText: string;
   splitText(offset: number): Text;
   replaceWholeText(content: string): Text;
@@ -1945,3 +1981,4 @@ declare var sessionStorage: Storage;
 declare var status: string;
 declare var top: WindowProxy;
 declare function getSelection(): Selection | null;
+declare var customElements: CustomElementRegistry;

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -782,7 +782,7 @@ declare class DOMTokenList {
 
 declare class Element extends Node {
   assignedSlot: ?HTMLSlotElement;
-  attachShadow: (shadowRootInitDict: ShadowRootInit): ShadowRoot;
+  attachShadow(shadowRootInitDict: ShadowRootInit): ShadowRoot;
   attributes: NamedNodeMap;
   childElementCount: number;
   children: HTMLCollection<HTMLElement>;
@@ -981,7 +981,7 @@ declare class HTMLElement extends Element {
 
 declare class HTMLSlotElement extends HTMLElement {
   name: string;
-  assignedNodes: (options?: {flatten: boolean}): Node[];
+  assignedNodes(options?: {flatten: boolean}): Node[];
 }
 
 declare class HTMLTableCellElement extends HTMLElement {

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -99,15 +99,15 @@ declare interface CustomElementRegistry {
 } 
 
 declare interface ShadowRoot extends DocumentFragment {
-	host: Element;
-	innerHTML: string;
+  host: Element;
+  innerHTML: string;
 }
 
 declare type ShadowRootMode = 'open'|'closed';
 
 declare type ShadowRootInit {
-	delegatesFocus?: boolean;
-	mode: ShadowRootMode;
+  delegatesFocus?: boolean;
+  mode: ShadowRootMode;
 }
 
 type EventHandler = (event: Event) => mixed
@@ -149,7 +149,7 @@ type Event$Init = {
   bubbles?: boolean,
   cancelable?: boolean,
   composed?: boolean,
-	scoped?: boolean
+  scoped?: boolean
 }
 
 declare class Event {
@@ -157,11 +157,11 @@ declare class Event {
   bubbles: boolean;
   cancelable: boolean;
   currentTarget: EventTarget;
-	deepPath?: () => EventTarget[];
+  deepPath?: () => EventTarget[];
   defaultPrevented: boolean;
   eventPhase: number;
   isTrusted: boolean;
-	scoped: boolean;
+  scoped: boolean;
   srcElement: Element;
   target: EventTarget;
   timeStamp: number;
@@ -781,8 +781,8 @@ declare class DOMTokenList {
 
 
 declare class Element extends Node {
-	assignedSlot: ?HTMLSlotElement;
-	attachShadow: (shadowRootInitDict: ShadowRootInit): ShadowRoot;
+  assignedSlot: ?HTMLSlotElement;
+  attachShadow: (shadowRootInitDict: ShadowRootInit): ShadowRoot;
   attributes: NamedNodeMap;
   childElementCount: number;
   children: HTMLCollection<HTMLElement>;
@@ -886,8 +886,8 @@ declare class Element extends Node {
   setAttributeNode(newAttr: Attr): Attr;
   setAttributeNodeNS(newAttr: Attr): Attr;
   setPointerCapture(pointerId: string): void;
-	shadowRoot?: ShadowRoot;
-	slot?: string;
+  shadowRoot?: ShadowRoot;
+  slot?: string;
 }
 
 declare class HTMLElement extends Element {
@@ -980,8 +980,8 @@ declare class HTMLElement extends Element {
 
 
 declare class HTMLSlotElement extends HTMLElement {
-	name: string;
-	assignedNodes: (options?: {flatten: boolean}): Node[];
+  name: string;
+  assignedNodes: (options?: {flatten: boolean}): Node[];
 }
 
 declare class HTMLTableCellElement extends HTMLElement {
@@ -1807,7 +1807,7 @@ declare class CharacterData extends Node {
 }
 
 declare class Text extends CharacterData {
-	assignedSlot?: HTMLSlotElement;
+  assignedSlot?: HTMLSlotElement;
   wholeText: string;
   splitText(offset: number): Text;
   replaceWholeText(content: string): Text;

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -105,7 +105,7 @@ declare interface ShadowRoot extends DocumentFragment {
 
 declare type ShadowRootMode = 'open'|'closed';
 
-declare type ShadowRootInit {
+declare type ShadowRootInit = {
   delegatesFocus?: boolean;
   mode: ShadowRootMode;
 }


### PR DESCRIPTION
This PR includes typings for the Custom Elements v1 and Shadow DOM specs.
I've based it on the official w3c documents: [Shadow DOM](https://www.w3.org/TR/shadow-dom/) and [Custom Elements](https://www.w3.org/TR/custom-elements/).

It also adds a few other additions and corrections:
- `navigator.getBattery()` mistakenly had the return value `GamePad`. Described the interface for a `BatteryManager` instead, which is the proper return value.
- Added a `moz` prefixed version of the `getBattery()` method on `navigator`
- Added a `moz` prefixed version of the `vibrate()` method on `navigator`.
- Added a `webkit` prefixed version of the `vibrate()` method on `navigator`.
- Added a few missing properties on `CSSStyleDeclaration`.
