### PR TITLE
Update types in node API: child_processes

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -144,6 +144,7 @@ type child_process$execSyncOpts = {
   input?: string | Buffer;
   stdio?: Array<any>;
   env?: Object;
+  shell?: string,
   uid?: number;
   gid?: number;
   timeout?: number;

--- a/lib/node.js
+++ b/lib/node.js
@@ -182,10 +182,12 @@ type child_process$Handle = any; // TODO
 type child_process$spawnOpts = {
   cwd?: string;
   env?: Object;
+  argv0?: string;
   stdio?: string | Array<any>;
   detached?: boolean;
   uid?: number;
   gid?: number;
+  shell?: boolean | string;
 };
 
 type child_process$spawnRet = {

--- a/lib/node.js
+++ b/lib/node.js
@@ -231,19 +231,20 @@ type child_process$spawnSyncRet = child_process$spawnRet;
 
 declare class child_process$ChildProcess extends events$EventEmitter {
   connected: boolean;
+  stderr: stream$Readable;
+  stdin: stream$Writable;
+  stdio: Array<any>;
+  stdout: stream$Readable;
+  pid: number;
+
   disconnect(): void;
   kill(signal?: string): void;
-  pid: number;
   send(
     message: Object,
     sendHandleOrCallback?: child_process$Handle,
     optionsOrCallback?: Object | () => void,
     callback?: () => void
   ): boolean;
-  stderr: stream$Readable;
-  stdin: stream$Writable;
-  stdio: Array<any>;
-  stdout: stream$Readable;
 }
 
 declare module "child_process" {

--- a/lib/node.js
+++ b/lib/node.js
@@ -166,6 +166,19 @@ type child_process$execFileOpts = {
 
 type child_process$execFileCallback = (error: ?child_process$Error, stdout: Buffer, stderr: Buffer) => void;
 
+type child_process$execFileSyncOpts = {
+  cwd?: string;
+  input?: string | Buffer;
+  stdio?: Array<any>;
+  env?: Object;
+  uid?: number;
+  gid?: number;
+  timeout?: number;
+  killSignal?: string;
+  maxBuffer?: number;
+  encoding?: string;
+};
+
 type child_process$forkOpts = {
   cwd?: string;
   env?: Object;
@@ -241,8 +254,8 @@ declare module "child_process" {
 
   declare function execFileSync(
     command: string,
-    argsOrOptions?: Array<string> | child_process$execFileOpts,
-    options?: child_process$execFileOpts
+    argsOrOptions?: Array<string> | child_process$execFileSyncOpts,
+    options?: child_process$execFileSyncOpts
   ): Buffer | string;
 
   declare function fork(

--- a/lib/node.js
+++ b/lib/node.js
@@ -213,6 +213,22 @@ type child_process$spawnRet = {
   error: Error;
 };
 
+type child_process$spawnSyncOpts = {
+  cwd?: string;
+  input?: string | Buffer;
+  stdio?: Array<any>;
+  env?: Object;
+  uid?: number;
+  gid?: number;
+  timeout?: number;
+  killSignal?: string;
+  maxBuffer?: number;
+  encoding?: string;
+  shell?: boolean | string;
+};
+
+type child_process$spawnSyncRet = child_process$spawnRet;
+
 declare class child_process$ChildProcess extends events$EventEmitter {
   stdin: stream$Writable;
   stdout: stream$Readable;
@@ -272,9 +288,9 @@ declare module "child_process" {
 
   declare function spawnSync(
     command: string,
-    argsOrOptions?: Array<string> | child_process$spawnOpts,
-    options?: child_process$spawnOpts
-  ): child_process$spawnRet;
+    argsOrOptions?: Array<string> | child_process$spawnSyncOpts,
+    options?: child_process$spawnSyncOpts
+  ): child_process$spawnSyncRet;
 }
 
 type cluster$Worker = {

--- a/lib/node.js
+++ b/lib/node.js
@@ -300,7 +300,7 @@ declare module "child_process" {
 }
 
 type cluster$Worker = {
-  id: string;
+  id: number;
   process: child_process$ChildProcess;
   suicide: boolean;
 

--- a/lib/node.js
+++ b/lib/node.js
@@ -230,15 +230,20 @@ type child_process$spawnSyncOpts = {
 type child_process$spawnSyncRet = child_process$spawnRet;
 
 declare class child_process$ChildProcess extends events$EventEmitter {
-  stdin: stream$Writable;
-  stdout: stream$Readable;
-  stderr: stream$Readable;
-  pid: number;
   connected: boolean;
-
   disconnect(): void;
   kill(signal?: string): void;
-  send(message: Object, sendHandle?: child_process$Handle): boolean;
+  pid: number;
+  send(
+    message: Object,
+    sendHandleOrCallback?: child_process$Handle,
+    optionsOrCallback?: Object | () => void,
+    callback?: () => void
+  ): boolean;
+  stderr: stream$Readable;
+  stdin: stream$Writable;
+  stdio: Array<any>;
+  stdout: stream$Readable;
 }
 
 declare module "child_process" {


### PR DESCRIPTION
This PR updates all the types of node's `child_process` to the [current](https://nodejs.org/dist/latest-v6.x/docs/api/child_process.html#child_process_class_childprocess) [supported](https://nodejs.org/dist/latest-v4.x/docs/api/child_process.html#child_process_class_childprocess) node API's (v4+).
