### PR TITLE
Avoid single quotes on Windows

### DIFF
--- a/tsrc/test/builder.js
+++ b/tsrc/test/builder.js
@@ -291,13 +291,15 @@ export class TestBuilder {
   async forceRecheck(files: Array<string>): Promise<void> {
     if (this.server && await isRunning(this.server)) {
       const [err, stdout, stderr] = await execManual(format(
-        "%s force-recheck --temp-dir %s %s",
+        "%s force-recheck --no-auto-start --temp-dir %s %s",
         this.bin,
         this.tmpDir,
-        files.map(s => `'${s}'`).join(" "),
+        files.map(s => `"${s}"`).join(" "),
       ));
 
-      if (err) {
+      // No server running (6) is ok - the file change might have killed the
+      // server and we raced it here
+      if (err && err.code !== 6) {
         throw new Error(
           format('flow force-recheck failed!', err, stdout, stderr, files),
         );


### PR DESCRIPTION
When node exec's on Windows, it uses cmd.exe.
Unlike Powershell and a unix shell, cmd.exe doesn't
recognize single quotes as quotes.

I originally added the --no-auto-start to debug, but then
noticed that the package_json_changes test was racing, and
force-recheck was restarting the server that we just killed.
So I left it in.

This fixes the tests that were broken on Windows by the recent
addition of force-recheck to the tool tests