### PR TITLE
Add type property of Selection class to declaration

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -698,6 +698,7 @@ declare class Selection {
   focusOffset: number;
   isCollapsed: boolean;
   rangeCount: number;
+  type: string;
   addRange(range: Range): void;
   getRangeAt(index: number): Range;
   removeRange(range: Range): void;

--- a/tests/dom/dom.exp
+++ b/tests/dom/dom.exp
@@ -3,128 +3,128 @@ CanvasRenderingContext2D.js:11
          ^^^^^^^^^^^^^^^^^^^^ call of method `moveTo`
  11:     ctx.moveTo('0', '1');  // error: should be numbers
                     ^^^ string. This type is incompatible with
-number. See lib: dom.js:1194
+number. See lib: dom.js:1195
 
 CanvasRenderingContext2D.js:11
  11:     ctx.moveTo('0', '1');  // error: should be numbers
          ^^^^^^^^^^^^^^^^^^^^ call of method `moveTo`
  11:     ctx.moveTo('0', '1');  // error: should be numbers
                          ^^^ string. This type is incompatible with
-number. See lib: dom.js:1194
+number. See lib: dom.js:1195
 
 Element.js:14
  14:     element.scrollIntoView({ behavior: 'invalid' });
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call of method `scrollIntoView`
  14:     element.scrollIntoView({ behavior: 'invalid' });
                                 ^^^^^^^^^^^^^^^^^^^^^^^ object literal. This type is incompatible with
-union: boolean | object type. See lib: dom.js:864
+union: boolean | object type. See lib: dom.js:865
   Member 1:
-  boolean. See lib: dom.js:864
+  boolean. See lib: dom.js:865
   Error:
    14:     element.scrollIntoView({ behavior: 'invalid' });
                                   ^^^^^^^^^^^^^^^^^^^^^^^ object literal. This type is incompatible with
-  boolean. See lib: dom.js:864
+  boolean. See lib: dom.js:865
   Member 2:
-  object type. See lib: dom.js:864
+  object type. See lib: dom.js:865
   Error:
    14:     element.scrollIntoView({ behavior: 'invalid' });
                                               ^^^^^^^^^ string. This type is incompatible with
-  string enum. See lib: dom.js:864
+  string enum. See lib: dom.js:865
 
 Element.js:15
  15:     element.scrollIntoView({ block: 'invalid' });
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call of method `scrollIntoView`
  15:     element.scrollIntoView({ block: 'invalid' });
                                 ^^^^^^^^^^^^^^^^^^^^ object literal. This type is incompatible with
-union: boolean | object type. See lib: dom.js:864
+union: boolean | object type. See lib: dom.js:865
   Member 1:
-  boolean. See lib: dom.js:864
+  boolean. See lib: dom.js:865
   Error:
    15:     element.scrollIntoView({ block: 'invalid' });
                                   ^^^^^^^^^^^^^^^^^^^^ object literal. This type is incompatible with
-  boolean. See lib: dom.js:864
+  boolean. See lib: dom.js:865
   Member 2:
-  object type. See lib: dom.js:864
+  object type. See lib: dom.js:865
   Error:
    15:     element.scrollIntoView({ block: 'invalid' });
                                            ^^^^^^^^^ string. This type is incompatible with
-  string enum. See lib: dom.js:864
+  string enum. See lib: dom.js:865
 
 Element.js:16
  16:     element.scrollIntoView(1);
          ^^^^^^^^^^^^^^^^^^^^^^^^^ call of method `scrollIntoView`
  16:     element.scrollIntoView(1);
                                 ^ number. This type is incompatible with
-union: boolean | object type. See lib: dom.js:864
+union: boolean | object type. See lib: dom.js:865
   Member 1:
-  boolean. See lib: dom.js:864
+  boolean. See lib: dom.js:865
   Error:
    16:     element.scrollIntoView(1);
                                   ^ number. This type is incompatible with
-  boolean. See lib: dom.js:864
+  boolean. See lib: dom.js:865
   Member 2:
-  object type. See lib: dom.js:864
+  object type. See lib: dom.js:865
   Error:
    16:     element.scrollIntoView(1);
                                   ^ number. This type is incompatible with
-  object type. See lib: dom.js:864
+  object type. See lib: dom.js:865
 
 HTMLElement.js:14
  14:     element.scrollIntoView({ behavior: 'invalid' });
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call of method `scrollIntoView`
  14:     element.scrollIntoView({ behavior: 'invalid' });
                                 ^^^^^^^^^^^^^^^^^^^^^^^ object literal. This type is incompatible with
-union: boolean | object type. See lib: dom.js:864
+union: boolean | object type. See lib: dom.js:865
   Member 1:
-  boolean. See lib: dom.js:864
+  boolean. See lib: dom.js:865
   Error:
    14:     element.scrollIntoView({ behavior: 'invalid' });
                                   ^^^^^^^^^^^^^^^^^^^^^^^ object literal. This type is incompatible with
-  boolean. See lib: dom.js:864
+  boolean. See lib: dom.js:865
   Member 2:
-  object type. See lib: dom.js:864
+  object type. See lib: dom.js:865
   Error:
    14:     element.scrollIntoView({ behavior: 'invalid' });
                                               ^^^^^^^^^ string. This type is incompatible with
-  string enum. See lib: dom.js:864
+  string enum. See lib: dom.js:865
 
 HTMLElement.js:15
  15:     element.scrollIntoView({ block: 'invalid' });
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call of method `scrollIntoView`
  15:     element.scrollIntoView({ block: 'invalid' });
                                 ^^^^^^^^^^^^^^^^^^^^ object literal. This type is incompatible with
-union: boolean | object type. See lib: dom.js:864
+union: boolean | object type. See lib: dom.js:865
   Member 1:
-  boolean. See lib: dom.js:864
+  boolean. See lib: dom.js:865
   Error:
    15:     element.scrollIntoView({ block: 'invalid' });
                                   ^^^^^^^^^^^^^^^^^^^^ object literal. This type is incompatible with
-  boolean. See lib: dom.js:864
+  boolean. See lib: dom.js:865
   Member 2:
-  object type. See lib: dom.js:864
+  object type. See lib: dom.js:865
   Error:
    15:     element.scrollIntoView({ block: 'invalid' });
                                            ^^^^^^^^^ string. This type is incompatible with
-  string enum. See lib: dom.js:864
+  string enum. See lib: dom.js:865
 
 HTMLElement.js:16
  16:     element.scrollIntoView(1);
          ^^^^^^^^^^^^^^^^^^^^^^^^^ call of method `scrollIntoView`
  16:     element.scrollIntoView(1);
                                 ^ number. This type is incompatible with
-union: boolean | object type. See lib: dom.js:864
+union: boolean | object type. See lib: dom.js:865
   Member 1:
-  boolean. See lib: dom.js:864
+  boolean. See lib: dom.js:865
   Error:
    16:     element.scrollIntoView(1);
                                   ^ number. This type is incompatible with
-  boolean. See lib: dom.js:864
+  boolean. See lib: dom.js:865
   Member 2:
-  object type. See lib: dom.js:864
+  object type. See lib: dom.js:865
   Error:
    16:     element.scrollIntoView(1);
                                   ^ number. This type is incompatible with
-  object type. See lib: dom.js:864
+  object type. See lib: dom.js:865
 
 HTMLInputElement.js:7
   7:     el.setRangeText('foo', 123); // end is required
@@ -132,17 +132,17 @@ HTMLInputElement.js:7
   7:     el.setRangeText('foo', 123); // end is required
          ^^^^^^^^^^^^^^^ intersection
   Member 1:
-  function type. See lib: dom.js:1539
-  Error:
-    7:     el.setRangeText('foo', 123); // end is required
-                                  ^^^ number. This type is incompatible with
-  undefined. See lib: dom.js:1539
-  Member 2:
   function type. See lib: dom.js:1540
   Error:
     7:     el.setRangeText('foo', 123); // end is required
+                                  ^^^ number. This type is incompatible with
+  undefined. See lib: dom.js:1540
+  Member 2:
+  function type. See lib: dom.js:1541
+  Error:
+    7:     el.setRangeText('foo', 123); // end is required
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^ undefined (too few arguments, expected default/rest parameters). This type is incompatible with
-  number. See lib: dom.js:1540
+  number. See lib: dom.js:1541
 
 HTMLInputElement.js:10
  10:     el.setRangeText('foo', 123, 234, 'bogus'); // invalid value
@@ -150,17 +150,17 @@ HTMLInputElement.js:10
  10:     el.setRangeText('foo', 123, 234, 'bogus'); // invalid value
          ^^^^^^^^^^^^^^^ intersection
   Member 1:
-  function type. See lib: dom.js:1539
-  Error:
-   10:     el.setRangeText('foo', 123, 234, 'bogus'); // invalid value
-                                  ^^^ number. This type is incompatible with
-  undefined. See lib: dom.js:1539
-  Member 2:
   function type. See lib: dom.js:1540
   Error:
    10:     el.setRangeText('foo', 123, 234, 'bogus'); // invalid value
+                                  ^^^ number. This type is incompatible with
+  undefined. See lib: dom.js:1540
+  Member 2:
+  function type. See lib: dom.js:1541
+  Error:
+   10:     el.setRangeText('foo', 123, 234, 'bogus'); // invalid value
                                             ^^^^^^^ string. This type is incompatible with
-  string enum. See lib: dom.js:1540
+  string enum. See lib: dom.js:1541
 
 URL.js:8
   8: const e: string = c.path; // not correct
@@ -186,17 +186,17 @@ path2d.js:9
   9:     (path.arcTo(0, 0, 0, 0, 10, '20', 5): void); // invalid
           ^^^^^^^^^^ intersection
   Member 1:
-  function type. See lib: dom.js:1068
-  Error:
-    9:     (path.arcTo(0, 0, 0, 0, 10, '20', 5): void); // invalid
-                                       ^^^^ string. This type is incompatible with
-  undefined. See lib: dom.js:1068
-  Member 2:
   function type. See lib: dom.js:1069
   Error:
     9:     (path.arcTo(0, 0, 0, 0, 10, '20', 5): void); // invalid
                                        ^^^^ string. This type is incompatible with
-  number. See lib: dom.js:1069
+  undefined. See lib: dom.js:1069
+  Member 2:
+  function type. See lib: dom.js:1070
+  Error:
+    9:     (path.arcTo(0, 0, 0, 0, 10, '20', 5): void); // invalid
+                                       ^^^^ string. This type is incompatible with
+  number. See lib: dom.js:1070
 
 registerElement.js:48
  48:     document.registerElement('custom-element', {
@@ -743,48 +743,48 @@ traversal.js:30
 traversal.js:183
 183:     document.createNodeIterator(document.body, -1, node => 'accept'); // invalid
                                                                 ^^^^^^^^ string. This type is incompatible with
-union: typeof typeof-annotation '<<object>>.FILTER_ACCEPT') | typeof typeof-annotation '<<object>>.FILTER_REJECT') | typeof typeof-annotation '<<object>>.FILTER_SKIP'). See lib: dom.js:1874
+union: typeof typeof-annotation '<<object>>.FILTER_ACCEPT') | typeof typeof-annotation '<<object>>.FILTER_REJECT') | typeof typeof-annotation '<<object>>.FILTER_SKIP'). See lib: dom.js:1875
   Member 1:
