### PR TITLE
Support for the @jsx pragma

### DIFF
--- a/newtests/jsx_pragma/_flowconfig
+++ b/newtests/jsx_pragma/_flowconfig
@@ -1,0 +1,8 @@
+[ignore]
+
+[include]
+
+[libs]
+
+[options]
+all=true

--- a/newtests/jsx_pragma/test.js
+++ b/newtests/jsx_pragma/test.js
@@ -1,0 +1,181 @@
+/* @flow */
+
+
+import {suite, test} from '../../tsrc/test/Tester';
+
+export default suite(({addFile, addFiles, addCode}) => [
+  test('@jsx pragma without expression is disallowed', [
+    addCode('// @jsx')
+      .newErrors(
+        `
+          test.js:3
+            3: // @jsx
+               ^^^^^^^ Invalid @jsx declaration. Should have form \`@jsx LeftHandSideExpression\` with no spaces.
+        `,
+      ),
+  ]),
+  test('@jsx pragma with a non-left-hand-side expression is disallowed', [
+    addCode('// @jsx (x)=>x')
+      .newErrors(
+        `
+          test.js:3
+            3: // @jsx (x)=>x
+               ^^^^^^^^^^^^^^ Invalid @jsx declaration. Should have form \`@jsx LeftHandSideExpression\` with no spaces. Parse error: Unexpected token =>
+        `,
+      ),
+  ]),
+  test('Line comment complex @jsx with unknown identifier points to pragma', [
+    addCode(`
+      // @jsx Foo['Bar']
+      var Bar = 123;
+      <Bar />;
+    `)
+      .newErrors(
+        `
+          test.js:4
+            4:       // @jsx Foo['Bar']
+                             ^^^ identifier \`Foo\`. Could not resolve name
+        `,
+      ),
+  ]),
+  test('Block comment complex @jsx with unknown identifier points to pragma', [
+    addCode(`
+      /*
+       * @jsx Foo['Bar']
+       */
+      var Bar = 123;
+      <Bar />;
+    `)
+      .newErrors(
+        `
+          test.js:5
+            5:        * @jsx Foo['Bar']
+                             ^^^ identifier \`Foo\`. Could not resolve name
+        `,
+      ),
+  ]),
+  test('Simple identifier @jsx with unknown identifier has better location', [
+    addCode(`
+      // @jsx Foo
+      var Bar = 123;
+      <Bar />;
+    `)
+      .newErrors(
+        `
+          test.js:6
+            6:       <Bar />;
+                     ^^^^^^^ JSX desugared to \`Foo(...)\`. identifier Foo. Could not resolve name
+        `,
+      ),
+  ]),
+  test('Simple member @jsx with unknown identifier has better location', [
+    addCode(`
+      // @jsx Foo.baz
+      var Bar = 123;
+      <Bar />;
+    `)
+      .newErrors(
+        `
+          test.js:6
+            6:       <Bar />;
+                     ^^^^^^^ JSX desugared to \`Foo.baz(...)\`. identifier Foo. Could not resolve name
+        `,
+      ),
+  ]),
+  test('Should respect local scope', [
+    addCode(`
+      // @jsx Foo
+      const Bar = 123;
+      function Foo(x: string) {}
+
+      <Bar />;
+
+      {
+        const Foo = (y: boolean) => {};
+        <Bar />;
+      }
+    `)
+    .newErrors(
+      `
+        test.js:8
+          8:       <Bar />;
+                   ^^^^^^^ JSX desugared to \`Foo(...)\`
+          5:       const Bar = 123;
+                               ^^^ number. This type is incompatible with
+          6:       function Foo(x: string) {}
+                                   ^^^^^^ string
+
+        test.js:12
+         12:         <Bar />;
+                     ^^^^^^^ JSX desugared to \`Foo(...)\`
+          5:       const Bar = 123;
+                               ^^^ number. This type is incompatible with
+         11:         const Foo = (y: boolean) => {};
+                                     ^^^^^^^ boolean
+      `,
+    ),
+  ]),
+  test('Second arg to jsx function should be props', [
+    addCode(`
+      // @jsx Foo
+      function Foo(elem: number, props: { x: string }) {}
+      const Bar = 123;
+
+      <Bar x={123} />;
+    `).newErrors(
+        `
+          test.js:8
+            8:       <Bar x={123} />;
+                     ^^^^^^^^^^^^^^^ JSX desugared to \`Foo(...)\`
+            8:       <Bar x={123} />;
+                             ^^^ number. This type is incompatible with
+            5:       function Foo(elem: number, props: { x: string }) {}
+                                                            ^^^^^^ string
+        `,
+      ),
+  ]),
+  test('Second arg to jsx function is null when there are no attributes', [
+    addCode(`
+      // @jsx Foo
+      function Foo(elem: number, props: { x: string }) {}
+      const Bar = 123;
+
+      <Bar />;
+    `).newErrors(
+        `
+          test.js:8
+            8:       <Bar />;
+                     ^^^^^^^ JSX desugared to \`Foo(...)\`
+            8:       <Bar />;
+                     ^^^^^^^ null. This type is incompatible with
+            5:       function Foo(elem: number, props: { x: string }) {}
+                                                       ^^^^^^^^^^^^^ object type
+        `,
+      ),
+  ]),
+  test('Children are passed after the element and props', [
+    addCode(`
+      // @jsx Foo
+      function Foo(elem: number, props: null, child1: number, child2: string) {}
+      const Bar = 123;
+
+      <Bar>{true}{/regex/}</Bar>
+    `).newErrors(
+        `
+          test.js:8
+            8:       <Bar>{true}{/regex/}</Bar>
+                     ^^^^^ JSX desugared to \`Foo(...)\`
+            8:       <Bar>{true}{/regex/}</Bar>
+                           ^^^^ boolean. This type is incompatible with
+            5:       function Foo(elem: number, props: null, child1: number, child2: string) {}
+                                                                     ^^^^^^ number
+
+          test.js:8
+            8:       <Bar>{true}{/regex/}</Bar>
+                                 ^^^^^^^ RegExp. This type is incompatible with
+            5:       function Foo(elem: number, props: null, child1: number, child2: string) {}
+                                                                                     ^^^^^^ string
+        `,
+      ),
+  ])
+]);

