### PR TITLE
Explicitly mention scope of type aliases

### DIFF
--- a/website/docs/01-type-aliases.md
+++ b/website/docs/01-type-aliases.md
@@ -21,8 +21,8 @@ var x: T = 0;
 ```
 
 We declare the new type `T` is an alias for the built-in type `number`.
-Anywhere we use `T`, we are asserting that `T` will have an underlying
-type of `number`.
+Type aliases are in scope throughout your project. Anywhere we use `T`,
+we are asserting that `T` will have an underlying type of `number`.
 
 ## Type Checking Aliases
 


### PR DESCRIPTION
I have been quite confused about the use of `declare` before type aliases. I thought that `declare` made a type alias available in the project's global scope, but after reading [this tweet](https://twitter.com/lbljeffmo/status/788504721439031296), I realised that just putting `type T = {...}` was enough to make `T` available to flow throughout the project. Rather than asking this on issues and getting a confirmation, I thought I would make a PR in case it helps. This change I propose would have made it clear to me.