### PR TITLE
Overload addEventListener method of Worker.

### DIFF
--- a/lib/bom.js
+++ b/lib/bom.js
@@ -325,6 +325,8 @@ declare class Worker extends EventTarget {
     constructor(stringUrl: string): void;
     onerror: (ev: Event) => any;
     onmessage: (ev: MessageEvent) => any;
+    addEventListener(type: 'message', listener: (evt: MessageEvent) => void, useCapture?: boolean): void;
+    addEventListener(type: string, listener: EventListener, useCapture?: boolean): void;
     postMessage(message: any, ports?: any): void;
     terminate(): void;
 }

--- a/tests/fetch/fetch.exp
+++ b/tests/fetch/fetch.exp
@@ -3,13 +3,13 @@ fetch.js:12
                                 ^^^^^^^^^^^^^^^^ function call
  12: const b: Promise<string> = fetch(myRequest); // incorrect
                       ^^^^^^ string. This type is incompatible with
-Response. See lib: bom.js:817
+Response. See lib: bom.js:819
 
 fetch.js:25
  25: const d: Promise<Blob> = fetch('image.png'); // incorrect
                               ^^^^^^^^^^^^^^^^^^ function call
-Library type error:. See lib: bom.js:817
-Response. This type is incompatible with. See lib: bom.js:817
+Library type error:. See lib: bom.js:819
+Response. This type is incompatible with. See lib: bom.js:819
  25: const d: Promise<Blob> = fetch('image.png'); // incorrect
                       ^^^^ Blob
 
@@ -18,80 +18,80 @@ headers.js:3
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructor call
   3: const a = new Headers("'Content-Type': 'image/jpeg'"); // not correct
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string. This type is incompatible with
-union: Headers | object type. See lib: bom.js:711
+union: Headers | object type. See lib: bom.js:713
   Member 1:
-  Headers. See lib: bom.js:704
+  Headers. See lib: bom.js:706
   Error:
     3: const a = new Headers("'Content-Type': 'image/jpeg'"); // not correct
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string. This type is incompatible with
-  Headers. See lib: bom.js:704
+  Headers. See lib: bom.js:706
   Member 2:
-  object type. See lib: bom.js:704
+  object type. See lib: bom.js:706
   Error:
     3: const a = new Headers("'Content-Type': 'image/jpeg'"); // not correct
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string. This type is incompatible with
-  object type. See lib: bom.js:704
+  object type. See lib: bom.js:706
 
 headers.js:4
   4: const b = new Headers(['Content-Type', 'image/jpeg']); // not correct
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructor call
   4: const b = new Headers(['Content-Type', 'image/jpeg']); // not correct
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ array literal. This type is incompatible with
-union: Headers | object type. See lib: bom.js:711
+union: Headers | object type. See lib: bom.js:713
   Member 1:
-  Headers. See lib: bom.js:704
+  Headers. See lib: bom.js:706
   Error:
     4: const b = new Headers(['Content-Type', 'image/jpeg']); // not correct
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ array literal. This type is incompatible with
-  Headers. See lib: bom.js:704
+  Headers. See lib: bom.js:706
   Member 2:
-  object type. See lib: bom.js:704
+  object type. See lib: bom.js:706
   Error:
     4: const b = new Headers(['Content-Type', 'image/jpeg']); // not correct
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ array literal. This type is incompatible with
-  object type. See lib: bom.js:704
+  object type. See lib: bom.js:706
 
 headers.js:9
   9: e.append('Content-Type'); // not correct
      ^^^^^^^^^^^^^^^^^^^^^^^^ call of method `append`
   9: e.append('Content-Type'); // not correct
      ^^^^^^^^^^^^^^^^^^^^^^^^ undefined (too few arguments, expected default/rest parameters). This type is incompatible with
