### PR TITLE
Add --quiet flag to server-related commands

### DIFF
--- a/src/commands/commandUtils.ml
+++ b/src/commands/commandUtils.ml
@@ -191,6 +191,12 @@ let verbose_flags =
         ~doc:"Recursively print types up to specified depth (default 1, implies --verbose)"
   )
 
+let quiet_flag prev = CommandSpec.ArgSpec.(
+  prev
+  |> flag "--quiet" no_arg
+      ~doc:"Suppress output about server startup"
+)
+
 let root_flag prev = CommandSpec.ArgSpec.(
   prev
   |> flag "--root" string
@@ -263,6 +269,7 @@ type command_params = {
   shm_hash_table_pow : int option;
   shm_log_level      : int option;
   ignore_version     : bool;
+  quiet              : bool;
 }
 
 let collect_server_flags
@@ -278,7 +285,8 @@ let collect_server_flags
     shm_hash_table_pow
     shm_log_level
     from
-    ignore_version =
+    ignore_version
+    quiet =
   let default def = function
   | Some x -> x
   | None -> def in
@@ -296,6 +304,7 @@ let collect_server_flags
     shm_hash_table_pow;
     shm_log_level;
     ignore_version;
+    quiet;
   }
 
 let server_flags prev = CommandSpec.ArgSpec.(
@@ -317,6 +326,7 @@ let server_flags prev = CommandSpec.ArgSpec.(
   |> shm_log_level_flag
   |> from_flag
   |> ignore_version_flag
+  |> quiet_flag
 )
 
 let ignores_of_arg root patterns extras =
@@ -369,6 +379,7 @@ let connect server_flags root =
     shm_log_level = server_flags.shm_log_level;
     log_file;
     ignore_version = server_flags.ignore_version;
+    quiet = server_flags.quiet;
   } in
   CommandConnect.connect env
 

--- a/src/commands/serverCommands.ml
+++ b/src/commands/serverCommands.ml
@@ -62,6 +62,7 @@ module OptionParser(Config : CONFIG) = struct
     |> shm_hash_table_pow_flag
     |> shm_log_level_flag
     |> from_flag
+    |> quiet_flag
     |> anon "root" (optional string) ~doc:"Root directory"
   )
 
@@ -73,8 +74,6 @@ module OptionParser(Config : CONFIG) = struct
           ~doc:"Output errors in JSON format"
       |> flag "--profile" no_arg
           ~doc:"Output profiling information"
-      |> flag "--quiet" no_arg
-          ~doc:"Suppress info messages to stdout (included in --json)"
       |> dummy None  (* log-file *)
       |> dummy false (* wait *)
       |> common_args
@@ -84,7 +83,6 @@ module OptionParser(Config : CONFIG) = struct
       |> dummy Options.default_error_flags (* error_flags *)
       |> dummy false (* json *)
       |> dummy false (* profile *)
-      |> dummy false (* quiet *)
       |> dummy None  (* log-file *)
       |> dummy false (* wait *)
       |> common_args
@@ -95,7 +93,6 @@ module OptionParser(Config : CONFIG) = struct
       |> flag "--json" no_arg
           ~doc:"Respond in JSON format"
       |> dummy false (* profile *)
-      |> dummy false (* quiet *)
       |> flag "--log-file" string
           ~doc:"Path to log file (default: /tmp/flow/<escaped root path>.log)"
       |> flag "--wait" no_arg
@@ -168,7 +165,6 @@ module OptionParser(Config : CONFIG) = struct
       error_flags
       json
       profile
-      quiet
       log_file
       wait
       debug
@@ -190,6 +186,7 @@ module OptionParser(Config : CONFIG) = struct
       shm_hash_table_pow
       shm_log_level
       from
+      quiet
       root
       () =
 

--- a/src/commands/stopCommand.ml
+++ b/src/commands/stopCommand.ml
@@ -14,7 +14,7 @@
 
 open Utils_js
 
-exception FailedToKill
+exception FailedToKill of string option
 
 let spec = {
   CommandSpec.
@@ -30,6 +30,7 @@ let spec = {
     empty
     |> CommandUtils.temp_dir_flag
     |> CommandUtils.from_flag
+    |> CommandUtils.quiet_flag
     |> anon "root" (optional string) ~doc:"Root directory"
   )
 }
@@ -46,35 +47,31 @@ let kill (ic, oc) =
   ServerProt.response_from_channel ic
 
 let nice_kill (ic, oc) ~tmp_dir root =
-  prerr_endlinef "Attempting to nicely kill server for %s"
-    (Path.to_string root);
   let response = kill (ic, oc) in
   if is_expected response then begin
     let i = ref 0 in
     while CommandConnectSimple.server_exists ~tmp_dir root do
       incr i;
       if !i < 5 then ignore @@ Unix.sleep 1
-      else raise FailedToKill
+      else raise (FailedToKill None)
     done;
-    prerr_endlinef "Successfully killed server for %s"
-      (Path.to_string root)
   end else begin
-    prerr_endlinef "Unexpected response from the server: %s\n"
-      (ServerProt.response_to_string response);
-    raise FailedToKill
+    let msg = Printf.sprintf "Unexpected response from the server: %s"
+      (ServerProt.response_to_string response) in
+    raise (FailedToKill (Some msg))
   end
 
 let mean_kill ~tmp_dir root =