--- a/src/common/reason.ml
+++ b/src/common/reason.ml
@@ -79,6 +79,8 @@ type reason_desc =
   | RFunctionType
   | RFunctionBody
   | RFunctionCall
+  | RJSXFunctionCall of string
+  | RJSXIdentifier of string * string
   | RAnyObject
   | RAnyFunction
   | RUnknownString
@@ -368,6 +370,9 @@ let rec string_of_desc = function
   | RFunctionType -> "function type"
   | RFunctionBody -> "function body"
   | RFunctionCall -> "function call"
+  | RJSXFunctionCall raw_jsx -> spf "JSX desugared to `%s(...)`" raw_jsx
+  | RJSXIdentifier (raw_jsx, name) ->
+      spf "JSX desugared to `%s(...)`. identifier %s" raw_jsx name
   | RAnyObject -> "any object"
   | RAnyFunction -> "any function"
   | RUnknownString -> "some string with unknown value"

--- a/src/common/reason.mli
+++ b/src/common/reason.mli
@@ -30,6 +30,8 @@ type reason_desc =
   | RFunctionType
   | RFunctionBody
   | RFunctionCall
+  | RJSXFunctionCall of string
+  | RJSXIdentifier of string * string
   | RAnyObject
   | RAnyFunction
   | RUnknownString

