### PR TITLE
Provide description for EmptyT

### DIFF
--- a/src/common/reason.ml
+++ b/src/common/reason.ml
@@ -342,7 +342,7 @@ let rec string_of_desc = function
   | RString -> "string"
   | RBoolean -> "boolean"
   | RMixed -> "mixed"
-  | REmpty -> ""
+  | REmpty -> "empty"
   | RAny -> "any"
   | RVoid -> "undefined"
   | RNull -> "null"


### PR DESCRIPTION
As mentioned in an internal post ( https://www.facebook.com/groups/flowtype/permalink/1145825575466056/ ), in case there's an impossible type, get-type-at-pos doesn't return anything meaningful because EmptyT description is "" instead of "empty". This is an attempt at fixing it.

Note that I wrote this from github and haven't compiled or tested the change, but I'd really love for this to be fixed inside of flow such that nuclide can show a proper typehint.