### PR TITLE
[parser] allow string literals as async property names

### DIFF
--- a/src/parser/parser_env.ml
+++ b/src/parser/parser_env.ml
@@ -384,6 +384,12 @@ module Peek = struct
     | T_IDENTIFIER -> true
     | _ -> false
 
+  let is_literal_property_name ?(i=0) env =
+    is_identifier ~i env || match token ~i env with
+    | T_STRING _
+    | T_NUMBER _ -> true
+    | _ -> false
+
   let is_function ?(i=0) env =
     token ~i env = T_FUNCTION ||
     (token ~i env = T_ASYNC && token ~i:(i+1) env = T_FUNCTION)

--- a/src/parser/parser_env.mli
+++ b/src/parser/parser_env.mli
@@ -115,6 +115,7 @@ module Peek : sig
   val is_implicit_semicolon : env -> bool
   val semicolon_loc : ?i:int -> env -> Loc.t option
   val is_identifier : ?i:int -> env -> bool
+  val is_literal_property_name : ?i:int -> env -> bool
   val is_function : ?i:int -> env -> bool
   val is_class : ?i:int -> env -> bool
 end

--- a/src/parser/parser_flow.ml
+++ b/src/parser/parser_flow.ml
@@ -2034,7 +2034,8 @@ end = struct
         end else begin
           (* look for a following identifier to tell whether to parse a function
            * or not *)
-          let async = Peek.is_identifier ~i:1 env && Declaration.async env in
+          let async =
+            Peek.is_literal_property_name ~i:1 env && Declaration.async env in
           Property (match async , Declaration.generator env async, key env with
           | false, false, (_, (Property.Identifier (_, { Ast.Identifier.name =
               "get"; _}) as key)) ->

--- a/src/parser/test/esprima_tests.js
+++ b/src/parser/test/esprima_tests.js
@@ -5327,6 +5327,8 @@ module.exports = {
         'foo(async () => await bar);',
         'var x = async\ny => y',
         'class A { async bar() { await foo; } }',
+        'var x = { async "foo"() { await y; } }',
+        'var x = { async 123() { await y; } }',
     ],
   }
 };


### PR DESCRIPTION
Fixes https://github.com/facebook/flow/issues/637

The [_AsyncMethod_](https://tc39.github.io/ecmascript-asyncawait/#prod-AsyncMethod) production allows any _PropertyName_, which are identifiers, string literals, number literals and computed properties.

This fixes strings and numbers, but not computed properties.