### PR TITLE
[tool] fix race condition with server restarts

### DIFF
--- a/newtests/package_json_changes/test.js
+++ b/newtests/package_json_changes/test.js
@@ -3,70 +3,67 @@
 
 import {suite, test} from '../../tsrc/test/Tester';
 
-const NO_SERVER_RUNNING = 6;
-const SERVER_RUNNING = 11;
-
 export default suite(({addFile, removeFile, exitCode, flowCmd}) => [
   test('node - Adding a package.json should kill the server', [
     addFile('start.json', 'package.json')
-      .flowCmd(['status', '--no-auto-start'])
-      .exitCodes([NO_SERVER_RUNNING])
+      .waitForServerToDie(2000)
+      .serverRunning(false)
   ]).flowConfig('node_flowconfig'),
   test('haste - Adding a package.json should kill the server', [
     addFile('start.json', 'package.json')
-      .flowCmd(['status', '--no-auto-start'])
-      .exitCodes([NO_SERVER_RUNNING])
+      .waitForServerToDie(2000)
+      .serverRunning(false)
   ]).flowConfig('haste_flowconfig'),
 
   test('node - Removing a package.json should kill the server', [
     addFile('start.json', 'package.json'),
     removeFile('package.json')
-      .flowCmd(['status', '--no-auto-start'])
-      .exitCodes([NO_SERVER_RUNNING])
+      .waitForServerToDie(2000)
+      .serverRunning(false)
   ]).flowConfig('node_flowconfig'),
   test('haste - Removing a package.json should kill the server', [
     addFile('start.json', 'package.json'),
     removeFile('package.json')
-      .flowCmd(['status', '--no-auto-start'])
-      .exitCodes([NO_SERVER_RUNNING])
+      .waitForServerToDie(2000)
+      .serverRunning(false)
   ]).flowConfig('haste_flowconfig'),
 
   test('node - Changing the name field should kill the server', [
     addFile('start.json', 'package.json'),
     addFile('nameChange.json', 'package.json')
-      .flowCmd(['status', '--no-auto-start'])
-      .exitCodes([NO_SERVER_RUNNING])
+      .waitForServerToDie(2000)
+      .serverRunning(false)
   ]).flowConfig('node_flowconfig'),
   test('haste - Changing the name field should kill the server', [
     addFile('start.json', 'package.json'),
     addFile('nameChange.json', 'package.json')
-      .flowCmd(['status', '--no-auto-start'])
-      .exitCodes([NO_SERVER_RUNNING])
+      .waitForServerToDie(2000)
+      .serverRunning(false)
   ]).flowConfig('haste_flowconfig'),
 
   test('node - Changing the main field should kill the server', [
     addFile('start.json', 'package.json'),
     addFile('mainChange.json', 'package.json')
-      .flowCmd(['status', '--no-auto-start'])
-      .exitCodes([NO_SERVER_RUNNING])
+      .waitForServerToDie(2000)
+      .serverRunning(false)
   ]).flowConfig('node_flowconfig'),
   test('haste - Changing the main field should kill the server', [
     addFile('start.json', 'package.json'),
     addFile('mainChange.json', 'package.json')
-      .flowCmd(['status', '--no-auto-start'])
-      .exitCodes([NO_SERVER_RUNNING])
+      .waitForServerToDie(2000)
+      .serverRunning(false)
   ]).flowConfig('haste_flowconfig'),
 
   test('node - Changing an irrelevant field should NOT kill the server', [
     addFile('start.json', 'package.json'),
     addFile('irrelevantChange.json', 'package.json')
-      .flowCmd(['start'])
-      .exitCodes([SERVER_RUNNING])
+      .waitForServerToDie(2000)
+      .serverRunning(true)
   ]).flowConfig('node_flowconfig'),
   test('haste - Changing an irrelevant field should NOT kill the server', [
     addFile('start.json', 'package.json'),
     addFile('irrelevantChange.json', 'package.json')
-      .flowCmd(['start'])
-      .exitCodes([SERVER_RUNNING])
+      .waitForServerToDie(2000)
+      .serverRunning(true)
   ]).flowConfig('haste_flowconfig'),
 ]);

--- a/tsrc/async.js
+++ b/tsrc/async.js
@@ -213,3 +213,20 @@ export function glob(
     });
   });
 }
+
+export function isRunning(pid: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    try {
+      process.kill(pid, 0);
+      resolve(true);
+    } catch (e) {
+      resolve(e.code === 'EPERM');
+    }
+  });
+}
+
+export function sleep(timeout: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, timeout);
+  });
+}

--- a/tsrc/test/TestStep.js
+++ b/tsrc/test/TestStep.js
@@ -6,6 +6,7 @@ import noNewErrors from './assertions/noNewErrors';
 import stderr from './assertions/stderr';
 import stdout from './assertions/stdout';
 import exitCodes from './assertions/exitCodes';
