### PR TITLE
[core] add missing isPrototypeOf

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -51,6 +51,7 @@ declare class Object {
     static setPrototypeOf(o: any, proto: ?Object): bool;
     static values(object: any): Array<mixed>;
     hasOwnProperty(prop: any): boolean;
+    isPrototypeOf(o: any): boolean;
     propertyIsEnumerable(prop: any): boolean;
     toLocaleString(): string;
     toString(): string;


### PR DESCRIPTION
Adds support for https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Object/isPrototypeOf

Fixes https://github.com/facebook/flow/issues/1483