### PR TITLE
Error when `import type` pulls from an untyped module

### DIFF
--- a/newtests/import_type_from_untyped/_flowconfig
+++ b/newtests/import_type_from_untyped/_flowconfig
@@ -1,0 +1,7 @@
+[ignore]
+
+[include]
+
+[libs]
+
+[options]

--- a/newtests/import_type_from_untyped/test.js
+++ b/newtests/import_type_from_untyped/test.js
@@ -1,0 +1,20 @@
+/* @flow */
+
+
+import {suite, test} from '../../tsrc/test/Tester';
+
+export default suite(({addFile, addFiles, addCode}) => [
+  test('importing a type from an untyped module errors', [
+    addFile('untyped.js'),
+    addCode('import type {TNamed} from "./untyped";').newErrors(`
+      test.js:3
+        3: import type {TNamed} from "./untyped";
+                        ^^^^^^ Named import from module ${'`'}./untyped${'`'}. Importing a type from an untyped module is not safe! Did you mean to add ${'`'}// @flow${'`'} to the top of the module that exports ${'`'}TNamed${'`'}?
+    `),
+    addCode('import type TDefault from "./untyped";').newErrors(`
+      test.js:5
+        5: import type TDefault from "./untyped";
+                       ^^^^^^^^ Default import from ${'`'}./untyped${'`'}. Importing a type from an untyped module is not safe! Did you mean to add ${'`'}// @flow${'`'} to the top of ${'`'}./untyped${'`'}?
+    `)
+  ]),
+]);

--- a/src/commands/lsCommand.ml
+++ b/src/commands/lsCommand.ml
@@ -154,7 +154,7 @@ let get_ls_files ~subdir ~root ~strip_root ~ignore_flag ~include_flag =
     opt_ignore_non_literal_requires = false;
     opt_max_header_tokens = FlowConfig.(
       flowconfig.options.Opts.max_header_tokens
-    )
+    );
   } in
 
   let _, libs = Files.init options in

--- a/src/commands/serverCommands.ml
+++ b/src/commands/serverCommands.ml
@@ -351,7 +351,7 @@ module OptionParser(Config : CONFIG) = struct
       );
       opt_max_header_tokens = FlowConfig.(
         flowconfig.options.Opts.max_header_tokens
-      )
+      );
     } in
     Main.start options
 

--- a/src/typing/flow_js.ml
+++ b/src/typing/flow_js.ml
@@ -1784,12 +1784,34 @@ let rec __flow cx ((l: Type.t), (u: Type.use_t)) trace =
 
     (* imports are `any`-typed when they are from (1) unchecked modules or (2)
        modules with `any`-typed exports *)
-    | (AnyT _ | AnyObjT _),
-        ( CJSRequireT(reason, t)
+    | (AnyObjT _, (
+        CJSRequireT(reason, t)
         | ImportModuleNsT(reason, t)
         | ImportDefaultT(reason, _, _, t)
         | ImportNamedT(reason, _, _, t)
-        ) ->
+      )) ->
+      rec_flow_t cx trace (AnyT.why reason, t)
+
+    | (AnyT _, (CJSRequireT(reason, t) | ImportModuleNsT(reason, t))) ->
+      rec_flow_t cx trace (AnyT.why reason, t)
+
+    | (AnyT _, ImportDefaultT(reason, import_kind, (_, module_name), t)) ->
+      if import_kind = ImportType then add_error cx (mk_info reason [
+        spf (
+          "Importing a type from an untyped module is not safe! Did you " ^^
+          "mean to add `// @flow` to the top of `%s`?"
+        ) module_name
+      ]);
+      rec_flow_t cx trace (AnyT.why reason, t)
+
+    | (AnyT _, ImportNamedT(reason, import_kind, export_name, t)) ->
+      if import_kind = ImportType then add_error cx (mk_info reason [
+        spf (
+          "Importing a type from an untyped module is not safe! Did you " ^^
+          "mean to add `// @flow` to the top of the module that exports " ^^
+          "`%s`?"
+        ) export_name
+      ]);
       rec_flow_t cx trace (AnyT.why reason, t)
 
     | ((PolyT (_, TypeT _) | TypeT _), AssertImportIsValueT(reason, name)) ->

--- a/tests/annot2/A.js
+++ b/tests/annot2/A.js
@@ -3,6 +3,7 @@
  * @flow
  */
 
+// $FlowFixMe
 import type T from "T";
 
 export default class {


### PR DESCRIPTION
Previously `import type {T} from "./untyped";` and `import type T from "./untyped";` would silently result in a local type, `T`, of type `any`. When importing from an untyped module, this is the best we can do really.

However, when importing a "type", it's usually the case that one expects the source module to be typed and it is often surprising when one discovers -- usually much later -- that the "type" you thought you were importing was `any` all along!

See https://github.com/facebook/flow/issues/2388 for the latest report on this. There have been other less formal reports of this in the past as well.

This PR makes `import type` error if the source module is not typed (i.e. the `ModuleT` is `AnyT`). In the rare case where a user is intentionally importing types from an untyped module and wants Flow to assume the implicit `any` behavior, they can simply use a `// $FlowFixMe` suppression comment.
