### PR TITLE
Fix prev/next links in docs pages.

### DIFF
--- a/website/docs/ref/builtins.doc.js
+++ b/website/docs/ref/builtins.doc.js
@@ -4,8 +4,8 @@
 id: builtins
 title: Built-in Types
 permalink: /docs/builtins.html
-prev: quick-reference.html
-next: syntax.html
+prev: syntax.html
+next: arrays.html
 ---
 */
 
@@ -240,7 +240,7 @@ unsafe.foo.bar.baz;
   ## mixed
 
   Like `any`, `mixed` is a supertype of all types. Unlike `any`, however,
-  `mixed` is not a subtype of all types. This means `mixed` is like a safe 
+  `mixed` is not a subtype of all types. This means `mixed` is like a safe
   but somewhat annoying version of `any`. It should be preferred over `any`
   whenever possible.
 */

--- a/website/docs/ref/quickref.doc.js
+++ b/website/docs/ref/quickref.doc.js
@@ -5,7 +5,7 @@ id: quick-reference
 title: Quick Reference
 permalink: /docs/quick-reference.html
 prev: advanced-configuration.html
-next: builtins.html
+next: syntax.html
 ---
 */
 /*

--- a/website/docs/ref/syntax.doc.js
+++ b/website/docs/ref/syntax.doc.js
@@ -4,8 +4,8 @@
 id: syntax
 title: Syntax
 permalink: /docs/syntax.html
-prev: builtins.html
-next: arrays.html
+prev: quick-reference.html
+next: builtins.html
 ---
 */
 /*


### PR DESCRIPTION
https://flowtype.org/docs/

This PR fixes the links on the bottom of three docs pages to match the order implied in the Table of Contents. 

Here's how the docs currently flow (if they are to match TOC on left of the page). Below are what they should be (and what the PR tries to implement).

"quickreference" -> "builtins"
**should be**
"quickreference" -> "syntax"

"syntax" -> "arrays"
**should be**
"syntax" -> "builtins"