### PR TITLE
FormData definitions

### DIFF
--- a/lib/bom.js
+++ b/lib/bom.js
@@ -241,7 +241,16 @@ declare class DOMParser {
 }
 
 declare class FormData {
-    append(name: any, value: any, blobName?: string): void;
+    constructor(form?: HTMLFormElement): void;
+    has(name: string): boolean;
+    get(name: string): ?string;
+    getAll(name: string): Array<string>;
+    set(name: string, value: string, blobName?: string): void;
+    append(name: string, value: string, blobName?: string): void;
+    delete(name: string): void;
+    keys(): Iterator<string>;
+    values(): Iterator<string>;
+    entries(): Iterator<[string, string]>;
 }
 
 declare class MutationRecord {

--- a/lib/bom.js
+++ b/lib/bom.js
@@ -240,17 +240,28 @@ declare class DOMParser {
     parseFromString(source: string, mimeType: string): Document;
 }
 
+type FormDataEntryValue = string | File
+
 declare class FormData {
     constructor(form?: HTMLFormElement): void;
+
     has(name: string): boolean;
-    get(name: string): ?string;
-    getAll(name: string): Array<string>;
-    set(name: string, value: string, blobName?: string): void;
-    append(name: string, value: string, blobName?: string): void;
+    get(name: string): ?FormDataEntryValue;
+    getAll(name: string): Array<FormDataEntryValue>;
+
+    set(name: string, value: string): void;
+    set(name: string, value: Blob, filename?: string): void;
+    set(name: string, value: File, filename?: string): void;
+
+    append(name: string, value: string): void;
+    append(name: string, value: Blob, filename?: string): void;
+    append(name: string, value: File, filename?: string): void;
+
     delete(name: string): void;
+
     keys(): Iterator<string>;
-    values(): Iterator<string>;
-    entries(): Iterator<[string, string]>;
+    values(): Iterator<FormDataEntryValue>;
+    entries(): Iterator<[string, FormDataEntryValue]>;
 }
 
 declare class MutationRecord {

--- a/tests/bom/FormData.js
+++ b/tests/bom/FormData.js
@@ -1,0 +1,52 @@
+/* @flow */
+
+// constructor
+const a: FormData = new FormData(); // correct
+new FormData(''); // incorrect
+new FormData(document.createElement('input')); // incorrect
+new FormData(document.createElement('form')); // correct
+
+// has
+const b: boolean = a.has('foo'); // correct
+
+// get
+const c: ?string = a.get('foo'); // correct
+const d: string = a.get('foo'); // incorrect
+a.get(2); // incorrect
+
+// getAll
+a.getAll('foo').map((x: string) => x); // correct
+a.getAll('foo').map((x: number) => x); // incorrect
+a.getAll(23); // incorrect
+
+// set
+a.set('foo', 'bar'); // correct
+a.set('foo', {}); // incorrect
+a.set(2, 'bar'); // incorrect
+a.set('foo', 'bar', 'baz'); // correct
+a.set('foo', 'bar', {}); // incorrect
+
+// append
+a.append('foo', 'bar'); // correct
+a.append('foo', {}); // incorrect
+a.append(2, 'bar'); // incorrect
+a.append('foo', 'bar', 'baz'); // correct
+a.append('foo', 'bar', {}); // incorrect
+
+// delete
+a.delete('xx'); // correct
+a.delete(3); // incorrect
+
+// keys
+for (let x: string of a.keys()) {} // correct
+for (let x: number of a.keys()) {} // incorrect
+
+// values
+for (let x: string of a.values()) {} // correct
+for (let x: number of a.values()) {} // incorrect
+
+// entries
+for (let [x, y]: [string, string] of a.entries()) {} // correct
+for (let [x, y]: [number, string] of a.entries()) {} // incorrect
+for (let [x, y]: [string, number] of a.entries()) {} // incorrect
+for (let [x, y]: [number, number] of a.entries()) {} // incorrect

--- a/tests/bom/FormData.js
+++ b/tests/bom/FormData.js
@@ -10,28 +10,42 @@ new FormData(document.createElement('form')); // correct
 const b: boolean = a.has('foo'); // correct
 
 // get
-const c: ?string = a.get('foo'); // correct
+const c: ?(string | File) = a.get('foo'); // correct
 const d: string = a.get('foo'); // incorrect
+const e: Blob = a.get('foo'); // incorrect
+const f: ?(string | File | Blob) = a.get('foo'); // incorrect
 a.get(2); // incorrect
 
 // getAll
-a.getAll('foo').map((x: string) => x); // correct
-a.getAll('foo').map((x: number) => x); // incorrect
+const a1: Array<string | File> = a.getAll('foo'); // correct
+const a2: Array<string | File | number> = a.getAll('foo'); // incorrect
+const a3: Array<string | Blob | File> = a.getAll('foo'); // incorrect
 a.getAll(23); // incorrect
 
 // set
 a.set('foo', 'bar'); // correct
 a.set('foo', {}); // incorrect
 a.set(2, 'bar'); // incorrect
-a.set('foo', 'bar', 'baz'); // correct
-a.set('foo', 'bar', {}); // incorrect
+a.set('foo', 'bar', 'baz'); // incorrect
+a.set('bar', new File([], 'q')) // correct
+a.set('bar', new File([], 'q'), 'x') // correct
+a.set('bar', new File([], 'q'), 2) // incorrect
+a.set('bar', new Blob) // correct
+a.set('bar', new Blob, 'x') // correct
+a.set('bar', new Blob, 2) // incorrect
 
 // append
 a.append('foo', 'bar'); // correct
 a.append('foo', {}); // incorrect
 a.append(2, 'bar'); // incorrect
-a.append('foo', 'bar', 'baz'); // correct
-a.append('foo', 'bar', {}); // incorrect
+a.append('foo', 'bar', 'baz'); // incorrect
+a.append('foo', 'bar'); // incorrect
+a.append('bar', new File([], 'q')) // correct
+a.append('bar', new File([], 'q'), 'x') // correct
+a.append('bar', new File([], 'q'), 2) // incorrect
+a.append('bar', new Blob) // correct
+a.append('bar', new Blob, 'x') // correct
+a.append('bar', new Blob, 2) // incorrect
 
 // delete
 a.delete('xx'); // correct
@@ -42,11 +56,12 @@ for (let x: string of a.keys()) {} // correct
 for (let x: number of a.keys()) {} // incorrect
 
 // values
-for (let x: string of a.values()) {} // correct
-for (let x: number of a.values()) {} // incorrect
+for (let x: string | File of a.values()) {} // correct
+for (let x: string | File | Blob of a.values()) {} // incorrect
 
 // entries
-for (let [x, y]: [string, string] of a.entries()) {} // correct
+for (let [x, y]: [string, string | File] of a.entries()) {} // correct
+for (let [x, y]: [string, string | File | Blob] of a.entries()) {} // incorrect
 for (let [x, y]: [number, string] of a.entries()) {} // incorrect
 for (let [x, y]: [string, number] of a.entries()) {} // incorrect
 for (let [x, y]: [number, number] of a.entries()) {} // incorrect

--- a/tests/bom/bom.exp
+++ b/tests/bom/bom.exp
@@ -3,14 +3,22 @@ FormData.js:5
      ^^^^^^^^^^^^^^^^ constructor call
   5: new FormData(''); // incorrect
                   ^^ string. This type is incompatible with
-HTMLFormElement. See lib: bom.js:244
+HTMLFormElement. See lib: bom.js:246
 
 FormData.js:6
   6: new FormData(document.createElement('input')); // incorrect
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call of method `createElement`
   6: new FormData(document.createElement('input')); // incorrect
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ HTMLInputElement. This type is incompatible with
-HTMLFormElement. See lib: bom.js:244
+HTMLFormElement. See lib: bom.js:246
+
+FormData.js:14
+ 14: const d: string = a.get('foo'); // incorrect
+                       ^^^^^^^^^^^^ call of method `get`
+ 14: const d: string = a.get('foo'); // incorrect
+                       ^^^^^^^^^^^^ File. This type is incompatible with
+ 14: const d: string = a.get('foo'); // incorrect
+              ^^^^^^ string
 
 FormData.js:14
  14: const d: string = a.get('foo'); // incorrect
@@ -29,126 +37,406 @@ FormData.js:14
               ^^^^^^ string
 
 FormData.js:15
- 15: a.get(2); // incorrect
+ 15: const e: Blob = a.get('foo'); // incorrect
+                     ^^^^^^^^^^^^ call of method `get`
+ 15: const e: Blob = a.get('foo'); // incorrect
+                     ^^^^^^^^^^^^ null. This type is incompatible with
+ 15: const e: Blob = a.get('foo'); // incorrect
+              ^^^^ Blob
+
+FormData.js:15
+ 15: const e: Blob = a.get('foo'); // incorrect
+                     ^^^^^^^^^^^^ call of method `get`
+ 15: const e: Blob = a.get('foo'); // incorrect
+                     ^^^^^^^^^^^^ string. This type is incompatible with
+ 15: const e: Blob = a.get('foo'); // incorrect
+              ^^^^ Blob
+
+FormData.js:15
+ 15: const e: Blob = a.get('foo'); // incorrect
+                     ^^^^^^^^^^^^ call of method `get`
+ 15: const e: Blob = a.get('foo'); // incorrect
+                     ^^^^^^^^^^^^ undefined. This type is incompatible with
+ 15: const e: Blob = a.get('foo'); // incorrect
+              ^^^^ Blob
+
+FormData.js:17
+ 17: a.get(2); // incorrect
      ^^^^^^^^ call of method `get`
- 15: a.get(2); // incorrect
+ 17: a.get(2); // incorrect
            ^ number. This type is incompatible with
-string. See lib: bom.js:246
+string. See lib: bom.js:249
 
-FormData.js:19
- 19: a.getAll('foo').map((x: number) => x); // incorrect
-     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call of method `map`
- 19: a.getAll('foo').map((x: number) => x); // incorrect
-                             ^^^^^^ number. This type is incompatible with
-string. See lib: bom.js:247
+FormData.js:21
+ 21: const a2: Array<string | File | number> = a.getAll('foo'); // incorrect
+                                               ^^^^^^^^^^^^^^^ call of method `getAll`
+ 21: const a2: Array<string | File | number> = a.getAll('foo'); // incorrect
+                                     ^^^^^^ number. This type is incompatible with
+union: string | File. See lib: bom.js:250
+  Member 1:
+  string. See lib: bom.js:243
+  Error:
+   21: const a2: Array<string | File | number> = a.getAll('foo'); // incorrect
+                                       ^^^^^^ number. This type is incompatible with
+  string. See lib: bom.js:243
+  Member 2:
+  File. See lib: bom.js:243
+  Error:
+   21: const a2: Array<string | File | number> = a.getAll('foo'); // incorrect
+                                       ^^^^^^ number. This type is incompatible with
+  File. See lib: bom.js:243
 
-FormData.js:20
- 20: a.getAll(23); // incorrect
+FormData.js:22
+ 22: const a3: Array<string | Blob | File> = a.getAll('foo'); // incorrect
+                                             ^^^^^^^^^^^^^^^ call of method `getAll`
+ 22: const a3: Array<string | Blob | File> = a.getAll('foo'); // incorrect
+                              ^^^^ Blob. This type is incompatible with
+union: string | File. See lib: bom.js:250
+  Member 1:
+  string. See lib: bom.js:243
+  Error:
+   22: const a3: Array<string | Blob | File> = a.getAll('foo'); // incorrect
+                                ^^^^ Blob. This type is incompatible with
+  string. See lib: bom.js:243
+  Member 2:
+  File. See lib: bom.js:243
+  Error:
+   22: const a3: Array<string | Blob | File> = a.getAll('foo'); // incorrect
+                                ^^^^ Blob. This type is incompatible with
+  File. See lib: bom.js:243
+
+FormData.js:23
+ 23: a.getAll(23); // incorrect
      ^^^^^^^^^^^^ call of method `getAll`
- 20: a.getAll(23); // incorrect
+ 23: a.getAll(23); // incorrect
               ^^ number. This type is incompatible with
-string. See lib: bom.js:247
-
-FormData.js:24
- 24: a.set('foo', {}); // incorrect
-     ^^^^^^^^^^^^^^^^ call of method `set`
- 24: a.set('foo', {}); // incorrect
-                  ^^ object literal. This type is incompatible with
-string. See lib: bom.js:248
-
-FormData.js:25
- 25: a.set(2, 'bar'); // incorrect
-     ^^^^^^^^^^^^^^^ call of method `set`
- 25: a.set(2, 'bar'); // incorrect
-           ^ number. This type is incompatible with
-string. See lib: bom.js:248
-
-FormData.js:27
- 27: a.set('foo', 'bar', {}); // incorrect
-     ^^^^^^^^^^^^^^^^^^^^^^^ call of method `set`
- 27: a.set('foo', 'bar', {}); // incorrect
-                         ^^ object literal. This type is incompatible with
-string. See lib: bom.js:248
-
-FormData.js:31
- 31: a.append('foo', {}); // incorrect
-     ^^^^^^^^^^^^^^^^^^^ call of method `append`
- 31: a.append('foo', {}); // incorrect
-                     ^^ object literal. This type is incompatible with
-string. See lib: bom.js:249
-
-FormData.js:32
- 32: a.append(2, 'bar'); // incorrect
-     ^^^^^^^^^^^^^^^^^^ call of method `append`
- 32: a.append(2, 'bar'); // incorrect
-              ^ number. This type is incompatible with
-string. See lib: bom.js:249
-
-FormData.js:34
- 34: a.append('foo', 'bar', {}); // incorrect
-     ^^^^^^^^^^^^^^^^^^^^^^^^^^ call of method `append`
- 34: a.append('foo', 'bar', {}); // incorrect
-                            ^^ object literal. This type is incompatible with
-string. See lib: bom.js:249
-
-FormData.js:38
- 38: a.delete(3); // incorrect
-     ^^^^^^^^^^^ call of method `delete`
- 38: a.delete(3); // incorrect
-              ^ number. This type is incompatible with
 string. See lib: bom.js:250
 
-FormData.js:42
- 42: for (let x: number of a.keys()) {} // incorrect
+FormData.js:27
+ 27: a.set('foo', {}); // incorrect
+     ^^^^^^^^^^^^^^^^ call of method `set`. Function cannot be called on any member of intersection type
+ 27: a.set('foo', {}); // incorrect
+     ^^^^^ intersection
+  Member 1:
+  function type. See lib: bom.js:252
+  Error:
+   27: a.set('foo', {}); // incorrect
+                    ^^ object literal. This type is incompatible with
+  string. See lib: bom.js:252
+  Member 2:
+  function type. See lib: bom.js:253
+  Error:
+   27: a.set('foo', {}); // incorrect
+                    ^^ object literal. This type is incompatible with
+  Blob. See lib: bom.js:253
+  Member 3:
+  function type. See lib: bom.js:254
+  Error:
+   27: a.set('foo', {}); // incorrect
+                    ^^ object literal. This type is incompatible with
+  File. See lib: bom.js:254
+
+FormData.js:28
+ 28: a.set(2, 'bar'); // incorrect
+     ^^^^^^^^^^^^^^^ call of method `set`. Function cannot be called on any member of intersection type
+ 28: a.set(2, 'bar'); // incorrect
+     ^^^^^ intersection
+  Member 1:
+  function type. See lib: bom.js:252
+  Error:
+   28: a.set(2, 'bar'); // incorrect
+             ^ number. This type is incompatible with
+  string. See lib: bom.js:252
+  Member 2:
+  function type. See lib: bom.js:253
+  Error:
+   28: a.set(2, 'bar'); // incorrect
+             ^ number. This type is incompatible with
+  string. See lib: bom.js:253
+  Member 3:
+  function type. See lib: bom.js:254
+  Error:
+   28: a.set(2, 'bar'); // incorrect
+             ^ number. This type is incompatible with
+  string. See lib: bom.js:254
+
+FormData.js:32
+ 32: a.set('bar', new File([], 'q'), 2) // incorrect
+     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call of method `set`. Function cannot be called on any member of intersection type
+ 32: a.set('bar', new File([], 'q'), 2) // incorrect
+     ^^^^^ intersection
+  Member 1:
+  function type. See lib: bom.js:252
+  Error:
+   32: a.set('bar', new File([], 'q'), 2) // incorrect
+                        ^^^^ File. This type is incompatible with
+  string. See lib: bom.js:252
+  Member 2:
+  function type. See lib: bom.js:253
+  Error:
+   32: a.set('bar', new File([], 'q'), 2) // incorrect
+                                       ^ number. This type is incompatible with
+  string. See lib: bom.js:253
+  Member 3:
+  function type. See lib: bom.js:254
+  Error:
+   32: a.set('bar', new File([], 'q'), 2) // incorrect
+                                       ^ number. This type is incompatible with
+  string. See lib: bom.js:254
+
+FormData.js:35
+ 35: a.set('bar', new Blob, 2) // incorrect
+     ^^^^^^^^^^^^^^^^^^^^^^^^^ call of method `set`. Function cannot be called on any member of intersection type
+ 35: a.set('bar', new Blob, 2) // incorrect
+     ^^^^^ intersection
+  Member 1:
+  function type. See lib: bom.js:252
+  Error:
+   35: a.set('bar', new Blob, 2) // incorrect
+                        ^^^^ Blob. This type is incompatible with
+  string. See lib: bom.js:252
+  Member 2:
+  function type. See lib: bom.js:253
+  Error:
+   35: a.set('bar', new Blob, 2) // incorrect
+                              ^ number. This type is incompatible with
+  string. See lib: bom.js:253
+  Member 3:
+  function type. See lib: bom.js:254
+  Error:
+   35: a.set('bar', new Blob, 2) // incorrect
+                        ^^^^ Blob. This type is incompatible with
+  File. See lib: bom.js:254
+
+FormData.js:39
+ 39: a.append('foo', {}); // incorrect
+     ^^^^^^^^^^^^^^^^^^^ call of method `append`. Function cannot be called on any member of intersection type
+ 39: a.append('foo', {}); // incorrect
+     ^^^^^^^^ intersection
+  Member 1:
+  function type. See lib: bom.js:256
+  Error:
+   39: a.append('foo', {}); // incorrect
+                       ^^ object literal. This type is incompatible with
+  string. See lib: bom.js:256
+  Member 2:
+  function type. See lib: bom.js:257
+  Error:
+   39: a.append('foo', {}); // incorrect
+                       ^^ object literal. This type is incompatible with
+  Blob. See lib: bom.js:257
+  Member 3:
+  function type. See lib: bom.js:258
+  Error:
+   39: a.append('foo', {}); // incorrect
+                       ^^ object literal. This type is incompatible with
+  File. See lib: bom.js:258
+
+FormData.js:40
+ 40: a.append(2, 'bar'); // incorrect
+     ^^^^^^^^^^^^^^^^^^ call of method `append`. Function cannot be called on any member of intersection type
+ 40: a.append(2, 'bar'); // incorrect
+     ^^^^^^^^ intersection
+  Member 1:
+  function type. See lib: bom.js:256
+  Error:
+   40: a.append(2, 'bar'); // incorrect
+                ^ number. This type is incompatible with
+  string. See lib: bom.js:256
+  Member 2:
+  function type. See lib: bom.js:257
+  Error:
+   40: a.append(2, 'bar'); // incorrect
+                ^ number. This type is incompatible with
+  string. See lib: bom.js:257
+  Member 3:
+  function type. See lib: bom.js:258
+  Error:
+   40: a.append(2, 'bar'); // incorrect
+                ^ number. This type is incompatible with
+  string. See lib: bom.js:258
+
+FormData.js:45
+ 45: a.append('bar', new File([], 'q'), 2) // incorrect
+     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call of method `append`. Function cannot be called on any member of intersection type
+ 45: a.append('bar', new File([], 'q'), 2) // incorrect
+     ^^^^^^^^ intersection
+  Member 1:
+  function type. See lib: bom.js:256
+  Error:
+   45: a.append('bar', new File([], 'q'), 2) // incorrect
+                           ^^^^ File. This type is incompatible with
+  string. See lib: bom.js:256
+  Member 2:
+  function type. See lib: bom.js:257
+  Error:
+   45: a.append('bar', new File([], 'q'), 2) // incorrect
+                                          ^ number. This type is incompatible with
+  string. See lib: bom.js:257
+  Member 3:
+  function type. See lib: bom.js:258
+  Error:
+   45: a.append('bar', new File([], 'q'), 2) // incorrect
+                                          ^ number. This type is incompatible with
+  string. See lib: bom.js:258
+
+FormData.js:48
+ 48: a.append('bar', new Blob, 2) // incorrect
+     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call of method `append`. Function cannot be called on any member of intersection type
+ 48: a.append('bar', new Blob, 2) // incorrect
+     ^^^^^^^^ intersection
+  Member 1:
+  function type. See lib: bom.js:256
+  Error:
+   48: a.append('bar', new Blob, 2) // incorrect
+                           ^^^^ Blob. This type is incompatible with
+  string. See lib: bom.js:256
+  Member 2:
+  function type. See lib: bom.js:257
+  Error:
+   48: a.append('bar', new Blob, 2) // incorrect
+                                 ^ number. This type is incompatible with
+  string. See lib: bom.js:257
+  Member 3:
+  function type. See lib: bom.js:258
+  Error:
+   48: a.append('bar', new Blob, 2) // incorrect
+                           ^^^^ Blob. This type is incompatible with
+  File. See lib: bom.js:258
+
+FormData.js:52
+ 52: a.delete(3); // incorrect
+     ^^^^^^^^^^^ call of method `delete`
+ 52: a.delete(3); // incorrect
+              ^ number. This type is incompatible with
+string. See lib: bom.js:260
+
+FormData.js:56
+ 56: for (let x: number of a.keys()) {} // incorrect
               ^^^^^^^^^ string. This type is incompatible with
- 42: for (let x: number of a.keys()) {} // incorrect
+ 56: for (let x: number of a.keys()) {} // incorrect
                  ^^^^^^ number
 
-FormData.js:46
- 46: for (let x: number of a.values()) {} // incorrect
-              ^^^^^^^^^ string. This type is incompatible with
- 46: for (let x: number of a.values()) {} // incorrect
-                 ^^^^^^ number
+FormData.js:64
+ 64: for (let [x, y]: [string, string | File | Blob] of a.entries()) {} // incorrect
+                                               ^^^^ Blob. This type is incompatible with
+union: string | File. See lib: bom.js:264
+  Member 1:
+  string. See lib: bom.js:243
+  Error:
+   64: for (let [x, y]: [string, string | File | Blob] of a.entries()) {} // incorrect
+                                                 ^^^^ Blob. This type is incompatible with
+  string. See lib: bom.js:243
+  Member 2:
+  File. See lib: bom.js:243
+  Error:
+   64: for (let [x, y]: [string, string | File | Blob] of a.entries()) {} // incorrect
+                                                 ^^^^ Blob. This type is incompatible with
+  File. See lib: bom.js:243
 
-FormData.js:50
- 50: for (let [x, y]: [number, string] of a.entries()) {} // incorrect
+FormData.js:65
+ 65: for (let [x, y]: [number, string] of a.entries()) {} // incorrect
                ^ number. This type is incompatible with
-string. See lib: bom.js:253
+string. See lib: bom.js:264
 
-FormData.js:50
- 50: for (let [x, y]: [number, string] of a.entries()) {} // incorrect
+FormData.js:65
+ 65: for (let [x, y]: [number, string] of a.entries()) {} // incorrect
+                  ^ string. This type is incompatible with
+File. See lib: bom.js:264
+
+FormData.js:65
+ 65: for (let [x, y]: [number, string] of a.entries()) {} // incorrect
                        ^^^^^^ number. This type is incompatible with
-string. See lib: bom.js:253
+string. See lib: bom.js:264
 
-FormData.js:51
- 51: for (let [x, y]: [string, number] of a.entries()) {} // incorrect
+FormData.js:65
+ 65: for (let [x, y]: [number, string] of a.entries()) {} // incorrect
+                               ^^^^^^ string. This type is incompatible with
+File. See lib: bom.js:264
+
+FormData.js:66
+ 66: for (let [x, y]: [string, number] of a.entries()) {} // incorrect
                   ^ number. This type is incompatible with
-string. See lib: bom.js:253
+File. See lib: bom.js:264
 
-FormData.js:51
- 51: for (let [x, y]: [string, number] of a.entries()) {} // incorrect
+FormData.js:66
+ 66: for (let [x, y]: [string, number] of a.entries()) {} // incorrect
+                  ^ number. This type is incompatible with
+string. See lib: bom.js:264
+
+FormData.js:66
+ 66: for (let [x, y]: [string, number] of a.entries()) {} // incorrect
                                ^^^^^^ number. This type is incompatible with
-string. See lib: bom.js:253
+File. See lib: bom.js:264
 
-FormData.js:52
- 52: for (let [x, y]: [number, number] of a.entries()) {} // incorrect
+FormData.js:66
+ 66: for (let [x, y]: [string, number] of a.entries()) {} // incorrect
+                               ^^^^^^ number. This type is incompatible with
+string. See lib: bom.js:264
+
+FormData.js:66
+ 66: for (let [x, y]: [string, number] of a.entries()) {} // incorrect
+                               ^^^^^^ number. This type is incompatible with
+union: string | File. See lib: bom.js:264
+  Member 1:
+  string. See lib: bom.js:243
+  Error:
+   66: for (let [x, y]: [string, number] of a.entries()) {} // incorrect
+                                 ^^^^^^ number. This type is incompatible with
+  string. See lib: bom.js:243
+  Member 2:
+  File. See lib: bom.js:243
+  Error:
+   66: for (let [x, y]: [string, number] of a.entries()) {} // incorrect
+                                 ^^^^^^ number. This type is incompatible with
+  File. See lib: bom.js:243
+
+FormData.js:67
+ 67: for (let [x, y]: [number, number] of a.entries()) {} // incorrect
                ^ number. This type is incompatible with
-string. See lib: bom.js:253
+string. See lib: bom.js:264
 
-FormData.js:52
- 52: for (let [x, y]: [number, number] of a.entries()) {} // incorrect
+FormData.js:67
+ 67: for (let [x, y]: [number, number] of a.entries()) {} // incorrect
                   ^ number. This type is incompatible with
-string. See lib: bom.js:253
+File. See lib: bom.js:264
 
-FormData.js:52
- 52: for (let [x, y]: [number, number] of a.entries()) {} // incorrect
+FormData.js:67
+ 67: for (let [x, y]: [number, number] of a.entries()) {} // incorrect
+                  ^ number. This type is incompatible with
+string. See lib: bom.js:264
+
+FormData.js:67
+ 67: for (let [x, y]: [number, number] of a.entries()) {} // incorrect
                        ^^^^^^ number. This type is incompatible with
-string. See lib: bom.js:253
+string. See lib: bom.js:264
 
-FormData.js:52
- 52: for (let [x, y]: [number, number] of a.entries()) {} // incorrect
+FormData.js:67
+ 67: for (let [x, y]: [number, number] of a.entries()) {} // incorrect
                                ^^^^^^ number. This type is incompatible with
-string. See lib: bom.js:253
+File. See lib: bom.js:264
+
+FormData.js:67
+ 67: for (let [x, y]: [number, number] of a.entries()) {} // incorrect
+                               ^^^^^^ number. This type is incompatible with
+string. See lib: bom.js:264
+
+FormData.js:67
+ 67: for (let [x, y]: [number, number] of a.entries()) {} // incorrect
+                               ^^^^^^ number. This type is incompatible with
+union: string | File. See lib: bom.js:264
+  Member 1:
+  string. See lib: bom.js:243
+  Error:
+   67: for (let [x, y]: [number, number] of a.entries()) {} // incorrect
+                                 ^^^^^^ number. This type is incompatible with
+  string. See lib: bom.js:243
+  Member 2:
+  File. See lib: bom.js:243
+  Error:
+   67: for (let [x, y]: [number, number] of a.entries()) {} // incorrect
+                                 ^^^^^^ number. This type is incompatible with
+  File. See lib: bom.js:243
 
 
-Found 24 errors
+Found 39 errors

--- a/tests/bom/bom.exp
+++ b/tests/bom/bom.exp
@@ -1,0 +1,154 @@
+FormData.js:5
+  5: new FormData(''); // incorrect
+     ^^^^^^^^^^^^^^^^ constructor call
+  5: new FormData(''); // incorrect
+                  ^^ string. This type is incompatible with
+HTMLFormElement. See lib: bom.js:244
+
+FormData.js:6
+  6: new FormData(document.createElement('input')); // incorrect
+                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call of method `createElement`
+  6: new FormData(document.createElement('input')); // incorrect
+                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ HTMLInputElement. This type is incompatible with
+HTMLFormElement. See lib: bom.js:244
+
+FormData.js:14
+ 14: const d: string = a.get('foo'); // incorrect
+                       ^^^^^^^^^^^^ call of method `get`
+ 14: const d: string = a.get('foo'); // incorrect
+                       ^^^^^^^^^^^^ null. This type is incompatible with
+ 14: const d: string = a.get('foo'); // incorrect
+              ^^^^^^ string
+
+FormData.js:14
+ 14: const d: string = a.get('foo'); // incorrect
+                       ^^^^^^^^^^^^ call of method `get`
+ 14: const d: string = a.get('foo'); // incorrect
+                       ^^^^^^^^^^^^ undefined. This type is incompatible with
+ 14: const d: string = a.get('foo'); // incorrect
+              ^^^^^^ string
+
+FormData.js:15
+ 15: a.get(2); // incorrect
+     ^^^^^^^^ call of method `get`
+ 15: a.get(2); // incorrect
+           ^ number. This type is incompatible with
+string. See lib: bom.js:246
+
+FormData.js:19
+ 19: a.getAll('foo').map((x: number) => x); // incorrect
+     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call of method `map`
+ 19: a.getAll('foo').map((x: number) => x); // incorrect
+                             ^^^^^^ number. This type is incompatible with
+string. See lib: bom.js:247
+
+FormData.js:20
+ 20: a.getAll(23); // incorrect
+     ^^^^^^^^^^^^ call of method `getAll`
+ 20: a.getAll(23); // incorrect
+              ^^ number. This type is incompatible with
+string. See lib: bom.js:247
+
+FormData.js:24
+ 24: a.set('foo', {}); // incorrect
+     ^^^^^^^^^^^^^^^^ call of method `set`
+ 24: a.set('foo', {}); // incorrect
+                  ^^ object literal. This type is incompatible with
+string. See lib: bom.js:248
+
+FormData.js:25
+ 25: a.set(2, 'bar'); // incorrect
+     ^^^^^^^^^^^^^^^ call of method `set`
+ 25: a.set(2, 'bar'); // incorrect
+           ^ number. This type is incompatible with
+string. See lib: bom.js:248
+
+FormData.js:27
+ 27: a.set('foo', 'bar', {}); // incorrect
+     ^^^^^^^^^^^^^^^^^^^^^^^ call of method `set`
+ 27: a.set('foo', 'bar', {}); // incorrect
+                         ^^ object literal. This type is incompatible with
+string. See lib: bom.js:248
+
+FormData.js:31
+ 31: a.append('foo', {}); // incorrect
+     ^^^^^^^^^^^^^^^^^^^ call of method `append`
+ 31: a.append('foo', {}); // incorrect
+                     ^^ object literal. This type is incompatible with
+string. See lib: bom.js:249
+
+FormData.js:32
+ 32: a.append(2, 'bar'); // incorrect
+     ^^^^^^^^^^^^^^^^^^ call of method `append`
+ 32: a.append(2, 'bar'); // incorrect
+              ^ number. This type is incompatible with
+string. See lib: bom.js:249
+
+FormData.js:34
+ 34: a.append('foo', 'bar', {}); // incorrect
+     ^^^^^^^^^^^^^^^^^^^^^^^^^^ call of method `append`
+ 34: a.append('foo', 'bar', {}); // incorrect
+                            ^^ object literal. This type is incompatible with
+string. See lib: bom.js:249
+
+FormData.js:38
+ 38: a.delete(3); // incorrect
+     ^^^^^^^^^^^ call of method `delete`
+ 38: a.delete(3); // incorrect
+              ^ number. This type is incompatible with
+string. See lib: bom.js:250
+
+FormData.js:42
+ 42: for (let x: number of a.keys()) {} // incorrect
+              ^^^^^^^^^ string. This type is incompatible with
+ 42: for (let x: number of a.keys()) {} // incorrect
+                 ^^^^^^ number
+
+FormData.js:46
+ 46: for (let x: number of a.values()) {} // incorrect
+              ^^^^^^^^^ string. This type is incompatible with
+ 46: for (let x: number of a.values()) {} // incorrect
+                 ^^^^^^ number
+
+FormData.js:50
+ 50: for (let [x, y]: [number, string] of a.entries()) {} // incorrect
+               ^ number. This type is incompatible with
+string. See lib: bom.js:253
+
+FormData.js:50
+ 50: for (let [x, y]: [number, string] of a.entries()) {} // incorrect
+                       ^^^^^^ number. This type is incompatible with
+string. See lib: bom.js:253
+
+FormData.js:51
+ 51: for (let [x, y]: [string, number] of a.entries()) {} // incorrect
+                  ^ number. This type is incompatible with
+string. See lib: bom.js:253
+
+FormData.js:51
+ 51: for (let [x, y]: [string, number] of a.entries()) {} // incorrect
+                               ^^^^^^ number. This type is incompatible with
+string. See lib: bom.js:253
+
+FormData.js:52
+ 52: for (let [x, y]: [number, number] of a.entries()) {} // incorrect
+               ^ number. This type is incompatible with
+string. See lib: bom.js:253
+
+FormData.js:52
+ 52: for (let [x, y]: [number, number] of a.entries()) {} // incorrect
+                  ^ number. This type is incompatible with
+string. See lib: bom.js:253
+
+FormData.js:52
+ 52: for (let [x, y]: [number, number] of a.entries()) {} // incorrect
+                       ^^^^^^ number. This type is incompatible with
+string. See lib: bom.js:253
+
+FormData.js:52
+ 52: for (let [x, y]: [number, number] of a.entries()) {} // incorrect
+                               ^^^^^^ number. This type is incompatible with
+string. See lib: bom.js:253
+
+
+Found 24 errors

--- a/tests/fetch/fetch.exp
+++ b/tests/fetch/fetch.exp
@@ -3,13 +3,13 @@ fetch.js:12
                                 ^^^^^^^^^^^^^^^^ function call
  12: const b: Promise<string> = fetch(myRequest); // incorrect
                       ^^^^^^ string. This type is incompatible with
-Response. See lib: bom.js:826
+Response. See lib: bom.js:837
 
 fetch.js:25
  25: const d: Promise<Blob> = fetch('image.png'); // incorrect
                               ^^^^^^^^^^^^^^^^^^ function call
-Library type error:. See lib: bom.js:826
-Response. This type is incompatible with. See lib: bom.js:826
+Library type error:. See lib: bom.js:837
+Response. This type is incompatible with. See lib: bom.js:837
  25: const d: Promise<Blob> = fetch('image.png'); // incorrect
                       ^^^^ Blob
 
@@ -18,80 +18,80 @@ headers.js:3
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructor call
   3: const a = new Headers("'Content-Type': 'image/jpeg'"); // not correct
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string. This type is incompatible with
-union: Headers | object type. See lib: bom.js:720
+union: Headers | object type. See lib: bom.js:731
   Member 1:
-  Headers. See lib: bom.js:713
+  Headers. See lib: bom.js:724
   Error:
     3: const a = new Headers("'Content-Type': 'image/jpeg'"); // not correct
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string. This type is incompatible with
-  Headers. See lib: bom.js:713
+  Headers. See lib: bom.js:724
   Member 2:
-  object type. See lib: bom.js:713
+  object type. See lib: bom.js:724
   Error:
     3: const a = new Headers("'Content-Type': 'image/jpeg'"); // not correct
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string. This type is incompatible with
-  object type. See lib: bom.js:713
+  object type. See lib: bom.js:724
 
 headers.js:4
   4: const b = new Headers(['Content-Type', 'image/jpeg']); // not correct
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructor call
   4: const b = new Headers(['Content-Type', 'image/jpeg']); // not correct
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ array literal. This type is incompatible with
-union: Headers | object type. See lib: bom.js:720
+union: Headers | object type. See lib: bom.js:731
   Member 1:
-  Headers. See lib: bom.js:713
+  Headers. See lib: bom.js:724
   Error:
     4: const b = new Headers(['Content-Type', 'image/jpeg']); // not correct
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ array literal. This type is incompatible with
-  Headers. See lib: bom.js:713
+  Headers. See lib: bom.js:724
   Member 2:
-  object type. See lib: bom.js:713
+  object type. See lib: bom.js:724
   Error:
     4: const b = new Headers(['Content-Type', 'image/jpeg']); // not correct
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ array literal. This type is incompatible with
-  object type. See lib: bom.js:713
+  object type. See lib: bom.js:724
 
 headers.js:9
   9: e.append('Content-Type'); // not correct
      ^^^^^^^^^^^^^^^^^^^^^^^^ call of method `append`
   9: e.append('Content-Type'); // not correct
      ^^^^^^^^^^^^^^^^^^^^^^^^ undefined (too few arguments, expected default/rest parameters). This type is incompatible with
-string. See lib: bom.js:721
+string. See lib: bom.js:732
 
 headers.js:10
  10: e.append({'Content-Type', 'image/jpeg'}); // not correct
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call of method `append`
  10: e.append({'Content-Type', 'image/jpeg'}); // not correct
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ undefined (too few arguments, expected default/rest parameters). This type is incompatible with
-string. See lib: bom.js:721
+string. See lib: bom.js:732
 
 headers.js:10
  10: e.append({'Content-Type', 'image/jpeg'}); // not correct
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call of method `append`
  10: e.append({'Content-Type', 'image/jpeg'}); // not correct
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ object literal. This type is incompatible with
-string. See lib: bom.js:721
+string. See lib: bom.js:732
 
 headers.js:12
  12: e.set('Content-Type'); // not correct
      ^^^^^^^^^^^^^^^^^^^^^ call of method `set`
  12: e.set('Content-Type'); // not correct
      ^^^^^^^^^^^^^^^^^^^^^ undefined (too few arguments, expected default/rest parameters). This type is incompatible with
-string. See lib: bom.js:728
+string. See lib: bom.js:739
 
 headers.js:13
  13: e.set({'Content-Type', 'image/jpeg'}); // not correct
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call of method `set`
  13: e.set({'Content-Type', 'image/jpeg'}); // not correct
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ undefined (too few arguments, expected default/rest parameters). This type is incompatible with
-string. See lib: bom.js:728
+string. See lib: bom.js:739
 
 headers.js:13
  13: e.set({'Content-Type', 'image/jpeg'}); // not correct
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call of method `set`
  13: e.set({'Content-Type', 'image/jpeg'}); // not correct
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ object literal. This type is incompatible with
-string. See lib: bom.js:728
+string. See lib: bom.js:739
 
 headers.js:15
  15: const f: Headers = e.append('Content-Type', 'image/jpeg'); // not correct
@@ -112,210 +112,210 @@ request.js:2
                         ^^^^^^^^^^^^^ constructor call
   2: const a: Request = new Request(); // incorrect
                         ^^^^^^^^^^^^^ undefined (too few arguments, expected default/rest parameters). This type is incompatible with
-union: string | Request. See lib: bom.js:801
+union: string | Request. See lib: bom.js:812
   Member 1:
-  string. See lib: bom.js:801
+  string. See lib: bom.js:812
   Error:
     2: const a: Request = new Request(); // incorrect
                           ^^^^^^^^^^^^^ undefined (too few arguments, expected default/rest parameters). This type is incompatible with
-  string. See lib: bom.js:801
+  string. See lib: bom.js:812
   Member 2:
-  Request. See lib: bom.js:801
+  Request. See lib: bom.js:812
   Error:
     2: const a: Request = new Request(); // incorrect
                           ^^^^^^^^^^^^^ undefined (too few arguments, expected default/rest parameters). This type is incompatible with
-  Request. See lib: bom.js:801
+  Request. See lib: bom.js:812
 
 request.js:6
   6: const e: Request = new Request(b, c); // incorrect
                         ^^^^^^^^^^^^^^^^^ constructor call
 inconsistent use of library definitions
-null. This type is incompatible with. See lib: bom.js:759
-string enum. See lib: bom.js:806
+null. This type is incompatible with. See lib: bom.js:770
+string enum. See lib: bom.js:817
 
 request.js:6
   6: const e: Request = new Request(b, c); // incorrect
                         ^^^^^^^^^^^^^^^^^ constructor call
 inconsistent use of library definitions
-undefined. This type is incompatible with. See lib: bom.js:759
-string enum. See lib: bom.js:806
+undefined. This type is incompatible with. See lib: bom.js:770
+string enum. See lib: bom.js:817
 
 request.js:6
   6: const e: Request = new Request(b, c); // incorrect
                         ^^^^^^^^^^^^^^^^^ constructor call
 inconsistent use of library definitions
-null. This type is incompatible with. See lib: bom.js:760
-string enum. See lib: bom.js:807
+null. This type is incompatible with. See lib: bom.js:771
+string enum. See lib: bom.js:818
 
 request.js:6
   6: const e: Request = new Request(b, c); // incorrect
                         ^^^^^^^^^^^^^^^^^ constructor call
 inconsistent use of library definitions
-undefined. This type is incompatible with. See lib: bom.js:760
-string enum. See lib: bom.js:807
+undefined. This type is incompatible with. See lib: bom.js:771
+string enum. See lib: bom.js:818
 
 request.js:6
   6: const e: Request = new Request(b, c); // incorrect
                         ^^^^^^^^^^^^^^^^^ constructor call
 inconsistent use of library definitions
-null. This type is incompatible with. See lib: bom.js:761
-Headers. See lib: bom.js:808
+null. This type is incompatible with. See lib: bom.js:772
+Headers. See lib: bom.js:819
 
 request.js:6
   6: const e: Request = new Request(b, c); // incorrect
                         ^^^^^^^^^^^^^^^^^ constructor call
 inconsistent use of library definitions
-object type. This type is incompatible with. See lib: bom.js:761
-Headers. See lib: bom.js:808
+object type. This type is incompatible with. See lib: bom.js:772
+Headers. See lib: bom.js:819
 
 request.js:6
   6: const e: Request = new Request(b, c); // incorrect
                         ^^^^^^^^^^^^^^^^^ constructor call
 inconsistent use of library definitions
-undefined. This type is incompatible with. See lib: bom.js:761
-Headers. See lib: bom.js:808
+undefined. This type is incompatible with. See lib: bom.js:772
+Headers. See lib: bom.js:819
 
 request.js:6
   6: const e: Request = new Request(b, c); // incorrect
                         ^^^^^^^^^^^^^^^^^ constructor call
 inconsistent use of library definitions
-null. This type is incompatible with. See lib: bom.js:762
-string. See lib: bom.js:809
+null. This type is incompatible with. See lib: bom.js:773
+string. See lib: bom.js:820
 
 request.js:6
   6: const e: Request = new Request(b, c); // incorrect
                         ^^^^^^^^^^^^^^^^^ constructor call
 inconsistent use of library definitions
-undefined. This type is incompatible with. See lib: bom.js:762
-string. See lib: bom.js:809
+undefined. This type is incompatible with. See lib: bom.js:773
+string. See lib: bom.js:820
 
 request.js:6
   6: const e: Request = new Request(b, c); // incorrect
                         ^^^^^^^^^^^^^^^^^ constructor call
 inconsistent use of library definitions
-null. This type is incompatible with. See lib: bom.js:763
-string enum. See lib: bom.js:810
+null. This type is incompatible with. See lib: bom.js:774
+string enum. See lib: bom.js:821
 
 request.js:6
   6: const e: Request = new Request(b, c); // incorrect
                         ^^^^^^^^^^^^^^^^^ constructor call
 inconsistent use of library definitions
-undefined. This type is incompatible with. See lib: bom.js:763
-string enum. See lib: bom.js:810
+undefined. This type is incompatible with. See lib: bom.js:774
+string enum. See lib: bom.js:821
 
 request.js:6
   6: const e: Request = new Request(b, c); // incorrect
                         ^^^^^^^^^^^^^^^^^ constructor call
 inconsistent use of library definitions
-null. This type is incompatible with. See lib: bom.js:764
-string enum. See lib: bom.js:811
+null. This type is incompatible with. See lib: bom.js:775
+string enum. See lib: bom.js:822
 
 request.js:6
   6: const e: Request = new Request(b, c); // incorrect
                         ^^^^^^^^^^^^^^^^^ constructor call
 inconsistent use of library definitions
-undefined. This type is incompatible with. See lib: bom.js:764
-string enum. See lib: bom.js:811
+undefined. This type is incompatible with. See lib: bom.js:775
+string enum. See lib: bom.js:822
 
 request.js:6
   6: const e: Request = new Request(b, c); // incorrect
                         ^^^^^^^^^^^^^^^^^ constructor call
 inconsistent use of library definitions
-null. This type is incompatible with. See lib: bom.js:765
-string enum. See lib: bom.js:812
+null. This type is incompatible with. See lib: bom.js:776
+string enum. See lib: bom.js:823
 
 request.js:6
   6: const e: Request = new Request(b, c); // incorrect
                         ^^^^^^^^^^^^^^^^^ constructor call
 inconsistent use of library definitions
-undefined. This type is incompatible with. See lib: bom.js:765
-string enum. See lib: bom.js:812
+undefined. This type is incompatible with. See lib: bom.js:776
+string enum. See lib: bom.js:823
 
 request.js:6
   6: const e: Request = new Request(b, c); // incorrect
                         ^^^^^^^^^^^^^^^^^ constructor call
 inconsistent use of library definitions
-null. This type is incompatible with. See lib: bom.js:766
-string. See lib: bom.js:813
+null. This type is incompatible with. See lib: bom.js:777
+string. See lib: bom.js:824
 
 request.js:6
   6: const e: Request = new Request(b, c); // incorrect
                         ^^^^^^^^^^^^^^^^^ constructor call
 inconsistent use of library definitions
-undefined. This type is incompatible with. See lib: bom.js:766
-string. See lib: bom.js:813
+undefined. This type is incompatible with. See lib: bom.js:777
+string. See lib: bom.js:824
 
 request.js:6
   6: const e: Request = new Request(b, c); // incorrect
                         ^^^^^^^^^^^^^^^^^ constructor call
 inconsistent use of library definitions
-null. This type is incompatible with. See lib: bom.js:767
-string enum. See lib: bom.js:814
+null. This type is incompatible with. See lib: bom.js:778
+string enum. See lib: bom.js:825
 
 request.js:6
   6: const e: Request = new Request(b, c); // incorrect
                         ^^^^^^^^^^^^^^^^^ constructor call
 inconsistent use of library definitions
-undefined. This type is incompatible with. See lib: bom.js:767
-string enum. See lib: bom.js:814
+undefined. This type is incompatible with. See lib: bom.js:778
+string enum. See lib: bom.js:825
 
 request.js:8
   8: const f: Request = new Request({}) // incorrect
                         ^^^^^^^^^^^^^^^ constructor call
   8: const f: Request = new Request({}) // incorrect
                                     ^^ object literal. This type is incompatible with
-union: string | Request. See lib: bom.js:801
+union: string | Request. See lib: bom.js:812
   Member 1:
-  string. See lib: bom.js:801
+  string. See lib: bom.js:812
   Error:
     8: const f: Request = new Request({}) // incorrect
                                       ^^ object literal. This type is incompatible with
-  string. See lib: bom.js:801
+  string. See lib: bom.js:812
   Member 2:
-  Request. See lib: bom.js:801
+  Request. See lib: bom.js:812
   Error:
     8: const f: Request = new Request({}) // incorrect
                                       ^^ object literal. This type is incompatible with
-  Request. See lib: bom.js:801
+  Request. See lib: bom.js:812
 
 request.js:30
  30: const j: Request = new Request('http://example.org', {
                         ^ constructor call
  32:   headers: 'Content-Type: image/jpeg',
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^ string. This type is incompatible with
-union: Headers | object type. See lib: bom.js:761
+union: Headers | object type. See lib: bom.js:772
   Member 1:
-  Headers. See lib: bom.js:713
+  Headers. See lib: bom.js:724
   Error:
    32:   headers: 'Content-Type: image/jpeg',
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^ string. This type is incompatible with
-  Headers. See lib: bom.js:713
+  Headers. See lib: bom.js:724
   Member 2:
-  object type. See lib: bom.js:713
+  object type. See lib: bom.js:724
   Error:
    32:   headers: 'Content-Type: image/jpeg',
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^ string. This type is incompatible with
-  object type. See lib: bom.js:713
+  object type. See lib: bom.js:724
 
 request.js:37
  37: const k: Request = new Request('http://example.org', {
                         ^ constructor call
  38:   method: 'CONNECT',
                ^^^^^^^^^ string. This type is incompatible with
-string enum. See lib: bom.js:763
+string enum. See lib: bom.js:774
 
 request.js:49
  49: h.text().then((t: Buffer) => t); // incorrect
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call of method `then`
  49: h.text().then((t: Buffer) => t); // incorrect
                        ^^^^^^ Buffer. This type is incompatible with
-string. See lib: bom.js:823
+string. See lib: bom.js:834
 
 request.js:51
  51: h.arrayBuffer().then((ab: Buffer) => ab); // incorrect
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call of method `then`
-Library type error:. See lib: bom.js:819
-ArrayBuffer. This type is incompatible with. See lib: bom.js:819
+Library type error:. See lib: bom.js:830
+ArrayBuffer. This type is incompatible with. See lib: bom.js:830
  51: h.arrayBuffer().then((ab: Buffer) => ab); // incorrect
                                ^^^^^^ Buffer
 
@@ -324,70 +324,70 @@ response.js:10
                          ^ constructor call
  11:     status: "404"
                  ^^^^^ string. This type is incompatible with
-number. See lib: bom.js:771
+number. See lib: bom.js:782
 
 response.js:14
  14: const f: Response = new Response("responsebody", {
                          ^ constructor call
  16:     headers: "'Content-Type': 'image/jpeg'"
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string. This type is incompatible with
-union: Headers | object type. See lib: bom.js:773
+union: Headers | object type. See lib: bom.js:784
   Member 1:
-  Headers. See lib: bom.js:713
+  Headers. See lib: bom.js:724
   Error:
    16:     headers: "'Content-Type': 'image/jpeg'"
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string. This type is incompatible with
-  Headers. See lib: bom.js:713
+  Headers. See lib: bom.js:724
   Member 2:
-  object type. See lib: bom.js:713
+  object type. See lib: bom.js:724
   Error:
    16:     headers: "'Content-Type': 'image/jpeg'"
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string. This type is incompatible with
-  object type. See lib: bom.js:713
+  object type. See lib: bom.js:724
 
 response.js:33
  33: const i: Response = new Response({
                          ^ constructor call
  33: const i: Response = new Response({
                                       ^ object literal. This type is incompatible with
-union: string | URLSearchParams | FormData | Blob. See lib: bom.js:777
+union: string | URLSearchParams | FormData | Blob. See lib: bom.js:788
   Member 1:
-  string. See lib: bom.js:777
+  string. See lib: bom.js:788
   Error:
    33: const i: Response = new Response({
                                         ^ object literal. This type is incompatible with
-  string. See lib: bom.js:777
+  string. See lib: bom.js:788
   Member 2:
-  URLSearchParams. See lib: bom.js:777
+  URLSearchParams. See lib: bom.js:788
   Error:
    33: const i: Response = new Response({
                                         ^ object literal. This type is incompatible with
-  URLSearchParams. See lib: bom.js:777
+  URLSearchParams. See lib: bom.js:788
   Member 3:
-  FormData. See lib: bom.js:777
+  FormData. See lib: bom.js:788
   Error:
    33: const i: Response = new Response({
                                         ^ object literal. This type is incompatible with
-  FormData. See lib: bom.js:777
+  FormData. See lib: bom.js:788
   Member 4:
-  Blob. See lib: bom.js:777
+  Blob. See lib: bom.js:788
   Error:
    33: const i: Response = new Response({
                                         ^ object literal. This type is incompatible with
-  Blob. See lib: bom.js:777
+  Blob. See lib: bom.js:788
 
 response.js:44
  44: h.text().then((t: Buffer) => t); // incorrect
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call of method `then`
  44: h.text().then((t: Buffer) => t); // incorrect
                        ^^^^^^ Buffer. This type is incompatible with
-string. See lib: bom.js:797
+string. See lib: bom.js:808
 
 response.js:46
  46: h.arrayBuffer().then((ab: Buffer) => ab); // incorrect
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call of method `then`
-Library type error:. See lib: bom.js:793
-ArrayBuffer. This type is incompatible with. See lib: bom.js:793
+Library type error:. See lib: bom.js:804
+ArrayBuffer. This type is incompatible with. See lib: bom.js:804
  46: h.arrayBuffer().then((ab: Buffer) => ab); // incorrect
                                ^^^^^^ Buffer
 
@@ -396,80 +396,80 @@ urlsearchparams.js:4
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructor call
   4: const b = new URLSearchParams(['key1', 'value1']); // not correct
                                    ^^^^^^^^^^^^^^^^^^ array literal. This type is incompatible with
-union: string | URLSearchParams. See lib: bom.js:734
+union: string | URLSearchParams. See lib: bom.js:745
   Member 1:
-  string. See lib: bom.js:734
+  string. See lib: bom.js:745
   Error:
     4: const b = new URLSearchParams(['key1', 'value1']); // not correct
                                      ^^^^^^^^^^^^^^^^^^ array literal. This type is incompatible with
-  string. See lib: bom.js:734
+  string. See lib: bom.js:745
   Member 2:
-  URLSearchParams. See lib: bom.js:734
+  URLSearchParams. See lib: bom.js:745
   Error:
     4: const b = new URLSearchParams(['key1', 'value1']); // not correct
                                      ^^^^^^^^^^^^^^^^^^ array literal. This type is incompatible with
-  URLSearchParams. See lib: bom.js:734
+  URLSearchParams. See lib: bom.js:745
 
 urlsearchparams.js:5
   5: const c = new URLSearchParams({'key1', 'value1'}); // not correct
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructor call
   5: const c = new URLSearchParams({'key1', 'value1'}); // not correct
                                    ^^^^^^^^^^^^^^^^^^ object literal. This type is incompatible with
-union: string | URLSearchParams. See lib: bom.js:734
+union: string | URLSearchParams. See lib: bom.js:745
   Member 1:
-  string. See lib: bom.js:734
+  string. See lib: bom.js:745
   Error:
     5: const c = new URLSearchParams({'key1', 'value1'}); // not correct
                                      ^^^^^^^^^^^^^^^^^^ object literal. This type is incompatible with
-  string. See lib: bom.js:734
+  string. See lib: bom.js:745
   Member 2:
-  URLSearchParams. See lib: bom.js:734
+  URLSearchParams. See lib: bom.js:745
   Error:
     5: const c = new URLSearchParams({'key1', 'value1'}); // not correct
                                      ^^^^^^^^^^^^^^^^^^ object literal. This type is incompatible with
-  URLSearchParams. See lib: bom.js:734
+  URLSearchParams. See lib: bom.js:745
 
 urlsearchparams.js:9
   9: e.append('key1'); // not correct
      ^^^^^^^^^^^^^^^^ call of method `append`
   9: e.append('key1'); // not correct
      ^^^^^^^^^^^^^^^^ undefined (too few arguments, expected default/rest parameters). This type is incompatible with
-string. See lib: bom.js:735
+string. See lib: bom.js:746
 
 urlsearchparams.js:10
  10: e.append({'key1', 'value1'}); // not correct
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call of method `append`
  10: e.append({'key1', 'value1'}); // not correct
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ undefined (too few arguments, expected default/rest parameters). This type is incompatible with
-string. See lib: bom.js:735
+string. See lib: bom.js:746
 
 urlsearchparams.js:10
  10: e.append({'key1', 'value1'}); // not correct
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call of method `append`
  10: e.append({'key1', 'value1'}); // not correct
               ^^^^^^^^^^^^^^^^^^ object literal. This type is incompatible with
-string. See lib: bom.js:735
+string. See lib: bom.js:746
 
 urlsearchparams.js:12
  12: e.set('key1'); // not correct
      ^^^^^^^^^^^^^ call of method `set`
  12: e.set('key1'); // not correct
      ^^^^^^^^^^^^^ undefined (too few arguments, expected default/rest parameters). This type is incompatible with
-string. See lib: bom.js:742
+string. See lib: bom.js:753
 
 urlsearchparams.js:13
  13: e.set({'key1', 'value1'}); // not correct
      ^^^^^^^^^^^^^^^^^^^^^^^^^ call of method `set`
  13: e.set({'key1', 'value1'}); // not correct
      ^^^^^^^^^^^^^^^^^^^^^^^^^ undefined (too few arguments, expected default/rest parameters). This type is incompatible with
-string. See lib: bom.js:742
+string. See lib: bom.js:753
 
 urlsearchparams.js:13
  13: e.set({'key1', 'value1'}); // not correct
      ^^^^^^^^^^^^^^^^^^^^^^^^^ call of method `set`
  13: e.set({'key1', 'value1'}); // not correct
            ^^^^^^^^^^^^^^^^^^ object literal. This type is incompatible with
-string. See lib: bom.js:742
+string. See lib: bom.js:753
 
 urlsearchparams.js:15
  15: const f: URLSearchParams = e.append('key1', 'value1'); // not correct

--- a/tests/fetch/fetch.exp
+++ b/tests/fetch/fetch.exp
@@ -3,13 +3,13 @@ fetch.js:12
                                 ^^^^^^^^^^^^^^^^ function call
  12: const b: Promise<string> = fetch(myRequest); // incorrect
                       ^^^^^^ string. This type is incompatible with
-Response. See lib: bom.js:817
+Response. See lib: bom.js:826
 
 fetch.js:25
  25: const d: Promise<Blob> = fetch('image.png'); // incorrect
                               ^^^^^^^^^^^^^^^^^^ function call
-Library type error:. See lib: bom.js:817
-Response. This type is incompatible with. See lib: bom.js:817
+Library type error:. See lib: bom.js:826
+Response. This type is incompatible with. See lib: bom.js:826
  25: const d: Promise<Blob> = fetch('image.png'); // incorrect
                       ^^^^ Blob
 
@@ -18,80 +18,80 @@ headers.js:3
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructor call
   3: const a = new Headers("'Content-Type': 'image/jpeg'"); // not correct
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string. This type is incompatible with
-union: Headers | object type. See lib: bom.js:711
+union: Headers | object type. See lib: bom.js:720
   Member 1:
-  Headers. See lib: bom.js:704
+  Headers. See lib: bom.js:713
   Error:
     3: const a = new Headers("'Content-Type': 'image/jpeg'"); // not correct
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string. This type is incompatible with
-  Headers. See lib: bom.js:704
+  Headers. See lib: bom.js:713
   Member 2:
-  object type. See lib: bom.js:704
+  object type. See lib: bom.js:713
   Error:
     3: const a = new Headers("'Content-Type': 'image/jpeg'"); // not correct
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string. This type is incompatible with
-  object type. See lib: bom.js:704
+  object type. See lib: bom.js:713
 
 headers.js:4
   4: const b = new Headers(['Content-Type', 'image/jpeg']); // not correct
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructor call
   4: const b = new Headers(['Content-Type', 'image/jpeg']); // not correct
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ array literal. This type is incompatible with
-union: Headers | object type. See lib: bom.js:711
+union: Headers | object type. See lib: bom.js:720
   Member 1:
-  Headers. See lib: bom.js:704
+  Headers. See lib: bom.js:713
   Error:
     4: const b = new Headers(['Content-Type', 'image/jpeg']); // not correct
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ array literal. This type is incompatible with
-  Headers. See lib: bom.js:704
+  Headers. See lib: bom.js:713
   Member 2:
-  object type. See lib: bom.js:704
+  object type. See lib: bom.js:713
   Error:
     4: const b = new Headers(['Content-Type', 'image/jpeg']); // not correct
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ array literal. This type is incompatible with
-  object type. See lib: bom.js:704
+  object type. See lib: bom.js:713
 
 headers.js:9
   9: e.append('Content-Type'); // not correct
      ^^^^^^^^^^^^^^^^^^^^^^^^ call of method `append`
   9: e.append('Content-Type'); // not correct
      ^^^^^^^^^^^^^^^^^^^^^^^^ undefined (too few arguments, expected default/rest parameters). This type is incompatible with
-string. See lib: bom.js:712
+string. See lib: bom.js:721
 
 headers.js:10
  10: e.append({'Content-Type', 'image/jpeg'}); // not correct
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call of method `append`
  10: e.append({'Content-Type', 'image/jpeg'}); // not correct
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ undefined (too few arguments, expected default/rest parameters). This type is incompatible with
-string. See lib: bom.js:712
+string. See lib: bom.js:721
 
 headers.js:10
  10: e.append({'Content-Type', 'image/jpeg'}); // not correct
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call of method `append`
  10: e.append({'Content-Type', 'image/jpeg'}); // not correct
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ object literal. This type is incompatible with
-string. See lib: bom.js:712
+string. See lib: bom.js:721
 
 headers.js:12
  12: e.set('Content-Type'); // not correct
      ^^^^^^^^^^^^^^^^^^^^^ call of method `set`
  12: e.set('Content-Type'); // not correct
      ^^^^^^^^^^^^^^^^^^^^^ undefined (too few arguments, expected default/rest parameters). This type is incompatible with
-string. See lib: bom.js:719
+string. See lib: bom.js:728
 
 headers.js:13
  13: e.set({'Content-Type', 'image/jpeg'}); // not correct
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call of method `set`
  13: e.set({'Content-Type', 'image/jpeg'}); // not correct
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ undefined (too few arguments, expected default/rest parameters). This type is incompatible with
-string. See lib: bom.js:719
+string. See lib: bom.js:728
 
 headers.js:13
  13: e.set({'Content-Type', 'image/jpeg'}); // not correct
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call of method `set`
  13: e.set({'Content-Type', 'image/jpeg'}); // not correct
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ object literal. This type is incompatible with
-string. See lib: bom.js:719
+string. See lib: bom.js:728
 
 headers.js:15
  15: const f: Headers = e.append('Content-Type', 'image/jpeg'); // not correct
@@ -112,210 +112,210 @@ request.js:2
                         ^^^^^^^^^^^^^ constructor call
   2: const a: Request = new Request(); // incorrect
                         ^^^^^^^^^^^^^ undefined (too few arguments, expected default/rest parameters). This type is incompatible with
-union: string | Request. See lib: bom.js:792
+union: string | Request. See lib: bom.js:801
   Member 1:
-  string. See lib: bom.js:792
+  string. See lib: bom.js:801
   Error:
     2: const a: Request = new Request(); // incorrect
                           ^^^^^^^^^^^^^ undefined (too few arguments, expected default/rest parameters). This type is incompatible with
-  string. See lib: bom.js:792
+  string. See lib: bom.js:801
   Member 2:
-  Request. See lib: bom.js:792
+  Request. See lib: bom.js:801
   Error:
     2: const a: Request = new Request(); // incorrect
                           ^^^^^^^^^^^^^ undefined (too few arguments, expected default/rest parameters). This type is incompatible with
-  Request. See lib: bom.js:792
+  Request. See lib: bom.js:801
 
 request.js:6
   6: const e: Request = new Request(b, c); // incorrect
                         ^^^^^^^^^^^^^^^^^ constructor call
 inconsistent use of library definitions
-null. This type is incompatible with. See lib: bom.js:750
-string enum. See lib: bom.js:797
+null. This type is incompatible with. See lib: bom.js:759
+string enum. See lib: bom.js:806
 
 request.js:6
   6: const e: Request = new Request(b, c); // incorrect
                         ^^^^^^^^^^^^^^^^^ constructor call
 inconsistent use of library definitions
-undefined. This type is incompatible with. See lib: bom.js:750
-string enum. See lib: bom.js:797
+undefined. This type is incompatible with. See lib: bom.js:759
+string enum. See lib: bom.js:806
 
 request.js:6
   6: const e: Request = new Request(b, c); // incorrect
                         ^^^^^^^^^^^^^^^^^ constructor call
 inconsistent use of library definitions
-null. This type is incompatible with. See lib: bom.js:751
-string enum. See lib: bom.js:798
+null. This type is incompatible with. See lib: bom.js:760
+string enum. See lib: bom.js:807
 
 request.js:6
   6: const e: Request = new Request(b, c); // incorrect
                         ^^^^^^^^^^^^^^^^^ constructor call
 inconsistent use of library definitions
-undefined. This type is incompatible with. See lib: bom.js:751
-string enum. See lib: bom.js:798
+undefined. This type is incompatible with. See lib: bom.js:760
+string enum. See lib: bom.js:807
 
 request.js:6
   6: const e: Request = new Request(b, c); // incorrect
                         ^^^^^^^^^^^^^^^^^ constructor call
 inconsistent use of library definitions
-null. This type is incompatible with. See lib: bom.js:752
-Headers. See lib: bom.js:799
+null. This type is incompatible with. See lib: bom.js:761
+Headers. See lib: bom.js:808
 
 request.js:6
   6: const e: Request = new Request(b, c); // incorrect
                         ^^^^^^^^^^^^^^^^^ constructor call
 inconsistent use of library definitions
-object type. This type is incompatible with. See lib: bom.js:752
-Headers. See lib: bom.js:799
+object type. This type is incompatible with. See lib: bom.js:761
+Headers. See lib: bom.js:808
 
 request.js:6
   6: const e: Request = new Request(b, c); // incorrect
                         ^^^^^^^^^^^^^^^^^ constructor call
 inconsistent use of library definitions
-undefined. This type is incompatible with. See lib: bom.js:752
-Headers. See lib: bom.js:799
+undefined. This type is incompatible with. See lib: bom.js:761
+Headers. See lib: bom.js:808
 
 request.js:6
   6: const e: Request = new Request(b, c); // incorrect
                         ^^^^^^^^^^^^^^^^^ constructor call
 inconsistent use of library definitions
-null. This type is incompatible with. See lib: bom.js:753
-string. See lib: bom.js:800
+null. This type is incompatible with. See lib: bom.js:762
+string. See lib: bom.js:809
 
 request.js:6
   6: const e: Request = new Request(b, c); // incorrect
                         ^^^^^^^^^^^^^^^^^ constructor call
 inconsistent use of library definitions
-undefined. This type is incompatible with. See lib: bom.js:753
-string. See lib: bom.js:800
+undefined. This type is incompatible with. See lib: bom.js:762
+string. See lib: bom.js:809
 
 request.js:6
   6: const e: Request = new Request(b, c); // incorrect
                         ^^^^^^^^^^^^^^^^^ constructor call
 inconsistent use of library definitions
-null. This type is incompatible with. See lib: bom.js:754
-string enum. See lib: bom.js:801
+null. This type is incompatible with. See lib: bom.js:763
+string enum. See lib: bom.js:810
 
 request.js:6
   6: const e: Request = new Request(b, c); // incorrect
                         ^^^^^^^^^^^^^^^^^ constructor call
 inconsistent use of library definitions
-undefined. This type is incompatible with. See lib: bom.js:754
-string enum. See lib: bom.js:801
+undefined. This type is incompatible with. See lib: bom.js:763
+string enum. See lib: bom.js:810
 
 request.js:6
   6: const e: Request = new Request(b, c); // incorrect
                         ^^^^^^^^^^^^^^^^^ constructor call
 inconsistent use of library definitions
-null. This type is incompatible with. See lib: bom.js:755
-string enum. See lib: bom.js:802
+null. This type is incompatible with. See lib: bom.js:764
+string enum. See lib: bom.js:811
 
 request.js:6
   6: const e: Request = new Request(b, c); // incorrect
                         ^^^^^^^^^^^^^^^^^ constructor call
 inconsistent use of library definitions
-undefined. This type is incompatible with. See lib: bom.js:755
-string enum. See lib: bom.js:802
+undefined. This type is incompatible with. See lib: bom.js:764
+string enum. See lib: bom.js:811
 
 request.js:6
   6: const e: Request = new Request(b, c); // incorrect
                         ^^^^^^^^^^^^^^^^^ constructor call
 inconsistent use of library definitions
-null. This type is incompatible with. See lib: bom.js:756
-string enum. See lib: bom.js:803
+null. This type is incompatible with. See lib: bom.js:765
+string enum. See lib: bom.js:812
 
 request.js:6
   6: const e: Request = new Request(b, c); // incorrect
                         ^^^^^^^^^^^^^^^^^ constructor call
 inconsistent use of library definitions
-undefined. This type is incompatible with. See lib: bom.js:756
-string enum. See lib: bom.js:803
+undefined. This type is incompatible with. See lib: bom.js:765
+string enum. See lib: bom.js:812
 
 request.js:6
   6: const e: Request = new Request(b, c); // incorrect
                         ^^^^^^^^^^^^^^^^^ constructor call
 inconsistent use of library definitions
-null. This type is incompatible with. See lib: bom.js:757
-string. See lib: bom.js:804
+null. This type is incompatible with. See lib: bom.js:766
+string. See lib: bom.js:813
 
 request.js:6
   6: const e: Request = new Request(b, c); // incorrect
                         ^^^^^^^^^^^^^^^^^ constructor call
 inconsistent use of library definitions
-undefined. This type is incompatible with. See lib: bom.js:757
-string. See lib: bom.js:804
+undefined. This type is incompatible with. See lib: bom.js:766
+string. See lib: bom.js:813
 
 request.js:6
   6: const e: Request = new Request(b, c); // incorrect
                         ^^^^^^^^^^^^^^^^^ constructor call
 inconsistent use of library definitions
-null. This type is incompatible with. See lib: bom.js:758
-string enum. See lib: bom.js:805
+null. This type is incompatible with. See lib: bom.js:767
+string enum. See lib: bom.js:814
 
 request.js:6
   6: const e: Request = new Request(b, c); // incorrect
                         ^^^^^^^^^^^^^^^^^ constructor call
 inconsistent use of library definitions
-undefined. This type is incompatible with. See lib: bom.js:758
-string enum. See lib: bom.js:805
+undefined. This type is incompatible with. See lib: bom.js:767
+string enum. See lib: bom.js:814
 
 request.js:8
   8: const f: Request = new Request({}) // incorrect
                         ^^^^^^^^^^^^^^^ constructor call
   8: const f: Request = new Request({}) // incorrect
                                     ^^ object literal. This type is incompatible with
-union: string | Request. See lib: bom.js:792
+union: string | Request. See lib: bom.js:801
   Member 1:
-  string. See lib: bom.js:792
+  string. See lib: bom.js:801
   Error:
     8: const f: Request = new Request({}) // incorrect
                                       ^^ object literal. This type is incompatible with
-  string. See lib: bom.js:792
+  string. See lib: bom.js:801
   Member 2:
-  Request. See lib: bom.js:792
+  Request. See lib: bom.js:801
   Error:
     8: const f: Request = new Request({}) // incorrect
                                       ^^ object literal. This type is incompatible with
-  Request. See lib: bom.js:792
+  Request. See lib: bom.js:801
 
 request.js:30
  30: const j: Request = new Request('http://example.org', {
                         ^ constructor call
  32:   headers: 'Content-Type: image/jpeg',
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^ string. This type is incompatible with
-union: Headers | object type. See lib: bom.js:752
+union: Headers | object type. See lib: bom.js:761
   Member 1:
-  Headers. See lib: bom.js:704
+  Headers. See lib: bom.js:713
   Error:
    32:   headers: 'Content-Type: image/jpeg',
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^ string. This type is incompatible with
-  Headers. See lib: bom.js:704
+  Headers. See lib: bom.js:713
   Member 2:
-  object type. See lib: bom.js:704
+  object type. See lib: bom.js:713
   Error:
    32:   headers: 'Content-Type: image/jpeg',
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^ string. This type is incompatible with
-  object type. See lib: bom.js:704
+  object type. See lib: bom.js:713
 
 request.js:37
  37: const k: Request = new Request('http://example.org', {
                         ^ constructor call
  38:   method: 'CONNECT',
                ^^^^^^^^^ string. This type is incompatible with
-string enum. See lib: bom.js:754
+string enum. See lib: bom.js:763
 
 request.js:49
  49: h.text().then((t: Buffer) => t); // incorrect
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call of method `then`
  49: h.text().then((t: Buffer) => t); // incorrect
                        ^^^^^^ Buffer. This type is incompatible with
-string. See lib: bom.js:814
+string. See lib: bom.js:823
 
 request.js:51
  51: h.arrayBuffer().then((ab: Buffer) => ab); // incorrect
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call of method `then`
-Library type error:. See lib: bom.js:810
-ArrayBuffer. This type is incompatible with. See lib: bom.js:810
+Library type error:. See lib: bom.js:819
+ArrayBuffer. This type is incompatible with. See lib: bom.js:819
  51: h.arrayBuffer().then((ab: Buffer) => ab); // incorrect
                                ^^^^^^ Buffer
 
@@ -324,70 +324,70 @@ response.js:10
                          ^ constructor call
  11:     status: "404"
                  ^^^^^ string. This type is incompatible with
-number. See lib: bom.js:762
+number. See lib: bom.js:771
 
 response.js:14
  14: const f: Response = new Response("responsebody", {
                          ^ constructor call
  16:     headers: "'Content-Type': 'image/jpeg'"
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string. This type is incompatible with
-union: Headers | object type. See lib: bom.js:764
+union: Headers | object type. See lib: bom.js:773
   Member 1:
-  Headers. See lib: bom.js:704
+  Headers. See lib: bom.js:713
   Error:
    16:     headers: "'Content-Type': 'image/jpeg'"
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string. This type is incompatible with
-  Headers. See lib: bom.js:704
+  Headers. See lib: bom.js:713
   Member 2:
-  object type. See lib: bom.js:704
+  object type. See lib: bom.js:713
   Error:
    16:     headers: "'Content-Type': 'image/jpeg'"
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string. This type is incompatible with
-  object type. See lib: bom.js:704
+  object type. See lib: bom.js:713
 
 response.js:33
  33: const i: Response = new Response({
                          ^ constructor call
  33: const i: Response = new Response({
                                       ^ object literal. This type is incompatible with
-union: string | URLSearchParams | FormData | Blob. See lib: bom.js:768
+union: string | URLSearchParams | FormData | Blob. See lib: bom.js:777
   Member 1:
-  string. See lib: bom.js:768
+  string. See lib: bom.js:777
   Error:
    33: const i: Response = new Response({
                                         ^ object literal. This type is incompatible with
-  string. See lib: bom.js:768
+  string. See lib: bom.js:777
   Member 2:
-  URLSearchParams. See lib: bom.js:768
+  URLSearchParams. See lib: bom.js:777
   Error:
    33: const i: Response = new Response({
                                         ^ object literal. This type is incompatible with
-  URLSearchParams. See lib: bom.js:768
+  URLSearchParams. See lib: bom.js:777
   Member 3:
-  FormData. See lib: bom.js:768
+  FormData. See lib: bom.js:777
   Error:
    33: const i: Response = new Response({
                                         ^ object literal. This type is incompatible with
-  FormData. See lib: bom.js:768
+  FormData. See lib: bom.js:777
   Member 4:
-  Blob. See lib: bom.js:768
+  Blob. See lib: bom.js:777
   Error:
    33: const i: Response = new Response({
                                         ^ object literal. This type is incompatible with
-  Blob. See lib: bom.js:768
+  Blob. See lib: bom.js:777
 
 response.js:44
  44: h.text().then((t: Buffer) => t); // incorrect
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call of method `then`
  44: h.text().then((t: Buffer) => t); // incorrect
                        ^^^^^^ Buffer. This type is incompatible with
-string. See lib: bom.js:788
+string. See lib: bom.js:797
 
 response.js:46
  46: h.arrayBuffer().then((ab: Buffer) => ab); // incorrect
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call of method `then`
-Library type error:. See lib: bom.js:784
-ArrayBuffer. This type is incompatible with. See lib: bom.js:784
+Library type error:. See lib: bom.js:793
+ArrayBuffer. This type is incompatible with. See lib: bom.js:793
  46: h.arrayBuffer().then((ab: Buffer) => ab); // incorrect
                                ^^^^^^ Buffer
 
@@ -396,80 +396,80 @@ urlsearchparams.js:4
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructor call
   4: const b = new URLSearchParams(['key1', 'value1']); // not correct
                                    ^^^^^^^^^^^^^^^^^^ array literal. This type is incompatible with
-union: string | URLSearchParams. See lib: bom.js:725
+union: string | URLSearchParams. See lib: bom.js:734
   Member 1:
-  string. See lib: bom.js:725
+  string. See lib: bom.js:734
   Error:
     4: const b = new URLSearchParams(['key1', 'value1']); // not correct
                                      ^^^^^^^^^^^^^^^^^^ array literal. This type is incompatible with
-  string. See lib: bom.js:725
+  string. See lib: bom.js:734
   Member 2:
-  URLSearchParams. See lib: bom.js:725
+  URLSearchParams. See lib: bom.js:734
   Error:
     4: const b = new URLSearchParams(['key1', 'value1']); // not correct
                                      ^^^^^^^^^^^^^^^^^^ array literal. This type is incompatible with
-  URLSearchParams. See lib: bom.js:725
+  URLSearchParams. See lib: bom.js:734
 
 urlsearchparams.js:5
   5: const c = new URLSearchParams({'key1', 'value1'}); // not correct
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructor call
   5: const c = new URLSearchParams({'key1', 'value1'}); // not correct
                                    ^^^^^^^^^^^^^^^^^^ object literal. This type is incompatible with
-union: string | URLSearchParams. See lib: bom.js:725
+union: string | URLSearchParams. See lib: bom.js:734
   Member 1:
-  string. See lib: bom.js:725
+  string. See lib: bom.js:734
   Error:
     5: const c = new URLSearchParams({'key1', 'value1'}); // not correct
                                      ^^^^^^^^^^^^^^^^^^ object literal. This type is incompatible with
-  string. See lib: bom.js:725
+  string. See lib: bom.js:734
   Member 2:
-  URLSearchParams. See lib: bom.js:725
+  URLSearchParams. See lib: bom.js:734
   Error:
     5: const c = new URLSearchParams({'key1', 'value1'}); // not correct
                                      ^^^^^^^^^^^^^^^^^^ object literal. This type is incompatible with
-  URLSearchParams. See lib: bom.js:725
+  URLSearchParams. See lib: bom.js:734
 
 urlsearchparams.js:9
   9: e.append('key1'); // not correct
      ^^^^^^^^^^^^^^^^ call of method `append`
   9: e.append('key1'); // not correct
      ^^^^^^^^^^^^^^^^ undefined (too few arguments, expected default/rest parameters). This type is incompatible with
-string. See lib: bom.js:726
+string. See lib: bom.js:735
 
 urlsearchparams.js:10
  10: e.append({'key1', 'value1'}); // not correct
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call of method `append`
  10: e.append({'key1', 'value1'}); // not correct
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ undefined (too few arguments, expected default/rest parameters). This type is incompatible with
-string. See lib: bom.js:726
+string. See lib: bom.js:735
 
 urlsearchparams.js:10
  10: e.append({'key1', 'value1'}); // not correct
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call of method `append`
  10: e.append({'key1', 'value1'}); // not correct
               ^^^^^^^^^^^^^^^^^^ object literal. This type is incompatible with
-string. See lib: bom.js:726
+string. See lib: bom.js:735
 
 urlsearchparams.js:12
  12: e.set('key1'); // not correct
      ^^^^^^^^^^^^^ call of method `set`
  12: e.set('key1'); // not correct
      ^^^^^^^^^^^^^ undefined (too few arguments, expected default/rest parameters). This type is incompatible with
-string. See lib: bom.js:733
+string. See lib: bom.js:742
 
 urlsearchparams.js:13
  13: e.set({'key1', 'value1'}); // not correct
      ^^^^^^^^^^^^^^^^^^^^^^^^^ call of method `set`
  13: e.set({'key1', 'value1'}); // not correct
      ^^^^^^^^^^^^^^^^^^^^^^^^^ undefined (too few arguments, expected default/rest parameters). This type is incompatible with
-string. See lib: bom.js:733
+string. See lib: bom.js:742
 
 urlsearchparams.js:13
  13: e.set({'key1', 'value1'}); // not correct
      ^^^^^^^^^^^^^^^^^^^^^^^^^ call of method `set`
  13: e.set({'key1', 'value1'}); // not correct
            ^^^^^^^^^^^^^^^^^^ object literal. This type is incompatible with
-string. See lib: bom.js:733
+string. See lib: bom.js:742
 
 urlsearchparams.js:15
  15: const f: URLSearchParams = e.append('key1', 'value1'); // not correct


### PR DESCRIPTION
Just filled out the definitions for [`FormData`](https://developer.mozilla.org/en/docs/Web/API/FormData).

I've updated the test which was failing from line numbers changing, and I've added a test for `FormData` (there was no `bom` dir - I assume this is the correct place for them?)

One concern there might be is I've tightened the types (on the sole existing method) from `any` to `string`, which seems to be correct as a string _is_ the correct value to give to these functions. Give it an object and you get `"[Object object]"` back.

``` diff
- append(name: any, value: any, blobName?: string): void;
+ append(name: string, value: string, blobName?: string): void;
```
