### PR TITLE
Add missing newline to error message

### DIFF
--- a/src/common/errors.ml
+++ b/src/common/errors.ml
@@ -878,7 +878,7 @@ let print_error_summary ?(out_channel=stdout) ~flags ?(stdin_file=None) ~strip_r
       (total - 50) (error_or_errors (total - 50)) total;
     Printf.fprintf
       out_channel
-      "To see all errors, re-run Flow with --show-all-errors";
+      "To see all errors, re-run Flow with --show-all-errors\n";
     flush out_channel
   ) else
     Printf.fprintf out_channel "Found %d %s\n" total (error_or_errors total)


### PR DESCRIPTION
This pull request adds a missing newline to the error message that's shown when the error summary is truncated.