-string. See lib: bom.js:712
+string. See lib: bom.js:714
 
 headers.js:10
  10: e.append({'Content-Type', 'image/jpeg'}); // not correct
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call of method `append`
  10: e.append({'Content-Type', 'image/jpeg'}); // not correct
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ undefined (too few arguments, expected default/rest parameters). This type is incompatible with
-string. See lib: bom.js:712
+string. See lib: bom.js:714
 
 headers.js:10
  10: e.append({'Content-Type', 'image/jpeg'}); // not correct
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call of method `append`
  10: e.append({'Content-Type', 'image/jpeg'}); // not correct
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ object literal. This type is incompatible with
-string. See lib: bom.js:712
+string. See lib: bom.js:714
 
 headers.js:12
  12: e.set('Content-Type'); // not correct
      ^^^^^^^^^^^^^^^^^^^^^ call of method `set`
  12: e.set('Content-Type'); // not correct
      ^^^^^^^^^^^^^^^^^^^^^ undefined (too few arguments, expected default/rest parameters). This type is incompatible with
-string. See lib: bom.js:719
+string. See lib: bom.js:721
 
 headers.js:13
  13: e.set({'Content-Type', 'image/jpeg'}); // not correct
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call of method `set`
  13: e.set({'Content-Type', 'image/jpeg'}); // not correct
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ undefined (too few arguments, expected default/rest parameters). This type is incompatible with
-string. See lib: bom.js:719
+string. See lib: bom.js:721
 
 headers.js:13
  13: e.set({'Content-Type', 'image/jpeg'}); // not correct
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call of method `set`
  13: e.set({'Content-Type', 'image/jpeg'}); // not correct
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ object literal. This type is incompatible with
-string. See lib: bom.js:719
+string. See lib: bom.js:721
 
 headers.js:15
  15: const f: Headers = e.append('Content-Type', 'image/jpeg'); // not correct
@@ -112,110 +112,82 @@ request.js:2
                         ^^^^^^^^^^^^^ constructor call
   2: const a: Request = new Request(); // incorrect
                         ^^^^^^^^^^^^^ undefined (too few arguments, expected default/rest parameters). This type is incompatible with
-union: string | Request. See lib: bom.js:792
+union: string | Request. See lib: bom.js:794
   Member 1:
-  string. See lib: bom.js:792
+  string. See lib: bom.js:794
   Error:
     2: const a: Request = new Request(); // incorrect
                           ^^^^^^^^^^^^^ undefined (too few arguments, expected default/rest parameters). This type is incompatible with
-  string. See lib: bom.js:792
+  string. See lib: bom.js:794
   Member 2:
-  Request. See lib: bom.js:792
+  Request. See lib: bom.js:794
   Error:
     2: const a: Request = new Request(); // incorrect
                           ^^^^^^^^^^^^^ undefined (too few arguments, expected default/rest parameters). This type is incompatible with
-  Request. See lib: bom.js:792
-
-request.js:6
-  6: const e: Request = new Request(b, c); // incorrect
-                        ^^^^^^^^^^^^^^^^^ constructor call
-inconsistent use of library definitions
-null. This type is incompatible with. See lib: bom.js:750
-string enum. See lib: bom.js:797
-
-request.js:6
-  6: const e: Request = new Request(b, c); // incorrect
-                        ^^^^^^^^^^^^^^^^^ constructor call
-inconsistent use of library definitions
-undefined. This type is incompatible with. See lib: bom.js:750
-string enum. See lib: bom.js:797
-
-request.js:6
-  6: const e: Request = new Request(b, c); // incorrect
-                        ^^^^^^^^^^^^^^^^^ constructor call
-inconsistent use of library definitions
-null. This type is incompatible with. See lib: bom.js:751
-string enum. See lib: bom.js:798
-
-request.js:6
-  6: const e: Request = new Request(b, c); // incorrect
-                        ^^^^^^^^^^^^^^^^^ constructor call
-inconsistent use of library definitions
-undefined. This type is incompatible with. See lib: bom.js:751
-string enum. See lib: bom.js:798
+  Request. See lib: bom.js:794
 
 request.js:6
   6: const e: Request = new Request(b, c); // incorrect
                         ^^^^^^^^^^^^^^^^^ constructor call
 inconsistent use of library definitions
 null. This type is incompatible with. See lib: bom.js:752
