### PR TITLE
[parser] parse `new.target`

### DIFF
--- a/newtests/new_target/_flowconfig
+++ b/newtests/new_target/_flowconfig
@@ -1,0 +1,8 @@
+[ignore]
+
+[include]
+
+[libs]
+
+[options]
+all=true

--- a/newtests/new_target/test.js
+++ b/newtests/new_target/test.js
@@ -1,0 +1,25 @@
+/* @flow */
+
+
+import {suite, test} from '../../tsrc/test/Tester';
+
+export default suite(({addFile, addFiles, addCode}) => [
+  test('new.target is not supported yet', [
+    addCode(`
+      function x() { new.target(); }
+    `).newErrors(
+        `
+          test.js:4
+            4:       function x() { new.target(); }
+                                    ^^^^^^^^^^ not (sup)ported
+        `,
+      ),
+  ]),
+
+  test('new.target can be suppressed', [
+    addCode(`
+      // $FlowFixMe
+      function x() { new.target; }
+    `).noNewErrors(),
+  ]),
+]);

--- a/src/parser/estree_translator.ml
+++ b/src/parser/estree_translator.ml
@@ -514,7 +514,13 @@ end with type t = Impl.t) = struct
     | loc, TemplateLiteral lit -> template_literal (loc, lit)
     | loc, TaggedTemplate tagged -> tagged_template (loc, tagged)
     | loc, Class c -> class_expression (loc, c)
-    | loc, JSXElement element -> jsx_element (loc, element))
+    | loc, JSXElement element -> jsx_element (loc, element)
+    | loc, MetaProperty meta_prop -> MetaProperty.(
+        node "MetaProperty" loc [|
+          "meta", identifier meta_prop.meta;
+          "property", identifier meta_prop.property;
+        |]
+      ))
 
   and function_expression (loc, _function) = Function.(
     let body = match _function.body with

--- a/src/parser/spider_monkey_ast.ml
+++ b/src/parser/spider_monkey_ast.ml
@@ -735,6 +735,12 @@ and Expression : sig
       typeAnnotation: Type.annotation;
     }
   end
+  module MetaProperty : sig
+    type t = {
+      meta: Identifier.t;
+      property: Identifier.t;
+    }
+  end
 
   type t = Loc.t * t'
   and t' =
@@ -764,6 +770,7 @@ and Expression : sig
     | JSXElement of JSX.element
     | Class of Class.t
     | TypeCast of TypeCast.t
+    | MetaProperty of MetaProperty.t
 end = Expression
 
 and JSX : sig

--- a/src/parser/test/hardcoded_tests.js
+++ b/src/parser/test/hardcoded_tests.js
@@ -1329,6 +1329,83 @@ module.exports = {
         ]
       }
     },
+    'ES6: new.target': {
+        'new.target': {
+          'errors': [
+            {'message': 'Unexpected token .'}
+          ],
+        },
+        'var x = function() { y = new..target; }': {
+          'errors.0': {'message': 'Unexpected token .', 'loc.start.column': 29},
+        },
+        'function x() { new.unknown_property; }': {
+          'errors.0': {
+            'message': 'Unexpected identifier',
+            'loc.start.column': 19,
+            'loc.end.column': 35,
+          },
+        },
+        'function x() { new.target }': {
+          'body.0.body.body.0.expression': {
+            'type': 'MetaProperty',
+            'meta': {'type': 'Identifier', 'name': 'new'},
+            'property': {'type': 'Identifier', 'name': 'target'},
+            'loc.start.column': 15,
+            'loc.end.column': 25,
+          },
+        },
+        'function x() { let x = new.target; }': {
+          'body.0.body.body.0.declarations.0.init': {
+            'type': 'MetaProperty',
+            'meta': {'type': 'Identifier', 'name': 'new'},
+            'property': {'type': 'Identifier', 'name': 'target'},
+            'loc.start.column': 23,
+            'loc.end.column': 33,
+          }
+        },
+        'function x() { new new.target; }': {
+          'body.0.body.body.0.expression': {
+            'type': 'NewExpression',
+            'callee': {
+              'type': 'MetaProperty',
+              'meta': {'type': 'Identifier', 'name': 'new'},
+              'property': {'type': 'Identifier', 'name': 'target'},
+              'loc.start.column': 19,
+              'loc.end.column': 29,
+            }
+          },
+        },
+        'function x() { new.target(); }': {
+          'body.0.body.body.0.expression': {
+            'type': 'CallExpression',
+            'callee': {
+              'type': 'MetaProperty',
+              'meta': {'type': 'Identifier', 'name': 'new'},
+              'property': {'type': 'Identifier', 'name': 'target'},
+              'loc.start.column': 15,
+              'loc.end.column': 25,
+            },
+            'arguments': [],
+          }
+        },
+        'function x() { new new.target()(); }': {
+          'body.0.body.body.0.expression': {
+            'type': 'CallExpression',
+            'callee': {
+              'type': 'NewExpression',
+              'callee': {
+                'type': 'MetaProperty',
+                'meta': {'type': 'Identifier', 'name': 'new'},
+                'property': {'type': 'Identifier', 'name': 'target'},
+                'loc.start.column': 19,
+                'loc.end.column': 29,
+              },
+              'arguments': [],
+            },
+            'arguments': [],
+          }
+        },
+    },
     'Declare Statements': {
       'declare var foo': {
         'body': [{

--- a/src/typing/statement.ml
+++ b/src/typing/statement.ml
@@ -2973,7 +2973,8 @@ and expression_ ~is_cond cx loc e = Ast.Expression.(match e with
   (* TODO *)
   | Comprehension _
   | Generator _
-  | Let _ ->
+  | Let _
+  | MetaProperty _->
     FlowError.add_error cx (loc, ["not (sup)ported"]);
     EmptyT.at loc
 )


### PR DESCRIPTION
Adds parser, but not type system, support for ES6's `new.target`.

See https://github.com/facebook/flow/issues/1152