### PR TITLE
Add Make server.close callback more specific.

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -822,7 +822,7 @@ declare module "http" {
     listen(port: number, hostname?: string, backlog?: number, callback?: Function): Server;
     listen(path: string, callback?: Function): Server;
     listen(handle: Object, callback?: Function): Server;
-    close(callback?: Function): Server;
+    close(callback?: (error: ?Error) => void): Server;
     maxHeadersCount: number;
     setTimeout(msecs: number, callback: Function): Server;
     timeout: number;
@@ -850,7 +850,7 @@ declare module "https" {
     listen(port: number, hostname?: string, backlog?: number, callback?: Function): Server;
     listen(path: string, callback?: Function): Server;
     listen(handle: Object, callback?: Function): Server;
-    close(callback?: Function): Server;
+    close(callback?: (error: ?Error) => void): Server;
     setTimeout(msecs: number, callback: Function): Server;
     timeout: number;
   }


### PR DESCRIPTION
Change the callback of `server.close` from `Function`
to one that takes an optional error and returns void.

Signed-off-by: Joe Grund joe.grund@intel.com
