### PR TITLE
[try flow] support multiple versions of flow

### DIFF
--- a/resources/travis/deploy.sh
+++ b/resources/travis/deploy.sh
@@ -17,10 +17,17 @@ bundle install
 printf "travis_fold:end:installing_jekyll\n"
 
 printf "travis_fold:start:jekyll_build\nBuilding Jekyll site\n"
+GEN_DIR=$([[ "$TRAVIS_TAG" = "" ]] && echo "master" || echo "$TRAVIS_TAG")
 mkdir -p "$PAGES_CHECKOUT"
-mkdir -p "website/_assets/gen"
-cp "bin/flow.js" "website/_assets/gen/flow.js"
-cp -r "lib" "website/static/flowlib"
+mkdir -p "website/_assets/gen/${GEN_DIR}"
+mkdir -p "website/static/$GEN_DIR"
+cp "bin/flow.js" "website/_assets/gen/${GEN_DIR}/flow.js"
+cp -r "lib" "website/static/${GEN_DIR}/flowlib"
+echo "version" > "website/_data/flow_dot_js_versions.csv"
+git tag -l | \
+  grep -e 'v[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}' | \
+  sort -s -t. -k 1,1nr -k 2,2nr -k 3,3nr | \
+  head -n 5 >> "website/_data/flow_dot_js_versions.csv"
 env \
   PATH="${TRAVIS_BUILD_DIR}/bin:$PATH" \
   bundle exec jekyll build -s website/ -d "$PAGES_CHECKOUT" --verbose

--- a/website/.gitignore
+++ b/website/.gitignore
@@ -16,3 +16,5 @@ _assets/third-party-bower
 # Flow build artifacts are copied here:
 _assets/gen
 static/flowlib
+/static/master
+/_data/flow_dot_js_versions.csv

--- a/website/README.md
+++ b/website/README.md
@@ -33,15 +33,16 @@ bundle install
 npm install
 node_modules/.bin/bower install
 rm -f "_assets/gen" "static/flowlib"
-ln -sf "../bin/flow.js" "_assets/gen"
-ln -sf "../lib" "static/flowlib"
+mkdir -p "_assets/gen"
+ln -sf "../../../bin/flow.js" "_assets/gen/flow.js"
+ln -sf "../../lib" "static/flowlib"
 ```
 
 ### Build and Run
 
 ```
 (cd ..; make js)
-jekyll serve -w
+bundle exec jekyll serve -w
 ```
 
 This will fire up a web server at http://localhost:8000 by default. To access it from other machines, add `--host ::` (all interfaces, including IPv6).

--- a/website/_assets/css/tryFlow.css
+++ b/website/_assets/css/tryFlow.css
@@ -46,6 +46,7 @@
 }
 
 .editor .results .toolbar {
+  position: relative;
   background: #fff;
   border-bottom: 1px solid #ddd;
   list-style: none;
@@ -70,6 +71,13 @@
   background: #f7f7f7;
   border-bottom: 1px solid #f7f7f7;
   margin-bottom: -1px;
+}
+
+.editor .results .toolbar .version {
+  position: absolute;
+  right: 5px;
+  top: 0px;
+  line-height: 36px;
 }
 
 .editor .results .errors,

--- a/website/_assets/js/prelude.js
+++ b/website/_assets/js/prelude.js
@@ -1,4 +1,5 @@
 //= require requirejs
+//= link_tree ../gen
 
 require.config({
   baseUrl: '/assets',

--- a/website/_plugins/jekyll_flowdoc.rb
+++ b/website/_plugins/jekyll_flowdoc.rb
@@ -35,6 +35,17 @@ module Jekyll
 
         true
       end
+
+      site.config['flow'] ||= {}
+      if site.data['flow_dot_js_versions'].nil?
+        version = ENV["TRAVIS_TAG"] || "master"
+        site.config['flow']['version'] = version
+        site.config['flow']['versions'] = [version]
+      else
+        versions = site.data['flow_dot_js_versions'].map {|v| v['version'] }
+        site.config['flow']['version'] = versions.first
+        site.config['flow']['versions'] = ["master"] + versions
+      end
     end
   end
 

--- a/website/s3_website.yml
+++ b/website/s3_website.yml
@@ -13,6 +13,12 @@ cloudfront_wildcard_invalidation: true
 redirects:
   docs/about-flow.html: about/
 
+ignore_on_server:
+  - assets/v.*
+  - assets/master
+  - static/v.*
+  - static/master
+
 # Below are examples of all the available configurations.
 # See README for more detailed info on each of them.
 

--- a/website/try/index.html
+++ b/website/try/index.html
@@ -15,13 +15,15 @@ layout: try
 </div>
 
 <script>
-  require(
-    ['{% asset_name 'tryFlow.js' %}', '{% asset_name 'flow.js' %}'],
-    function(tryFlow) {
-      tryFlow.createEditor(
-        document.getElementById("code"),
-        document.getElementById("results")
-      );
-    }
-  );
+(function() {
+  require(['{{ site.flow.version }}/flow'], function() {}); // preload flow
+  require(['{% asset_name 'tryFlow.js' %}'], function(tryFlow) {
+    tryFlow.createEditor(
+      '{{ site.flow.version }}/flow',
+      document.getElementById("code"),
+      document.getElementById("results"),
+      ["{{ site.flow.versions | join: '", "' }}"]
+    );
+  });
+})();
 </script>


### PR DESCRIPTION
adds a version selector to /try, letting you run master + the 5 most recent versions. it defaults to the most recent release, instead of tracking master like it does now.

when travis builds the site, it writes `flow.js` and the libs to a versioned path, which are uploaded to S3. the old versions are kept in S3. I manually backfilled the last 5 tags to S3.

aside: also fixed the website install instructions, and mocked the github API when not running in Travis