--- a/src/parser/parser_env.ml
+++ b/src/parser/parser_env.ml
@@ -189,6 +189,7 @@ type env = {
   no_in             : bool;
   no_call           : bool;
   no_let            : bool;
+  no_new            : bool;
   allow_yield       : bool;
   allow_await       : bool;
   error_callback    : (env -> Error.t -> unit) option;
@@ -237,6 +238,7 @@ let init_env ?(token_sink=None) ?(parse_options=None) source content =
     no_in             = false;
     no_call           = false;
     no_let            = false;
+    no_new            = false;
     allow_yield       = true;
     allow_await       = false;
     error_callback    = None;
@@ -262,6 +264,7 @@ let allow_await env = env.allow_await
 let no_in env = env.no_in
 let no_call env = env.no_call
 let no_let env = env.no_let
+let no_new env = env.no_new
 let errors env = !(env.errors)
 let parse_options env = env.parse_options
 let source env = env.source
@@ -294,6 +297,7 @@ let with_allow_await allow_await env = { env with allow_await }
 let with_no_let no_let env = { env with no_let }
 let with_in_loop in_loop env = { env with in_loop }
 let with_no_in no_in env = { env with no_in }
+let with_no_new no_new env = { env with no_new }
 let with_in_switch in_switch env = { env with in_switch }
 let with_in_export in_export env = { env with in_export }
 let with_no_call no_call env = { env with no_call }

--- a/src/parser/parser_env.mli
+++ b/src/parser/parser_env.mli
@@ -65,6 +65,7 @@ val allow_await: env -> bool
 val no_in : env -> bool
 val no_call : env -> bool
 val no_let : env -> bool
+val no_new : env -> bool
 val errors : env -> (Loc.t * Parse_error.t) list
 val parse_options : env -> parse_options
 val source : env -> Loc.filename option
@@ -91,6 +92,7 @@ val with_allow_await : bool -> env -> env
 val with_no_let : bool -> env -> env
 val with_in_loop : bool -> env -> env
 val with_no_in : bool -> env -> env
+val with_no_new : bool -> env -> env
 val with_in_switch : bool -> env -> env
 val with_in_export : bool -> env -> env
 val with_no_call : bool -> env -> env

--- a/src/parser/parser_flow.ml
+++ b/src/parser/parser_flow.ml
@@ -70,6 +70,7 @@ module rec Parse : sig
   val expression : env -> Ast.Expression.t
   val conditional : env -> Ast.Expression.t
   val assignment : env -> Ast.Expression.t
+  val left_hand_side : env -> Ast.Expression.t
   val object_initializer : env -> Loc.t * Ast.Expression.Object.t
   val array_initializer : env -> Loc.t * Ast.Expression.Array.t
   val identifier : ?restricted_error:Error.t -> env -> Ast.Identifier.t
@@ -1437,8 +1438,10 @@ end = struct
 
     and left_hand_side env =
       let start_loc = Peek.loc env in
+      let allow_new = not (no_new env) in
+      let env = with_no_new false env in
       let expr = match Peek.token env with
-      | T_NEW -> new_expression env
+      | T_NEW when allow_new -> new_expression env
       | _ when Peek.is_function env -> _function env
       | _ -> primary env in
       let expr = member env start_loc expr in
@@ -4414,6 +4417,7 @@ end = struct
 
   and conditional = Expression.conditional
   and assignment = Expression.assignment
+  and left_hand_side = Expression.left_hand_side
   and object_initializer = Object._initializer
   and object_key = Object.key
   and class_declaration = Object.class_declaration
@@ -4544,3 +4548,13 @@ let json_file ?(fail=true) ?(token_sink=None) ?(parse_options=None) content file
   | _ ->
     error_unexpected env;
     raise (Error.Error (errors env))
+
+let jsx_pragma_expression =
+  let left_hand_side env =
+    let ast = Parse.left_hand_side (with_no_new true env) in
+    Expect.token env T_EOF;
+    ast
+
+  in fun content filename ->
+    let env = init_env ~token_sink:None ~parse_options:None filename content in
+    do_parse env left_hand_side true

--- a/src/parsing/parsing_service_js.ml
+++ b/src/parsing/parsing_service_js.ml
@@ -138,6 +138,14 @@ let string_of_docblock_error = function
     "Unexpected @flow declaration. Only one per file is allowed."
   | Docblock.MultipleProvidesModuleAttributes ->
     "Unexpected @providesModule declaration. Only one per file is allowed."
+  | Docblock.MultipleJSXAttributes ->
+    "Unexpected @jsx declaration. Only one per file is allowed."
+  | Docblock.InvalidJSXAttribute first_error ->
+    "Invalid @jsx declaration. Should have form `@jsx LeftHandSideExpression` "^
+    "with no spaces."^
+    (match first_error with
+    | None -> ""
+    | Some first_error -> spf " Parse error: %s" first_error)
 
 let get_docblock
   ~max_tokens file content

--- a/src/services/inference/infer_service.ml
+++ b/src/services/inference/infer_service.ml
@@ -16,6 +16,8 @@ let rev_append_triple (x1, y1, z1) (x2, y2, z2) =
 let apply_docblock_overrides metadata docblock_info =
   let open Context in
 
+  let metadata = { metadata with jsx = Docblock.jsx docblock_info } in
+
   let metadata = match Docblock.flow docblock_info with
   | None -> metadata
   | Some Docblock.OptIn -> { metadata with checked = true; }

--- a/src/typing/context.ml
+++ b/src/typing/context.ml
@@ -33,6 +33,7 @@ type metadata = {
   verbose: Verbose.t option;
   weak: bool;
   max_workers: int;
+  jsx: (string * Spider_monkey_ast.Expression.t) option;
 }
 
 (* TODO this has a bunch of stuff in it that should be localized *)
@@ -117,6 +118,7 @@ let metadata_of_options options = {
   verbose = Options.verbose options;
   weak = Options.weak_by_default options;
   max_workers = Options.max_workers options;
+  jsx = None;
 }
 
 (* create a new context structure.
@@ -206,6 +208,7 @@ let type_graph cx = cx.type_graph
 let type_table cx = cx.type_table
 let verbose cx = cx.metadata.verbose
 let max_workers cx = cx.metadata.max_workers
+let jsx cx = cx.metadata.jsx
 
 let pid_prefix cx =
   if max_workers cx > 0

--- a/src/typing/context.mli
+++ b/src/typing/context.mli
@@ -32,6 +32,7 @@ type metadata = {
   verbose: Verbose.t option;
   weak: bool;
   max_workers: int;
+  jsx: (string * Spider_monkey_ast.Expression.t) option;
 }
 type module_exports_type =
   | CommonJSModule of Loc.t option
@@ -87,6 +88,7 @@ val type_graph: t -> Graph_explorer.graph
 val type_table: t -> (Loc.t, Type.t) Hashtbl.t
 val verbose: t -> Verbose.t option
 val max_workers: t -> int
+val jsx: t -> (string * Spider_monkey_ast.Expression.t) option
 val pid_prefix: t -> string
 
 val copy_of_context: t -> t

--- a/src/typing/statement.ml
+++ b/src/typing/statement.ml
@@ -2732,7 +2732,8 @@ and expression_ ~is_cond cx loc e = Ast.Expression.(match e with
       (* method call *)
       let ot = expression cx _object in
       let argts = List.map (expression_or_spread cx) arguments in
-      method_call cx loc prop_loc (callee, ot, name) argts
+      let reason = mk_reason (RMethodCall name) loc in
+      method_call cx reason prop_loc (callee, ot, name) argts
 
   | Call {
       Call.callee = ploc, Super;
@@ -3032,8 +3033,7 @@ and func_call cx reason func_t argts =
     Flow.flow cx (func_t, CallT(reason, app))
   )
 
-and method_call cx loc prop_loc (expr, obj_t, name) argts =
-  let reason = mk_reason (RMethodCall name) loc in
+and method_call cx reason prop_loc (expr, obj_t, name) argts =
   Type_inference_hooks_js.dispatch_call_hook cx name prop_loc obj_t;
   (match Refinement.get cx expr reason with
   | Some f ->
@@ -3445,7 +3445,7 @@ and jsx cx = Ast.JSX.(
   jsx_title cx openingElement (List.map (jsx_body cx) children)
 )
 
-and jsx_title cx openingElement _children = Ast.JSX.(
+and jsx_title cx openingElement children = Ast.JSX.(
   let eloc, { Opening.name; attributes; _ } = openingElement in
   let facebook_fbt = Context.facebook_fbt cx in
 
@@ -3507,21 +3507,47 @@ and jsx_title cx openingElement _children = Ast.JSX.(
   | (Identifier (loc, { Identifier.name }), _) when name = String.capitalize name ->
     if Type_inference_hooks_js.dispatch_id_hook cx name loc
     then AnyT.at eloc
-    else
+    else begin
       let reason = mk_reason (RReactElement (Some name)) eloc in
       let c = Env.get_var cx name reason in
       let o = mk_props reason c name in
-      (* TODO: children *)
-      let react = require cx ~internal:true "react" eloc in
-      Flow.mk_tvar_where cx reason (fun tvar ->
-        let reason_createElement = mk_reason (RProperty "createElement") eloc in
-        Flow.flow cx (react, MethodT(
-          reason,
-          reason_createElement,
-          (reason_createElement, "createElement"),
-          Flow.mk_methodtype react [c;o] tvar
-        ))
-      )
+      match Context.jsx cx with
+      | None ->
+          (* TODO: children *)
+          let react = require cx ~internal:true "react" eloc in
+          Flow.mk_tvar_where cx reason (fun tvar ->
+            let reason_createElement =
+              mk_reason (RProperty "createElement") eloc in
+            Flow.flow cx (react, MethodT(
+              reason,
+              reason_createElement,
+              (reason_createElement, "createElement"),
+              Flow.mk_methodtype react [c;o] tvar
+            ))
+          )
+      | Some (raw_jsx_expr, jsx_expr) ->
+          let reason = mk_reason (RJSXFunctionCall raw_jsx_expr) eloc in
+
+          (* A JSX element with no attributes should pass in null as the second
+           * arg *)
+          let o = match attributes with
+          | [] -> NullT.at eloc
+          | _ -> o in
+          let argts = [c;o] @ children in
+          Ast.Expression.(match jsx_expr with
+          | _, Member {
+            Member._object;
+            property = Member.PropertyIdentifier (prop_loc,
+              { Ast.Identifier.name; _ });
+              _;
+            } ->
+              let ot = jsx_pragma_expression cx raw_jsx_expr eloc _object in
+              method_call cx reason prop_loc (jsx_expr, ot, name) argts
+          | _ ->
+              let f = jsx_pragma_expression cx raw_jsx_expr eloc jsx_expr in
+              func_call cx reason f argts
+          )
+    end
 
   | (Identifier (loc, { Identifier.name }), _) ->
       (**
@@ -3589,6 +3615,30 @@ and jsx_title cx openingElement _children = Ast.JSX.(
   | _ ->
       (* TODO? covers namespaced names, member expressions as element names *)
       AnyT.at eloc
+)
+
+(* The @jsx pragma specifies a left hand side expression EXPR such that
+ *
+ * <Foo />
+ *
+ * is transformed into
+ *
+ * EXPR(Foo, props, child1, child2, etc)
+ *
+ * This means we need to process EXPR. However, EXPR is not inline in the code,
+ * it's up in a comment at the top of the file. This means if we run into an
+ * error, we're going to point at the comment at the top.
+ *
+ * We can cover almost all the cases by just explicitly handling identifiers,
+ * since the common error is that the identifier is not in scope.
+ *)
+and jsx_pragma_expression cx raw_jsx_expr loc = Ast.Expression.(function
+  | _, Identifier (_, { Ast.Identifier.name; _ }) ->
+      let reason = mk_reason (RJSXIdentifier(raw_jsx_expr, name)) loc in
+      Env.var_ref ~lookup_mode:ForValue cx name reason
+  | expr ->
+      (* Oh well, we tried *)
+      expression cx expr
 )
 
 and jsx_body cx = Ast.JSX.(function
@@ -4661,12 +4711,14 @@ and static_method_call_Object cx loc prop_loc expr obj_t m args_ =
       Flow.flow cx (arg_t, ObjFreezeT (reason_arg, tvar));
     ) in
 
-    method_call cx loc prop_loc (expr, obj_t, m) [arg_t]
+    let reason = mk_reason (RMethodCall m) loc in
+    method_call cx reason prop_loc (expr, obj_t, m) [arg_t]
 
   (* TODO *)
   | (_, args) ->
     let argts = List.map (expression_or_spread cx) args in
-    method_call cx loc prop_loc (expr, obj_t, m) argts
+    let reason = mk_reason (RMethodCall m) loc in
+    method_call cx reason prop_loc (expr, obj_t, m) argts
 
 and extract_setter_type = function
   | FunT (_, _, _, { params_tlist = [param_t]; _; }) -> param_t


### PR DESCRIPTION
Normally, the JSX `<Foo a="123">Hello {123}</Foo>` is interpreted as

```
React.createElement(
  Foo,
  { a: "123" },
  "Hello ",
  123
);
```

however, if you add the pragma `// @jsx Bar`, then it is interpreted as

```
Bar(
  Foo,
  { a: "123" },
  "Hello ",
  123
);
```

This commit teaches Flow about that behavior.