### PR TITLE
Add failing test for issue

### DIFF
--- a/tests/unions_with_generics/test-module.js
+++ b/tests/unions_with_generics/test-module.js
@@ -1,0 +1,4 @@
+/* @flow */
+
+export type X = {name: 'X'};
+export type Y = {name: 'Y'};

--- a/tests/unions_with_generics/test.js
+++ b/tests/unions_with_generics/test.js
@@ -1,0 +1,15 @@
+/* @flow */
+
+import type {X} from './test-module';
+
+type Y = {name: 'Y'};
+
+class Clazz<T1: Object, T2: Object> {
+  method<t1: T1, t2: T2>(func: () => t1 | t2) { // fix by flipping the order of `t1` and `t2` here
+    func();
+  }
+}
+
+const r: Clazz<X, Y> = new Clazz(); // or by flipping the order of `X` and `Y` here
+r.method((): X => ({name: 'X'}));
+r.method((): Y => ({name: 'Y'}));

--- a/tests/unions_with_generics/unions_with_generics.exp
+++ b/tests/unions_with_generics/unions_with_generics.exp
@@ -1,0 +1,1 @@
+Found 0 errors


### PR DESCRIPTION
This pull-request currently contains a failing test for https://github.com/facebook/flow/issues/2455. I'm not sure how useful some failing tests are, but you never know!

I'd be happy to try tracking down the underlying cause of the divergence as a result of re-ordering the union types, but I'm not sure the right way to go about this. For example, are there:
1. Trace statements I could enable so I can diff both traces and narrow down the broad area of code where the divergence occurs.
2. Ways to debug the code, or do developers rely on adding log lines when debugging?

Any guidance here would be much appreciated!
