### PR TITLE
Array#pop and Array#shift should return nullables

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -198,7 +198,7 @@ declare class Array<T> {
     keys(): Iterator<number>;
     lastIndexOf(searchElement: T, fromIndex?: number): number;
     map<U>(callbackfn: (value: T, index: number, array: Array<T>) => U, thisArg?: any): Array<U>;
-    pop(): ?T;
+    pop(): T | void;
     push(...items: Array<T>): number;
     reduce(
       callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: Array<T>) => T,
@@ -217,7 +217,7 @@ declare class Array<T> {
       initialValue: U
     ): U;
     reverse(): Array<T>;
-    shift(): ?T;
+    shift(): T | void;
     slice(start?: number, end?: number): Array<T>;
     some(callbackfn: (value: T, index: number, array: Array<T>) => any, thisArg?: any): boolean;
     sort(compareFn?: (a: T, b: T) => number): Array<T>;

--- a/lib/core.js
+++ b/lib/core.js
@@ -198,7 +198,7 @@ declare class Array<T> {
     keys(): Iterator<number>;
     lastIndexOf(searchElement: T, fromIndex?: number): number;
     map<U>(callbackfn: (value: T, index: number, array: Array<T>) => U, thisArg?: any): Array<U>;
-    pop(): T;
+    pop(): ?T;
     push(...items: Array<T>): number;
     reduce(
       callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: Array<T>) => T,
@@ -217,7 +217,7 @@ declare class Array<T> {
       initialValue: U
     ): U;
     reverse(): Array<T>;
-    shift(): T;
+    shift(): ?T;
     slice(start?: number, end?: number): Array<T>;
     some(callbackfn: (value: T, index: number, array: Array<T>) => any, thisArg?: any): boolean;
     sort(compareFn?: (a: T, b: T) => number): Array<T>;

--- a/package.json
+++ b/package.json
@@ -17,14 +17,15 @@
     "diff": "~2.2.1",
     "flow-parser": "~0.21.0",
     "glob": "^7.0.3",
+    "invariant": "^2.2.2",
     "minimist": "~1.2.0",
     "mkdirp": "^0.5.1",
     "ncp": "~2.0.0",
+    "resolve": "^1.1.7",
     "rimraf": "^2.5.2",
     "sane": "^1.4.0",
     "source-map-support": "~0.4.0",
-    "twit": "^2.1.5",
-    "resolve": "^1.1.7"
+    "twit": "^2.1.5"
   },
   "babel": {
     "presets": [

--- a/tsrc/comment/getPathToLoc.js
+++ b/tsrc/comment/getPathToLoc.js
@@ -1,6 +1,7 @@
 /* @flow */
 
 import type {FlowLoc} from '../flowResult';
+import invariant from 'invariant';
 
 type PathNode = {
   ast: Object,
@@ -48,6 +49,7 @@ class Path {
         continue;
       }
       const prop = last.todo.pop();
+      invariant(prop !== undefined, 'We just did a length check');
       const ast = last.ast[prop];
       if (this.push(prop, ast)) {
         return ast;

--- a/tsrc/test/RunQueue.js
+++ b/tsrc/test/RunQueue.js
@@ -9,6 +9,8 @@ import type Builder from './builder';
 import type Suite from './Suite';
 import type {SuiteResult} from './runTestSuite';
 
+import invariant from 'invariant';
+
 /* Cool little thingy that runs tests in parallel and prints out a multiline
  * status view of what is running and what is done */
 export default class RunQueue {
@@ -188,7 +190,7 @@ export default class RunQueue {
       this.almostDone = this.almostDone.sort();
       while (this.almostDone.length > 0 && (this.running.length == 0 || this.almostDone[0] <= this.running[0])) {
         const suiteName = this.almostDone.shift();
-        this.done.push(suiteName);
+        invariant(suiteName !== undefined, 'We just did a length check');
         if (this.isTTY) {
           // $FlowFixMe Add to lib
           process.stdout.moveCursor(0, -this.fancyStatusSize);


### PR DESCRIPTION
Calling Array#pop and Array#shift on empty arrays returns `undefined`, so the return value of these functions should be annotated as nullable.