-Headers. See lib: bom.js:799
-
-request.js:6
-  6: const e: Request = new Request(b, c); // incorrect
-                        ^^^^^^^^^^^^^^^^^ constructor call
-inconsistent use of library definitions
-object type. This type is incompatible with. See lib: bom.js:752
-Headers. See lib: bom.js:799
+string enum. See lib: bom.js:799
 
 request.js:6
   6: const e: Request = new Request(b, c); // incorrect
                         ^^^^^^^^^^^^^^^^^ constructor call
 inconsistent use of library definitions
 undefined. This type is incompatible with. See lib: bom.js:752
-Headers. See lib: bom.js:799
+string enum. See lib: bom.js:799
 
 request.js:6
   6: const e: Request = new Request(b, c); // incorrect
                         ^^^^^^^^^^^^^^^^^ constructor call
 inconsistent use of library definitions
 null. This type is incompatible with. See lib: bom.js:753
-string. See lib: bom.js:800
+string enum. See lib: bom.js:800
 
 request.js:6
   6: const e: Request = new Request(b, c); // incorrect
                         ^^^^^^^^^^^^^^^^^ constructor call
 inconsistent use of library definitions
 undefined. This type is incompatible with. See lib: bom.js:753
-string. See lib: bom.js:800
+string enum. See lib: bom.js:800
 
 request.js:6
   6: const e: Request = new Request(b, c); // incorrect
                         ^^^^^^^^^^^^^^^^^ constructor call
 inconsistent use of library definitions
 null. This type is incompatible with. See lib: bom.js:754
-string enum. See lib: bom.js:801
+Headers. See lib: bom.js:801
+
+request.js:6
+  6: const e: Request = new Request(b, c); // incorrect
+                        ^^^^^^^^^^^^^^^^^ constructor call
+inconsistent use of library definitions
+object type. This type is incompatible with. See lib: bom.js:754
+Headers. See lib: bom.js:801
 
 request.js:6
   6: const e: Request = new Request(b, c); // incorrect
                         ^^^^^^^^^^^^^^^^^ constructor call
 inconsistent use of library definitions
 undefined. This type is incompatible with. See lib: bom.js:754
-string enum. See lib: bom.js:801
+Headers. See lib: bom.js:801
 
 request.js:6
   6: const e: Request = new Request(b, c); // incorrect
                         ^^^^^^^^^^^^^^^^^ constructor call
 inconsistent use of library definitions
 null. This type is incompatible with. See lib: bom.js:755
-string enum. See lib: bom.js:802
+string. See lib: bom.js:802
 
 request.js:6
   6: const e: Request = new Request(b, c); // incorrect
                         ^^^^^^^^^^^^^^^^^ constructor call
 inconsistent use of library definitions
 undefined. This type is incompatible with. See lib: bom.js:755
-string enum. See lib: bom.js:802
+string. See lib: bom.js:802
 
 request.js:6
   6: const e: Request = new Request(b, c); // incorrect
@@ -236,14 +208,14 @@ request.js:6
                         ^^^^^^^^^^^^^^^^^ constructor call
 inconsistent use of library definitions
 null. This type is incompatible with. See lib: bom.js:757
-string. See lib: bom.js:804
+string enum. See lib: bom.js:804
 
 request.js:6
   6: const e: Request = new Request(b, c); // incorrect
                         ^^^^^^^^^^^^^^^^^ constructor call
 inconsistent use of library definitions
 undefined. This type is incompatible with. See lib: bom.js:757
-string. See lib: bom.js:804
+string enum. See lib: bom.js:804
 
 request.js:6
   6: const e: Request = new Request(b, c); // incorrect
@@ -259,63 +231,91 @@ inconsistent use of library definitions
 undefined. This type is incompatible with. See lib: bom.js:758
 string enum. See lib: bom.js:805
 
