### PR TITLE
Revamp "third-party code" docs

### DIFF
--- a/website/_assets/css/default.scss
+++ b/website/_assets/css/default.scss
@@ -41,6 +41,13 @@ code, pre {
     -webkit-font-smoothing: subpixel-antialiased;
 }
 
+p code {
+    background-color: #eee;
+    border: 1px solid #ccc;
+    font-size: 80%;
+    padding: 1px;
+}
+
 td {
     vertical-align: top;
 }

--- a/website/docs/02-third-party.md
+++ b/website/docs/02-third-party.md
@@ -6,29 +6,104 @@ prev: type-annotations.html
 next: running.html
 ---
 
-Most real JavaScript programs depend on third-party libraries. This guide shows how to use Flow in a project with external dependencies, without having to typecheck library code.
+Most real JavaScript programs depend on third-party libraries. 
+To handle this, Flow supports the concept of a "Library Definition" 
+(or "libdef" for short).
 
-## Interface Files
+# Library Definitions
 
-Flow supports *interface files* for the purpose of understanding third party code you did not write. These files define the interface to a library, including types, separately from the actual code of the library. You never need to change library code to use interface files, but your code will be typechecked against the types declared in the interface file.
+Often you will want to use libraries and code that you didn't write -- such as
+npm packages. For these circumstances, Flow supports the concept of a 
+"libdef" which allows you to describe the interface and types of the library 
+seperate from the library and without needing to add types to or change the 
+library itself. 
 
