### PR TITLE
Add next_of_filename_set

### DIFF
--- a/src/parsing/parsing_service_js.ml
+++ b/src/parsing/parsing_service_js.ml
@@ -276,6 +276,9 @@ let merge r1 r2 =
 
 (***************************** public ********************************)
 
+let next_of_filename_set workers filenames =
+  MultiWorker.next workers (FilenameSet.elements filenames)
+
 let parse
   ~types_mode ~use_strict ~profile ~max_header_tokens
   workers next
@@ -306,7 +309,7 @@ let parse
 let reparse ~types_mode ~use_strict ~profile ~max_header_tokens workers files =
   (* save old parsing info for files *)
   ParserHeap.oldify_batch files;
-  let next = MultiWorker.next workers (FilenameSet.elements files) in
+  let next = next_of_filename_set workers files in
   let results =
     parse ~types_mode ~use_strict ~profile ~max_header_tokens workers next in
   let modified =

--- a/src/parsing/parsing_service_js.mli
+++ b/src/parsing/parsing_service_js.mli
@@ -95,3 +95,9 @@ val do_parse:
   string ->                 (* contents of the file *)
   filename ->               (* filename *)
   result
+
+(* Utility to create the `next` parameter that `parse` requires *)
+val next_of_filename_set:
+  Worker.t list option ->
+  FilenameSet.t ->
+  (unit -> filename list)


### PR DESCRIPTION
The `next` parameter to `parse` isn't very ergonomic, and it's inconsistent with `reparse` and `do_parse`. This alleviates that pain a bit.