### PR TITLE
GraphQL: Parser and schema loading.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,7 @@ MODULES=\
   src/embedded\
   src/parser\
   src/parsing\
+  src/graphql\
   src/server\
   src/services/autocomplete\
   src/services/inference\

--- a/examples/graphql/.flowconfig
+++ b/examples/graphql/.flowconfig
@@ -1,0 +1,2 @@
+[options]
+graphql_schema=schema.graphql

--- a/examples/graphql/schema.graphql
+++ b/examples/graphql/schema.graphql
@@ -1,0 +1,15 @@
+scalar Int
+scalar Float
+scalar String
+scalar Boolean
+scalar ID
+
+type User {
+  id: ID!
+  name: String
+  friends: [User]!
+}
+
+type Query {
+  me: User
+}

--- a/src/commands/lsCommand.ml
+++ b/src/commands/lsCommand.ml
@@ -154,7 +154,8 @@ let get_ls_files ~subdir ~root ~strip_root ~ignore_flag ~include_flag =
     opt_ignore_non_literal_requires = false;
     opt_max_header_tokens = FlowConfig.(
       flowconfig.options.Opts.max_header_tokens
-    )
+    );
+    opt_graphql_schema = None;
   } in
 
   let _, libs = Files.init options in

--- a/src/commands/serverCommands.ml
+++ b/src/commands/serverCommands.ml
@@ -261,6 +261,13 @@ module OptionParser(Config : CONFIG) = struct
     let all = all || FlowConfig.(flowconfig.options.Opts.all) in
     let opt_max_workers = min opt_max_workers Sys_utils.nbr_procs in
 
+    let opt_graphql_schema = FlowConfig.(
+      flowconfig.options.Opts.graphql_schema
+    ) in
+    let opt_graphql_schema = Option.map opt_graphql_schema (fun file ->
+      Files.make_path_absolute root file
+    ) in
+
     let options = { Options.
       opt_check_mode = Config.(mode = Check);
       opt_server_mode = Config.(mode = Server);
@@ -348,7 +355,9 @@ module OptionParser(Config : CONFIG) = struct
       );
       opt_max_header_tokens = FlowConfig.(
         flowconfig.options.Opts.max_header_tokens
-      )
+      );
+
+      opt_graphql_schema;
     } in
     Main.start options
 

--- a/src/common/flowConfig.ml
+++ b/src/common/flowConfig.ml
@@ -75,6 +75,7 @@ module Opts = struct
     shm_hash_table_pow: int;
     shm_log_level: int;
     version: string option;
+    graphql_schema: string option;
   }
 
   type _initializer =
@@ -170,6 +171,7 @@ module Opts = struct
     shm_hash_table_pow = 19;
     shm_log_level = 0;
     version = None;
+    graphql_schema = None;
   }
 
   let parse =
@@ -704,6 +706,15 @@ let parse_options config lines =
       optparser = optparse_boolean;
       setter = (fun opts v ->
         {opts with enforce_strict_type_args = v;}
+      );
+    }
+
+    |> define_opt "graphql_schema" {
+      _initializer = USE_DEFAULT;
+      flags = [];
+      optparser = optparse_string;
+      setter = (fun opts v ->
+        {opts with graphql_schema = Some v;}
       );
     }
 

--- a/src/common/flowConfig.mli
+++ b/src/common/flowConfig.mli
@@ -44,6 +44,7 @@ module Opts : sig
     shm_hash_table_pow: int;
     shm_log_level: int;
     version: string option;
+    graphql_schema: string option;
   }
   val default_options : t
 end