-The workflow for dealing with library code is:
+It's always possible to write a libdef file yourself if you need to, but for 
+public libraries we recommend using [flow-*typed*](https://github.com/flowtype/flow-typed/).
+flow-*typed* is a community-run project that organizes and shares existing, 
+high-quality libdefs for popular libraries.
+
+If you can't find the libdef you need there, consider writing one and then
+contributing it back so that the next person who needs it can benefit!
+
+Note that if you have a 3rd party library present in your project that isn't
+itself typed, Flow will treat it just like any other untyped JS file in your 
+project: It and all imports from it will be marked as `any` by default. This
+is the only place in Flow where `any` is ever injected in to your program by
+Flow.
+
+# Using flow-*typed*
+
+Using the [flow-*typed*](https://github.com/flowtype/flow-typed/) project for npm 
+projects is pretty straightforward. First, make sure you have the `flow-typed` 
+CLI installed:
+
+```bash
+$> npm install -g flow-typed
+```
+
+Then, from within your project directory, run `flow-typed install` after running 
+`npm install`:
+
+```bash
+$> npm install
+$> flow-typed install
+```
+
+The `flow-typed install` command will do the following:
+
+1. Read your `package.json` to identify the dependencies of your project
+1. For each dependency, look in the flow-*typed* repo for a compatible libdef.
+1. For each dependency:
+  * **If a compatible libdef is found**, download it into the 
+     `<PROJECT_ROOT>/flow-typed/` directory.
+  * **If no compatible libdef is found** and the library does not come with types, 
+     generate a stub libdef so that you can go fill in the types yourself. Don't
+     forget to contribute your work back up to flow-*typed* when you're done :)
+
+Since libdefs can be improved over time, **we recommend that you commit all
+libdefs into version control.** This ensures that all developers working in your
+project's repository have a consistent and predictable set of types. It is good 
+to periodically run `flow-typed update` to check and see if there have been any 
+improvements or bug fixes made to the libdefs you've installed for your project.
+
+## Writing custom library definition files
+
+Library definition files ("libdefs") define the interface to a library, 
+including types, separately from the actual code of the library. You never need 
+to change library code to use a library definition, but your code will be 
+typechecked against the types declared in the libdef.
+
+For libdefs of public libraries, consider using and contributing to 
+[flow-*typed*](https://github.com/flowtype/flow-typed/). If you have private 
+libraries or just want to write your own libdefs, here is the workflow for doing 
+so:
 
 * Do not change the library files or add `@flow` to them
-* Add one or more interface files for your libraries in a special directory in your project - for example `interfaces`
-* Point Flow at those interface files by starting it with `flow start --lib  <path to your interface files>` or by specifying a `[libs]` section in your `.flowconfig` file as such:
+* Add one or more libdefs for your libraries in to the 
+  "`<PROJECT_ROOT>/flow-typed/`" directory of your project. Flow recognizes this
+  directory as special by default and interprets it as a directory that contains
+  libdef files.
+
+If you need to customize the directory where libdefs are stored in your project,
+you can do so by adding a `[libs]` configuration to your .flowconfig file:
 
 ```
 [libs]
-interfaces/
+my-custom-libdefs-directory/
 ```
 
-## Example
+## Example: Writing a custom libdef
 
-To illustrate this workflow, we'll pick the [Underscore](http://underscorejs.org/) library. Let's say we have this simple file using Underscore:
+To illustrate this workflow, we'll start with the [lodash](https://lodash.com) 
+library. Let's say we have a simple file in our project using lodash:
+
+**main.js**
 
 ```js +line_numbers
-/* @flow */
+// @flow
+
+import _ from "lodash";
 
 var pizzas = [
   { title: 'Margherita', vegetarian: true },
@@ -38,47 +113,68 @@ var pizzas = [
 ];
 
 function vegetarianPizzas() {
-  return _.findWhere(pizzas, {vegetarian: true});
+  return _.ffind(pizas, {vegetarian: true});
 }
 ```
 
-Running `flow` will unsurprisingly produce an error:
-
-```text
-underscore_example.js:11:10,10: unknown global name: _
-```
-{: .cli-error}
-
-This is because Flow doesn't know anything about the global variable `_`. To fix this we need to create an interface file for Underscore. If we set the `[libs]` configuration to `interfaces/`, Flow will look for any `.js` files located inside that directory for declarations.
-
-```js +line_numbers
-// interfaces/underscore.js
-declare class Underscore {
-  findWhere<T>(list: Array<T>, properties: {}): T;
-}
-
-declare var _: Underscore;
-```
-
-This only describes (part of) the interface for Underscore, eliding all implementation details - so Flow never has to understand the Underscore code itself.
-
-If we now add the `interfaces/` directory to our flow config under a `[libs]` section:
-
-```
-[libs]
-interfaces/
-```
-
-We can run flow again and see that the error goes away:
+Running `flow` will produce no errors:
 
 ```bash
 $> flow
-```
-
-```
 Found 0 errors
 ```
 
-If you temporarily modify your code that uses Underscore to purposefully introduce a type error, you can verify that it's now being checked against this interface file.
+If you look closely at our example, though, you'll notice there is a bug! We've
+misspelled `find` as `ffind` on line 13.
 
-When defining the interface for a library, you can use the `any` type whenever you don't need Flow to check a value. This lets you gradually add type definitions for the parts of the library you care most about. See the reference guide on [declarations](declarations.html) for more details.
+The problem here is that Flow doesn't know anything about the lodash library
+since it is untyped (i.e. its code lacks `@flow` comments). To fix this we need
+a libdef file for lodash -- so let's write one ourselves:
+
+**flow-typed/lodash.js**
+
+```js
+declare module "lodash" {
+  declare module.exports: {
+    find<T>(list: Array<T>, properties: Object): T;
+  };
+}
+```
+
+Here we've written a file that contains a `declare module` statement.
+`declare module` inside a libdef tells Flow about the interface defined by a
+module of the given name.
+
+Within the body of this statement, we have another statement: 
+`declare module.exports: ...`. This is how we explain to Flow what the type of
+the `module.exports` object inside this module should be. In this case, we say
+that it is an object type with one `find` method.
+
+Everything after the `:` in "`declare module.exports: ...`" is just a normal type
+annotation, so you can read more about type annotations 
+[here](type-annotations.html).
+
+Now we can run flow again and see that Flow gives us an error as we'd expect:
+
+```bash
+$> flow
+main.js:13
+ 13:   return _.ffind(pizzas, {vegetarian: true});
+                ^^^^^ property `ffind`. Property not found in
+ 13:   return _.ffind(pizzas, {vegetarian: true});
+              ^ object type
+
+
+Found 1 error
+```
+
+If we fix the typeo in our code and run Flow again, we'll see that the Flow 
+error goes away:
+
+```bash
+$> flow
+Found 0 errors
+```
+
+For more information about `declare` statements in libdefs, see the reference 
+guide on [declarations](declarations.html).


### PR DESCRIPTION
Refreshes this docs page to:

* Use consistent "library definition"/"libdef" terminology
* Refer to the `flow-typed` for public library library definitions
* Recommend using the built-in `<PROJECT_ROOT>/flow-typed/` directory (rather than making your own + writing config)
* Fix the damn CSS on the site to make inline `<code>` text stand apart better from the rest of the text.