### PR TITLE
Add inline code to "a"

### DIFF
--- a/website/docs/01-arrays.md
+++ b/website/docs/01-arrays.md
@@ -51,9 +51,9 @@ This type is incompatible with
 ```
 {: .cli-error}
 
-The type of a is not pinned to `Array<number>` by the element write `a[i] = 0`
+The type of `a` is not pinned to `Array<number>` by the element write `a[i] = 0`
 at line 4: if it did, Flow would report an error for an incompatible element
-write `a[i] = ''` at line 5. Instead, based on lines 4 and 5, the type of a
+write `a[i] = ''` at line 5. Instead, based on lines 4 and 5, the type of `a`
 becomes `Array<T>` where `T` is `number` or `string`. Since it is impossible
 to know which element is read on line 11, Flow must account for the possibility
 that it could be `number`, in which case it would be incompatible with the


### PR DESCRIPTION
Some doc improvement: a --> `a`