### PR TITLE
Fix open source builds after sqlite work

### DIFF
--- a/hack/heap/hh_shared.c
+++ b/hack/heap/hh_shared.c
@@ -2127,15 +2127,18 @@ CAMLprim value hh_get_dep_sqlite(value ocaml_key) {
 
 #else
 CAMLprim value hh_save_dep_table_sqlite(value out_filename) {
+  CAMLparam0();
   CAMLreturn(Val_long(0));
 }
 
 CAMLprim value hh_load_dep_table_sqlite(value in_filename) {
+  CAMLparam0();
   CAMLreturn(Val_long(0));
 }
 
 CAMLprim value hh_get_dep_sqlite(value ocaml_key) {
   // Empty list
+  CAMLparam0();
   CAMLreturn(Val_int(0));
 }
 #endif

--- a/ocp_build_hack.ocp.fb
+++ b/ocp_build_hack.ocp.fb
@@ -24,13 +24,17 @@ begin library "lz4"
   files = begin fb-glob "src/third-party/lz4" end
 end
 
+hh_shared_flags = [
+  "-I"; "src/third-party/lz4";
+  "-D"; "NO_SQLITE3";
+]
 begin library "hh-heap"
   sort = true
   files = begin fb-glob "hack/heap"
      excludes = [ "hh_shared.c" ]
   end
   files += [
-    "hack/heap/hh_shared.c" (ccopt = ["-I"; "src/third-party/lz4"])
+    "hack/heap/hh_shared.c" (ccopt = hh_shared_flags)
   ]
   requires += [
     "hh-stubs"

--- a/src/parser/Makefile
+++ b/src/parser/Makefile
@@ -76,7 +76,7 @@ test-js: build-parser js
 ../../_build/$(REL_DIR)/test/run_hardcoded_tests.native: build-parser
 	cd $(TOP); \
 	ocamlbuild \
-		-ocamlc "ocamlopt -DNO_SQLITE3" \
+		-ocamlc "ocamlopt -ccopt -DNO_SQLITE3" \
 		$(NATIVE_OBJECT_FILES); \
 	ocamlbuild \
 		$(foreach dir,$(RUNNER_DEPS),-I $(dir)) \


### PR DESCRIPTION
`CAMLparam0()` declares `caml__frame`, so if you forget it, you get errors like

```
hh_shared.c:2130:3: error: use of undeclared identifier 'caml__frame'; did you mean 'caml_raise'?
  CAMLreturn(Val_long(0));
  ^
/Users/glevi/.opam/4.02.1/lib/ocaml/caml/memory.h:231:28: note: expanded from macro 'CAMLreturn'
#define CAMLreturn(result) CAMLreturnT(value, result)
                           ^
/Users/glevi/.opam/4.02.1/lib/ocaml/caml/memory.h:227:22: note: expanded from macro 'CAMLreturnT'
  caml_local_roots = caml__frame; \
```

And for ocp-build, we just need to set the `NO_SQLITE3` flag