### PR TITLE
Call out intentional typo in React docs

### DIFF
--- a/website/docs/ref/react.doc.js
+++ b/website/docs/ref/react.doc.js
@@ -103,7 +103,7 @@ const Counter = React.createClass({
     });
   },
   decrement() {
-    // Note: Type below is intentional
+    // Note: Typo below is intentional
     // $ExpectError(todo: improve this error position)
     this.setState({
       valu: this.state.value - 1,

--- a/website/docs/ref/react.doc.js
+++ b/website/docs/ref/react.doc.js
@@ -103,6 +103,7 @@ const Counter = React.createClass({
     });
   },
   decrement() {
+    // Note: Type below is intentional
     // $ExpectError(todo: improve this error position)
     this.setState({
       valu: this.state.value - 1,


### PR DESCRIPTION
We've gotten a few PRs "fixing" this typo. I think this will help.