### PR TITLE
Make ElementRegistrationOptions properties covariant

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -385,12 +385,12 @@ declare class HTMLCollection<Elem: HTMLElement> {
 
 // from https://www.w3.org/TR/custom-elements/#extensions-to-document-interface-to-register
 type ElementRegistrationOptions = {
-  prototype?: {
+  +prototype?: {
     // from https://www.w3.org/TR/custom-elements/#types-of-callbacks
-    createdCallback?: () => mixed;
-    attachedCallback?: () => mixed;
-    detachedCallback?: () => mixed;
-    attributeChangedCallback?:
+    +createdCallback?: () => mixed;
+    +attachedCallback?: () => mixed;
+    +detachedCallback?: () => mixed;
+    +attributeChangedCallback?:
     // attribute is set
     ((
       attributeLocalName: string,
@@ -413,7 +413,7 @@ type ElementRegistrationOptions = {
       attributeNamespace: string
     ) => mixed);
   };
-  extends?: string;
+  +extends?: string;
 }
 
 declare class Document extends Node {


### PR DESCRIPTION
This fixes a bunch of errors in the Nuclide codebase