+request.js:6
+  6: const e: Request = new Request(b, c); // incorrect
+                        ^^^^^^^^^^^^^^^^^ constructor call
+inconsistent use of library definitions
+null. This type is incompatible with. See lib: bom.js:759
+string. See lib: bom.js:806
+
+request.js:6
+  6: const e: Request = new Request(b, c); // incorrect
+                        ^^^^^^^^^^^^^^^^^ constructor call
+inconsistent use of library definitions
+undefined. This type is incompatible with. See lib: bom.js:759
+string. See lib: bom.js:806
+
+request.js:6
+  6: const e: Request = new Request(b, c); // incorrect
+                        ^^^^^^^^^^^^^^^^^ constructor call
+inconsistent use of library definitions
+null. This type is incompatible with. See lib: bom.js:760
+string enum. See lib: bom.js:807
+
+request.js:6
+  6: const e: Request = new Request(b, c); // incorrect
+                        ^^^^^^^^^^^^^^^^^ constructor call
+inconsistent use of library definitions
+undefined. This type is incompatible with. See lib: bom.js:760
+string enum. See lib: bom.js:807
+
 request.js:8
   8: const f: Request = new Request({}) // incorrect
                         ^^^^^^^^^^^^^^^ constructor call
   8: const f: Request = new Request({}) // incorrect
                                     ^^ object literal. This type is incompatible with
-union: string | Request. See lib: bom.js:792
+union: string | Request. See lib: bom.js:794
   Member 1:
-  string. See lib: bom.js:792
+  string. See lib: bom.js:794
   Error:
     8: const f: Request = new Request({}) // incorrect
                                       ^^ object literal. This type is incompatible with
-  string. See lib: bom.js:792
+  string. See lib: bom.js:794
   Member 2:
-  Request. See lib: bom.js:792
+  Request. See lib: bom.js:794
   Error:
     8: const f: Request = new Request({}) // incorrect
                                       ^^ object literal. This type is incompatible with
