### PR TITLE
Update types of node cluster

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -267,25 +267,41 @@ type cluster$Worker = {
   suicide: boolean;
 
   disconnect(): void;
+  isConnected(): boolean;
+  isDead(): boolean;
   kill(signal?: string): void;
-  send(message: Object, sendHandle?: child_process$Handle): boolean;
+  send(
+    message: Object,
+    sendHandleOrCallback?: child_process$Handle | () => void,
+    callback?: () => void,
+  ): boolean;
+}
+
+type cluster$setupMasterOpts = {
+  exec?: string;
+  args?: Array<string>;
+  silent?: boolean;
+  stdio?: Array<any>;
 }
 
 declare module "cluster" {
   declare var isMaster: boolean;
   declare var isWorker: boolean;
   declare var settings: {
-    args: Array<string>;
-    exec: string;
     execArgv: Array<string>;
+    exec: string;
+    args: Array<string>;
     silent: boolean;
+    stdio: Array<any>;
+    uid: number;
+    gid: number;
   };
   declare var worker: cluster$Worker;
   declare var workers: Object;
 
   declare function disconnect(callback?: () => void): void;
   declare function fork(env?: Object): cluster$Worker;
-  declare function setupMaster(settings?: Object): void;
+  declare function setupMaster(settings?: cluster$setupMasterOpts): void;
 }
 
 type crypto$createCredentialsDetails = any; // TODO


### PR DESCRIPTION
This PR updates all the types of [`Cluster`](https://nodejs.org/dist/latest-v6.x/docs/api/cluster.html) to the current Node API.
