### PR TITLE
Add `$FlowFixMe` to the default config

### DIFF
--- a/newtests/suppression_default/_flowconfig
+++ b/newtests/suppression_default/_flowconfig
@@ -1,0 +1,7 @@
+[ignore]
+
+[include]
+
+[libs]
+
+[options]

--- a/newtests/suppression_default/_flowconfig_custom_comment
+++ b/newtests/suppression_default/_flowconfig_custom_comment
@@ -1,0 +1,8 @@
+[ignore]
+
+[include]
+
+[libs]
+
+[options]
+suppress_comment=\\(.\\|\n\\)*\\$TestSuppression

--- a/newtests/suppression_default/test.js
+++ b/newtests/suppression_default/test.js
@@ -1,0 +1,31 @@
+/* @flow */
+
+
+import {suite, test} from '../../tsrc/test/Tester';
+
+export default suite(({addFile, addFiles, addCode}) => [
+  test('No custom suppress_comments', [
+    addCode(`
+      // $FlowFixMe
+      ("a": number);
+    `).noNewErrors(''),
+  ]),
+
+  test('Custom suppress_comments', [
+    addCode(`
+      // $TestSuppression
+      ('a': number);
+    `).noNewErrors(''),
+
+    addCode(`
+      // $FlowFixMe
+      ('a': number);
+    `).newErrors(`
+      test.js:10
+       10:       ('a': number);
+                  ^^^ string. This type is incompatible with
+       10:       ('a': number);
+                       ^^^^^^ number
+    `),
+  ]).flowConfig('_flowconfig_custom_comment'),
+]);

--- a/src/common/flowConfig.ml
+++ b/src/common/flowConfig.ml
@@ -153,8 +153,8 @@ module Opts = struct
     module_file_exts;
     module_resource_exts;
     modules_are_use_strict = false;
-    suppress_comments = [];
-    suppress_types = SSet.empty;
+    suppress_comments = [Str.regexp "\\(.\\|\n\\)*\\$FlowFixMe"];
+    suppress_types = SSet.empty |> SSet.add "$FlowFixMe";
     traces = 0;
     strip_root = false;
     all = false;
