### PR TITLE
Improve declaration for Node's process.versions

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -1529,7 +1529,11 @@ declare class Process extends events$EventEmitter {
   umask(mask : number) : number;
   uptime() : number;
   version : string;
-  versions : { [key: string] : ?string };
+  versions : {
+    node : string;
+    v8 : string;
+    [key: string] : ?string;
+  };
 }
 declare var process: Process;
 


### PR DESCRIPTION
Take this snippet:

```js
const nodeVersion = Number(
  process.versions.node.split('.')[0] // WARNING HERE
);

if (nodeVersion >= 4) {
  console.log('yay this is node 4 or higher!');
}
```

Currently, flow warns that `process.versions.node` might be `null`. But that would never be the case.

(Although some of the [process.versions properties](https://nodejs.org/api/process.html#process_process_versions) might not exist on every system, it's a safe bet that `node` and `v8` will always exist, so this PR declares those keys explicitly.)