-  typeof typeof-annotation '<<object>>.FILTER_ACCEPT'). See lib: dom.js:1874
+  typeof typeof-annotation '<<object>>.FILTER_ACCEPT'). See lib: dom.js:1875
   Error:
   183:     document.createNodeIterator(document.body, -1, node => 'accept'); // invalid
                                                                   ^^^^^^^^ string. This type is incompatible with
-  number literal `1`. See lib: dom.js:1874
+  number literal `1`. See lib: dom.js:1875
   Member 2:
-  typeof typeof-annotation '<<object>>.FILTER_REJECT'). See lib: dom.js:1875
+  typeof typeof-annotation '<<object>>.FILTER_REJECT'). See lib: dom.js:1876
   Error:
   183:     document.createNodeIterator(document.body, -1, node => 'accept'); // invalid
                                                                   ^^^^^^^^ string. This type is incompatible with
-  number literal `2`. See lib: dom.js:1875
+  number literal `2`. See lib: dom.js:1876
   Member 3:
-  typeof typeof-annotation '<<object>>.FILTER_SKIP'). See lib: dom.js:1876
+  typeof typeof-annotation '<<object>>.FILTER_SKIP'). See lib: dom.js:1877
   Error:
   183:     document.createNodeIterator(document.body, -1, node => 'accept'); // invalid
                                                                   ^^^^^^^^ string. This type is incompatible with
