### PR TITLE
make Event polymorphic

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -129,7 +129,7 @@ type Event$Init = {
   composed?: boolean,
 }
 
-declare class Event {
+declare class Event<TTarget: EventTarget> {
   constructor(type: string, eventInitDict?: Event$Init): void;
   bubbles: boolean;
   cancelable: boolean;
@@ -138,7 +138,7 @@ declare class Event {
   eventPhase: number;
   isTrusted: boolean;
   srcElement: Element;
-  target: EventTarget;
+  target: TTarget;
   timeStamp: number;
   type: string;
   preventDefault(): void;


### PR DESCRIPTION
this allows to annotate "primitive" events better, like [iceconnectionstatechange](https://developer.mozilla.org/en-US/docs/Web/Events/iceconnectionstatechange), where the only difference is the type of `event.target: RTCPeerConnection`

---

example use-case:

```js
peerConnection.addEventListener(
  'iceconnectionstatechange',
  (ev: Event<RTCPeerConnection>): void => {
    doSomethingWith(ev.target.iceConnectionState);
  }
);
```