-  Request. See lib: bom.js:792
+  Request. See lib: bom.js:794
 
 request.js:30
  30: const j: Request = new Request('http://example.org', {
                         ^ constructor call
  32:   headers: 'Content-Type: image/jpeg',
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^ string. This type is incompatible with
-union: Headers | object type. See lib: bom.js:752
+union: Headers | object type. See lib: bom.js:754
   Member 1:
-  Headers. See lib: bom.js:704
+  Headers. See lib: bom.js:706
   Error:
    32:   headers: 'Content-Type: image/jpeg',
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^ string. This type is incompatible with
-  Headers. See lib: bom.js:704
+  Headers. See lib: bom.js:706
   Member 2:
-  object type. See lib: bom.js:704
+  object type. See lib: bom.js:706
   Error:
    32:   headers: 'Content-Type: image/jpeg',
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^ string. This type is incompatible with
-  object type. See lib: bom.js:704
+  object type. See lib: bom.js:706
 
 request.js:37
  37: const k: Request = new Request('http://example.org', {
                         ^ constructor call
  38:   method: 'CONNECT',
                ^^^^^^^^^ string. This type is incompatible with
-string enum. See lib: bom.js:754
+string enum. See lib: bom.js:756
 
 request.js:49
  49: h.text().then((t: Buffer) => t); // incorrect
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call of method `then`
  49: h.text().then((t: Buffer) => t); // incorrect
                        ^^^^^^ Buffer. This type is incompatible with
-string. See lib: bom.js:814
+string. See lib: bom.js:816
 
 request.js:51
  51: h.arrayBuffer().then((ab: Buffer) => ab); // incorrect
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call of method `then`
-Library type error:. See lib: bom.js:810
-ArrayBuffer. This type is incompatible with. See lib: bom.js:810
+Library type error:. See lib: bom.js:812
+ArrayBuffer. This type is incompatible with. See lib: bom.js:812
  51: h.arrayBuffer().then((ab: Buffer) => ab); // incorrect
                                ^^^^^^ Buffer
 
@@ -324,70 +324,70 @@ response.js:10
                          ^ constructor call
  11:     status: "404"
                  ^^^^^ string. This type is incompatible with
-number. See lib: bom.js:762
+number. See lib: bom.js:764
 
 response.js:14
  14: const f: Response = new Response("responsebody", {
                          ^ constructor call
  16:     headers: "'Content-Type': 'image/jpeg'"
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string. This type is incompatible with
-union: Headers | object type. See lib: bom.js:764
+union: Headers | object type. See lib: bom.js:766
   Member 1:
-  Headers. See lib: bom.js:704
+  Headers. See lib: bom.js:706
   Error:
    16:     headers: "'Content-Type': 'image/jpeg'"
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string. This type is incompatible with
-  Headers. See lib: bom.js:704
+  Headers. See lib: bom.js:706
   Member 2:
-  object type. See lib: bom.js:704
+  object type. See lib: bom.js:706
   Error:
    16:     headers: "'Content-Type': 'image/jpeg'"
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string. This type is incompatible with
-  object type. See lib: bom.js:704
+  object type. See lib: bom.js:706
 
 response.js:33
  33: const i: Response = new Response({
                          ^ constructor call
  33: const i: Response = new Response({
                                       ^ object literal. This type is incompatible with
-union: string | URLSearchParams | FormData | Blob. See lib: bom.js:768
+union: string | URLSearchParams | FormData | Blob. See lib: bom.js:770
   Member 1:
-  string. See lib: bom.js:768
+  string. See lib: bom.js:770
   Error:
    33: const i: Response = new Response({
                                         ^ object literal. This type is incompatible with
-  string. See lib: bom.js:768
+  string. See lib: bom.js:770
   Member 2:
-  URLSearchParams. See lib: bom.js:768
+  URLSearchParams. See lib: bom.js:770
   Error:
    33: const i: Response = new Response({
                                         ^ object literal. This type is incompatible with
-  URLSearchParams. See lib: bom.js:768
+  URLSearchParams. See lib: bom.js:770
   Member 3:
-  FormData. See lib: bom.js:768
+  FormData. See lib: bom.js:770
   Error:
    33: const i: Response = new Response({
                                         ^ object literal. This type is incompatible with
-  FormData. See lib: bom.js:768
+  FormData. See lib: bom.js:770
   Member 4:
-  Blob. See lib: bom.js:768
+  Blob. See lib: bom.js:770
   Error:
    33: const i: Response = new Response({
                                         ^ object literal. This type is incompatible with
-  Blob. See lib: bom.js:768
+  Blob. See lib: bom.js:770
 
 response.js:44
  44: h.text().then((t: Buffer) => t); // incorrect
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call of method `then`
  44: h.text().then((t: Buffer) => t); // incorrect
                        ^^^^^^ Buffer. This type is incompatible with
-string. See lib: bom.js:788
+string. See lib: bom.js:790
 
 response.js:46
  46: h.arrayBuffer().then((ab: Buffer) => ab); // incorrect
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call of method `then`
-Library type error:. See lib: bom.js:784
-ArrayBuffer. This type is incompatible with. See lib: bom.js:784
+Library type error:. See lib: bom.js:786
+ArrayBuffer. This type is incompatible with. See lib: bom.js:786
  46: h.arrayBuffer().then((ab: Buffer) => ab); // incorrect
                                ^^^^^^ Buffer
 
@@ -396,80 +396,80 @@ urlsearchparams.js:4
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructor call
   4: const b = new URLSearchParams(['key1', 'value1']); // not correct
                                    ^^^^^^^^^^^^^^^^^^ array literal. This type is incompatible with
-union: string | URLSearchParams. See lib: bom.js:725
+union: string | URLSearchParams. See lib: bom.js:727
   Member 1:
-  string. See lib: bom.js:725
+  string. See lib: bom.js:727
   Error:
     4: const b = new URLSearchParams(['key1', 'value1']); // not correct
                                      ^^^^^^^^^^^^^^^^^^ array literal. This type is incompatible with
-  string. See lib: bom.js:725
+  string. See lib: bom.js:727
   Member 2:
-  URLSearchParams. See lib: bom.js:725
+  URLSearchParams. See lib: bom.js:727
   Error:
     4: const b = new URLSearchParams(['key1', 'value1']); // not correct
                                      ^^^^^^^^^^^^^^^^^^ array literal. This type is incompatible with
-  URLSearchParams. See lib: bom.js:725
+  URLSearchParams. See lib: bom.js:727
 
 urlsearchparams.js:5
   5: const c = new URLSearchParams({'key1', 'value1'}); // not correct
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructor call
   5: const c = new URLSearchParams({'key1', 'value1'}); // not correct
                                    ^^^^^^^^^^^^^^^^^^ object literal. This type is incompatible with
-union: string | URLSearchParams. See lib: bom.js:725
+union: string | URLSearchParams. See lib: bom.js:727
   Member 1:
-  string. See lib: bom.js:725
+  string. See lib: bom.js:727
   Error:
     5: const c = new URLSearchParams({'key1', 'value1'}); // not correct
                                      ^^^^^^^^^^^^^^^^^^ object literal. This type is incompatible with
-  string. See lib: bom.js:725
+  string. See lib: bom.js:727
   Member 2:
-  URLSearchParams. See lib: bom.js:725
+  URLSearchParams. See lib: bom.js:727
   Error:
     5: const c = new URLSearchParams({'key1', 'value1'}); // not correct
                                      ^^^^^^^^^^^^^^^^^^ object literal. This type is incompatible with
-  URLSearchParams. See lib: bom.js:725
+  URLSearchParams. See lib: bom.js:727
 
 urlsearchparams.js:9
   9: e.append('key1'); // not correct
      ^^^^^^^^^^^^^^^^ call of method `append`
   9: e.append('key1'); // not correct
      ^^^^^^^^^^^^^^^^ undefined (too few arguments, expected default/rest parameters). This type is incompatible with
-string. See lib: bom.js:726
+string. See lib: bom.js:728
 
 urlsearchparams.js:10
  10: e.append({'key1', 'value1'}); // not correct
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call of method `append`
  10: e.append({'key1', 'value1'}); // not correct
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ undefined (too few arguments, expected default/rest parameters). This type is incompatible with
-string. See lib: bom.js:726
+string. See lib: bom.js:728
 
 urlsearchparams.js:10
  10: e.append({'key1', 'value1'}); // not correct
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call of method `append`
  10: e.append({'key1', 'value1'}); // not correct
               ^^^^^^^^^^^^^^^^^^ object literal. This type is incompatible with
-string. See lib: bom.js:726
+string. See lib: bom.js:728
 
 urlsearchparams.js:12
  12: e.set('key1'); // not correct
      ^^^^^^^^^^^^^ call of method `set`
  12: e.set('key1'); // not correct
      ^^^^^^^^^^^^^ undefined (too few arguments, expected default/rest parameters). This type is incompatible with
-string. See lib: bom.js:733
+string. See lib: bom.js:735
 
 urlsearchparams.js:13
  13: e.set({'key1', 'value1'}); // not correct
      ^^^^^^^^^^^^^^^^^^^^^^^^^ call of method `set`
  13: e.set({'key1', 'value1'}); // not correct
      ^^^^^^^^^^^^^^^^^^^^^^^^^ undefined (too few arguments, expected default/rest parameters). This type is incompatible with
-string. See lib: bom.js:733
+string. See lib: bom.js:735
 
 urlsearchparams.js:13
  13: e.set({'key1', 'value1'}); // not correct
      ^^^^^^^^^^^^^^^^^^^^^^^^^ call of method `set`
  13: e.set({'key1', 'value1'}); // not correct
            ^^^^^^^^^^^^^^^^^^ object literal. This type is incompatible with
-string. See lib: bom.js:733
+string. See lib: bom.js:735
 
 urlsearchparams.js:15
  15: const f: URLSearchParams = e.append('key1', 'value1'); // not correct

--- a/tests/worker/.flowconfig
+++ b/tests/worker/.flowconfig
@@ -1,0 +1,2 @@
+[options]
+module.system=haste

--- a/tests/worker/worker.exp
+++ b/tests/worker/worker.exp
@@ -1,0 +1,1 @@
+Found 0 errors

--- a/tests/worker/worker.js
+++ b/tests/worker/worker.js
@@ -1,0 +1,9 @@
+// @flow
+
+var worker = new Worker('some/path');
+
+worker.addEventListener('message', (ev: MessageEvent) => {});
+worker.addEventListener('error', (ev: Event) => {});
+
+worker.onerror = (ev: Event) => {};
+worker.onmessage = (ev: MessageEvent) => {};


### PR DESCRIPTION
A `Worker` instance that listens for a message event
should receive a `MessageEvent` object.

Overload `addEventListener` for `Worker`.