-  number literal `3`. See lib: dom.js:1876
+  number literal `3`. See lib: dom.js:1877
 
 traversal.js:185
 185:     document.createNodeIterator(document.body, -1, { accept: node => 'accept' }); // invalid
                                                                           ^^^^^^^^ string. This type is incompatible with
-union: typeof typeof-annotation '<<object>>.FILTER_ACCEPT') | typeof typeof-annotation '<<object>>.FILTER_REJECT') | typeof typeof-annotation '<<object>>.FILTER_SKIP'). See lib: dom.js:1874
+union: typeof typeof-annotation '<<object>>.FILTER_ACCEPT') | typeof typeof-annotation '<<object>>.FILTER_REJECT') | typeof typeof-annotation '<<object>>.FILTER_SKIP'). See lib: dom.js:1875
   Member 1:
-  typeof typeof-annotation '<<object>>.FILTER_ACCEPT'). See lib: dom.js:1874
+  typeof typeof-annotation '<<object>>.FILTER_ACCEPT'). See lib: dom.js:1875
   Error:
   185:     document.createNodeIterator(document.body, -1, { accept: node => 'accept' }); // invalid
                                                                             ^^^^^^^^ string. This type is incompatible with
-  number literal `1`. See lib: dom.js:1874
+  number literal `1`. See lib: dom.js:1875
   Member 2:
