### PR TITLE
Add missing type "stdio" of child_process.fork option properties

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -171,7 +171,7 @@ type child_process$forkOpts = {
   execPath?: string;
   execArgv?: Array<string>;
   silent?: boolean;
-  stdio?: Array<any>;
+  stdio?: Array<number | 'ipc'>;
   uid?: number;
   gid?: number;
 };

--- a/lib/node.js
+++ b/lib/node.js
@@ -171,6 +171,7 @@ type child_process$forkOpts = {
   execPath?: string;
   execArgv?: Array<string>;
   silent?: boolean;
+  stdio?: Array<any>;
   uid?: number;
   gid?: number;
 };


### PR DESCRIPTION
This adds `stdio` type `child_process.fork` in `options` property

According to the description in the [official Node.js API] they say:
> The array must contain exactly one item with value 'ipc' or an error will be thrown. For instance [0, 1, 2, 'ipc']

I'm sure this could be typed a bit smarter instead of `Array<any>`, but anyway better than not typed. I'd be very grateful for any help or suggestions 🙌