--- a/src/common/options.ml
+++ b/src/common/options.ml
@@ -70,6 +70,7 @@ type t = {
   opt_shm_hash_table_pow: int;
   opt_shm_log_level: int;
   opt_max_header_tokens: int;
+  opt_graphql_schema: Path.t option;
 }
 
 let default_error_flags = {
@@ -132,3 +133,4 @@ let shm_hash_table_pow opts = opts.opt_shm_hash_table_pow
 let shm_log_level opts = opts.opt_shm_log_level
 let verbose opts = opts.opt_verbose
 let weak_by_default opts = opts.opt_weak
+let graphql_schema opts = opts.opt_graphql_schema

--- a/src/common/reason.ml
+++ b/src/common/reason.ml
@@ -182,6 +182,8 @@ type reason_desc =
   | RPropTypeShape
   | RPropTypeFbt
 
+  | RGraphqlSchema
+
 and reason_desc_function =
   | RAsync
   | RGenerator
@@ -486,6 +488,8 @@ let rec string_of_desc = function
   | RPropTypeOneOfType -> "oneOfType"
   | RPropTypeShape -> "shape"
   | RPropTypeFbt -> "Fbd"
+
+  | RGraphqlSchema -> "Graphql schema"
 
 let string_of_reason r =
   let spos = string_of_loc (loc_of_reason r) in

--- a/src/common/reason.mli
+++ b/src/common/reason.mli
@@ -133,6 +133,8 @@ type reason_desc =
   | RPropTypeShape
   | RPropTypeFbt
 
+  | RGraphqlSchema
+
 and reason_desc_function =
   | RAsync
   | RGenerator

--- a/src/graphql/graphql_ast.ml
+++ b/src/graphql/graphql_ast.ml
@@ -1,0 +1,237 @@
+module rec Document : sig
+  type t = {
+    definitions: Definition.t list;
+  }
+end = Document
+
+and Definition : sig
+
+  type t =
+    | Operation of OperationDef.t
+    | Fragment of FragmentDef.t
+    | ScalarType of ScalarTypeDef.t
+    | ObjectType of ObjectTypeDef.t
+    | InterfaceType of InterfaceTypeDef.t
+    | UnionType of UnionTypeDef.t
+    | EnumType of EnumTypeDef.t
+    | InputObjectType of InputObjectTypeDef.t
+    | Schema of SchemaDef.t
+end = Definition
+
+and OperationDef : sig
+  type t = {
+    operation: OperationType.op;
+    name: Name.t option;
+    selectionSet: SelectionSet.t;
+    variableDefs: VariableDef.t list option;
+    directives: Directive.t list option;
+  }
+end = OperationDef
+
+and VariableDef : sig
+  type t = {
+    variable: Variable.t;
+    type_: Type.t;
+    defaultValue: Value.t option;
+    loc: Loc.t;
+  }
+end = VariableDef
+
+and Variable : sig
+  type t = Loc.t * Name.t
+end = Variable
+
+and FragmentDef : sig
+  type t = {
+    name: Name.t option;
+    typeCondition: Name.t;
+    selectionSet: SelectionSet.t;
+    directives: Directive.t list option;
+    loc: Loc.t;
+  }
+end = FragmentDef
+
+and ScalarTypeDef : sig
+  type t = {
+    name: Name.t;
+    directives: Directive.t list option;
+    loc: Loc.t;
+  }
+end = ScalarTypeDef
+
+and ObjectTypeDef : sig
+  type t = {
+    name: Name.t;
+    fields: FieldDef.t list;
+    interfaces: Name.t list;
+    directives: Directive.t list option;
+  }
+end = ObjectTypeDef
+
+and FieldDef : sig
+  type t = {
+    name: Name.t;
+    type_: Type.t;
+    args: InputValueDef.t list;
+    directives: Directive.t list option;
+  }
+end = FieldDef
+
+and InputValueDef : sig
+  type t = {
+    name: Name.t;
+    type_: Type.t;
+    defaultValue: Value.t option;
+    directives: Directive.t list option;
+    loc: Loc.t;
+  }
+end = InputValueDef
+
+and InterfaceTypeDef : sig
+  type t = {
+    name: Name.t;
+    fields: FieldDef.t list;
+    directives: Directive.t list option;
+  }
+end = InterfaceTypeDef
+
+and UnionTypeDef : sig
+  type t = {
+    name: Name.t;
+    types: Name.t list;
+    directives: Directive.t list option;
+  }
+end = UnionTypeDef
+
+and EnumTypeDef : sig
+  type t = {
+    name: Name.t;
+    values: EnumValueDef.t list;
+    directives: Directive.t list option;
+  }
+end = EnumTypeDef
+
+and EnumValueDef : sig
+  type t = {
+    name: Name.t;
+    directives: Directive.t list option;
+    loc: Loc.t;
+  }
+end = EnumValueDef
+
+and InputObjectTypeDef : sig
+  type t = {
+    name: Name.t;
+    fields: InputValueDef.t list;
+    directives: Directive.t list option;
+  }
+end = InputObjectTypeDef
+
+and Value : sig
+  type t =
+    | Variable of Variable.t
+    | IntValue of Loc.t * string
+    | FloatValue of Loc.t * string
+    | StringValue of Loc.t * string
+    | BooleanValue of Loc.t * bool
+    | EnumValue of Loc.t * string
+    | ListValue of Loc.t * Value.t list
+    | ObjectValue of ObjectValue.t
+end = Value
+
+and ObjectValue : sig
+  type t = {
+    fields: ObjectField.t list;
+    loc: Loc.t;
+  }
+end = ObjectValue
+
+and ObjectField : sig
+  type t = {
+    name: Name.t;
+    value: Value.t;
+    loc: Loc.t;
+  }
+end = ObjectField
+
+and Directive : sig
+  type t = {
+    name: Name.t;
+    arguments: Argument.t list option;
+    loc: Loc.t;
+  }
+end = Directive
+
+and SchemaDef : sig
+  type t = {
+    operationTypes: OperationType.t list;
+    directives: Directive.t list option;
+  }
+end = SchemaDef
+
+and OperationType : sig
+  type op = Query | Mutation | Subscription
+
+  type t = {
+    operation: op;
+    type_: Name.t;
+  }
+end = OperationType
+
+and Name : sig
+  type t = Loc.t * string
+end = Name
+
+and Type : sig
+  type t =
+    | Named of Name.t
+    | List of Loc.t * t
+    | NonNull of Loc.t * t
+end = Type
+
+and SelectionSet : sig
+  type t = {
+    selections: Selection.t list;
+    loc: Loc.t;
+  }
+end = SelectionSet
+
+and Selection : sig
+  type t =
+    | Field of Field.t
+    | FragmentSpread of FragmentSpread.t
+    | InlineFragment of InlineFragment.t
+end = Selection
+
+and Field : sig
+  type t = {
+    alias: Name.t option;
+    name: Name.t;
+    args: Argument.t list option;
+    selectionSet: SelectionSet.t option;
+    directives: Directive.t list option;
+  }
+end = Field
+
+and Argument : sig
+  type t = {
+    name: Name.t;
+    value: Value.t;
+    loc: Loc.t;
+  }
+end = Argument
+
+and FragmentSpread : sig
+  type t = {
+    name: Name.t;
+    directives: Directive.t list option;
+  }
+end = FragmentSpread
+
+and InlineFragment : sig
+  type t = {
+    typeCondition: Name.t option;
+    selectionSet: SelectionSet.t;
+    directives: Directive.t list option;
+  }
+end = InlineFragment

--- a/src/graphql/graphql_conv.ml
+++ b/src/graphql/graphql_conv.ml
@@ -1,0 +1,105 @@
+module Ast = Graphql_ast
+module Schema = Graphql_schema
+
+let names_to_strings names = List.map (fun (_, name) -> name) names
+
+let rec conv_type t =
+  match t with
+  | Ast.Type.Named (_, name) -> Schema.Type.Named name
+  | Ast.Type.List (_, t) -> Schema.Type.List (conv_type t)
+  | Ast.Type.NonNull (_, t) -> Schema.Type.NonNull (conv_type t)
+
+let conv_input_vals values =
+  List.fold_left (fun map value ->
+    let (_, name) = value.Ast.InputValueDef.name in
+    let type_ = conv_type value.Ast.InputValueDef.type_ in
+    let value = { Schema.InputVal.
+      name;
+      type_;
+    } in
+    SMap.add name value map
+  ) SMap.empty values
+
+let conv_fields fields =
+  List.fold_left (fun map field ->
+    let (_, name) = field.Ast.FieldDef.name in
+    let type_ = conv_type field.Ast.FieldDef.type_ in
+    let field = {
+      Schema.Field.name = name;
+      args = conv_input_vals field.Ast.FieldDef.args;
+      type_;
+    } in
+    SMap.add name field map
+  ) SMap.empty fields
+
+let schema_from_ast doc =
+  let query = ref None in
+  let mutation = ref None in
+  let subscription = ref None in
+  let type_map = ref SMap.empty in
+
+  let add_type name type_ = type_map := SMap.add name type_ !type_map in
+
+  List.iter (fun stmt ->
+    let module Def = Ast.Definition in
+    match stmt with
+    | Def.ScalarType scalar ->
+        let (_, name) = scalar.Ast.ScalarTypeDef.name in
+        add_type name (Schema.Type.Scalar name)
+    | Def.ObjectType {
+        Ast.ObjectTypeDef.name = (_, name);
+        fields;
+        interfaces;
+        directives = _;
+      } ->
+        let interfaces = names_to_strings interfaces in
+        add_type name (Schema.Type.Obj (name, conv_fields fields, interfaces))
+    | Def.InterfaceType {
+        Ast.InterfaceTypeDef.name = (_, name);
+        fields;
+        directives = _;
+      } ->
+        add_type name (Schema.Type.Interface (name, conv_fields fields))
+    | Def.UnionType {
+        Ast.UnionTypeDef.name = (_, name);
+        types;
+        directives = _;
+      } ->
+        let types = names_to_strings types in
+        add_type name (Schema.Type.Union (name, types))
+    | Def.EnumType {
+        Ast.EnumTypeDef.name = (_, name);
+        values;
+        directives = _;
+      } ->
+        let values = List.map (fun v -> v.Ast.EnumValueDef.name) values in
+        let values = names_to_strings values in
+        add_type name (Schema.Type.Enum (name, values))
+    | Def.InputObjectType {
+        Ast.InputObjectTypeDef.name = (_, name);
+        fields;
+        directives = _;
+      } ->
+        add_type name (Schema.Type.InputObj (name, conv_input_vals fields))
+    | Def.Schema obj ->
+        List.iter (fun t ->
+          let typeRef =
+            match t.Ast.OperationType.operation with
+            | Ast.OperationType.Query -> query
+            | Ast.OperationType.Mutation -> mutation
+            | Ast.OperationType.Subscription -> subscription
+          in
+          let (_, type_) = t.Ast.OperationType.type_ in
+          typeRef := Some type_
+        ) obj.Ast.SchemaDef.operationTypes
+    | Def.Operation _
+    | Def.Fragment _ ->
+        failwith "Schema definition can not contain operation/fragment definitions"
+  ) doc.Ast.Document.definitions;
+
+  Schema.{
+    query_name = (match !query with Some x -> x | None -> "Query");
+    mutation_name = !mutation;
+    subscription_name = !subscription;
+    type_map = !type_map;
+  }

--- a/src/graphql/graphql_lexer.mll
+++ b/src/graphql/graphql_lexer.mll
@@ -1,0 +1,74 @@
+{
+open Lexing
+open Graphql_parser
+}
+
+let white = [' ' '\t' ',']+
+let comment = '#' [^ '\n' '\r']*
+let newline = '\r' | '\n' | "\r\n"
+
+let digit = ['0'-'9']
+let int = '-'? '0' | '-'? ['1'-'9'] digit*
+let fract_part = '.' digit+
+let exp_part = ['e' 'E'] ['+' '-']? digit+
+let float = int fract_part | int exp_part | int fract_part exp_part
+
+let name = ['_' 'A'-'Z' 'a'-'z'] ['_' '0'-'9' 'A'-'Z' 'a'-'z']*
+
+rule token = parse
+  | white { token lexbuf }
+  | comment { token lexbuf }
+  | newline { new_line lexbuf; token lexbuf }
+
+  | int { INT (lexeme lexbuf) }
+  | float { FLOAT (lexeme lexbuf) }
+  | '"' { read_string (Buffer.create 17) lexbuf }
+
+  | "enum" { ENUM }
+  | "false" { FALSE }
+  | "fragment" { FRAGMENT }
+  | "implements" { IMPLEMENTS }
+  | "input" { INPUT }
+  | "interface" { INTERFACE }
+  | "mutation" { MUTATION }
+  | "null" { NULL }
+  | "on" { ON }
+  | "query" { QUERY }
+  | "scalar" { SCALAR }
+  | "schema" { SCHEMA }
+  | "subscription" { SUBSCRIPTION }
+  | "true" { TRUE }
+  | "type" { TYPE }
+  | "union" { UNION }
+  | name { NAME (lexeme lexbuf) }
+
+  | '(' { LBRACE }
+  | ')' { RBRACE }
+  | '{' { LCURLY }
+  | '}' { RCURLY }
+  | ':' { COLON }
+  | '=' { EQUAL }
+  | '[' { LBRACKET }
+  | ']' { RBRACKET }
+  | '!' { BANG }
+  | '|' { PIPE }
+  | "..." { ELLIPSIS }
+  | '$' { DOLLAR }
+  | '@' { AT }
+  | eof { EOF }
+
+and read_string buf = parse
+  | '"' { STRING (Buffer.contents buf) }
+  | '\\' '"' { Buffer.add_char buf '"'; read_string buf lexbuf }
+  | '\\' '\\' { Buffer.add_char buf '\\'; read_string buf lexbuf }
+  | '\\' '/' { Buffer.add_char buf '/'; read_string buf lexbuf }
+  | '\\' 'b' { Buffer.add_char buf '\b'; read_string buf lexbuf }
+  | '\\' 'f' { Buffer.add_char buf '\012'; read_string buf lexbuf }
+  | '\\' 'n' { Buffer.add_char buf '\n'; read_string buf lexbuf }
+  | '\\' 'r' { Buffer.add_char buf '\r'; read_string buf lexbuf }
+  | '\\' 't' { Buffer.add_char buf '\t'; read_string buf lexbuf }
+  | [^ '"' '\\' '\n' '\r']+
+    {
+      Buffer.add_string buf (lexeme lexbuf);
+      read_string buf lexbuf
+    }

--- a/src/graphql/graphql_parser.mly
+++ b/src/graphql/graphql_parser.mly
@@ -1,0 +1,414 @@
+%{
+open Parsing
+open Graphql_ast
+
+let symbol_loc () =
+  let source = Graphql_parsing.curr_source () in
+  Loc.from_lb_p source (symbol_start_pos ()) (symbol_end_pos ())
+%}
+
+%token <string> NAME
+%token LBRACE
+%token RBRACE
+%token LCURLY
+%token RCURLY
+%token LBRACKET
+%token RBRACKET
+%token COLON
+%token EQUAL
+%token BANG
+%token PIPE
+%token ELLIPSIS
+%token DOLLAR
+%token AT
+%token <string> INT
+%token <string> FLOAT
+%token <string> STRING
+
+%token ENUM
+%token FALSE
+%token FRAGMENT
+%token IMPLEMENTS
+%token INPUT
+%token INTERFACE
+%token MUTATION
+%token NULL
+%token ON
+%token QUERY
+%token SCALAR
+%token SCHEMA
+%token SUBSCRIPTION
+%token TRUE
+%token TYPE
+%token UNION
+
+%token EOF
+
+%start doc
+%type <Graphql_ast.Document.t> doc
+
+%%
+
+doc:
+  | definitions {
+      {
+        Document.definitions = $1;
+      }
+    }
+
+definitions:
+  | EOF { [] }
+  | definition definitions { $1 :: $2 }
+
+definition:
+  | selection_set {
+      Definition.Operation { OperationDef.
+        operation = OperationType.Query;
+        name = None;
+        directives = None;
+        selectionSet = $1;
+        variableDefs = None;
+      }
+    }
+  | operation_type name_opt var_defs directives_opt selection_set {
+      Definition.Operation { OperationDef.
+        operation = $1;
+        name = $2;
+        directives = $4;
+        selectionSet = $5;
+        variableDefs = $3;
+      }
+    }
+  | FRAGMENT fragment_name_opt ON name directives_opt selection_set {
+      Definition.Fragment { FragmentDef.
+        name = $2;
+        typeCondition = $4;
+        selectionSet = $6;
+        directives = $5;
+        loc = symbol_loc ();
+      }
+    }
+  | SCALAR name directives_opt {
+      Definition.ScalarType {
+        ScalarTypeDef.name = $2;
+        directives = $3;
+        loc = symbol_loc ();
+      }
+    }
+  | TYPE name interfaces directives_opt LCURLY field_defs RCURLY {
+      Definition.ObjectType {
+        ObjectTypeDef.name = $2;
+        fields = $6;
+        interfaces = $3;
+        directives = $4;
+      }
+    }
+  | INTERFACE name directives_opt LCURLY field_defs RCURLY {
+      Definition.InterfaceType {
+        InterfaceTypeDef.name = $2;
+        fields = $5;
+        directives = $3;
+      }
+    }
+  | UNION name directives_opt EQUAL union_types {
+      Definition.UnionType {
+        UnionTypeDef.name = $2;
+        types = $5;
+        directives = $3;
+      }
+    }
+  | ENUM name directives_opt LCURLY enum_values RCURLY {
+      Definition.EnumType {
+        EnumTypeDef.name = $2;
+        values = $5;
+        directives = $3;
+      }
+    }
+  | INPUT name directives_opt LCURLY input_value_defs RCURLY {
+      Definition.InputObjectType {
+        InputObjectTypeDef.name = $2;
+        fields = $5;
+        directives = $3;
+      }
+    }
+  | SCHEMA directives_opt LCURLY operation_types RCURLY {
+      Definition.Schema { SchemaDef.
+        operationTypes = $4;
+        directives = $2;
+      }
+    }
+
+var_defs:
+  | { None }
+  | LBRACE var_defs_ RBRACE { Some $2 }
+
+var_defs_:
+  | var_def { [$1] }
+  | var_def var_defs_ { $1 :: $2 }
+
+var_def:
+  | var COLON type_ref default_value_opt {
+      { VariableDef.
+        variable = $1;
+        type_ = $3;
+        defaultValue = $4;
+        loc = symbol_loc ();
+      }
+    }
+
+selection_set:
+  | LCURLY selections RCURLY {
+      {
+        SelectionSet.selections = $2;
+        loc = symbol_loc ();
+      }
+    }
+
+selection_set_opt:
+  | { None }
+  | selection_set { Some $1 }
+
+selections:
+  | selection { [$1] }
+  | selection selections { $1 :: $2 }
+
+selection:
+  | field_name arguments_opt directives_opt selection_set_opt {
+      let (alias, name) = $1 in
+      Selection.Field {
+        Field.alias = alias;
+        name = name;
+        args = $2;
+        selectionSet = $4;
+        directives = $3;
+      }
+    }
+  | ELLIPSIS fragment_name directives_opt {
+      Selection.FragmentSpread {
+        FragmentSpread.name = $2;
+        directives = $3;
+      }
+    }
+  | ELLIPSIS type_condition_opt directives_opt selection_set {
+      Selection.InlineFragment {
+        InlineFragment.typeCondition = $2;
+        selectionSet = $4;
+        directives = $3;
+      }
+    }
+
+field_name:
+  | name { (None, $1) }
+  | name COLON name { (Some $1, $3) }
+
+type_condition_opt:
+  | { None }
+  | ON name { Some $2 }
+
+union_types:
+  | name { [$1] }
+  | name PIPE union_types { $1 :: $3 }
+
+enum_values:
+  | enum_value { [$1] }
+  | enum_value enum_values { $1 :: $2 }
+
+enum_value:
+  | name directives_opt {
+      { EnumValueDef.
+        name = $1;
+        directives = $2;
+        loc = symbol_loc ();
+      }
+    }
+
+field_defs:
+  | { [] }
+  | field_def field_defs { $1 :: $2 }
+
+field_def:
+  | name arg_defs COLON type_ref directives_opt {
+      {
+        FieldDef.name = $1;
+        type_ = $4;
+        args = $2;
+        directives = $5;
+      }
+    }
+
+arg_defs:
+  | { [] }
+  | LBRACE arg_defs_ RBRACE { $2 }
+
+arg_defs_:
+  | input_value_def { [$1] }
+  | input_value_def arg_defs_ { $1 :: $2 }
+
+input_value_defs:
+  | { [] }
+  | input_value_def input_value_defs { $1 :: $2 }
+
+input_value_def:
+  | name COLON type_ref default_value_opt directives_opt {
+      { InputValueDef.
+        name = $1;
+        type_ = $3;
+        defaultValue = $4;
+        directives = $5;
+        loc = symbol_loc ();
+      }
+    }
+
+default_value_opt:
+  | { None }
+  | EQUAL value { Some $2 }
+
+type_ref:
+  | name { Type.Named $1 }
+  | LBRACKET type_ref RBRACKET { Type.List (symbol_loc (), $2) }
+  | type_ref BANG { Type.NonNull (symbol_loc (), $1) }
+
+interfaces:
+  | { [] }
+  | IMPLEMENTS interfaces_list { $2 }
+
+interfaces_list:
+  | name { [$1] }
+  | name interfaces_list { $1 :: $2 }
+
+name: name_ { (symbol_loc (), $1) }
+
+name_:
+  | fragment_name_ { $1 }
+  | ON { "on" }
+
+enum_value_str:
+  | NAME { $1 }
+  | ENUM { "enum" }
+  | FRAGMENT { "fragment" }
+  | IMPLEMENTS { "implements" }
+  | INPUT { "input" }
+  | INTERFACE { "interface" }
+  | MUTATION { "mutation" }
+  | ON { "on" }
+  | QUERY { "query" }
+  | SCALAR { "scalar" }
+  | SCHEMA { "schema" }
+  | SUBSCRIPTION { "subscription" }
+  | TYPE { "type" }
+  | UNION { "union" }
+
+fragment_name: fragment_name_ { (symbol_loc (), $1) }
+
+fragment_name_:
+  | NAME { $1 }
+  | ENUM { "enum" }
+  | FALSE { "false" }
+  | FRAGMENT { "fragment" }
+  | IMPLEMENTS { "implements" }
+  | INPUT { "input" }
+  | INTERFACE { "interface" }
+  | MUTATION { "mutation" }
+  | NULL { "null" }
+  | QUERY { "query" }
+  | SCALAR { "scalar" }
+  | SCHEMA { "schema" }
+  | SUBSCRIPTION { "subscription" }
+  | TRUE { "true" }
+  | TYPE { "type" }
+  | UNION { "union" }
+
+fragment_name_opt:
+  | { None }
+  | fragment_name { Some $1 }
+
+name_opt:
+  | { None }
+  | name { Some $1 }
+
+var:
+  | DOLLAR name { (symbol_loc (), $2) }
+
+value:
+  | var { Value.Variable $1 }
+  | INT { Value.IntValue (symbol_loc(), $1) }
+  | FLOAT { Value.FloatValue (symbol_loc(), $1) }
+  | STRING { Value.StringValue (symbol_loc(), $1) }
+  | TRUE { Value.BooleanValue (symbol_loc(), true) }
+  | FALSE { Value.BooleanValue (symbol_loc(), false) }
+  | enum_value_str { Value.EnumValue (symbol_loc (), $1) }
+  | LBRACKET list_values RBRACKET { Value.ListValue (symbol_loc (), $2) }
+  | LCURLY object_fields RCURLY {
+      let obj = { ObjectValue.
+        fields = $2;
+        loc = symbol_loc ();
+      } in
+      Value.ObjectValue obj
+    }
+
+list_values:
+  | { [] }
+  | value list_values { $1 :: $2 }
+
+object_fields:
+  | { [] }
+  | object_field object_fields {
+      $1 :: $2
+    }
+
+object_field:
+  | name COLON value {
+      { ObjectField.name = $1; value = $3; loc = symbol_loc () }
+    }
+
+arguments:
+  | LBRACE arguments_ RBRACE { $2 }
+
+arguments_opt:
+  | { None }
+  | arguments { Some $1 }
+
+arguments_:
+  | argument { [$1] }
+  | argument arguments_ { $1 :: $2 }
+
+argument:
+  | name COLON value {
+      { Argument.
+        name = $1;
+        value = $3;
+        loc = symbol_loc ();
+      }
+    }
+
+directives:
+  | directive { [$1] }
+  | directive directives { $1 :: $2 }
+
+directives_opt:
+  | { None }
+  | directives { Some $1 }
+
+directive:
+  | AT name arguments_opt {
+      { Directive.
+        name = $2;
+        arguments = $3;
+        loc = symbol_loc ();
+      }
+    }
+
+operation_types:
+  | { [] }
+  | operation_type COLON name operation_types {
+      let node = {
+        OperationType.operation = $1;
+        type_ = $3;
+      } in
+      node :: $4
+    }
+
+operation_type:
+  | QUERY { OperationType.Query }
+  | MUTATION { OperationType.Mutation }
+  | SUBSCRIPTION { OperationType.Subscription }

--- a/src/graphql/graphql_parsing.ml
+++ b/src/graphql/graphql_parsing.ml
@@ -1,0 +1,17 @@
+type state = {
+  mutable source: Loc.filename option;
+}
+
+let state = {
+  source = None;
+}
+
+let with_source source fn =
+  try
+    state.source <- source;
+    fn ()
+  with e ->
+    state.source <- None;
+    raise e
+
+let curr_source () = state.source

--- a/src/graphql/graphql_parsing.mli
+++ b/src/graphql/graphql_parsing.mli
@@ -1,0 +1,3 @@
+val with_source: Loc.filename option -> (unit -> 'a) -> 'a
+
+val curr_source: unit -> Loc.filename option

--- a/src/graphql/graphql_schema.ml
+++ b/src/graphql/graphql_schema.ml
@@ -1,0 +1,54 @@
+module SMap = Map.Make(String)
+
+module rec Type: sig
+  type def =
+    | Scalar of string
+    | Obj of string * Field.t SMap.t * string list
+    | Interface of string * Field.t SMap.t
+    | Union of string * string list
+    | Enum of string * string list
+    | InputObj of string * InputVal.t SMap.t
+
+  and t =
+    | Named of string
+    | List of t
+    | NonNull of t
+end = Type
+
+and Field: sig
+  type t = {
+    name: string;
+    args: InputVal.t SMap.t;
+    type_: Type.t;
+  }
+end = Field
+
+and InputVal: sig
+  type t = {
+    name: string;
+    type_: Type.t;
+  }
+end = InputVal
+
+type t = {
+  query_name: string;
+  mutation_name: string option;
+  subscription_name: string option;
+  type_map: Type.def SMap.t;
+}
+
+let rec name_of_type f = match f with
+  | Type.Named name -> name
+  | Type.List f
+  | Type.NonNull f -> name_of_type f
+
+let query_type_name s = s.mutation_name
+
+let type_def s type_name =
+  SMap.find type_name s.type_map
+
+let rec type_name s _type =
+  match _type with
+  | Type.Named name -> name
+  | Type.List t
+  | Type.NonNull t -> type_name s t

--- a/src/typing/codegen.ml
+++ b/src/typing/codegen.ml
@@ -328,6 +328,7 @@ let rec gen_type t env = Type.(
   | IdxWrapper _
   | ModuleT _
   | TaintT _
+  | GraphqlSchemaT _
     -> add_str (spf "mixed /* UNEXPECTED TYPE: %s */" (string_of_ctor t)) env
 )
 

--- a/src/typing/debug_js.ml
+++ b/src/typing/debug_js.ml
@@ -300,6 +300,8 @@ and _json_of_t_impl json_cx t = Hh_json.(
       ]
     ]
 
+  | GraphqlSchemaT _ -> []
+
   )
 )
 