-  typeof typeof-annotation '<<object>>.FILTER_REJECT'). See lib: dom.js:1875
+  typeof typeof-annotation '<<object>>.FILTER_REJECT'). See lib: dom.js:1876
   Error:
   185:     document.createNodeIterator(document.body, -1, { accept: node => 'accept' }); // invalid
                                                                             ^^^^^^^^ string. This type is incompatible with
-  number literal `2`. See lib: dom.js:1875
+  number literal `2`. See lib: dom.js:1876
   Member 3:
-  typeof typeof-annotation '<<object>>.FILTER_SKIP'). See lib: dom.js:1876
+  typeof typeof-annotation '<<object>>.FILTER_SKIP'). See lib: dom.js:1877
   Error:
   185:     document.createNodeIterator(document.body, -1, { accept: node => 'accept' }); // invalid
                                                                             ^^^^^^^^ string. This type is incompatible with
-  number literal `3`. See lib: dom.js:1876
+  number literal `3`. See lib: dom.js:1877
 
 traversal.js:186
 186:     document.createNodeIterator(document.body, -1, {}); // invalid
@@ -1038,15 +1038,15 @@ traversal.js:186
                                                           ^^ object literal. This type is incompatible with
   union: NodeFilterCallback | object type. See lib: dom.js:665
     Member 1:
-    NodeFilterCallback. See lib: dom.js:1878
+    NodeFilterCallback. See lib: dom.js:1879
     Error:
-    function type. Callable signature not found in. See lib: dom.js:1878
+    function type. Callable signature not found in. See lib: dom.js:1879
     186:     document.createNodeIterator(document.body, -1, {}); // invalid
                                                             ^^ object literal
     Member 2:
-    object type. See lib: dom.js:1878
+    object type. See lib: dom.js:1879
     Error:
-    property `accept`. Property not found in. See lib: dom.js:1878
+    property `accept`. Property not found in. See lib: dom.js:1879
     186:     document.createNodeIterator(document.body, -1, {}); // invalid
                                                             ^^ object literal
   Member 42:
@@ -1065,48 +1065,48 @@ traversal.js:186
 traversal.js:190
 190:     document.createTreeWalker(document.body, -1, node => 'accept'); // invalid
                                                               ^^^^^^^^ string. This type is incompatible with
-union: typeof typeof-annotation '<<object>>.FILTER_ACCEPT') | typeof typeof-annotation '<<object>>.FILTER_REJECT') | typeof typeof-annotation '<<object>>.FILTER_SKIP'). See lib: dom.js:1874
+union: typeof typeof-annotation '<<object>>.FILTER_ACCEPT') | typeof typeof-annotation '<<object>>.FILTER_REJECT') | typeof typeof-annotation '<<object>>.FILTER_SKIP'). See lib: dom.js:1875
   Member 1:
-  typeof typeof-annotation '<<object>>.FILTER_ACCEPT'). See lib: dom.js:1874
+  typeof typeof-annotation '<<object>>.FILTER_ACCEPT'). See lib: dom.js:1875
   Error:
   190:     document.createTreeWalker(document.body, -1, node => 'accept'); // invalid
                                                                 ^^^^^^^^ string. This type is incompatible with
-  number literal `1`. See lib: dom.js:1874
+  number literal `1`. See lib: dom.js:1875
   Member 2:
-  typeof typeof-annotation '<<object>>.FILTER_REJECT'). See lib: dom.js:1875
+  typeof typeof-annotation '<<object>>.FILTER_REJECT'). See lib: dom.js:1876
   Error:
   190:     document.createTreeWalker(document.body, -1, node => 'accept'); // invalid
                                                                 ^^^^^^^^ string. This type is incompatible with
-  number literal `2`. See lib: dom.js:1875
+  number literal `2`. See lib: dom.js:1876
   Member 3:
-  typeof typeof-annotation '<<object>>.FILTER_SKIP'). See lib: dom.js:1876
+  typeof typeof-annotation '<<object>>.FILTER_SKIP'). See lib: dom.js:1877
   Error:
   190:     document.createTreeWalker(document.body, -1, node => 'accept'); // invalid
                                                                 ^^^^^^^^ string. This type is incompatible with