@@ -596,7 +596,9 @@ let parse_options config lines =
     }
 
     |> define_opt "suppress_comment" {
-      _initializer = USE_DEFAULT;
+      _initializer = INIT_FN (fun opts ->
+        {opts with suppress_comments = [];}
+      );
       flags = [ALLOW_DUPLICATE];
       optparser = optparse_regexp;
       setter = (fun opts v -> {
@@ -605,7 +607,9 @@ let parse_options config lines =
     }
 
     |> define_opt "suppress_type" {
-      _initializer = USE_DEFAULT;
+      _initializer = INIT_FN (fun opts ->
+        {opts with suppress_types = SSet.empty;}
+      );
       flags = [ALLOW_DUPLICATE];
       optparser = optparse_string;
       setter = (fun opts v -> {

--- a/tests/any/flowfixme.js
+++ b/tests/any/flowfixme.js
@@ -1,5 +1,5 @@
 /*
-  $FlowFixMe is a synonym for any, used by the Flow team to
+  FlowFixMe is a synonym for any, used by the Flow team to
   signal a needed mod to JS devs.
 
   @flow

--- a/tests/dom/dom.exp
+++ b/tests/dom/dom.exp
@@ -3,128 +3,128 @@ CanvasRenderingContext2D.js:11
          ^^^^^^^^^^^^^^^^^^^^ call of method `moveTo`
  11:     ctx.moveTo('0', '1');  // error: should be numbers
                     ^^^ string. This type is incompatible with
-number. See lib: dom.js:1186
+number. See lib: dom.js:1193
 
 CanvasRenderingContext2D.js:11
  11:     ctx.moveTo('0', '1');  // error: should be numbers
          ^^^^^^^^^^^^^^^^^^^^ call of method `moveTo`
  11:     ctx.moveTo('0', '1');  // error: should be numbers
                          ^^^ string. This type is incompatible with
-number. See lib: dom.js:1186
+number. See lib: dom.js:1193
 
 Element.js:14
  14:     element.scrollIntoView({ behavior: 'invalid' });
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call of method `scrollIntoView`
  14:     element.scrollIntoView({ behavior: 'invalid' });
                                 ^^^^^^^^^^^^^^^^^^^^^^^ object literal. This type is incompatible with
-union: boolean | object type. See lib: dom.js:856
+union: boolean | object type. See lib: dom.js:863
   Member 1:
-  boolean. See lib: dom.js:856
+  boolean. See lib: dom.js:863
   Error:
    14:     element.scrollIntoView({ behavior: 'invalid' });
                                   ^^^^^^^^^^^^^^^^^^^^^^^ object literal. This type is incompatible with
-  boolean. See lib: dom.js:856
+  boolean. See lib: dom.js:863
   Member 2:
-  object type. See lib: dom.js:856
+  object type. See lib: dom.js:863
   Error:
    14:     element.scrollIntoView({ behavior: 'invalid' });
                                               ^^^^^^^^^ string. This type is incompatible with
-  string enum. See lib: dom.js:856
+  string enum. See lib: dom.js:863
 
 Element.js:15
  15:     element.scrollIntoView({ block: 'invalid' });
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call of method `scrollIntoView`
  15:     element.scrollIntoView({ block: 'invalid' });
                                 ^^^^^^^^^^^^^^^^^^^^ object literal. This type is incompatible with
-union: boolean | object type. See lib: dom.js:856
+union: boolean | object type. See lib: dom.js:863
   Member 1:
-  boolean. See lib: dom.js:856
+  boolean. See lib: dom.js:863
   Error:
    15:     element.scrollIntoView({ block: 'invalid' });
                                   ^^^^^^^^^^^^^^^^^^^^ object literal. This type is incompatible with
-  boolean. See lib: dom.js:856
+  boolean. See lib: dom.js:863
   Member 2:
-  object type. See lib: dom.js:856
+  object type. See lib: dom.js:863
   Error:
    15:     element.scrollIntoView({ block: 'invalid' });
                                            ^^^^^^^^^ string. This type is incompatible with
-  string enum. See lib: dom.js:856
+  string enum. See lib: dom.js:863
 
 Element.js:16
  16:     element.scrollIntoView(1);
          ^^^^^^^^^^^^^^^^^^^^^^^^^ call of method `scrollIntoView`
  16:     element.scrollIntoView(1);
                                 ^ number. This type is incompatible with
-union: boolean | object type. See lib: dom.js:856
+union: boolean | object type. See lib: dom.js:863
   Member 1:
-  boolean. See lib: dom.js:856
+  boolean. See lib: dom.js:863
   Error:
    16:     element.scrollIntoView(1);
                                   ^ number. This type is incompatible with
-  boolean. See lib: dom.js:856
+  boolean. See lib: dom.js:863
   Member 2:
-  object type. See lib: dom.js:856
+  object type. See lib: dom.js:863
   Error:
    16:     element.scrollIntoView(1);
                                   ^ number. This type is incompatible with
-  object type. See lib: dom.js:856
+  object type. See lib: dom.js:863
 
 HTMLElement.js:14
  14:     element.scrollIntoView({ behavior: 'invalid' });
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call of method `scrollIntoView`
  14:     element.scrollIntoView({ behavior: 'invalid' });
                                 ^^^^^^^^^^^^^^^^^^^^^^^ object literal. This type is incompatible with
-union: boolean | object type. See lib: dom.js:856
+union: boolean | object type. See lib: dom.js:863
   Member 1:
-  boolean. See lib: dom.js:856
+  boolean. See lib: dom.js:863
   Error:
    14:     element.scrollIntoView({ behavior: 'invalid' });
                                   ^^^^^^^^^^^^^^^^^^^^^^^ object literal. This type is incompatible with
-  boolean. See lib: dom.js:856
+  boolean. See lib: dom.js:863
   Member 2:
-  object type. See lib: dom.js:856
+  object type. See lib: dom.js:863
   Error:
    14:     element.scrollIntoView({ behavior: 'invalid' });
                                               ^^^^^^^^^ string. This type is incompatible with
-  string enum. See lib: dom.js:856
+  string enum. See lib: dom.js:863
 
 HTMLElement.js:15
  15:     element.scrollIntoView({ block: 'invalid' });
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call of method `scrollIntoView`
  15:     element.scrollIntoView({ block: 'invalid' });
                                 ^^^^^^^^^^^^^^^^^^^^ object literal. This type is incompatible with
-union: boolean | object type. See lib: dom.js:856
+union: boolean | object type. See lib: dom.js:863
   Member 1:
-  boolean. See lib: dom.js:856
+  boolean. See lib: dom.js:863
   Error:
    15:     element.scrollIntoView({ block: 'invalid' });
                                   ^^^^^^^^^^^^^^^^^^^^ object literal. This type is incompatible with
-  boolean. See lib: dom.js:856
+  boolean. See lib: dom.js:863
   Member 2:
-  object type. See lib: dom.js:856
+  object type. See lib: dom.js:863
   Error:
    15:     element.scrollIntoView({ block: 'invalid' });
                                            ^^^^^^^^^ string. This type is incompatible with
-  string enum. See lib: dom.js:856
+  string enum. See lib: dom.js:863
 
 HTMLElement.js:16
  16:     element.scrollIntoView(1);
          ^^^^^^^^^^^^^^^^^^^^^^^^^ call of method `scrollIntoView`
  16:     element.scrollIntoView(1);
                                 ^ number. This type is incompatible with
-union: boolean | object type. See lib: dom.js:856
+union: boolean | object type. See lib: dom.js:863
   Member 1:
-  boolean. See lib: dom.js:856
+  boolean. See lib: dom.js:863
   Error:
    16:     element.scrollIntoView(1);
                                   ^ number. This type is incompatible with
-  boolean. See lib: dom.js:856
+  boolean. See lib: dom.js:863
   Member 2:
-  object type. See lib: dom.js:856
+  object type. See lib: dom.js:863
   Error:
    16:     element.scrollIntoView(1);
                                   ^ number. This type is incompatible with
-  object type. See lib: dom.js:856
+  object type. See lib: dom.js:863
 
 HTMLInputElement.js:7
   7:     el.setRangeText('foo', 123); // end is required
@@ -132,17 +132,17 @@ HTMLInputElement.js:7
   7:     el.setRangeText('foo', 123); // end is required
          ^^^^^^^^^^^^^^^ intersection
   Member 1:
-  function type. See lib: dom.js:1531
+  function type. See lib: dom.js:1538
   Error:
     7:     el.setRangeText('foo', 123); // end is required
                                   ^^^ number. This type is incompatible with
-  undefined. See lib: dom.js:1531
+  undefined. See lib: dom.js:1538
   Member 2:
-  function type. See lib: dom.js:1532
+  function type. See lib: dom.js:1539
   Error:
     7:     el.setRangeText('foo', 123); // end is required
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^ undefined (too few arguments, expected default/rest parameters). This type is incompatible with
-  number. See lib: dom.js:1532
+  number. See lib: dom.js:1539
 
 HTMLInputElement.js:10
  10:     el.setRangeText('foo', 123, 234, 'bogus'); // invalid value
@@ -150,17 +150,17 @@ HTMLInputElement.js:10
  10:     el.setRangeText('foo', 123, 234, 'bogus'); // invalid value
          ^^^^^^^^^^^^^^^ intersection
   Member 1:
-  function type. See lib: dom.js:1531
+  function type. See lib: dom.js:1538
   Error:
    10:     el.setRangeText('foo', 123, 234, 'bogus'); // invalid value
                                   ^^^ number. This type is incompatible with
-  undefined. See lib: dom.js:1531
+  undefined. See lib: dom.js:1538
   Member 2:
-  function type. See lib: dom.js:1532
+  function type. See lib: dom.js:1539
   Error:
    10:     el.setRangeText('foo', 123, 234, 'bogus'); // invalid value
                                             ^^^^^^^ string. This type is incompatible with
-  string enum. See lib: dom.js:1532
+  string enum. See lib: dom.js:1539
 
 URL.js:8
   8: const e: string = c.path; // not correct
@@ -186,31 +186,31 @@ path2d.js:9
   9:     (path.arcTo(0, 0, 0, 0, 10, '20', 5): void); // invalid
           ^^^^^^^^^^ intersection
   Member 1:
-  function type. See lib: dom.js:1060
+  function type. See lib: dom.js:1067
   Error:
     9:     (path.arcTo(0, 0, 0, 0, 10, '20', 5): void); // invalid
                                        ^^^^ string. This type is incompatible with
-  undefined. See lib: dom.js:1060
+  undefined. See lib: dom.js:1067
   Member 2:
-  function type. See lib: dom.js:1061
+  function type. See lib: dom.js:1068
   Error:
     9:     (path.arcTo(0, 0, 0, 0, 10, '20', 5): void); // invalid
                                        ^^^^ string. This type is incompatible with
-  number. See lib: dom.js:1061
+  number. See lib: dom.js:1068
 
 registerElement.js:48
  48:     document.registerElement('custom-element', {
          ^ call of method `registerElement`
  52:           oldVal: string, // Error: This might be null
                        ^^^^^^ string. This type is incompatible with
-null. See lib: dom.js:390
+null. See lib: dom.js:397
 
 registerElement.js:48
  48:     document.registerElement('custom-element', {
          ^ call of method `registerElement`
  53:           newVal: string, // Error: This might be null
                        ^^^^^^ string. This type is incompatible with
-null. See lib: dom.js:405
+null. See lib: dom.js:412
 
 traversal.js:26
  26:     document.createNodeIterator({}); // invalid
@@ -218,263 +218,263 @@ traversal.js:26
  26:     document.createNodeIterator({}); // invalid
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^ intersection
   Member 1:
-  polymorphic type: function type. See lib: dom.js:571
+  polymorphic type: function type. See lib: dom.js:578
   Error:
    26:     document.createNodeIterator({}); // invalid
                                        ^^ object literal. This type is incompatible with
-  Attr. See lib: dom.js:571
+  Attr. See lib: dom.js:578
   Member 2:
-  polymorphic type: function type. See lib: dom.js:579
-  Error:
-   26:     document.createNodeIterator({}); // invalid
-                                       ^^ object literal. This type is incompatible with
-  Document. See lib: dom.js:579
-  Member 3:
-  polymorphic type: function type. See lib: dom.js:580
-  Error:
-   26:     document.createNodeIterator({}); // invalid
-                                       ^^ object literal. This type is incompatible with
-  Document. See lib: dom.js:580
-  Member 4:
-  polymorphic type: function type. See lib: dom.js:581
-  Error:
-   26:     document.createNodeIterator({}); // invalid
-                                       ^^ object literal. This type is incompatible with
-  Document. See lib: dom.js:581
-  Member 5:
-  polymorphic type: function type. See lib: dom.js:582
-  Error:
-   26:     document.createNodeIterator({}); // invalid
-                                       ^^ object literal. This type is incompatible with
-  Document. See lib: dom.js:582
-  Member 6:
-  polymorphic type: function type. See lib: dom.js:583
-  Error:
-   26:     document.createNodeIterator({}); // invalid
-                                       ^^ object literal. This type is incompatible with
-  Document. See lib: dom.js:583
-  Member 7:
-  polymorphic type: function type. See lib: dom.js:584
-  Error:
-   26:     document.createNodeIterator({}); // invalid
-                                       ^^ object literal. This type is incompatible with
-  Document. See lib: dom.js:584
-  Member 8:
-  polymorphic type: function type. See lib: dom.js:585
-  Error:
-   26:     document.createNodeIterator({}); // invalid
-                                       ^^ object literal. This type is incompatible with
-  Document. See lib: dom.js:585
-  Member 9:
   polymorphic type: function type. See lib: dom.js:586
   Error:
    26:     document.createNodeIterator({}); // invalid
                                        ^^ object literal. This type is incompatible with
   Document. See lib: dom.js:586
-  Member 10:
+  Member 3:
   polymorphic type: function type. See lib: dom.js:587
   Error:
    26:     document.createNodeIterator({}); // invalid
                                        ^^ object literal. This type is incompatible with
   Document. See lib: dom.js:587
-  Member 11:
+  Member 4:
   polymorphic type: function type. See lib: dom.js:588
   Error:
    26:     document.createNodeIterator({}); // invalid
                                        ^^ object literal. This type is incompatible with
   Document. See lib: dom.js:588
-  Member 12:
+  Member 5:
   polymorphic type: function type. See lib: dom.js:589
   Error:
    26:     document.createNodeIterator({}); // invalid
                                        ^^ object literal. This type is incompatible with
   Document. See lib: dom.js:589
-  Member 13:
+  Member 6:
   polymorphic type: function type. See lib: dom.js:590
   Error:
    26:     document.createNodeIterator({}); // invalid
                                        ^^ object literal. This type is incompatible with
   Document. See lib: dom.js:590
-  Member 14:
+  Member 7:
   polymorphic type: function type. See lib: dom.js:591
   Error:
    26:     document.createNodeIterator({}); // invalid
                                        ^^ object literal. This type is incompatible with
   Document. See lib: dom.js:591
-  Member 15:
+  Member 8:
   polymorphic type: function type. See lib: dom.js:592
   Error:
    26:     document.createNodeIterator({}); // invalid
                                        ^^ object literal. This type is incompatible with
   Document. See lib: dom.js:592
-  Member 16:
+  Member 9:
   polymorphic type: function type. See lib: dom.js:593
   Error:
    26:     document.createNodeIterator({}); // invalid
                                        ^^ object literal. This type is incompatible with
   Document. See lib: dom.js:593
-  Member 17:
+  Member 10:
   polymorphic type: function type. See lib: dom.js:594
   Error:
    26:     document.createNodeIterator({}); // invalid
                                        ^^ object literal. This type is incompatible with
   Document. See lib: dom.js:594
-  Member 18:
+  Member 11:
   polymorphic type: function type. See lib: dom.js:595
   Error:
    26:     document.createNodeIterator({}); // invalid
                                        ^^ object literal. This type is incompatible with
   Document. See lib: dom.js:595
-  Member 19:
+  Member 12:
   polymorphic type: function type. See lib: dom.js:596
   Error:
    26:     document.createNodeIterator({}); // invalid
                                        ^^ object literal. This type is incompatible with
   Document. See lib: dom.js:596
-  Member 20:
+  Member 13:
   polymorphic type: function type. See lib: dom.js:597
   Error:
    26:     document.createNodeIterator({}); // invalid
                                        ^^ object literal. This type is incompatible with
   Document. See lib: dom.js:597
-  Member 21:
+  Member 14:
   polymorphic type: function type. See lib: dom.js:598
   Error:
    26:     document.createNodeIterator({}); // invalid
                                        ^^ object literal. This type is incompatible with
   Document. See lib: dom.js:598
-  Member 22:
+  Member 15:
   polymorphic type: function type. See lib: dom.js:599
   Error:
    26:     document.createNodeIterator({}); // invalid
                                        ^^ object literal. This type is incompatible with
   Document. See lib: dom.js:599
-  Member 23:
+  Member 16:
   polymorphic type: function type. See lib: dom.js:600
   Error:
    26:     document.createNodeIterator({}); // invalid
                                        ^^ object literal. This type is incompatible with
   Document. See lib: dom.js:600
-  Member 24:
+  Member 17:
   polymorphic type: function type. See lib: dom.js:601
   Error:
    26:     document.createNodeIterator({}); // invalid
                                        ^^ object literal. This type is incompatible with
   Document. See lib: dom.js:601
-  Member 25:
+  Member 18:
   polymorphic type: function type. See lib: dom.js:602
   Error:
    26:     document.createNodeIterator({}); // invalid
                                        ^^ object literal. This type is incompatible with
   Document. See lib: dom.js:602
+  Member 19:
+  polymorphic type: function type. See lib: dom.js:603
+  Error:
+   26:     document.createNodeIterator({}); // invalid
+                                       ^^ object literal. This type is incompatible with
+  Document. See lib: dom.js:603
+  Member 20:
+  polymorphic type: function type. See lib: dom.js:604
+  Error:
+   26:     document.createNodeIterator({}); // invalid
+                                       ^^ object literal. This type is incompatible with
+  Document. See lib: dom.js:604
+  Member 21:
+  polymorphic type: function type. See lib: dom.js:605
+  Error:
+   26:     document.createNodeIterator({}); // invalid
+                                       ^^ object literal. This type is incompatible with
+  Document. See lib: dom.js:605
+  Member 22:
+  polymorphic type: function type. See lib: dom.js:606
+  Error:
+   26:     document.createNodeIterator({}); // invalid
+                                       ^^ object literal. This type is incompatible with
+  Document. See lib: dom.js:606
+  Member 23:
+  polymorphic type: function type. See lib: dom.js:607
+  Error:
+   26:     document.createNodeIterator({}); // invalid
+                                       ^^ object literal. This type is incompatible with
+  Document. See lib: dom.js:607
+  Member 24:
+  polymorphic type: function type. See lib: dom.js:608
+  Error:
+   26:     document.createNodeIterator({}); // invalid
+                                       ^^ object literal. This type is incompatible with
+  Document. See lib: dom.js:608
+  Member 25:
+  polymorphic type: function type. See lib: dom.js:609
+  Error:
+   26:     document.createNodeIterator({}); // invalid
+                                       ^^ object literal. This type is incompatible with
+  Document. See lib: dom.js:609
   Member 26:
-  polymorphic type: function type. See lib: dom.js:630
-  Error:
-   26:     document.createNodeIterator({}); // invalid
-                                       ^^ object literal. This type is incompatible with
-  DocumentFragment. See lib: dom.js:630
-  Member 27:
-  polymorphic type: function type. See lib: dom.js:631
-  Error:
-   26:     document.createNodeIterator({}); // invalid
-                                       ^^ object literal. This type is incompatible with
-  DocumentFragment. See lib: dom.js:631
-  Member 28:
-  polymorphic type: function type. See lib: dom.js:632
-  Error:
-   26:     document.createNodeIterator({}); // invalid
-                                       ^^ object literal. This type is incompatible with
-  DocumentFragment. See lib: dom.js:632
-  Member 29:
-  polymorphic type: function type. See lib: dom.js:633
-  Error:
-   26:     document.createNodeIterator({}); // invalid
-                                       ^^ object literal. This type is incompatible with
-  DocumentFragment. See lib: dom.js:633
-  Member 30:
-  polymorphic type: function type. See lib: dom.js:634
-  Error:
-   26:     document.createNodeIterator({}); // invalid
-                                       ^^ object literal. This type is incompatible with
-  DocumentFragment. See lib: dom.js:634
-  Member 31:
-  polymorphic type: function type. See lib: dom.js:635
-  Error:
-   26:     document.createNodeIterator({}); // invalid
-                                       ^^ object literal. This type is incompatible with
-  DocumentFragment. See lib: dom.js:635
-  Member 32:
-  polymorphic type: function type. See lib: dom.js:636
-  Error:
-   26:     document.createNodeIterator({}); // invalid
-                                       ^^ object literal. This type is incompatible with
-  DocumentFragment. See lib: dom.js:636
-  Member 33:
   polymorphic type: function type. See lib: dom.js:637
   Error:
    26:     document.createNodeIterator({}); // invalid
                                        ^^ object literal. This type is incompatible with
   DocumentFragment. See lib: dom.js:637
+  Member 27:
+  polymorphic type: function type. See lib: dom.js:638
+  Error:
+   26:     document.createNodeIterator({}); // invalid
+                                       ^^ object literal. This type is incompatible with
+  DocumentFragment. See lib: dom.js:638
+  Member 28:
+  polymorphic type: function type. See lib: dom.js:639
+  Error:
+   26:     document.createNodeIterator({}); // invalid
+                                       ^^ object literal. This type is incompatible with
+  DocumentFragment. See lib: dom.js:639
+  Member 29:
+  polymorphic type: function type. See lib: dom.js:640
+  Error:
+   26:     document.createNodeIterator({}); // invalid
+                                       ^^ object literal. This type is incompatible with
+  DocumentFragment. See lib: dom.js:640
+  Member 30:
+  polymorphic type: function type. See lib: dom.js:641
+  Error:
+   26:     document.createNodeIterator({}); // invalid
+                                       ^^ object literal. This type is incompatible with
+  DocumentFragment. See lib: dom.js:641
+  Member 31:
+  polymorphic type: function type. See lib: dom.js:642
+  Error:
+   26:     document.createNodeIterator({}); // invalid
+                                       ^^ object literal. This type is incompatible with
+  DocumentFragment. See lib: dom.js:642
+  Member 32:
+  polymorphic type: function type. See lib: dom.js:643
+  Error:
+   26:     document.createNodeIterator({}); // invalid
+                                       ^^ object literal. This type is incompatible with
+  DocumentFragment. See lib: dom.js:643
+  Member 33:
+  polymorphic type: function type. See lib: dom.js:644
+  Error:
+   26:     document.createNodeIterator({}); // invalid
+                                       ^^ object literal. This type is incompatible with
+  DocumentFragment. See lib: dom.js:644
   Member 34:
-  polymorphic type: function type. See lib: dom.js:650
-  Error:
-   26:     document.createNodeIterator({}); // invalid
-                                       ^^ object literal. This type is incompatible with
-  Node. See lib: dom.js:650
-  Member 35:
-  polymorphic type: function type. See lib: dom.js:651
-  Error:
-   26:     document.createNodeIterator({}); // invalid
-                                       ^^ object literal. This type is incompatible with
-  Node. See lib: dom.js:651
-  Member 36:
-  polymorphic type: function type. See lib: dom.js:652
-  Error:
-   26:     document.createNodeIterator({}); // invalid
-                                       ^^ object literal. This type is incompatible with
-  Node. See lib: dom.js:652
-  Member 37:
-  polymorphic type: function type. See lib: dom.js:653
-  Error:
-   26:     document.createNodeIterator({}); // invalid
-                                       ^^ object literal. This type is incompatible with
-  Node. See lib: dom.js:653
-  Member 38:
-  polymorphic type: function type. See lib: dom.js:654
-  Error:
-   26:     document.createNodeIterator({}); // invalid
-                                       ^^ object literal. This type is incompatible with
-  Node. See lib: dom.js:654
-  Member 39:
-  polymorphic type: function type. See lib: dom.js:655
-  Error:
-   26:     document.createNodeIterator({}); // invalid
-                                       ^^ object literal. This type is incompatible with
-  Node. See lib: dom.js:655
-  Member 40:
-  polymorphic type: function type. See lib: dom.js:656
-  Error:
-   26:     document.createNodeIterator({}); // invalid
-                                       ^^ object literal. This type is incompatible with
-  Node. See lib: dom.js:656
-  Member 41:
   polymorphic type: function type. See lib: dom.js:657
   Error:
    26:     document.createNodeIterator({}); // invalid
                                        ^^ object literal. This type is incompatible with
   Node. See lib: dom.js:657
+  Member 35:
+  polymorphic type: function type. See lib: dom.js:658
+  Error:
+   26:     document.createNodeIterator({}); // invalid
+                                       ^^ object literal. This type is incompatible with
+  Node. See lib: dom.js:658
+  Member 36:
+  polymorphic type: function type. See lib: dom.js:659
+  Error:
+   26:     document.createNodeIterator({}); // invalid
+                                       ^^ object literal. This type is incompatible with
+  Node. See lib: dom.js:659
+  Member 37:
+  polymorphic type: function type. See lib: dom.js:660
+  Error:
+   26:     document.createNodeIterator({}); // invalid
+                                       ^^ object literal. This type is incompatible with
+  Node. See lib: dom.js:660
+  Member 38:
+  polymorphic type: function type. See lib: dom.js:661
+  Error:
+   26:     document.createNodeIterator({}); // invalid
+                                       ^^ object literal. This type is incompatible with
+  Node. See lib: dom.js:661
+  Member 39:
+  polymorphic type: function type. See lib: dom.js:662
+  Error:
+   26:     document.createNodeIterator({}); // invalid
+                                       ^^ object literal. This type is incompatible with
+  Node. See lib: dom.js:662
+  Member 40:
+  polymorphic type: function type. See lib: dom.js:663
+  Error:
+   26:     document.createNodeIterator({}); // invalid
+                                       ^^ object literal. This type is incompatible with
+  Node. See lib: dom.js:663
+  Member 41:
+  polymorphic type: function type. See lib: dom.js:664
+  Error:
+   26:     document.createNodeIterator({}); // invalid
+                                       ^^ object literal. This type is incompatible with
+  Node. See lib: dom.js:664
   Member 42:
-  polymorphic type: function type. See lib: dom.js:668
+  polymorphic type: function type. See lib: dom.js:675
   Error:
    26:     document.createNodeIterator({}); // invalid
                                        ^^ object literal. This type is incompatible with
-  Document. See lib: dom.js:668
+  Document. See lib: dom.js:675
   Member 43:
-  polymorphic type: function type. See lib: dom.js:672
+  polymorphic type: function type. See lib: dom.js:679
   Error:
    26:     document.createNodeIterator({}); // invalid
                                        ^^ object literal. This type is incompatible with
-  Node. See lib: dom.js:672
+  Node. See lib: dom.js:679
 
 traversal.js:30
  30:     document.createTreeWalker({}); // invalid
@@ -482,309 +482,309 @@ traversal.js:30
  30:     document.createTreeWalker({}); // invalid
          ^^^^^^^^^^^^^^^^^^^^^^^^^ intersection
   Member 1:
-  polymorphic type: function type. See lib: dom.js:572
+  polymorphic type: function type. See lib: dom.js:579
   Error:
    30:     document.createTreeWalker({}); // invalid
                                      ^^ object literal. This type is incompatible with
-  Attr. See lib: dom.js:572
+  Attr. See lib: dom.js:579
   Member 2:
-  polymorphic type: function type. See lib: dom.js:603
-  Error:
-   30:     document.createTreeWalker({}); // invalid
-                                     ^^ object literal. This type is incompatible with
-  Document. See lib: dom.js:603
-  Member 3:
-  polymorphic type: function type. See lib: dom.js:604
-  Error:
-   30:     document.createTreeWalker({}); // invalid
-                                     ^^ object literal. This type is incompatible with
-  Document. See lib: dom.js:604
-  Member 4:
-  polymorphic type: function type. See lib: dom.js:605
-  Error:
-   30:     document.createTreeWalker({}); // invalid
-                                     ^^ object literal. This type is incompatible with
-  Document. See lib: dom.js:605
-  Member 5:
-  polymorphic type: function type. See lib: dom.js:606
-  Error:
-   30:     document.createTreeWalker({}); // invalid
-                                     ^^ object literal. This type is incompatible with
-  Document. See lib: dom.js:606
-  Member 6:
-  polymorphic type: function type. See lib: dom.js:607
-  Error:
-   30:     document.createTreeWalker({}); // invalid
-                                     ^^ object literal. This type is incompatible with
-  Document. See lib: dom.js:607
-  Member 7:
-  polymorphic type: function type. See lib: dom.js:608
-  Error:
-   30:     document.createTreeWalker({}); // invalid
-                                     ^^ object literal. This type is incompatible with
-  Document. See lib: dom.js:608
-  Member 8:
-  polymorphic type: function type. See lib: dom.js:609
-  Error:
-   30:     document.createTreeWalker({}); // invalid
-                                     ^^ object literal. This type is incompatible with
-  Document. See lib: dom.js:609
-  Member 9:
   polymorphic type: function type. See lib: dom.js:610
   Error:
    30:     document.createTreeWalker({}); // invalid
                                      ^^ object literal. This type is incompatible with
   Document. See lib: dom.js:610
-  Member 10:
+  Member 3:
   polymorphic type: function type. See lib: dom.js:611
   Error:
    30:     document.createTreeWalker({}); // invalid
                                      ^^ object literal. This type is incompatible with
   Document. See lib: dom.js:611
-  Member 11:
+  Member 4:
   polymorphic type: function type. See lib: dom.js:612
   Error:
    30:     document.createTreeWalker({}); // invalid
                                      ^^ object literal. This type is incompatible with
   Document. See lib: dom.js:612
-  Member 12:
+  Member 5:
   polymorphic type: function type. See lib: dom.js:613
   Error:
    30:     document.createTreeWalker({}); // invalid
                                      ^^ object literal. This type is incompatible with
   Document. See lib: dom.js:613
-  Member 13:
+  Member 6:
   polymorphic type: function type. See lib: dom.js:614
   Error:
    30:     document.createTreeWalker({}); // invalid
                                      ^^ object literal. This type is incompatible with
   Document. See lib: dom.js:614
-  Member 14:
+  Member 7:
   polymorphic type: function type. See lib: dom.js:615
   Error:
    30:     document.createTreeWalker({}); // invalid
                                      ^^ object literal. This type is incompatible with
   Document. See lib: dom.js:615
-  Member 15:
+  Member 8:
   polymorphic type: function type. See lib: dom.js:616
   Error:
    30:     document.createTreeWalker({}); // invalid
                                      ^^ object literal. This type is incompatible with
   Document. See lib: dom.js:616
-  Member 16:
+  Member 9:
   polymorphic type: function type. See lib: dom.js:617
   Error:
    30:     document.createTreeWalker({}); // invalid
                                      ^^ object literal. This type is incompatible with
   Document. See lib: dom.js:617
-  Member 17:
+  Member 10:
   polymorphic type: function type. See lib: dom.js:618
   Error:
    30:     document.createTreeWalker({}); // invalid
                                      ^^ object literal. This type is incompatible with
   Document. See lib: dom.js:618
-  Member 18:
+  Member 11:
   polymorphic type: function type. See lib: dom.js:619
   Error:
    30:     document.createTreeWalker({}); // invalid
                                      ^^ object literal. This type is incompatible with
   Document. See lib: dom.js:619
-  Member 19:
+  Member 12:
   polymorphic type: function type. See lib: dom.js:620
   Error:
    30:     document.createTreeWalker({}); // invalid
                                      ^^ object literal. This type is incompatible with
   Document. See lib: dom.js:620
-  Member 20:
+  Member 13:
   polymorphic type: function type. See lib: dom.js:621
   Error:
    30:     document.createTreeWalker({}); // invalid
                                      ^^ object literal. This type is incompatible with
   Document. See lib: dom.js:621
-  Member 21:
+  Member 14:
   polymorphic type: function type. See lib: dom.js:622
   Error:
    30:     document.createTreeWalker({}); // invalid
                                      ^^ object literal. This type is incompatible with
   Document. See lib: dom.js:622
-  Member 22:
+  Member 15:
   polymorphic type: function type. See lib: dom.js:623
   Error:
    30:     document.createTreeWalker({}); // invalid
                                      ^^ object literal. This type is incompatible with
   Document. See lib: dom.js:623
-  Member 23:
+  Member 16:
   polymorphic type: function type. See lib: dom.js:624
   Error:
    30:     document.createTreeWalker({}); // invalid
                                      ^^ object literal. This type is incompatible with
   Document. See lib: dom.js:624
-  Member 24:
+  Member 17:
   polymorphic type: function type. See lib: dom.js:625
   Error:
    30:     document.createTreeWalker({}); // invalid
                                      ^^ object literal. This type is incompatible with
   Document. See lib: dom.js:625
-  Member 25:
+  Member 18:
   polymorphic type: function type. See lib: dom.js:626
   Error:
    30:     document.createTreeWalker({}); // invalid
                                      ^^ object literal. This type is incompatible with
   Document. See lib: dom.js:626
+  Member 19:
+  polymorphic type: function type. See lib: dom.js:627
+  Error:
+   30:     document.createTreeWalker({}); // invalid
+                                     ^^ object literal. This type is incompatible with
+  Document. See lib: dom.js:627
+  Member 20:
+  polymorphic type: function type. See lib: dom.js:628
+  Error:
+   30:     document.createTreeWalker({}); // invalid
+                                     ^^ object literal. This type is incompatible with
+  Document. See lib: dom.js:628
+  Member 21:
+  polymorphic type: function type. See lib: dom.js:629
+  Error:
+   30:     document.createTreeWalker({}); // invalid
+                                     ^^ object literal. This type is incompatible with
+  Document. See lib: dom.js:629
+  Member 22:
+  polymorphic type: function type. See lib: dom.js:630
+  Error:
+   30:     document.createTreeWalker({}); // invalid
+                                     ^^ object literal. This type is incompatible with
+  Document. See lib: dom.js:630
+  Member 23:
+  polymorphic type: function type. See lib: dom.js:631
+  Error:
+   30:     document.createTreeWalker({}); // invalid
+                                     ^^ object literal. This type is incompatible with
+  Document. See lib: dom.js:631
+  Member 24:
+  polymorphic type: function type. See lib: dom.js:632
+  Error:
+   30:     document.createTreeWalker({}); // invalid
+                                     ^^ object literal. This type is incompatible with
+  Document. See lib: dom.js:632
+  Member 25:
+  polymorphic type: function type. See lib: dom.js:633
+  Error:
+   30:     document.createTreeWalker({}); // invalid
+                                     ^^ object literal. This type is incompatible with
+  Document. See lib: dom.js:633
   Member 26:
-  polymorphic type: function type. See lib: dom.js:638
-  Error:
-   30:     document.createTreeWalker({}); // invalid
-                                     ^^ object literal. This type is incompatible with
-  DocumentFragment. See lib: dom.js:638
-  Member 27:
-  polymorphic type: function type. See lib: dom.js:639
-  Error:
-   30:     document.createTreeWalker({}); // invalid
-                                     ^^ object literal. This type is incompatible with
-  DocumentFragment. See lib: dom.js:639
-  Member 28:
-  polymorphic type: function type. See lib: dom.js:640
-  Error:
-   30:     document.createTreeWalker({}); // invalid
-                                     ^^ object literal. This type is incompatible with
-  DocumentFragment. See lib: dom.js:640
-  Member 29:
-  polymorphic type: function type. See lib: dom.js:641
-  Error:
-   30:     document.createTreeWalker({}); // invalid
-                                     ^^ object literal. This type is incompatible with
-  DocumentFragment. See lib: dom.js:641
-  Member 30:
-  polymorphic type: function type. See lib: dom.js:642
-  Error:
-   30:     document.createTreeWalker({}); // invalid
-                                     ^^ object literal. This type is incompatible with
-  DocumentFragment. See lib: dom.js:642
-  Member 31:
-  polymorphic type: function type. See lib: dom.js:643
-  Error:
-   30:     document.createTreeWalker({}); // invalid
-                                     ^^ object literal. This type is incompatible with
-  DocumentFragment. See lib: dom.js:643
-  Member 32:
-  polymorphic type: function type. See lib: dom.js:644
-  Error:
-   30:     document.createTreeWalker({}); // invalid
-                                     ^^ object literal. This type is incompatible with
-  DocumentFragment. See lib: dom.js:644
-  Member 33:
   polymorphic type: function type. See lib: dom.js:645
   Error:
    30:     document.createTreeWalker({}); // invalid
                                      ^^ object literal. This type is incompatible with
   DocumentFragment. See lib: dom.js:645
+  Member 27:
+  polymorphic type: function type. See lib: dom.js:646
+  Error:
+   30:     document.createTreeWalker({}); // invalid
+                                     ^^ object literal. This type is incompatible with
+  DocumentFragment. See lib: dom.js:646
+  Member 28:
+  polymorphic type: function type. See lib: dom.js:647
+  Error:
+   30:     document.createTreeWalker({}); // invalid
+                                     ^^ object literal. This type is incompatible with
+  DocumentFragment. See lib: dom.js:647
+  Member 29:
+  polymorphic type: function type. See lib: dom.js:648
+  Error:
+   30:     document.createTreeWalker({}); // invalid
+                                     ^^ object literal. This type is incompatible with
+  DocumentFragment. See lib: dom.js:648
+  Member 30:
+  polymorphic type: function type. See lib: dom.js:649
+  Error:
+   30:     document.createTreeWalker({}); // invalid
+                                     ^^ object literal. This type is incompatible with
+  DocumentFragment. See lib: dom.js:649
+  Member 31:
+  polymorphic type: function type. See lib: dom.js:650
+  Error:
+   30:     document.createTreeWalker({}); // invalid
+                                     ^^ object literal. This type is incompatible with
+  DocumentFragment. See lib: dom.js:650
+  Member 32:
+  polymorphic type: function type. See lib: dom.js:651
+  Error:
+   30:     document.createTreeWalker({}); // invalid
+                                     ^^ object literal. This type is incompatible with
+  DocumentFragment. See lib: dom.js:651
+  Member 33:
+  polymorphic type: function type. See lib: dom.js:652
+  Error:
+   30:     document.createTreeWalker({}); // invalid
+                                     ^^ object literal. This type is incompatible with
+  DocumentFragment. See lib: dom.js:652
   Member 34:
-  polymorphic type: function type. See lib: dom.js:658
-  Error:
-   30:     document.createTreeWalker({}); // invalid
-                                     ^^ object literal. This type is incompatible with
-  Node. See lib: dom.js:658
-  Member 35:
-  polymorphic type: function type. See lib: dom.js:659
-  Error:
-   30:     document.createTreeWalker({}); // invalid
-                                     ^^ object literal. This type is incompatible with
-  Node. See lib: dom.js:659
-  Member 36:
-  polymorphic type: function type. See lib: dom.js:660
-  Error:
-   30:     document.createTreeWalker({}); // invalid
-                                     ^^ object literal. This type is incompatible with
-  Node. See lib: dom.js:660
-  Member 37:
-  polymorphic type: function type. See lib: dom.js:661
-  Error:
-   30:     document.createTreeWalker({}); // invalid
-                                     ^^ object literal. This type is incompatible with
-  Node. See lib: dom.js:661
-  Member 38:
-  polymorphic type: function type. See lib: dom.js:662
-  Error:
-   30:     document.createTreeWalker({}); // invalid
-                                     ^^ object literal. This type is incompatible with
-  Node. See lib: dom.js:662
-  Member 39:
-  polymorphic type: function type. See lib: dom.js:663
-  Error:
-   30:     document.createTreeWalker({}); // invalid
-                                     ^^ object literal. This type is incompatible with
-  Node. See lib: dom.js:663
-  Member 40:
-  polymorphic type: function type. See lib: dom.js:664
-  Error:
-   30:     document.createTreeWalker({}); // invalid
-                                     ^^ object literal. This type is incompatible with
-  Node. See lib: dom.js:664
-  Member 41:
   polymorphic type: function type. See lib: dom.js:665
   Error:
    30:     document.createTreeWalker({}); // invalid
                                      ^^ object literal. This type is incompatible with
   Node. See lib: dom.js:665
-  Member 42:
+  Member 35:
+  polymorphic type: function type. See lib: dom.js:666
+  Error:
+   30:     document.createTreeWalker({}); // invalid
+                                     ^^ object literal. This type is incompatible with
+  Node. See lib: dom.js:666
+  Member 36:
+  polymorphic type: function type. See lib: dom.js:667
+  Error:
+   30:     document.createTreeWalker({}); // invalid
+                                     ^^ object literal. This type is incompatible with
+  Node. See lib: dom.js:667
+  Member 37:
+  polymorphic type: function type. See lib: dom.js:668
+  Error:
+   30:     document.createTreeWalker({}); // invalid
+                                     ^^ object literal. This type is incompatible with
+  Node. See lib: dom.js:668
+  Member 38:
   polymorphic type: function type. See lib: dom.js:669
   Error:
    30:     document.createTreeWalker({}); // invalid
                                      ^^ object literal. This type is incompatible with
   Node. See lib: dom.js:669
-  Member 43:
-  polymorphic type: function type. See lib: dom.js:673
+  Member 39:
+  polymorphic type: function type. See lib: dom.js:670
   Error:
    30:     document.createTreeWalker({}); // invalid
                                      ^^ object literal. This type is incompatible with
-  Node. See lib: dom.js:673
+  Node. See lib: dom.js:670
+  Member 40:
+  polymorphic type: function type. See lib: dom.js:671
+  Error:
+   30:     document.createTreeWalker({}); // invalid
+                                     ^^ object literal. This type is incompatible with
+  Node. See lib: dom.js:671
+  Member 41:
+  polymorphic type: function type. See lib: dom.js:672
+  Error:
+   30:     document.createTreeWalker({}); // invalid
+                                     ^^ object literal. This type is incompatible with
+  Node. See lib: dom.js:672
+  Member 42:
+  polymorphic type: function type. See lib: dom.js:676
+  Error:
+   30:     document.createTreeWalker({}); // invalid
+                                     ^^ object literal. This type is incompatible with
+  Node. See lib: dom.js:676
+  Member 43:
+  polymorphic type: function type. See lib: dom.js:680
+  Error:
+   30:     document.createTreeWalker({}); // invalid
+                                     ^^ object literal. This type is incompatible with
+  Node. See lib: dom.js:680
 
 traversal.js:183
 183:     document.createNodeIterator(document.body, -1, node => 'accept'); // invalid
                                                                 ^^^^^^^^ string. This type is incompatible with
-union: typeof typeof-annotation '<<object>>.FILTER_ACCEPT') | typeof typeof-annotation '<<object>>.FILTER_REJECT') | typeof typeof-annotation '<<object>>.FILTER_SKIP'). See lib: dom.js:1866
+union: typeof typeof-annotation '<<object>>.FILTER_ACCEPT') | typeof typeof-annotation '<<object>>.FILTER_REJECT') | typeof typeof-annotation '<<object>>.FILTER_SKIP'). See lib: dom.js:1873
   Member 1:
-  typeof typeof-annotation '<<object>>.FILTER_ACCEPT'). See lib: dom.js:1866
+  typeof typeof-annotation '<<object>>.FILTER_ACCEPT'). See lib: dom.js:1873
   Error:
   183:     document.createNodeIterator(document.body, -1, node => 'accept'); // invalid
                                                                   ^^^^^^^^ string. This type is incompatible with
-  number literal `1`. See lib: dom.js:1866
+  number literal `1`. See lib: dom.js:1873
   Member 2:
-  typeof typeof-annotation '<<object>>.FILTER_REJECT'). See lib: dom.js:1867
+  typeof typeof-annotation '<<object>>.FILTER_REJECT'). See lib: dom.js:1874
   Error:
   183:     document.createNodeIterator(document.body, -1, node => 'accept'); // invalid
                                                                   ^^^^^^^^ string. This type is incompatible with
-  number literal `2`. See lib: dom.js:1867
+  number literal `2`. See lib: dom.js:1874
   Member 3:
-  typeof typeof-annotation '<<object>>.FILTER_SKIP'). See lib: dom.js:1868
+  typeof typeof-annotation '<<object>>.FILTER_SKIP'). See lib: dom.js:1875
   Error:
   183:     document.createNodeIterator(document.body, -1, node => 'accept'); // invalid
                                                                   ^^^^^^^^ string. This type is incompatible with
-  number literal `3`. See lib: dom.js:1868
+  number literal `3`. See lib: dom.js:1875
 
 traversal.js:185
 185:     document.createNodeIterator(document.body, -1, { accept: node => 'accept' }); // invalid
                                                                           ^^^^^^^^ string. This type is incompatible with
-union: typeof typeof-annotation '<<object>>.FILTER_ACCEPT') | typeof typeof-annotation '<<object>>.FILTER_REJECT') | typeof typeof-annotation '<<object>>.FILTER_SKIP'). See lib: dom.js:1866
+union: typeof typeof-annotation '<<object>>.FILTER_ACCEPT') | typeof typeof-annotation '<<object>>.FILTER_REJECT') | typeof typeof-annotation '<<object>>.FILTER_SKIP'). See lib: dom.js:1873
   Member 1:
-  typeof typeof-annotation '<<object>>.FILTER_ACCEPT'). See lib: dom.js:1866
+  typeof typeof-annotation '<<object>>.FILTER_ACCEPT'). See lib: dom.js:1873
   Error:
   185:     document.createNodeIterator(document.body, -1, { accept: node => 'accept' }); // invalid
                                                                             ^^^^^^^^ string. This type is incompatible with
-  number literal `1`. See lib: dom.js:1866
+  number literal `1`. See lib: dom.js:1873
   Member 2:
-  typeof typeof-annotation '<<object>>.FILTER_REJECT'). See lib: dom.js:1867
+  typeof typeof-annotation '<<object>>.FILTER_REJECT'). See lib: dom.js:1874
   Error:
   185:     document.createNodeIterator(document.body, -1, { accept: node => 'accept' }); // invalid
                                                                             ^^^^^^^^ string. This type is incompatible with
-  number literal `2`. See lib: dom.js:1867
+  number literal `2`. See lib: dom.js:1874
   Member 3:
-  typeof typeof-annotation '<<object>>.FILTER_SKIP'). See lib: dom.js:1868
+  typeof typeof-annotation '<<object>>.FILTER_SKIP'). See lib: dom.js:1875
   Error:
   185:     document.createNodeIterator(document.body, -1, { accept: node => 'accept' }); // invalid
                                                                             ^^^^^^^^ string. This type is incompatible with
-  number literal `3`. See lib: dom.js:1868
+  number literal `3`. See lib: dom.js:1875
 
 traversal.js:186
 186:     document.createNodeIterator(document.body, -1, {}); // invalid
@@ -792,321 +792,321 @@ traversal.js:186
 186:     document.createNodeIterator(document.body, -1, {}); // invalid
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^ intersection
   Member 1:
-  polymorphic type: function type. See lib: dom.js:571
+  polymorphic type: function type. See lib: dom.js:578
   Error:
   186:     document.createNodeIterator(document.body, -1, {}); // invalid
                                        ^^^^^^^^^^^^^ HTMLElement. This type is incompatible with
-  Attr. See lib: dom.js:571
+  Attr. See lib: dom.js:578
   Member 2:
-  polymorphic type: function type. See lib: dom.js:579
-  Error:
-  186:     document.createNodeIterator(document.body, -1, {}); // invalid
-                                       ^^^^^^^^^^^^^ HTMLElement. This type is incompatible with
-  Document. See lib: dom.js:579
-  Member 3:
-  polymorphic type: function type. See lib: dom.js:580
-  Error:
-  186:     document.createNodeIterator(document.body, -1, {}); // invalid
-                                       ^^^^^^^^^^^^^ HTMLElement. This type is incompatible with
-  Document. See lib: dom.js:580
-  Member 4:
-  polymorphic type: function type. See lib: dom.js:581
-  Error:
-  186:     document.createNodeIterator(document.body, -1, {}); // invalid
-                                       ^^^^^^^^^^^^^ HTMLElement. This type is incompatible with
-  Document. See lib: dom.js:581
-  Member 5:
-  polymorphic type: function type. See lib: dom.js:582
-  Error:
-  186:     document.createNodeIterator(document.body, -1, {}); // invalid
-                                       ^^^^^^^^^^^^^ HTMLElement. This type is incompatible with
-  Document. See lib: dom.js:582
-  Member 6:
-  polymorphic type: function type. See lib: dom.js:583
-  Error:
-  186:     document.createNodeIterator(document.body, -1, {}); // invalid
-                                       ^^^^^^^^^^^^^ HTMLElement. This type is incompatible with
-  Document. See lib: dom.js:583
-  Member 7:
-  polymorphic type: function type. See lib: dom.js:584
-  Error:
-  186:     document.createNodeIterator(document.body, -1, {}); // invalid
-                                       ^^^^^^^^^^^^^ HTMLElement. This type is incompatible with
-  Document. See lib: dom.js:584
-  Member 8:
-  polymorphic type: function type. See lib: dom.js:585
-  Error:
-  186:     document.createNodeIterator(document.body, -1, {}); // invalid
-                                       ^^^^^^^^^^^^^ HTMLElement. This type is incompatible with
-  Document. See lib: dom.js:585
-  Member 9:
   polymorphic type: function type. See lib: dom.js:586
   Error:
   186:     document.createNodeIterator(document.body, -1, {}); // invalid
                                        ^^^^^^^^^^^^^ HTMLElement. This type is incompatible with
   Document. See lib: dom.js:586
-  Member 10:
+  Member 3:
   polymorphic type: function type. See lib: dom.js:587
   Error:
   186:     document.createNodeIterator(document.body, -1, {}); // invalid
                                        ^^^^^^^^^^^^^ HTMLElement. This type is incompatible with
   Document. See lib: dom.js:587
-  Member 11:
+  Member 4:
   polymorphic type: function type. See lib: dom.js:588
   Error:
   186:     document.createNodeIterator(document.body, -1, {}); // invalid
                                        ^^^^^^^^^^^^^ HTMLElement. This type is incompatible with
   Document. See lib: dom.js:588
-  Member 12:
+  Member 5:
   polymorphic type: function type. See lib: dom.js:589
   Error:
   186:     document.createNodeIterator(document.body, -1, {}); // invalid
                                        ^^^^^^^^^^^^^ HTMLElement. This type is incompatible with
   Document. See lib: dom.js:589
-  Member 13:
+  Member 6:
   polymorphic type: function type. See lib: dom.js:590
   Error:
   186:     document.createNodeIterator(document.body, -1, {}); // invalid
                                        ^^^^^^^^^^^^^ HTMLElement. This type is incompatible with
   Document. See lib: dom.js:590
-  Member 14:
+  Member 7:
   polymorphic type: function type. See lib: dom.js:591
   Error:
   186:     document.createNodeIterator(document.body, -1, {}); // invalid
                                        ^^^^^^^^^^^^^ HTMLElement. This type is incompatible with
   Document. See lib: dom.js:591
-  Member 15:
+  Member 8:
   polymorphic type: function type. See lib: dom.js:592
   Error:
   186:     document.createNodeIterator(document.body, -1, {}); // invalid
                                        ^^^^^^^^^^^^^ HTMLElement. This type is incompatible with
   Document. See lib: dom.js:592
-  Member 16:
+  Member 9:
   polymorphic type: function type. See lib: dom.js:593
   Error:
   186:     document.createNodeIterator(document.body, -1, {}); // invalid
                                        ^^^^^^^^^^^^^ HTMLElement. This type is incompatible with
   Document. See lib: dom.js:593
-  Member 17:
+  Member 10:
   polymorphic type: function type. See lib: dom.js:594
   Error:
   186:     document.createNodeIterator(document.body, -1, {}); // invalid
                                        ^^^^^^^^^^^^^ HTMLElement. This type is incompatible with
   Document. See lib: dom.js:594
-  Member 18:
+  Member 11:
   polymorphic type: function type. See lib: dom.js:595
   Error:
   186:     document.createNodeIterator(document.body, -1, {}); // invalid
                                        ^^^^^^^^^^^^^ HTMLElement. This type is incompatible with
   Document. See lib: dom.js:595
-  Member 19:
+  Member 12:
   polymorphic type: function type. See lib: dom.js:596
   Error:
   186:     document.createNodeIterator(document.body, -1, {}); // invalid
                                        ^^^^^^^^^^^^^ HTMLElement. This type is incompatible with
   Document. See lib: dom.js:596
-  Member 20:
+  Member 13:
   polymorphic type: function type. See lib: dom.js:597
   Error:
   186:     document.createNodeIterator(document.body, -1, {}); // invalid
                                        ^^^^^^^^^^^^^ HTMLElement. This type is incompatible with
   Document. See lib: dom.js:597
-  Member 21:
+  Member 14:
   polymorphic type: function type. See lib: dom.js:598
   Error:
   186:     document.createNodeIterator(document.body, -1, {}); // invalid
                                        ^^^^^^^^^^^^^ HTMLElement. This type is incompatible with
   Document. See lib: dom.js:598
-  Member 22:
+  Member 15:
   polymorphic type: function type. See lib: dom.js:599
   Error:
   186:     document.createNodeIterator(document.body, -1, {}); // invalid
                                        ^^^^^^^^^^^^^ HTMLElement. This type is incompatible with
   Document. See lib: dom.js:599
-  Member 23:
+  Member 16:
   polymorphic type: function type. See lib: dom.js:600
   Error:
   186:     document.createNodeIterator(document.body, -1, {}); // invalid
                                        ^^^^^^^^^^^^^ HTMLElement. This type is incompatible with
   Document. See lib: dom.js:600
-  Member 24:
+  Member 17:
   polymorphic type: function type. See lib: dom.js:601
   Error:
   186:     document.createNodeIterator(document.body, -1, {}); // invalid
                                        ^^^^^^^^^^^^^ HTMLElement. This type is incompatible with
   Document. See lib: dom.js:601
-  Member 25:
+  Member 18:
   polymorphic type: function type. See lib: dom.js:602
   Error:
   186:     document.createNodeIterator(document.body, -1, {}); // invalid
                                        ^^^^^^^^^^^^^ HTMLElement. This type is incompatible with
   Document. See lib: dom.js:602
+  Member 19:
+  polymorphic type: function type. See lib: dom.js:603
+  Error:
+  186:     document.createNodeIterator(document.body, -1, {}); // invalid
+                                       ^^^^^^^^^^^^^ HTMLElement. This type is incompatible with
+  Document. See lib: dom.js:603
+  Member 20:
+  polymorphic type: function type. See lib: dom.js:604
+  Error:
+  186:     document.createNodeIterator(document.body, -1, {}); // invalid
+                                       ^^^^^^^^^^^^^ HTMLElement. This type is incompatible with
+  Document. See lib: dom.js:604
+  Member 21:
+  polymorphic type: function type. See lib: dom.js:605
+  Error:
+  186:     document.createNodeIterator(document.body, -1, {}); // invalid
+                                       ^^^^^^^^^^^^^ HTMLElement. This type is incompatible with
+  Document. See lib: dom.js:605
+  Member 22:
+  polymorphic type: function type. See lib: dom.js:606
+  Error:
+  186:     document.createNodeIterator(document.body, -1, {}); // invalid
+                                       ^^^^^^^^^^^^^ HTMLElement. This type is incompatible with
+  Document. See lib: dom.js:606
+  Member 23:
+  polymorphic type: function type. See lib: dom.js:607
+  Error:
+  186:     document.createNodeIterator(document.body, -1, {}); // invalid
+                                       ^^^^^^^^^^^^^ HTMLElement. This type is incompatible with
+  Document. See lib: dom.js:607
+  Member 24:
+  polymorphic type: function type. See lib: dom.js:608
+  Error:
+  186:     document.createNodeIterator(document.body, -1, {}); // invalid
+                                       ^^^^^^^^^^^^^ HTMLElement. This type is incompatible with
+  Document. See lib: dom.js:608
+  Member 25:
+  polymorphic type: function type. See lib: dom.js:609
+  Error:
+  186:     document.createNodeIterator(document.body, -1, {}); // invalid
+                                       ^^^^^^^^^^^^^ HTMLElement. This type is incompatible with
+  Document. See lib: dom.js:609
   Member 26:
-  polymorphic type: function type. See lib: dom.js:630
-  Error:
-  186:     document.createNodeIterator(document.body, -1, {}); // invalid
-                                       ^^^^^^^^^^^^^ HTMLElement. This type is incompatible with
-  DocumentFragment. See lib: dom.js:630
-  Member 27:
-  polymorphic type: function type. See lib: dom.js:631
-  Error:
-  186:     document.createNodeIterator(document.body, -1, {}); // invalid
-                                       ^^^^^^^^^^^^^ HTMLElement. This type is incompatible with
-  DocumentFragment. See lib: dom.js:631
-  Member 28:
-  polymorphic type: function type. See lib: dom.js:632
-  Error:
-  186:     document.createNodeIterator(document.body, -1, {}); // invalid
-                                       ^^^^^^^^^^^^^ HTMLElement. This type is incompatible with
-  DocumentFragment. See lib: dom.js:632
-  Member 29:
-  polymorphic type: function type. See lib: dom.js:633
-  Error:
-  186:     document.createNodeIterator(document.body, -1, {}); // invalid
-                                       ^^^^^^^^^^^^^ HTMLElement. This type is incompatible with
-  DocumentFragment. See lib: dom.js:633
-  Member 30:
-  polymorphic type: function type. See lib: dom.js:634
-  Error:
-  186:     document.createNodeIterator(document.body, -1, {}); // invalid
-                                       ^^^^^^^^^^^^^ HTMLElement. This type is incompatible with
-  DocumentFragment. See lib: dom.js:634
-  Member 31:
-  polymorphic type: function type. See lib: dom.js:635
-  Error:
-  186:     document.createNodeIterator(document.body, -1, {}); // invalid
-                                       ^^^^^^^^^^^^^ HTMLElement. This type is incompatible with
-  DocumentFragment. See lib: dom.js:635
-  Member 32:
-  polymorphic type: function type. See lib: dom.js:636
-  Error:
-  186:     document.createNodeIterator(document.body, -1, {}); // invalid
-                                       ^^^^^^^^^^^^^ HTMLElement. This type is incompatible with
-  DocumentFragment. See lib: dom.js:636
-  Member 33:
   polymorphic type: function type. See lib: dom.js:637
   Error:
   186:     document.createNodeIterator(document.body, -1, {}); // invalid
                                        ^^^^^^^^^^^^^ HTMLElement. This type is incompatible with
   DocumentFragment. See lib: dom.js:637
-  Member 34:
-  polymorphic type: function type. See lib: dom.js:650
-  Error:
-  186:     document.createNodeIterator(document.body, -1, {}); // invalid
-                                                      ^^ number. Expected number literal `1`, got `-1` instead
-  number literal `1`. See lib: dom.js:650
-  Member 35:
-  polymorphic type: function type. See lib: dom.js:651
-  Error:
-  186:     document.createNodeIterator(document.body, -1, {}); // invalid
-                                                      ^^ number. Expected number literal `4`, got `-1` instead
-  number literal `4`. See lib: dom.js:651
-  Member 36:
-  polymorphic type: function type. See lib: dom.js:652
-  Error:
-  186:     document.createNodeIterator(document.body, -1, {}); // invalid
-                                                      ^^ number. Expected number literal `5`, got `-1` instead
-  number literal `5`. See lib: dom.js:652
-  Member 37:
-  polymorphic type: function type. See lib: dom.js:653
-  Error:
-  186:     document.createNodeIterator(document.body, -1, {}); // invalid
-                                                      ^^ number. Expected number literal `128`, got `-1` instead
-  number literal `128`. See lib: dom.js:653
-  Member 38:
-  polymorphic type: function type. See lib: dom.js:654
-  Error:
-  186:     document.createNodeIterator(document.body, -1, {}); // invalid
-                                                      ^^ number. Expected number literal `129`, got `-1` instead
-  number literal `129`. See lib: dom.js:654
-  Member 39:
-  polymorphic type: function type. See lib: dom.js:655
-  Error:
-  186:     document.createNodeIterator(document.body, -1, {}); // invalid
-                                                      ^^ number. Expected number literal `132`, got `-1` instead
-  number literal `132`. See lib: dom.js:655
-  Member 40:
-  polymorphic type: function type. See lib: dom.js:656
-  Error:
-  186:     document.createNodeIterator(document.body, -1, {}); // invalid
-                                                      ^^ number. Expected number literal `133`, got `-1` instead
-  number literal `133`. See lib: dom.js:656
-  Member 41:
-  polymorphic type: function type. See lib: dom.js:657
-  Error:
-  186:     document.createNodeIterator(document.body, -1, {}); // invalid
-                                                          ^^ object literal. This type is incompatible with
-  union: NodeFilterCallback | object type. See lib: dom.js:657
-    Member 1:
-    NodeFilterCallback. See lib: dom.js:1870
-    Error:
-    function type. Callable signature not found in. See lib: dom.js:1870
-    186:     document.createNodeIterator(document.body, -1, {}); // invalid
-                                                            ^^ object literal
-    Member 2:
-    object type. See lib: dom.js:1870
-    Error:
-    property `accept`. Property not found in. See lib: dom.js:1870
-    186:     document.createNodeIterator(document.body, -1, {}); // invalid
-                                                            ^^ object literal
-  Member 42:
-  polymorphic type: function type. See lib: dom.js:668
+  Member 27:
+  polymorphic type: function type. See lib: dom.js:638
   Error:
   186:     document.createNodeIterator(document.body, -1, {}); // invalid
                                        ^^^^^^^^^^^^^ HTMLElement. This type is incompatible with
-  Document. See lib: dom.js:668
+  DocumentFragment. See lib: dom.js:638
+  Member 28:
+  polymorphic type: function type. See lib: dom.js:639
+  Error:
+  186:     document.createNodeIterator(document.body, -1, {}); // invalid
+                                       ^^^^^^^^^^^^^ HTMLElement. This type is incompatible with
+  DocumentFragment. See lib: dom.js:639
+  Member 29:
+  polymorphic type: function type. See lib: dom.js:640
+  Error:
+  186:     document.createNodeIterator(document.body, -1, {}); // invalid
+                                       ^^^^^^^^^^^^^ HTMLElement. This type is incompatible with
+  DocumentFragment. See lib: dom.js:640
+  Member 30:
+  polymorphic type: function type. See lib: dom.js:641
+  Error:
+  186:     document.createNodeIterator(document.body, -1, {}); // invalid
+                                       ^^^^^^^^^^^^^ HTMLElement. This type is incompatible with
+  DocumentFragment. See lib: dom.js:641
+  Member 31:
+  polymorphic type: function type. See lib: dom.js:642
+  Error:
+  186:     document.createNodeIterator(document.body, -1, {}); // invalid
+                                       ^^^^^^^^^^^^^ HTMLElement. This type is incompatible with
+  DocumentFragment. See lib: dom.js:642
+  Member 32:
+  polymorphic type: function type. See lib: dom.js:643
+  Error:
+  186:     document.createNodeIterator(document.body, -1, {}); // invalid
+                                       ^^^^^^^^^^^^^ HTMLElement. This type is incompatible with
+  DocumentFragment. See lib: dom.js:643
+  Member 33:
+  polymorphic type: function type. See lib: dom.js:644
+  Error:
+  186:     document.createNodeIterator(document.body, -1, {}); // invalid
+                                       ^^^^^^^^^^^^^ HTMLElement. This type is incompatible with
+  DocumentFragment. See lib: dom.js:644
+  Member 34:
+  polymorphic type: function type. See lib: dom.js:657
+  Error:
+  186:     document.createNodeIterator(document.body, -1, {}); // invalid
+                                                      ^^ number. Expected number literal `1`, got `-1` instead
+  number literal `1`. See lib: dom.js:657
+  Member 35:
+  polymorphic type: function type. See lib: dom.js:658
+  Error:
+  186:     document.createNodeIterator(document.body, -1, {}); // invalid
+                                                      ^^ number. Expected number literal `4`, got `-1` instead
+  number literal `4`. See lib: dom.js:658
+  Member 36:
+  polymorphic type: function type. See lib: dom.js:659
+  Error:
+  186:     document.createNodeIterator(document.body, -1, {}); // invalid
+                                                      ^^ number. Expected number literal `5`, got `-1` instead
+  number literal `5`. See lib: dom.js:659
+  Member 37:
+  polymorphic type: function type. See lib: dom.js:660
+  Error:
+  186:     document.createNodeIterator(document.body, -1, {}); // invalid
+                                                      ^^ number. Expected number literal `128`, got `-1` instead
+  number literal `128`. See lib: dom.js:660
+  Member 38:
+  polymorphic type: function type. See lib: dom.js:661
+  Error:
+  186:     document.createNodeIterator(document.body, -1, {}); // invalid
+                                                      ^^ number. Expected number literal `129`, got `-1` instead
+  number literal `129`. See lib: dom.js:661
+  Member 39:
+  polymorphic type: function type. See lib: dom.js:662
+  Error:
+  186:     document.createNodeIterator(document.body, -1, {}); // invalid
+                                                      ^^ number. Expected number literal `132`, got `-1` instead
+  number literal `132`. See lib: dom.js:662
+  Member 40:
+  polymorphic type: function type. See lib: dom.js:663
+  Error:
+  186:     document.createNodeIterator(document.body, -1, {}); // invalid
+                                                      ^^ number. Expected number literal `133`, got `-1` instead
+  number literal `133`. See lib: dom.js:663
+  Member 41:
+  polymorphic type: function type. See lib: dom.js:664
+  Error:
+  186:     document.createNodeIterator(document.body, -1, {}); // invalid
+                                                          ^^ object literal. This type is incompatible with
+  union: NodeFilterCallback | object type. See lib: dom.js:664
+    Member 1:
+    NodeFilterCallback. See lib: dom.js:1877
+    Error:
+    function type. Callable signature not found in. See lib: dom.js:1877
+    186:     document.createNodeIterator(document.body, -1, {}); // invalid
+                                                            ^^ object literal
+    Member 2:
+    object type. See lib: dom.js:1877
+    Error:
+    property `accept`. Property not found in. See lib: dom.js:1877
+    186:     document.createNodeIterator(document.body, -1, {}); // invalid
+                                                            ^^ object literal
+  Member 42:
+  polymorphic type: function type. See lib: dom.js:675
+  Error:
+  186:     document.createNodeIterator(document.body, -1, {}); // invalid
+                                       ^^^^^^^^^^^^^ HTMLElement. This type is incompatible with
+  Document. See lib: dom.js:675
   Member 43:
-  polymorphic type: function type. See lib: dom.js:672
+  polymorphic type: function type. See lib: dom.js:679
   Error:
   186:     document.createNodeIterator(document.body, -1, {}); // invalid
                                                       ^^ number. This type is incompatible with
-  undefined. See lib: dom.js:672
+  undefined. See lib: dom.js:679
 
 traversal.js:190
 190:     document.createTreeWalker(document.body, -1, node => 'accept'); // invalid
                                                               ^^^^^^^^ string. This type is incompatible with
-union: typeof typeof-annotation '<<object>>.FILTER_ACCEPT') | typeof typeof-annotation '<<object>>.FILTER_REJECT') | typeof typeof-annotation '<<object>>.FILTER_SKIP'). See lib: dom.js:1866
+union: typeof typeof-annotation '<<object>>.FILTER_ACCEPT') | typeof typeof-annotation '<<object>>.FILTER_REJECT') | typeof typeof-annotation '<<object>>.FILTER_SKIP'). See lib: dom.js:1873
   Member 1:
-  typeof typeof-annotation '<<object>>.FILTER_ACCEPT'). See lib: dom.js:1866
+  typeof typeof-annotation '<<object>>.FILTER_ACCEPT'). See lib: dom.js:1873
   Error:
   190:     document.createTreeWalker(document.body, -1, node => 'accept'); // invalid
                                                                 ^^^^^^^^ string. This type is incompatible with
-  number literal `1`. See lib: dom.js:1866
+  number literal `1`. See lib: dom.js:1873
   Member 2:
-  typeof typeof-annotation '<<object>>.FILTER_REJECT'). See lib: dom.js:1867
+  typeof typeof-annotation '<<object>>.FILTER_REJECT'). See lib: dom.js:1874
   Error:
   190:     document.createTreeWalker(document.body, -1, node => 'accept'); // invalid
                                                                 ^^^^^^^^ string. This type is incompatible with
-  number literal `2`. See lib: dom.js:1867
+  number literal `2`. See lib: dom.js:1874
   Member 3:
-  typeof typeof-annotation '<<object>>.FILTER_SKIP'). See lib: dom.js:1868
+  typeof typeof-annotation '<<object>>.FILTER_SKIP'). See lib: dom.js:1875
   Error:
   190:     document.createTreeWalker(document.body, -1, node => 'accept'); // invalid
                                                                 ^^^^^^^^ string. This type is incompatible with
-  number literal `3`. See lib: dom.js:1868
+  number literal `3`. See lib: dom.js:1875
 
 traversal.js:192
 192:     document.createTreeWalker(document.body, -1, { accept: node => 'accept' }); // invalid
                                                                         ^^^^^^^^ string. This type is incompatible with
-union: typeof typeof-annotation '<<object>>.FILTER_ACCEPT') | typeof typeof-annotation '<<object>>.FILTER_REJECT') | typeof typeof-annotation '<<object>>.FILTER_SKIP'). See lib: dom.js:1866
+union: typeof typeof-annotation '<<object>>.FILTER_ACCEPT') | typeof typeof-annotation '<<object>>.FILTER_REJECT') | typeof typeof-annotation '<<object>>.FILTER_SKIP'). See lib: dom.js:1873
   Member 1:
-  typeof typeof-annotation '<<object>>.FILTER_ACCEPT'). See lib: dom.js:1866
+  typeof typeof-annotation '<<object>>.FILTER_ACCEPT'). See lib: dom.js:1873
   Error:
   192:     document.createTreeWalker(document.body, -1, { accept: node => 'accept' }); // invalid
                                                                           ^^^^^^^^ string. This type is incompatible with
-  number literal `1`. See lib: dom.js:1866
+  number literal `1`. See lib: dom.js:1873
   Member 2:
-  typeof typeof-annotation '<<object>>.FILTER_REJECT'). See lib: dom.js:1867
+  typeof typeof-annotation '<<object>>.FILTER_REJECT'). See lib: dom.js:1874
   Error:
   192:     document.createTreeWalker(document.body, -1, { accept: node => 'accept' }); // invalid
                                                                           ^^^^^^^^ string. This type is incompatible with
-  number literal `2`. See lib: dom.js:1867
+  number literal `2`. See lib: dom.js:1874
   Member 3:
-  typeof typeof-annotation '<<object>>.FILTER_SKIP'). See lib: dom.js:1868
+  typeof typeof-annotation '<<object>>.FILTER_SKIP'). See lib: dom.js:1875
   Error:
   192:     document.createTreeWalker(document.body, -1, { accept: node => 'accept' }); // invalid
                                                                           ^^^^^^^^ string. This type is incompatible with
-  number literal `3`. See lib: dom.js:1868
+  number literal `3`. See lib: dom.js:1875
 
 traversal.js:193
 193:     document.createTreeWalker(document.body, -1, {}); // invalid
@@ -1114,287 +1114,287 @@ traversal.js:193
 193:     document.createTreeWalker(document.body, -1, {}); // invalid
          ^^^^^^^^^^^^^^^^^^^^^^^^^ intersection
   Member 1:
-  polymorphic type: function type. See lib: dom.js:572
+  polymorphic type: function type. See lib: dom.js:579
   Error:
   193:     document.createTreeWalker(document.body, -1, {}); // invalid
                                      ^^^^^^^^^^^^^ HTMLElement. This type is incompatible with
-  Attr. See lib: dom.js:572
+  Attr. See lib: dom.js:579
   Member 2:
-  polymorphic type: function type. See lib: dom.js:603
-  Error:
-  193:     document.createTreeWalker(document.body, -1, {}); // invalid
-                                     ^^^^^^^^^^^^^ HTMLElement. This type is incompatible with
-  Document. See lib: dom.js:603
-  Member 3:
-  polymorphic type: function type. See lib: dom.js:604
-  Error:
-  193:     document.createTreeWalker(document.body, -1, {}); // invalid
-                                     ^^^^^^^^^^^^^ HTMLElement. This type is incompatible with
-  Document. See lib: dom.js:604
-  Member 4:
-  polymorphic type: function type. See lib: dom.js:605
-  Error:
-  193:     document.createTreeWalker(document.body, -1, {}); // invalid
-                                     ^^^^^^^^^^^^^ HTMLElement. This type is incompatible with
-  Document. See lib: dom.js:605
-  Member 5:
-  polymorphic type: function type. See lib: dom.js:606
-  Error:
-  193:     document.createTreeWalker(document.body, -1, {}); // invalid
-                                     ^^^^^^^^^^^^^ HTMLElement. This type is incompatible with
-  Document. See lib: dom.js:606
-  Member 6:
-  polymorphic type: function type. See lib: dom.js:607
-  Error:
-  193:     document.createTreeWalker(document.body, -1, {}); // invalid
-                                     ^^^^^^^^^^^^^ HTMLElement. This type is incompatible with
-  Document. See lib: dom.js:607
-  Member 7:
-  polymorphic type: function type. See lib: dom.js:608
-  Error:
-  193:     document.createTreeWalker(document.body, -1, {}); // invalid
-                                     ^^^^^^^^^^^^^ HTMLElement. This type is incompatible with
-  Document. See lib: dom.js:608
-  Member 8:
-  polymorphic type: function type. See lib: dom.js:609
-  Error:
-  193:     document.createTreeWalker(document.body, -1, {}); // invalid
-                                     ^^^^^^^^^^^^^ HTMLElement. This type is incompatible with
-  Document. See lib: dom.js:609
-  Member 9:
   polymorphic type: function type. See lib: dom.js:610
   Error:
   193:     document.createTreeWalker(document.body, -1, {}); // invalid
                                      ^^^^^^^^^^^^^ HTMLElement. This type is incompatible with
   Document. See lib: dom.js:610
-  Member 10:
+  Member 3:
   polymorphic type: function type. See lib: dom.js:611
   Error:
   193:     document.createTreeWalker(document.body, -1, {}); // invalid
                                      ^^^^^^^^^^^^^ HTMLElement. This type is incompatible with
   Document. See lib: dom.js:611
-  Member 11:
+  Member 4:
   polymorphic type: function type. See lib: dom.js:612
   Error:
   193:     document.createTreeWalker(document.body, -1, {}); // invalid
                                      ^^^^^^^^^^^^^ HTMLElement. This type is incompatible with
   Document. See lib: dom.js:612
-  Member 12:
+  Member 5:
   polymorphic type: function type. See lib: dom.js:613
   Error:
   193:     document.createTreeWalker(document.body, -1, {}); // invalid
                                      ^^^^^^^^^^^^^ HTMLElement. This type is incompatible with
   Document. See lib: dom.js:613
-  Member 13:
+  Member 6:
   polymorphic type: function type. See lib: dom.js:614
   Error:
   193:     document.createTreeWalker(document.body, -1, {}); // invalid
                                      ^^^^^^^^^^^^^ HTMLElement. This type is incompatible with
   Document. See lib: dom.js:614
-  Member 14:
+  Member 7:
   polymorphic type: function type. See lib: dom.js:615
   Error:
   193:     document.createTreeWalker(document.body, -1, {}); // invalid
                                      ^^^^^^^^^^^^^ HTMLElement. This type is incompatible with
   Document. See lib: dom.js:615
-  Member 15:
+  Member 8:
   polymorphic type: function type. See lib: dom.js:616
   Error:
   193:     document.createTreeWalker(document.body, -1, {}); // invalid
                                      ^^^^^^^^^^^^^ HTMLElement. This type is incompatible with
   Document. See lib: dom.js:616
-  Member 16:
+  Member 9:
   polymorphic type: function type. See lib: dom.js:617
   Error:
   193:     document.createTreeWalker(document.body, -1, {}); // invalid
                                      ^^^^^^^^^^^^^ HTMLElement. This type is incompatible with
   Document. See lib: dom.js:617
-  Member 17:
+  Member 10:
   polymorphic type: function type. See lib: dom.js:618
   Error:
   193:     document.createTreeWalker(document.body, -1, {}); // invalid
                                      ^^^^^^^^^^^^^ HTMLElement. This type is incompatible with
   Document. See lib: dom.js:618
-  Member 18:
+  Member 11:
   polymorphic type: function type. See lib: dom.js:619
   Error:
   193:     document.createTreeWalker(document.body, -1, {}); // invalid
                                      ^^^^^^^^^^^^^ HTMLElement. This type is incompatible with
   Document. See lib: dom.js:619
-  Member 19:
+  Member 12:
   polymorphic type: function type. See lib: dom.js:620
   Error:
   193:     document.createTreeWalker(document.body, -1, {}); // invalid
                                      ^^^^^^^^^^^^^ HTMLElement. This type is incompatible with
   Document. See lib: dom.js:620
-  Member 20:
+  Member 13:
   polymorphic type: function type. See lib: dom.js:621
   Error:
   193:     document.createTreeWalker(document.body, -1, {}); // invalid
                                      ^^^^^^^^^^^^^ HTMLElement. This type is incompatible with
   Document. See lib: dom.js:621
-  Member 21:
+  Member 14:
   polymorphic type: function type. See lib: dom.js:622
   Error:
   193:     document.createTreeWalker(document.body, -1, {}); // invalid
                                      ^^^^^^^^^^^^^ HTMLElement. This type is incompatible with
   Document. See lib: dom.js:622
-  Member 22:
+  Member 15:
   polymorphic type: function type. See lib: dom.js:623
   Error:
   193:     document.createTreeWalker(document.body, -1, {}); // invalid
                                      ^^^^^^^^^^^^^ HTMLElement. This type is incompatible with
   Document. See lib: dom.js:623
-  Member 23:
+  Member 16:
   polymorphic type: function type. See lib: dom.js:624
   Error:
   193:     document.createTreeWalker(document.body, -1, {}); // invalid
                                      ^^^^^^^^^^^^^ HTMLElement. This type is incompatible with
   Document. See lib: dom.js:624
-  Member 24:
+  Member 17:
   polymorphic type: function type. See lib: dom.js:625
   Error:
   193:     document.createTreeWalker(document.body, -1, {}); // invalid
                                      ^^^^^^^^^^^^^ HTMLElement. This type is incompatible with
   Document. See lib: dom.js:625
-  Member 25:
+  Member 18:
   polymorphic type: function type. See lib: dom.js:626
   Error:
   193:     document.createTreeWalker(document.body, -1, {}); // invalid
                                      ^^^^^^^^^^^^^ HTMLElement. This type is incompatible with
   Document. See lib: dom.js:626
+  Member 19:
+  polymorphic type: function type. See lib: dom.js:627
+  Error:
+  193:     document.createTreeWalker(document.body, -1, {}); // invalid
+                                     ^^^^^^^^^^^^^ HTMLElement. This type is incompatible with
+  Document. See lib: dom.js:627
+  Member 20:
+  polymorphic type: function type. See lib: dom.js:628
+  Error:
+  193:     document.createTreeWalker(document.body, -1, {}); // invalid
+                                     ^^^^^^^^^^^^^ HTMLElement. This type is incompatible with
+  Document. See lib: dom.js:628
+  Member 21:
+  polymorphic type: function type. See lib: dom.js:629
+  Error:
+  193:     document.createTreeWalker(document.body, -1, {}); // invalid
+                                     ^^^^^^^^^^^^^ HTMLElement. This type is incompatible with
+  Document. See lib: dom.js:629
+  Member 22:
+  polymorphic type: function type. See lib: dom.js:630
+  Error:
+  193:     document.createTreeWalker(document.body, -1, {}); // invalid
+                                     ^^^^^^^^^^^^^ HTMLElement. This type is incompatible with
+  Document. See lib: dom.js:630
+  Member 23:
+  polymorphic type: function type. See lib: dom.js:631
+  Error:
+  193:     document.createTreeWalker(document.body, -1, {}); // invalid
+                                     ^^^^^^^^^^^^^ HTMLElement. This type is incompatible with
+  Document. See lib: dom.js:631
+  Member 24:
+  polymorphic type: function type. See lib: dom.js:632
+  Error:
+  193:     document.createTreeWalker(document.body, -1, {}); // invalid
+                                     ^^^^^^^^^^^^^ HTMLElement. This type is incompatible with
+  Document. See lib: dom.js:632
+  Member 25:
+  polymorphic type: function type. See lib: dom.js:633
+  Error:
+  193:     document.createTreeWalker(document.body, -1, {}); // invalid
+                                     ^^^^^^^^^^^^^ HTMLElement. This type is incompatible with
+  Document. See lib: dom.js:633
   Member 26:
-  polymorphic type: function type. See lib: dom.js:638
-  Error:
-  193:     document.createTreeWalker(document.body, -1, {}); // invalid
-                                     ^^^^^^^^^^^^^ HTMLElement. This type is incompatible with
-  DocumentFragment. See lib: dom.js:638
-  Member 27:
-  polymorphic type: function type. See lib: dom.js:639
-  Error:
-  193:     document.createTreeWalker(document.body, -1, {}); // invalid
-                                     ^^^^^^^^^^^^^ HTMLElement. This type is incompatible with
-  DocumentFragment. See lib: dom.js:639
-  Member 28:
-  polymorphic type: function type. See lib: dom.js:640
-  Error:
-  193:     document.createTreeWalker(document.body, -1, {}); // invalid
-                                     ^^^^^^^^^^^^^ HTMLElement. This type is incompatible with
-  DocumentFragment. See lib: dom.js:640
-  Member 29:
-  polymorphic type: function type. See lib: dom.js:641
-  Error:
-  193:     document.createTreeWalker(document.body, -1, {}); // invalid
-                                     ^^^^^^^^^^^^^ HTMLElement. This type is incompatible with
-  DocumentFragment. See lib: dom.js:641
-  Member 30:
-  polymorphic type: function type. See lib: dom.js:642
-  Error:
-  193:     document.createTreeWalker(document.body, -1, {}); // invalid
-                                     ^^^^^^^^^^^^^ HTMLElement. This type is incompatible with
-  DocumentFragment. See lib: dom.js:642
-  Member 31:
-  polymorphic type: function type. See lib: dom.js:643
-  Error:
-  193:     document.createTreeWalker(document.body, -1, {}); // invalid
-                                     ^^^^^^^^^^^^^ HTMLElement. This type is incompatible with
-  DocumentFragment. See lib: dom.js:643
-  Member 32:
-  polymorphic type: function type. See lib: dom.js:644
-  Error:
-  193:     document.createTreeWalker(document.body, -1, {}); // invalid
-                                     ^^^^^^^^^^^^^ HTMLElement. This type is incompatible with
-  DocumentFragment. See lib: dom.js:644
-  Member 33:
   polymorphic type: function type. See lib: dom.js:645
   Error:
   193:     document.createTreeWalker(document.body, -1, {}); // invalid
                                      ^^^^^^^^^^^^^ HTMLElement. This type is incompatible with
   DocumentFragment. See lib: dom.js:645
+  Member 27:
+  polymorphic type: function type. See lib: dom.js:646
+  Error:
+  193:     document.createTreeWalker(document.body, -1, {}); // invalid
+                                     ^^^^^^^^^^^^^ HTMLElement. This type is incompatible with
+  DocumentFragment. See lib: dom.js:646
+  Member 28:
+  polymorphic type: function type. See lib: dom.js:647
+  Error:
+  193:     document.createTreeWalker(document.body, -1, {}); // invalid
+                                     ^^^^^^^^^^^^^ HTMLElement. This type is incompatible with
+  DocumentFragment. See lib: dom.js:647
+  Member 29:
+  polymorphic type: function type. See lib: dom.js:648
+  Error:
+  193:     document.createTreeWalker(document.body, -1, {}); // invalid
+                                     ^^^^^^^^^^^^^ HTMLElement. This type is incompatible with
+  DocumentFragment. See lib: dom.js:648
+  Member 30:
+  polymorphic type: function type. See lib: dom.js:649
+  Error:
+  193:     document.createTreeWalker(document.body, -1, {}); // invalid
+                                     ^^^^^^^^^^^^^ HTMLElement. This type is incompatible with
+  DocumentFragment. See lib: dom.js:649
+  Member 31:
+  polymorphic type: function type. See lib: dom.js:650
+  Error:
+  193:     document.createTreeWalker(document.body, -1, {}); // invalid
+                                     ^^^^^^^^^^^^^ HTMLElement. This type is incompatible with
+  DocumentFragment. See lib: dom.js:650
+  Member 32:
+  polymorphic type: function type. See lib: dom.js:651
+  Error:
+  193:     document.createTreeWalker(document.body, -1, {}); // invalid
+                                     ^^^^^^^^^^^^^ HTMLElement. This type is incompatible with
+  DocumentFragment. See lib: dom.js:651
+  Member 33:
+  polymorphic type: function type. See lib: dom.js:652
+  Error:
+  193:     document.createTreeWalker(document.body, -1, {}); // invalid
+                                     ^^^^^^^^^^^^^ HTMLElement. This type is incompatible with
+  DocumentFragment. See lib: dom.js:652
   Member 34:
-  polymorphic type: function type. See lib: dom.js:658
-  Error:
-  193:     document.createTreeWalker(document.body, -1, {}); // invalid
-                                                    ^^ number. Expected number literal `1`, got `-1` instead
-  number literal `1`. See lib: dom.js:658
-  Member 35:
-  polymorphic type: function type. See lib: dom.js:659
-  Error:
-  193:     document.createTreeWalker(document.body, -1, {}); // invalid
-                                                    ^^ number. Expected number literal `4`, got `-1` instead
-  number literal `4`. See lib: dom.js:659
-  Member 36:
-  polymorphic type: function type. See lib: dom.js:660
-  Error:
-  193:     document.createTreeWalker(document.body, -1, {}); // invalid
-                                                    ^^ number. Expected number literal `5`, got `-1` instead
-  number literal `5`. See lib: dom.js:660
-  Member 37:
-  polymorphic type: function type. See lib: dom.js:661
-  Error:
-  193:     document.createTreeWalker(document.body, -1, {}); // invalid
-                                                    ^^ number. Expected number literal `128`, got `-1` instead
-  number literal `128`. See lib: dom.js:661
-  Member 38:
-  polymorphic type: function type. See lib: dom.js:662
-  Error:
-  193:     document.createTreeWalker(document.body, -1, {}); // invalid
-                                                    ^^ number. Expected number literal `129`, got `-1` instead
-  number literal `129`. See lib: dom.js:662
-  Member 39:
-  polymorphic type: function type. See lib: dom.js:663
-  Error:
-  193:     document.createTreeWalker(document.body, -1, {}); // invalid
-                                                    ^^ number. Expected number literal `132`, got `-1` instead
-  number literal `132`. See lib: dom.js:663
-  Member 40:
-  polymorphic type: function type. See lib: dom.js:664
-  Error:
-  193:     document.createTreeWalker(document.body, -1, {}); // invalid
-                                                    ^^ number. Expected number literal `133`, got `-1` instead
-  number literal `133`. See lib: dom.js:664
-  Member 41:
   polymorphic type: function type. See lib: dom.js:665
   Error:
   193:     document.createTreeWalker(document.body, -1, {}); // invalid
-                                                        ^^ object literal. This type is incompatible with
-  union: NodeFilterCallback | object type. See lib: dom.js:665
-    Member 1:
-    NodeFilterCallback. See lib: dom.js:1870
-    Error:
-    function type. Callable signature not found in. See lib: dom.js:1870
-    193:     document.createTreeWalker(document.body, -1, {}); // invalid
-                                                          ^^ object literal
-    Member 2:
-    object type. See lib: dom.js:1870
-    Error:
-    property `accept`. Property not found in. See lib: dom.js:1870
-    193:     document.createTreeWalker(document.body, -1, {}); // invalid
-                                                          ^^ object literal
-  Member 42:
+                                                    ^^ number. Expected number literal `1`, got `-1` instead
+  number literal `1`. See lib: dom.js:665
+  Member 35:
+  polymorphic type: function type. See lib: dom.js:666
+  Error:
+  193:     document.createTreeWalker(document.body, -1, {}); // invalid
+                                                    ^^ number. Expected number literal `4`, got `-1` instead
+  number literal `4`. See lib: dom.js:666
+  Member 36:
+  polymorphic type: function type. See lib: dom.js:667
+  Error:
+  193:     document.createTreeWalker(document.body, -1, {}); // invalid
+                                                    ^^ number. Expected number literal `5`, got `-1` instead
+  number literal `5`. See lib: dom.js:667
+  Member 37:
+  polymorphic type: function type. See lib: dom.js:668
+  Error:
+  193:     document.createTreeWalker(document.body, -1, {}); // invalid
+                                                    ^^ number. Expected number literal `128`, got `-1` instead
+  number literal `128`. See lib: dom.js:668
+  Member 38:
   polymorphic type: function type. See lib: dom.js:669
   Error:
   193:     document.createTreeWalker(document.body, -1, {}); // invalid
+                                                    ^^ number. Expected number literal `129`, got `-1` instead
+  number literal `129`. See lib: dom.js:669
+  Member 39:
+  polymorphic type: function type. See lib: dom.js:670
+  Error:
+  193:     document.createTreeWalker(document.body, -1, {}); // invalid
+                                                    ^^ number. Expected number literal `132`, got `-1` instead
+  number literal `132`. See lib: dom.js:670
+  Member 40:
+  polymorphic type: function type. See lib: dom.js:671
+  Error:
+  193:     document.createTreeWalker(document.body, -1, {}); // invalid
+                                                    ^^ number. Expected number literal `133`, got `-1` instead
+  number literal `133`. See lib: dom.js:671
+  Member 41:
+  polymorphic type: function type. See lib: dom.js:672
+  Error:
+  193:     document.createTreeWalker(document.body, -1, {}); // invalid
                                                         ^^ object literal. This type is incompatible with
-  union: NodeFilterCallback | object type. See lib: dom.js:669
+  union: NodeFilterCallback | object type. See lib: dom.js:672
     Member 1:
-    NodeFilterCallback. See lib: dom.js:1870
+    NodeFilterCallback. See lib: dom.js:1877
     Error:
-    function type. Callable signature not found in. See lib: dom.js:1870
+    function type. Callable signature not found in. See lib: dom.js:1877
     193:     document.createTreeWalker(document.body, -1, {}); // invalid
                                                           ^^ object literal
     Member 2:
-    object type. See lib: dom.js:1870
+    object type. See lib: dom.js:1877
     Error:
-    property `accept`. Property not found in. See lib: dom.js:1870
+    property `accept`. Property not found in. See lib: dom.js:1877
+    193:     document.createTreeWalker(document.body, -1, {}); // invalid
+                                                          ^^ object literal
+  Member 42:
+  polymorphic type: function type. See lib: dom.js:676
+  Error:
+  193:     document.createTreeWalker(document.body, -1, {}); // invalid
+                                                        ^^ object literal. This type is incompatible with
+  union: NodeFilterCallback | object type. See lib: dom.js:676
+    Member 1:
+    NodeFilterCallback. See lib: dom.js:1877
+    Error:
+    function type. Callable signature not found in. See lib: dom.js:1877
+    193:     document.createTreeWalker(document.body, -1, {}); // invalid
+                                                          ^^ object literal
+    Member 2:
+    object type. See lib: dom.js:1877
+    Error:
+    property `accept`. Property not found in. See lib: dom.js:1877
     193:     document.createTreeWalker(document.body, -1, {}); // invalid
                                                           ^^ object literal
   Member 43:
-  polymorphic type: function type. See lib: dom.js:673
+  polymorphic type: function type. See lib: dom.js:680
   Error:
   193:     document.createTreeWalker(document.body, -1, {}); // invalid
                                                     ^^ number. This type is incompatible with
-  undefined. See lib: dom.js:673
+  undefined. See lib: dom.js:680
 
 
 Found 24 errors

--- a/website/docs/02-advanced-configuration.md
+++ b/website/docs/02-advanced-configuration.md
@@ -206,7 +206,9 @@ can be overridden with command line flags.
 
     and suppress the error. If there is no error on the next line (the suppression is unnecessary), an "Unused suppression" error will be shown instead.
 
-    **Note:** you can specify `suppress_comment` multiple times. We recommend defining something like `$FlowFixMe` (for type errors that need to be fixed) in addition to `$FlowIssue` (to suppress errors caused by bugs in Flow).
+    If no suppression comments are specified in your config, Flow will apply one default: `// $FlowFixMe`.
+
+    **Note:** You can specify `suppress_comment` multiple times. If you do define any `suppress_comment`s, the built-in `$FlowFixMe` suppression will be erased in favor of the regexps you specify. If you wish to use `$FlowFixMe` with some additional custom suppression comments, you must manually specify `\\(.\\|\n\\)*\\$FlowFixMe` in your custom list of suppressions.
 
 - `temp_dir` (string): Tell Flow which directory to use as a temp directory.
   Defaults to `/tmp/flow`. Can be overridden with the commandline flag


### PR DESCRIPTION
Lots of stuff already uses these and people rarely have a need to specify a
custom one, so let's just ship them by default.

This applies these defaults *only* when no `suppress_comment` or `suppress_type`
entries are set by the user. If the user decides to specify custom comments,
these defaults get blown away.

We consider setting custom `suppress_*` entries to be a configuration for
"power users" -- so if they want the defaults in addition to new comments, they
simply need to specify the defaults explicitly.