@@ -1276,6 +1278,7 @@ and dump_t_ (depth, tvars) cx t =
       (string_of_type_map kind)
       (kid t1)
       (kid t2)) t
+  | GraphqlSchemaT _ -> p t
 
 and dump_use_t ?(depth=3) cx t =
   dump_use_t_ (depth, ISet.empty) cx t

--- a/src/typing/flow_js.ml
+++ b/src/typing/flow_js.ml
@@ -1028,6 +1028,7 @@ module ResolvableTypeJob = struct
     | ExistsT _
     | OpenPredT _
     | TypeMapT _
+    | GraphqlSchemaT _
       ->
       acc
 
@@ -5323,6 +5324,8 @@ and subst cx ?(force=true) (map: Type.t SMap.t) t =
     let t2' = subst cx ~force map t2 in
     if t1 == t1' && t2 == t2' then t else TypeMapT (r, kind, t1', t2')
 
+  | GraphqlSchemaT _ -> t
+
 and subst_defer_use_t cx ~force map t = match t with
   | DestructuringT (reason, s) ->
       let s_ = subst_selector cx force map s in
@@ -5483,6 +5486,7 @@ and check_polarity cx polarity = function
   | CustomFunT _
   | OpenPredT _
   | TypeMapT _
+  | GraphqlSchemaT _
     -> () (* TODO *)
 
 and check_polarity_propmap cx id =