-  number literal `3`. See lib: dom.js:1876
+  number literal `3`. See lib: dom.js:1877
 
 traversal.js:192
 192:     document.createTreeWalker(document.body, -1, { accept: node => 'accept' }); // invalid
                                                                         ^^^^^^^^ string. This type is incompatible with
-union: typeof typeof-annotation '<<object>>.FILTER_ACCEPT') | typeof typeof-annotation '<<object>>.FILTER_REJECT') | typeof typeof-annotation '<<object>>.FILTER_SKIP'). See lib: dom.js:1874
+union: typeof typeof-annotation '<<object>>.FILTER_ACCEPT') | typeof typeof-annotation '<<object>>.FILTER_REJECT') | typeof typeof-annotation '<<object>>.FILTER_SKIP'). See lib: dom.js:1875
   Member 1:
-  typeof typeof-annotation '<<object>>.FILTER_ACCEPT'). See lib: dom.js:1874
+  typeof typeof-annotation '<<object>>.FILTER_ACCEPT'). See lib: dom.js:1875
   Error:
   192:     document.createTreeWalker(document.body, -1, { accept: node => 'accept' }); // invalid
                                                                           ^^^^^^^^ string. This type is incompatible with
-  number literal `1`. See lib: dom.js:1874
+  number literal `1`. See lib: dom.js:1875
   Member 2:
-  typeof typeof-annotation '<<object>>.FILTER_REJECT'). See lib: dom.js:1875
+  typeof typeof-annotation '<<object>>.FILTER_REJECT'). See lib: dom.js:1876
   Error:
   192:     document.createTreeWalker(document.body, -1, { accept: node => 'accept' }); // invalid
                                                                           ^^^^^^^^ string. This type is incompatible with
-  number literal `2`. See lib: dom.js:1875
+  number literal `2`. See lib: dom.js:1876
   Member 3:
-  typeof typeof-annotation '<<object>>.FILTER_SKIP'). See lib: dom.js:1876
+  typeof typeof-annotation '<<object>>.FILTER_SKIP'). See lib: dom.js:1877
   Error:
   192:     document.createTreeWalker(document.body, -1, { accept: node => 'accept' }); // invalid
                                                                           ^^^^^^^^ string. This type is incompatible with
-  number literal `3`. See lib: dom.js:1876
+  number literal `3`. See lib: dom.js:1877
 
 traversal.js:193
 193:     document.createTreeWalker(document.body, -1, {}); // invalid
@@ -1360,15 +1360,15 @@ traversal.js:193
                                                         ^^ object literal. This type is incompatible with
   union: NodeFilterCallback | object type. See lib: dom.js:673
     Member 1:
-    NodeFilterCallback. See lib: dom.js:1878
+    NodeFilterCallback. See lib: dom.js:1879
     Error:
-    function type. Callable signature not found in. See lib: dom.js:1878
+    function type. Callable signature not found in. See lib: dom.js:1879
     193:     document.createTreeWalker(document.body, -1, {}); // invalid
                                                           ^^ object literal
     Member 2:
-    object type. See lib: dom.js:1878
+    object type. See lib: dom.js:1879
     Error:
-    property `accept`. Property not found in. See lib: dom.js:1878
+    property `accept`. Property not found in. See lib: dom.js:1879
     193:     document.createTreeWalker(document.body, -1, {}); // invalid
                                                           ^^ object literal
   Member 42:
@@ -1378,15 +1378,15 @@ traversal.js:193
                                                         ^^ object literal. This type is incompatible with
   union: NodeFilterCallback | object type. See lib: dom.js:677
     Member 1:
-    NodeFilterCallback. See lib: dom.js:1878
+    NodeFilterCallback. See lib: dom.js:1879
     Error:
-    function type. Callable signature not found in. See lib: dom.js:1878
+    function type. Callable signature not found in. See lib: dom.js:1879
     193:     document.createTreeWalker(document.body, -1, {}); // invalid
                                                           ^^ object literal
     Member 2:
-    object type. See lib: dom.js:1878
+    object type. See lib: dom.js:1879
     Error:
-    property `accept`. Property not found in. See lib: dom.js:1878
+    property `accept`. Property not found in. See lib: dom.js:1879
     193:     document.createTreeWalker(document.body, -1, {}); // invalid
                                                           ^^ object literal
   Member 43:


### PR DESCRIPTION
The type definition for the `Selection` class is missing the `type` property. See [https://www.w3.org/TR/selection-api/#attributes](https://www.w3.org/TR/selection-api/#attributes).