### PR TITLE
Add special cases for touch and wheel events in EventTarget class

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -94,25 +94,39 @@ type MouseEventHandler = (event: MouseEvent) => mixed
 type MouseEventListener = {handleEvent: MouseEventHandler} | MouseEventHandler
 type KeyboardEventHandler = (event: KeyboardEvent) => mixed
 type KeyboardEventListener = {handleEvent: KeyboardEventHandler} | KeyboardEventHandler
+type TouchEventHandler = (event: TouchEvent) => mixed
+type TouchEventListener = {handleEvent: TouchEventHandler} | TouchEventHandler
+type WheelEventHandler = (event: WheelEvent) => mixed
+type WheelEventListener = {handleEvent: WheelEventHandler} | WheelEventHandler
 
 type MouseEventTypes = 'contextmenu' | 'mousedown' | 'mouseenter' | 'mouseleave' | 'mousemove' | 'mouseout' | 'mouseover' | 'mouseup' | 'click' | 'dblclick';
 type KeyboardEventTypes = 'keydown' | 'keyup' | 'keypress';
+type TouchEventTypes = 'touchstart' | 'touchmove' | 'touchend' | 'touchcancel';
+type WheelEventTypes = 'wheel';
 
 declare class EventTarget {
   addEventListener(type: MouseEventTypes, listener: MouseEventListener, useCapture?: boolean): void;
   addEventListener(type: KeyboardEventTypes, listener: KeyboardEventListener, useCapture?: boolean): void;
+  addEventListener(type: TouchEventTypes, listener: TouchEventListener, useCapture?: boolean): void;
+  addEventListener(type: WheelEventTypes, listener: WheelEventListener, useCapture?: boolean): void;
   addEventListener(type: string, listener: EventListener, useCapture?: boolean): void;
 
   removeEventListener(type: MouseEventTypes, listener: MouseEventListener, useCapture?: boolean): void;
   removeEventListener(type: KeyboardEventTypes, listener: KeyboardEventListener, useCapture?: boolean): void;
+  removeEventListener(type: TouchEventTypes, listener: TouchEventListener, useCapture?: boolean): void;
+  removeEventListener(type: WheelEventTypes, listener: WheelEventListener, useCapture?: boolean): void;
   removeEventListener(type: string, listener: EventListener, useCapture?: boolean): void;
 
   attachEvent?: (type: MouseEventTypes, listener: MouseEventListener) => void;
   attachEvent?: (type: KeyboardEventTypes, listener: KeyboardEventListener) => void;
+  attachEvent?: (type: TouchEventTypes, listener: TouchEventListener) => void;
+  attachEvent?: (type: WheelEventTypes, listener: WheelEventListener) => void;
   attachEvent?: (type: string, listener: EventListener) => void;
 
   detachEvent?: (type: MouseEventTypes, listener: MouseEventListener) => void;
   detachEvent?: (type: KeyboardEventTypes, listener: KeyboardEventListener) => void;
+  detachEvent?: (type: TouchEventTypes, listener: TouchEventListener) => void;
+  detachEvent?: (type: WheelEventTypes, listener: WheelEventListener) => void;
   detachEvent?: (type: string, listener: EventListener) => void;
 
   dispatchEvent(evt: Event): boolean;


### PR DESCRIPTION
Hi, I've stumbled upon an issue while adding flow annotations to existing module. Example:

```
el.addEventListener('wheel', handleWheel)

function handleWheel (event: WheelEvent) {
  const { deltaX, deltaY } = event
  console.log(deltaX, deltaY)
}
```

With that code I am not getting any errors for `deltaX` and `deltaY` because they exist in `WheelEvent`. I am getting error because there is a mismatch between declaration for `EventTarget` in `dom.js`, which defines that event handler should have parameter with `Event` type instead of `WheelEvent`.

If I replace `WheelEvent` annotation with `Event` or remove it completely I am getting errors that `deltaX` and `deltaY` are not found in `Event`.

If I add special cases for `EventTarget` declarations in `dom.js` like presented in this PR everything works fine. Unfortunately I have very little experience with flow and would be happy to know if this is a right direction or I am missing some essential knowledge about doing it with annotations and without the need of editing current declarations.
