### PR TITLE
Fix typo

### DIFF
--- a/website/docs/02-third-party.md
+++ b/website/docs/02-third-party.md
@@ -112,9 +112,10 @@ var pizzas = [
 ];
 
 function vegetarianPizzas() {
-  return _.ffind(pizas, {vegetarian: true});
+  return _.ffind(pizzas, {vegetarian: true});
 }
 ```
+
 
 Running `flow` will produce no errors:
 


### PR DESCRIPTION
As later snippets use the right name and does not use it as an example of undefined value