@@ -8552,6 +8556,8 @@ let rec assert_ground ?(infer=false) cx skip ids t =
   | TypeMapT (_, _, t1, t2) ->
     recurse t1;
     recurse t2
+
+  | GraphqlSchemaT _ -> ()
 
   | ObjProtoT _
   | FunProtoT _

--- a/src/typing/graph.ml
+++ b/src/typing/graph.ml
@@ -217,6 +217,7 @@ and parts_of_t cx = function
 | IdxWrapper (_, inner) -> ["inner", Def inner]
 | OpenPredT (_, base, _, _) -> ["base", Def base]
 | TypeMapT (_, _, t1, t2) -> ["t", Def t1; "mapfn", Def t2]
+| GraphqlSchemaT _ -> []
 
 and parts_of_funtype { params_tlist; params_names; return_t; _ } =
   (* OMITTED: static, prototype, this_t *)

--- a/src/typing/type.ml
+++ b/src/typing/type.ml
@@ -260,6 +260,8 @@ module rec TypeTerm : sig
     (* Map a FunT over a structure *)
     | TypeMapT of reason * type_map * t * t
 
+    | GraphqlSchemaT of reason * Graphql_schema.t
+
 
   and defer_use_t =
     (* type of a variable / parameter / property extracted from a pattern *)
