### PR TITLE
Add AnimationEvent to DOM types

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -261,6 +261,22 @@ declare class KeyboardEvent extends UIEvent {
   which: number;
 }
 
+declare class AnimationEvent extends UIEvent {
+  animationName: string;
+  elapsedTime: number;
+  pseudoElement: string;
+
+  // deprecated
+
+  initAnimationEvent: (
+    type: 'animationstart' | 'animationend' | 'animationiteration',
+    canBubble: boolean,
+    cancelable: boolean,
+    animationName: string,
+    elapsedTime: number
+  ) => void;
+}
+
 // https://www.w3.org/TR/touch-events/#idl-def-Touch
 declare class Touch {
   clientX: number,


### PR DESCRIPTION
All DOM event types with basic browser support should be added to lib/dom.js.
However, AnimationEvent was still missing, this adds support for it.

see https://github.com/facebook/flow/issues/2393