+import serverRunning from './assertions/serverRunning';
 import noop from './assertions/noop';
 
 import type {
@@ -123,6 +124,11 @@ class TestStepFirstOrSecondStage extends TestStep {
     return this._cloneWithAssertion(exitCodes(expected, assertLoc));
   }
 
+  serverRunning(expected: boolean): TestStepSecondStage {
+    const assertLoc = searchStackForTestAssertion();
+    return this._cloneWithAssertion(serverRunning(expected, assertLoc));
+  }
+
   _cloneWithAssertion(assertion: ErrorAssertion) {
     const ret = new TestStepSecondStage(this);
     ret._assertions.push(assertion);
@@ -192,6 +198,17 @@ export class TestStepFirstStage extends TestStepFirstOrSecondStage {
           env.reportStdout(stdout);
           env.reportStderr(stderr);
           env.triggerFlowCheck();
+        }
+      );
+      ret._needsFlowServer = true;
+      return ret;
+    };
+
+  waitForServerToDie: (timeout: number) => TestStepFirstStage =
+    (timeout) => {
+      const ret = this._cloneWithAction(
+        async (builder, env) => {
+          await builder.waitForServerToDie(timeout);
         }
       );
       ret._needsFlowServer = true;

--- a/tsrc/test/assertions/assertionTypes.js
+++ b/tsrc/test/assertions/assertionTypes.js
@@ -8,7 +8,13 @@ export type AssertionLocation = {
   column: number
 };
 
-type AssertionMethod = 'noNewErrors' | 'newErrors' | 'stdout' | 'stderr' | 'exitCodes';
+type AssertionMethod =
+  | 'noNewErrors'
+  | 'newErrors'
+  | 'stdout'
+  | 'stderr'
+  | 'exitCodes'
+  | 'serverRunning';
 
 export type Suggestion = {
   method: AssertionMethod,

--- a/tsrc/test/assertions/serverRunning.js
+++ b/tsrc/test/assertions/serverRunning.js
@@ -1,0 +1,33 @@
+/* @flow */
+
+import simpleDiffAssertion from './simpleDiffAssertion';
+
+import type {AssertionLocation, ErrorAssertion} from './assertionTypes';
+
+function isRunning(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (e) {
+    return e.code === 'EPERM';
+  }
+}
+
+export default function(
+  expected: boolean,
+  assertLoc: ?AssertionLocation,
+): ErrorAssertion {
+  return (reason: ?string, env) => {
+    const pid = env.getServerPid();
+    const actual = pid == null ? 'never started' : isRunning(pid);
+    const suggestion = { method: 'serverRunning', args: [actual] };
+    return simpleDiffAssertion(
+      String(expected),
+      String(actual),
+      assertLoc,
+      reason,
+      "server to be running",
+      suggestion,
+    );
+  };
+}

--- a/tsrc/test/builder.js
+++ b/tsrc/test/builder.js
@@ -10,9 +10,11 @@ import {
   appendFile,
   exec,
   execManual,
+  isRunning,
   mkdirp,
   readdir,
   readFile,
+  sleep,
   unlink,
   writeFile,
 } from '../async';
@@ -255,6 +257,18 @@ export class TestBuilder {
           console.log("Failed to kill server %s", server);
         }
       }
+    }
+  }
+
+  async waitForServerToDie(timeout: number): Promise<void> {
+    const pid = this.server;
+    if (pid == null) {
+      throw new Error('Cannot wait for a server that never started');
+    }
+    let remaining = timeout;
+    while (remaining > 0 && await isRunning(pid)) {
+      remaining -= 100;
+      await sleep(100);
     }
   }
 }

--- a/tsrc/test/runTestSuite.js
+++ b/tsrc/test/runTestSuite.js
@@ -128,6 +128,10 @@ export default async function(
           flowErrors = null;
         }
 
+        // expose the pid of the server to the env, so that assertions can check
+        // on the server status
+        envWrite.setServerPid(testBuilder.server);
+
         let result = step.checkAssertions(envRead);
         if (result.passed) {
           stepsPassed++;

--- a/tsrc/test/stepEnv.js
+++ b/tsrc/test/stepEnv.js
@@ -7,6 +7,7 @@ export interface StepEnvWriteable {
   reportStderr(output: string): void;
   reportExitCode(code: number): void;
   setNewErrors(errors: FlowResult): void;
+  setServerPid(pid: ?number): void;
   triggerFlowCheck(): void;
 }
 
@@ -16,6 +17,7 @@ export interface StepEnvReadable {
   getExitCodes(): Array<number>;
   getOldErrors(): FlowResult;
   getNewErrors(): FlowResult;
+  getServerPid(): ?number;
   shouldRunFlow(): boolean;
 }
 
@@ -26,6 +28,7 @@ export function newEnv(
   let stderr = [];
   let exitCodes = [];
   let newErrors = oldErrors;
+  let serverPid = undefined;
   let shouldRunFlow = false;
 
   const envWrite = {
@@ -43,6 +46,10 @@ export function newEnv(
 
     setNewErrors(errors) {
       newErrors = errors;
+    },
+
+    setServerPid(pid) {
+      serverPid = pid;
     },
 
     triggerFlowCheck() {
@@ -69,6 +76,10 @@ export function newEnv(
 
     getNewErrors() {
       return newErrors;
+    },
+
+    getServerPid() {
+      return serverPid;
     },
 
     shouldRunFlow() {


### PR DESCRIPTION
the `package_json_changes` test was racy. adding a file that should kill the server might not have been noticed by the server by the time the next action runs.

added a new action, `waitForServerToDie(timeout)`, which just sleeps until the server dies or the timeout occurs.

added a new assertion, `serverRunning(isRunning)`, which confirms that the same PID is still running (or not running).