### PR TITLE
[website] fix broken any links

### DIFF
--- a/website/docs/02-existing.md
+++ b/website/docs/02-existing.md
@@ -19,7 +19,7 @@ It is typically a much larger effort, and requires much more programmer annotati
 
 ## Weak mode
 
-Flow has a special mode, known as *weak mode*, to get started with complex library code without having to pay the full cost up front. The difference between weak mode and regular mode is how Flow deals with missing type annotations. In regular mode Flow will infer types for all missing annotations, and produce errors whenever it detects a mismatch. In weak mode, Flow will do much less type inference. It will still infer types within functions, but will otherwise treat unannotated variables as having the [`any`](base-types.html#any) type - meaning no typechecking happens on them.
+Flow has a special mode, known as *weak mode*, to get started with complex library code without having to pay the full cost up front. The difference between weak mode and regular mode is how Flow deals with missing type annotations. In regular mode Flow will infer types for all missing annotations, and produce errors whenever it detects a mismatch. In weak mode, Flow will do much less type inference. It will still infer types within functions, but will otherwise treat unannotated variables as having the [`any`](quick-reference.html#any) type - meaning no typechecking happens on them.
 
 A good first step towards typechecking existing library code is to use weak mode, rather than regular mode. Simply change the header declaration in the file you want to typecheck:
 

--- a/website/docs/02-new-project.md
+++ b/website/docs/02-new-project.md
@@ -82,4 +82,4 @@ Read more about testing existing libraries or code in the [Running Flow on exist
 
 As Flow starts to typecheck your files you may run into type errors. Check out the [Troubleshooting](troubleshooting.html) section for common errors and how to resolve them. Your goal is to get the number of errors down to zero as fast as possible so you can continue on with your development.
 
-In some cases, errors may be due to inherent imprecision of the analysis - which means Flow won't always get it right and could give errors that are false positives. In those cases you can either try to refactor your code to help Flow understand it, or you can use the [`any`](base-types.html#any) type to tell Flow about values that should not be checked.
+In some cases, errors may be due to inherent imprecision of the analysis - which means Flow won't always get it right and could give errors that are false positives. In those cases you can either try to refactor your code to help Flow understand it, or you can use the [`any`](quick-reference.html#any) type to tell Flow about values that should not be checked.


### PR DESCRIPTION
`base-types.html#any` no longer exists, this PR changes the links to `quick-reference.html#any` instead.