### PR TITLE
Document the existence of compiled-to-JS Flow parser on npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Flow can also compile its parser to JavaScript. [Read how here](src/parser/READM
 
 While Flow is written in OCaml, its parser is available as a compiled-to-JavaScript module published to npm, named [flow-parser](https://www.npmjs.com/package/flow-parser). **Most end users of Flow
 will not need to use this parser directly** (and should install [flow-bin](https://www.npmjs.org/package/flow-bin) from npm above), but JavaScript packages which make use of parsing
-Flow-typed JavaScript can use this to generate Flow's syntax tree with inferred types attached.
+Flow-typed JavaScript can use this to generate Flow's syntax tree with annotated types attached.
 
 ## Running the tests
 

--- a/README.md
+++ b/README.md
@@ -114,6 +114,14 @@ This produces a `bin` folder containing the `flow` binary.
 
 *Note: at this time, the OCaml dependency prevents us from adding Flow to [npm](http://npmjs.org). Try [flow-bin](https://www.npmjs.org/package/flow-bin) if you need a npm binary wrapper.*
 
+Flow can also compile its parser to JavaScript. [Read how here](src/parser/README.md).
+
+## Using Flow's parser from JavaScript
+
+While Flow is written in OCaml, its parser is available as a compiled-to-JavaScript module published to npm, named [flow-parser](https://www.npmjs.com/package/flow-parser). **Most end users of Flow
+will not need to use this parser directly** (and should install [flow-bin](https://www.npmjs.org/package/flow-bin) from npm above), but JavaScript packages which make use of parsing
+Flow-typed JavaScript can use this to generate Flow's syntax tree with inferred types attached.
+
 ## Running the tests
 
 To run the tests, first compile flow using `make`. Then run `bash ./runtests.sh bin/flow`


### PR DESCRIPTION
I figured this could be useful to promote more prominently on the main
README. Feel free to refine or reject.

Also, while setting up a build for the JS parser, I found I also needed
to install ocamlfind (used in the Makefile) which didn't come alongside
any of the other packages. If this is the case, I can add that to the
parser README.
