### PR TITLE
Click and Double click are mouse events

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -95,7 +95,7 @@ type MouseEventListener = {handleEvent: MouseEventHandler} | MouseEventHandler
 type KeyboardEventHandler = (event: KeyboardEvent) => mixed
 type KeyboardEventListener = {handleEvent: KeyboardEventHandler} | KeyboardEventHandler
 
-type MouseEventTypes = 'contextmenu' | 'mousedown' | 'mouseenter' | 'mouseleave' | 'mousemove' | 'mouseout' | 'mouseover' | 'mouseup'
+type MouseEventTypes = 'contextmenu' | 'mousedown' | 'mouseenter' | 'mouseleave' | 'mousemove' | 'mouseout' | 'mouseover' | 'mouseup' | 'click' | 'dblclick';
 type KeyboardEventTypes = 'keydown' | 'keyup' | 'keypress';
 
 declare class EventTarget {


### PR DESCRIPTION
Summary: Add click and doubleClick to DOM MouseEventTypes.

Fixes #2661

Test plan: Run tests