@@ -1507,6 +1509,8 @@ let rec reason_of_t = function
 
   | TypeMapT (reason, _, _, _) -> reason
 
+  | GraphqlSchemaT (reason, _) -> reason
+
 and reason_of_defer_use_t = function
   | DestructuringT (reason, _)
   | TypeDestructorT (reason, _) ->
@@ -1714,6 +1718,8 @@ let rec mod_reason_of_t f = function
 
   | TypeMapT (reason, kind, t1, t2) -> TypeMapT (f reason, kind, t1, t2)
 
+  | GraphqlSchemaT (reason, schema) -> GraphqlSchemaT (reason, schema)
+
 and mod_reason_of_defer_use_t f = function
   | DestructuringT (reason, s) -> DestructuringT (f reason, s)
   | TypeDestructorT (reason, s) -> TypeDestructorT (f reason, s)
@@ -1910,6 +1916,7 @@ let string_of_ctor = function
   | IdxWrapper _ -> "IdxWrapper"
   | OpenPredT _ -> "OpenPredT"
   | TypeMapT _ -> "TypeMapT"
+  | GraphqlSchemaT _ -> "GraphqlSchemaT"
 
 let string_of_use_op = function
   | FunCallThis _ -> "FunCallThis"

--- a/src/typing/type_normalizer.ml
+++ b/src/typing/type_normalizer.ml
@@ -390,6 +390,8 @@ let rec normalize_type_impl cx ids t = match t with
 
   | ObjProtoT _ -> ObjProtoT (locationless_reason RDummyPrototype)
 
+  | GraphqlSchemaT _ -> t
+
   | FunProtoT _
   | ExtendsT (_, _, _)
   ->

--- a/src/typing/type_visitor.ml
+++ b/src/typing/type_visitor.ml
@@ -159,6 +159,8 @@ class ['a] t = object(self)
     let acc = self#type_ cx acc t2 in
     acc
 
+  | GraphqlSchemaT _ -> acc
+
   method private defer_use_type cx acc = function
   | DestructuringT (_, s) -> self#selector cx acc s
   | TypeDestructorT (_, d) -> self#destructor cx acc d


### PR DESCRIPTION
This PR is a first step towards GraphQL support (briefly discussed in #2307). It adds the graphql language parser and loads graphql-schema.
### Schema loading

There is a new option in flowconfig:

```
[options]
graphql_schema=schema.graphql
```

if this option is set, we parse the schema (in `Init_js.init` function) and store it in the master context as a global variable (with newly introduced type `GraphqlSchemaT`). If the schema file changes we shut down the server.

My idea is to make schema flow into all graphql related types (e.g. `GraphqlSchemaT ~> GraphqlQueryT`).

cc @samwgoldman @mroch 