-  prerr_endlinef "Attempting to meanly kill server for %s"
-    (Path.to_string root);
   let pids =
     try PidLog.get_pids (Server_files_js.pids_file ~tmp_dir root)
-    with PidLog.FailedToGetPids -> Printf.fprintf stderr
+    with PidLog.FailedToGetPids ->
+      let msg = Printf.sprintf
         "Unable to figure out pids of running Flow server. \
         Try manually killing it with 'pkill %s' (be careful on shared \
-        devservers)\n%!"
-        CommandUtils.exe_name;
-      raise FailedToKill
+        devservers)"
+        CommandUtils.exe_name
+      in
+      raise (FailedToKill (Some msg))
   in
   List.iter (fun (pid, _) ->
     try
@@ -87,11 +84,10 @@ let mean_kill ~tmp_dir root =
   ) pids;
   ignore(Unix.sleep 1);
   if CommandConnectSimple.server_exists ~tmp_dir root
-  then raise FailedToKill
-  else prerr_endlinef "Successfully killed server for %s\n%!"
-    (Path.to_string root)
+  then raise (FailedToKill None);
+  ()
 
-let main temp_dir from root () =
+let main temp_dir from quiet root () =
   let root = CommandUtils.guess_root root in
   let config = FlowConfig.get (Server_files_js.config_file root) in
   let root_s = Path.to_string root in
@@ -101,31 +97,51 @@ let main temp_dir from root () =
   in
   let tmp_dir = Path.to_string (Path.make tmp_dir) in
   FlowEventLogger.set_from from;
-  prerr_endlinef
+  if not quiet then prerr_endlinef
     "Trying to connect to server for %s"
     (Path.to_string root);
   CommandConnectSimple.(
     match connect_once ~tmp_dir root with
     | Result.Ok conn ->
-        (try nice_kill conn ~tmp_dir root
-        with FailedToKill ->
-            let msg = spf
-              "Failed to kill server nicely for %s\n%!"
-            root_s in
-            FlowExitStatus.(exit ~msg Kill_error))
+        begin try
+          if not quiet then prerr_endlinef
+            "Attempting to nicely kill server for %s"
+            (Path.to_string root);
+          nice_kill conn ~tmp_dir root;
+          if not quiet then prerr_endlinef
+            "Successfully killed server for %s"
+            (Path.to_string root)
+        with FailedToKill err ->
+          if not quiet then match err with
+          | Some err -> prerr_endline err
+          | None -> ();
+          let msg = spf "Failed to kill server nicely for %s" root_s in
+          FlowExitStatus.(exit ~msg Kill_error)
+        end
     | Result.Error Server_missing ->
-        prerr_endlinef "Error: no server to kill for %s" root_s
+        if not quiet then prerr_endlinef
+          "Warning: no server to kill for %s" root_s
     | Result.Error Build_id_mismatch ->
-        prerr_endlinef "Successfully killed server for %s" root_s
+        if not quiet then prerr_endlinef
+          "Successfully killed server for %s" root_s
     | Result.Error Server_initializing
     | Result.Error Server_rechecking
     | Result.Error Server_busy ->
-        try mean_kill ~tmp_dir root
-        with FailedToKill ->
-          let msg = spf
-            "Failed to kill server meanly for %s"
-            root_s in
+        begin try
+          if not quiet then prerr_endlinef
+            "Attempting to meanly kill server for %s"
+            (Path.to_string root);
+          mean_kill ~tmp_dir root;
+          if not quiet then prerr_endlinef
+            "Successfully killed server for %s"
+            (Path.to_string root)
+        with FailedToKill err ->
+          if not quiet then match err with
+          | Some err -> prerr_endline err
+          | None -> ();
+          let msg = spf "Failed to kill server meanly for %s" root_s in
           FlowExitStatus.(exit ~msg Kill_error)
+        end
   )
 
 let command = CommandSpec.command spec main

--- a/src/common/options.ml
+++ b/src/common/options.ml
@@ -97,6 +97,7 @@ let includes opts = opts.opt_includes
 let is_check_mode opts = opts.opt_check_mode
 let is_debug_mode opts = opts.opt_debug
 let is_server_mode opts = opts.opt_server_mode
+let is_quiet opts = opts.opt_quiet
 let lib_paths opts = opts.opt_libs
 let log_file opts = opts.opt_log_file
 let max_header_tokens opts = opts.opt_max_header_tokens

--- a/src/server/serverFunctors.ml
+++ b/src/server/serverFunctors.ml
@@ -422,7 +422,7 @@ end = struct
         "log_file", JSON_String log_file;
       ]) in
       print_string json
-    end else begin
+    end else if not (Options.is_quiet options) then begin
       Printf.eprintf
         "Spawned %s (pid=%d)\n" (Program.name) pretty_pid;
       Printf.eprintf


### PR DESCRIPTION
Added a `--quiet` flag to all of the client commands (things that might start a server, like `check-contents`, `start`, `status`, etc.)

This suppresses the server-status information that was being printed to stderr.

Fixes https://github.com/facebook/flow/issues/2185