### PR TITLE
[parser] use AssignmentPattern for function param defaults

### DIFF
--- a/src/parser/estree_translator.ml
+++ b/src/parser/estree_translator.ml
@@ -217,7 +217,6 @@ end with type t = Impl.t) = struct
       node node_type loc [|
         "id", node_value;
         "params", array_of_list pattern fn.params;
-        "defaults", array_of_list (option expression) fn.defaults;
         "rest", option identifier fn.rest;
         "body", body;
         "async", bool fn.async;
@@ -324,7 +323,6 @@ end with type t = Impl.t) = struct
         node "ArrowFunctionExpression" loc [|
           "id", option identifier arrow.id;
           "params", array_of_list pattern arrow.params;
-          "defaults", array_of_list (option expression) arrow.defaults;
           "rest", option identifier arrow.rest;
           "body", body;
           "async", bool arrow.async;
@@ -528,7 +526,6 @@ end with type t = Impl.t) = struct
     node "FunctionExpression" loc [|
       "id", option identifier _function.id;
       "params", array_of_list pattern _function.params;
-      "defaults", array_of_list (option expression) _function.defaults;
       "rest", option identifier _function.rest;
       "body", body;
       "async", bool _function.async;

--- a/src/parser/spider_monkey_ast.ml
+++ b/src/parser/spider_monkey_ast.ml
@@ -997,7 +997,6 @@ and Function : sig
   type t = {
     id: Identifier.t option;
     params: Pattern.t list;
-    defaults: Expression.t option list;
     rest: Identifier.t option;
     body: body;
     async: bool;

--- a/src/parser/test/hardcoded_tests.js
+++ b/src/parser/test/hardcoded_tests.js
@@ -412,10 +412,11 @@ module.exports = {
             'optional': false,
           },
           {
-            'optional': true,
+            'type': 'AssignmentPattern',
+            'left.optional': true,
+            'right.value': 123,
           },
         ],
-        'body.0.defaults.1.value': 123,
       },
       'class Foo {set fooProp(value:number){}}': {
         'body.0.body.body.0.value.params.0.typeAnnotation.typeAnnotation': {
@@ -4276,7 +4277,6 @@ module.exports = {
               'optional':false
             }
           ],
-          'defaults':[],
           'rest':null,
           'body':{
             'type':'BlockStatement',
@@ -4344,7 +4344,6 @@ module.exports = {
                     'optional':false
                   }
                 ],
-                'defaults':[],
                 'rest':null,
                 'body':{
                   'type':'BinaryExpression',
@@ -4389,7 +4388,6 @@ module.exports = {
                 'optional':false
               }
             ],
-            'defaults':[],
             'rest':null,
             'body':{
               'type':'BinaryExpression',

--- a/src/typing/statement.ml
+++ b/src/typing/statement.ml
@@ -4721,7 +4721,6 @@ and declare_function_to_function_declaration cx id predicate =
           Some (Ast.Statement.FunctionDeclaration Ast.Function.({
             id = Some id;
             params = params;
-            defaults = [];
             rest = None;
             body = body;
             async = false;

--- a/tests/ast_tokens/ast_tokens.exp
+++ b/tests/ast_tokens/ast_tokens.exp
@@ -412,7 +412,6 @@
             "range":[196,210],
             "id":null,
             "params":[],
-            "defaults":[],
             "rest":null,
             "body":{
               "type":"Literal",


### PR DESCRIPTION
ESTree/esprima changed from storing function param defaults in an array parallel to the params, to storing them as `AssignmentPattern` params.

Fixes https://github.com/facebook/flow/issues/2503