### PR TITLE
Const imports

### DIFF
--- a/newtests/const_imports/_flowconfig
+++ b/newtests/const_imports/_flowconfig
@@ -1,0 +1,8 @@
+[ignore]
+
+[include]
+
+[libs]
+
+[options]
+all=true

--- a/newtests/const_imports/dep.js
+++ b/newtests/const_imports/dep.js
@@ -1,0 +1,2 @@
+export default 42;
+export var named = 'asdf';

--- a/newtests/const_imports/test.js
+++ b/newtests/const_imports/test.js
@@ -1,0 +1,39 @@
+/* @flow */
+
+
+import {suite, test} from '../../tsrc/test/Tester';
+
+export default suite(({addFile, addFiles, addCode}) => [
+  test('const named imports', [
+    addFile('dep.js'),
+    addCode('import {named} from "./dep.js"; named = 43;').newErrors(`
+      test.js:3
+        3: import {named} from "./dep.js"; named = 43;
+                                           ^^^^^ named. import cannot be reassigned
+        3: import {named} from "./dep.js"; named = 43;
+                   ^^^^^ import named
+    `),
+  ]),
+
+  test('const default imports', [
+    addFile('dep.js'),
+    addCode('import def from "./dep.js"; def = "nope";').newErrors(`
+      test.js:3
+        3: import def from "./dep.js"; def = "nope";
+                                       ^^^ def. import cannot be reassigned
+        3: import def from "./dep.js"; def = "nope";
+                  ^^^ import def
+    `)
+  ]),
+
+  test('const namespace imports', [
+    addFile('dep.js'),
+    addCode('import * as ns from "./dep.js"; ns = {};').newErrors(`
+      test.js:3
+        3: import * as ns from "./dep.js"; ns = {};
+                                           ^^ ns. import cannot be reassigned
+        3: import * as ns from "./dep.js"; ns = {};
+                       ^^ import ns
+    `)
+  ]),
+]);

--- a/newtests/tool_test_example/test.js
+++ b/newtests/tool_test_example/test.js
@@ -62,7 +62,7 @@ export default suite(({addFile, addFiles, addCode}) => [
 
     // Directories are automatically created when you add files to them
     addFile('B.js', 'some/dir/E.js')
-      .addCode('import D from "./some/dir/E"')
+      .addCode('import E from "./some/dir/E"')
       .noNewErrors(),
   ]),
 

--- a/src/typing/env.ml
+++ b/src/typing/env.ml
@@ -498,6 +498,10 @@ let bind_const ?(state=State.Undeclared) cx name t r =
   let loc = loc_of_reason r in
   bind_entry cx name (Entry.new_const t ~loc ~state) r
 
+let bind_import cx name t r =
+  let loc = loc_of_reason r in
+  bind_entry cx name (Entry.new_import t ~loc) r
+
 (* bind implicit const entry *)
 let bind_implicit_const ?(state=State.Undeclared) kind cx name t r =
   let loc = loc_of_reason r in
@@ -824,6 +828,10 @@ let update_var op cx name specific reason =
     Some change
   | Value { Entry.kind = Const ConstVarBinding; _ } ->
     let msg = FlowError.EConstReassigned in
+    binding_error msg cx name entry reason;
+    None
+  | Value { Entry.kind = Const ConstImportBinding; _; } ->
+    let msg = FlowError.EImportReassigned in
     binding_error msg cx name entry reason;
     None
   | Value { Entry.kind = Const ConstParamBinding; _ } ->

--- a/src/typing/env.mli
+++ b/src/typing/env.mli
@@ -69,6 +69,8 @@ val bind_implicit_const: ?state:State.t -> Entry.const_binding_kind ->
 val bind_const: ?state:State.t -> Context.t -> string -> Type.t ->
   reason -> unit
 
+val bind_import: Context.t -> string -> Type.t -> reason -> unit
+
 val bind_type: ?state:State.t -> Context.t -> string -> Type.t ->
   reason -> unit
 

--- a/src/typing/flow_error.ml
+++ b/src/typing/flow_error.ml
@@ -108,6 +108,7 @@ and binding_error =
   | ETypeAliasInValuePosition
   | EConstReassigned
   | EConstParamReassigned
+  | EImportReassigned
 
 and internal_error =
   | PackageHeapNotFound of string
@@ -760,7 +761,8 @@ end = struct
               "type referenced from value position"
           | ETypeAliasInValuePosition ->
               "type alias referenced from value position"
-          | EConstReassigned ->
+          | EConstReassigned
+          | EImportReassigned ->
               spf "%s cannot be reassigned" (Scope.Entry.string_of_kind entry)
           | EConstParamReassigned ->
               spf

--- a/src/typing/scope.ml
+++ b/src/typing/scope.ml
@@ -52,8 +52,9 @@ module Entry = struct
     | Var
 
   and const_binding_kind =
-    | ConstVarBinding
+    | ConstImportBinding
     | ConstParamBinding
+    | ConstVarBinding
 
   and let_binding_kind =
     | LetVarBinding
@@ -63,8 +64,9 @@ module Entry = struct
     | ParamBinding
 
   let string_of_value_kind = function
-  | Const ConstVarBinding -> "const"
+  | Const ConstImportBinding -> "import"
   | Const ConstParamBinding -> "const param"
+  | Const ConstVarBinding -> "const"
   | Let LetVarBinding -> "let"
   | Let ClassNameBinding -> "class"
   | Let CatchParamBinding -> "catch"
@@ -109,6 +111,9 @@ module Entry = struct
 
   let new_const ~loc ?(state=State.Undeclared) ?(kind=ConstVarBinding) t =
     new_value (Const kind) state t t loc
+
+  let new_import ~loc t =
+    new_value (Const ConstImportBinding) State.Initialized t t loc
 
   let new_let ~loc ?(state=State.Undeclared) ?(kind=LetVarBinding) t =
     new_value (Let kind) state t t loc

--- a/src/typing/scope.mli
+++ b/src/typing/scope.mli
@@ -17,10 +17,13 @@ module State :
 module Entry :
   sig
     type value_kind =
-        Const of const_binding_kind
+      | Const of const_binding_kind
       | Let of let_binding_kind
       | Var
-    and const_binding_kind = ConstVarBinding | ConstParamBinding
+    and const_binding_kind =
+      | ConstImportBinding
+      | ConstParamBinding
+      | ConstVarBinding
     and let_binding_kind =
         LetVarBinding
       | ClassNameBinding
@@ -45,6 +48,8 @@ module Entry :
     val new_value : value_kind -> State.t -> Type.t -> Type.t -> Loc.t -> t
     val new_const :
       loc:Loc.t -> ?state:State.t -> ?kind:const_binding_kind -> Type.t -> t
+    val new_import :
+      loc:Loc.t -> Type.t -> t
     val new_let :
       loc:Loc.t -> ?state:State.t -> ?kind:let_binding_kind -> Type.t -> t
     val new_var :

--- a/src/typing/statement.ml
+++ b/src/typing/statement.ml
@@ -407,7 +407,7 @@ and statement_decl cx = Ast.Statement.(
         let state = Scope.State.Initialized in
         if isType
         then Env.bind_type ~state cx local_name tvar reason
-        else Env.bind_var ~state cx local_name tvar reason
+        else Env.bind_import cx local_name tvar reason
       )
 )
 

--- a/tests/config_module_name_rewrite_haste/A.js
+++ b/tests/config_module_name_rewrite_haste/A.js
@@ -1,13 +1,13 @@
 /* @flow */
 
 var m1 = require('1DoesntExist');
-import {numVal} from '1DoesntExist';
+import {numVal as numVal1} from '1DoesntExist';
 var a_1: number = m1.numVal;
-var a_2: number = numVal;
+var a_2: number = numVal1;
 
 // Error: 'Exists2' is not a valid module name
 //
 // This tests that, for haste, the first name_mapper regexp that happens to
 // match the given module name string is picked.
 var m2 = require('2DoesntExist'); // Error
-import {numVal} from '3DoesntExist'; // Error
+import {numVal as numVal2} from '3DoesntExist'; // Error

--- a/tests/config_module_name_rewrite_haste/config_module_name_rewrite_haste.exp
+++ b/tests/config_module_name_rewrite_haste/config_module_name_rewrite_haste.exp
@@ -3,8 +3,8 @@ A.js:12
               ^^^^^^^^^^^^^^^^^^^^^^^ 2DoesntExist. Required module not found
 
 A.js:13
- 13: import {numVal} from '3DoesntExist'; // Error
-                          ^^^^^^^^^^^^^^ 3DoesntExist. Required module not found
+ 13: import {numVal as numVal2} from '3DoesntExist'; // Error
+                                     ^^^^^^^^^^^^^^ 3DoesntExist. Required module not found
 
 
 Found 2 errors

--- a/tests/declare_export/declare_export.exp
+++ b/tests/declare_export/declare_export.exp
@@ -19,8 +19,8 @@ es6modules.js:21
                           ^^^^^ ./D. Required module not found
 
 es6modules.js:27
- 27: import {doesntExist} from "CommonJS_Clobbering_Lit"; // Error: Not an exported binding
-             ^^^^^^^^^^^ Named import from module `CommonJS_Clobbering_Lit`. This module has no named export called `doesntExist`.
+ 27: import {doesntExist1} from "CommonJS_Clobbering_Lit"; // Error: Not an exported binding
+             ^^^^^^^^^^^^ Named import from module `CommonJS_Clobbering_Lit`. This module has no named export called `doesntExist1`.
 
 es6modules.js:31
  31: var c2: string = numberValue1; // Error: number ~> string
@@ -65,8 +65,8 @@ es6modules.js:47
              ^^^^^^ string
 
 es6modules.js:53
- 53: import {doesntExist} from "CommonJS_Clobbering_Class"; // Error: Not an exported binding
-             ^^^^^^^^^^^ Named import from module `CommonJS_Clobbering_Class`. This module only has a default export. Did you mean `import doesntExist from ...`?
+ 53: import {doesntExist2} from "CommonJS_Clobbering_Class"; // Error: Not an exported binding
+             ^^^^^^^^^^^^ Named import from module `CommonJS_Clobbering_Class`. This module only has a default export. Did you mean `import doesntExist2 from ...`?
 
 es6modules.js:59
  59: import {staticNumber1, baseProp, childProp} from "CommonJS_Clobbering_Class"; // Error
@@ -123,8 +123,8 @@ es6modules.js:73
              ^^^^^^ string
 
 es6modules.js:79
- 79: import {doesntExist} from "CommonJS_Named"; // Error: Not an exported binding
-             ^^^^^^^^^^^ Named import from module `CommonJS_Named`. This module has no named export called `doesntExist`.
+ 79: import {doesntExist3} from "CommonJS_Named"; // Error: Not an exported binding
+             ^^^^^^^^^^^^ Named import from module `CommonJS_Named`. This module has no named export called `doesntExist3`.
 
 es6modules.js:83
  83: var j2: string = numberValue2; // Error: number ~> string
@@ -163,8 +163,8 @@ es6modules.js:97
              ^^^^^^ string
 
 es6modules.js:103
-103: import {doesntExist} from "ES6_Default_AnonFunction1"; // Error: Not an exported binding
-             ^^^^^^^^^^^ Named import from module `ES6_Default_AnonFunction1`. This module only has a default export. Did you mean `import doesntExist from ...`?
+103: import {doesntExist4} from "ES6_Default_AnonFunction1"; // Error: Not an exported binding
+             ^^^^^^^^^^^^ Named import from module `ES6_Default_AnonFunction1`. This module only has a default export. Did you mean `import doesntExist4 from ...`?
 
 es6modules.js:107
 107: var n2: string = ES6_Def_AnonFunc1(); // Error: number ~> string
@@ -191,13 +191,13 @@ es6modules.js:119
              ^^^^^^ string
 
 es6modules.js:125
-125: import doesntExist from "ES6_Named1"; // Error: Not an exported binding
-            ^^^^^^^^^^^ Default import from `ES6_Named1`. This module has no default export.
+125: import doesntExist5 from "ES6_Named1"; // Error: Not an exported binding
+            ^^^^^^^^^^^^ Default import from `ES6_Named1`. This module has no default export.
 
 es6modules.js:129
-129: var r2: string = specifierNumber1; // Error: number ~> string
-                      ^^^^^^^^^^^^^^^^ number. This type is incompatible with
-129: var r2: string = specifierNumber1; // Error: number ~> string
+129: var r2: string = specifierNumber1_1; // Error: number ~> string
+                      ^^^^^^^^^^^^^^^^^^ number. This type is incompatible with
+129: var r2: string = specifierNumber1_1; // Error: number ~> string
              ^^^^^^ string
 
 es6modules.js:133

--- a/tests/declare_export/es6modules.js
+++ b/tests/declare_export/es6modules.js
@@ -24,7 +24,7 @@ import DefaultD from "./D"; // Error: No such module
 // == CommonJS Clobbering Literal Exports -> ES6 == //
 // ================================================ //
 
-import {doesntExist} from "CommonJS_Clobbering_Lit"; // Error: Not an exported binding
+import {doesntExist1} from "CommonJS_Clobbering_Lit"; // Error: Not an exported binding
 
 import {numberValue1} from "CommonJS_Clobbering_Lit";
 var c1: number = numberValue1;
@@ -50,7 +50,7 @@ var f4: string = CJS_Clobb_Lit_NS.default.numberValue5; // Error: number ~> stri
 // == CommonJS Clobbering Class Exports -> ES6 == //
 // ============================================== //
 
-import {doesntExist} from "CommonJS_Clobbering_Class"; // Error: Not an exported binding
+import {doesntExist2} from "CommonJS_Clobbering_Class"; // Error: Not an exported binding
 
 // The following import should error because class statics are not turned into
 // named exports for now. This avoids complexities with polymorphic static
@@ -76,7 +76,7 @@ var i3: string = new CJS_Clobb_Class_NS.default().instNumber2(); // Error: numbe
 // == CommonJS Named Exports -> ES6 == //
 // =================================== //
 
-import {doesntExist} from "CommonJS_Named"; // Error: Not an exported binding
+import {doesntExist3} from "CommonJS_Named"; // Error: Not an exported binding
 
 import {numberValue2} from "CommonJS_Named";
 var j1: number = numberValue2;
@@ -100,7 +100,7 @@ var m3: string = CJS_Named_NS.numberValue4; // Error: number ~> string
 // == ES6 Default -> ES6 == //
 //////////////////////////////
 
-import {doesntExist} from "ES6_Default_AnonFunction1"; // Error: Not an exported binding
+import {doesntExist4} from "ES6_Default_AnonFunction1"; // Error: Not an exported binding
 
 import ES6_Def_AnonFunc1 from "ES6_Default_AnonFunction1";
 var n1: number = ES6_Def_AnonFunc1();
@@ -122,11 +122,11 @@ var q2: string = new ES6_Def_NamedClass1().givesANum(); // Error: number ~> stri
 // == ES6 Named -> ES6 == //
 ////////////////////////////
 
-import doesntExist from "ES6_Named1"; // Error: Not an exported binding
+import doesntExist5 from "ES6_Named1"; // Error: Not an exported binding
 
-import {specifierNumber1} from "ES6_Named1";
-var r1: number = specifierNumber1;
-var r2: string = specifierNumber1; // Error: number ~> string
+import {specifierNumber1 as specifierNumber1_1} from "ES6_Named1";
+var r1: number = specifierNumber1_1;
+var r2: string = specifierNumber1_1; // Error: number ~> string
 
 import {specifierNumber2Renamed} from "ES6_Named1";
 var s1: number = specifierNumber2Renamed;

--- a/tests/es6modules/es6modules.exp
+++ b/tests/es6modules/es6modules.exp
@@ -19,8 +19,8 @@ es6modules.js:21
                           ^^^^^ ./D. Required module not found
 
 es6modules.js:27
- 27: import {doesntExist} from "CommonJS_Clobbering_Lit"; // Error: Not an exported binding
-             ^^^^^^^^^^^ Named import from module `CommonJS_Clobbering_Lit`. This module has no named export called `doesntExist`.
+ 27: import {doesntExist1} from "CommonJS_Clobbering_Lit"; // Error: Not an exported binding
+             ^^^^^^^^^^^^ Named import from module `CommonJS_Clobbering_Lit`. This module has no named export called `doesntExist1`.
 
 es6modules.js:31
  31: var c2: string = numberValue1; // Error: number ~> string
@@ -65,8 +65,8 @@ es6modules.js:47
              ^^^^^^ string
 
 es6modules.js:53
- 53: import {doesntExist} from "CommonJS_Clobbering_Class"; // Error: Not an exported binding
-             ^^^^^^^^^^^ Named import from module `CommonJS_Clobbering_Class`. This module only has a default export. Did you mean `import doesntExist from ...`?
+ 53: import {doesntExist2} from "CommonJS_Clobbering_Class"; // Error: Not an exported binding
+             ^^^^^^^^^^^^ Named import from module `CommonJS_Clobbering_Class`. This module only has a default export. Did you mean `import doesntExist2 from ...`?
 
 es6modules.js:59
  59: import {staticNumber1, baseProp, childProp} from "CommonJS_Clobbering_Class"; // Error
@@ -123,8 +123,8 @@ es6modules.js:73
              ^^^^^^ string
 
 es6modules.js:79
- 79: import {doesntExist} from "CommonJS_Named"; // Error: Not an exported binding
-             ^^^^^^^^^^^ Named import from module `CommonJS_Named`. This module has no named export called `doesntExist`.
+ 79: import {doesntExist3} from "CommonJS_Named"; // Error: Not an exported binding
+             ^^^^^^^^^^^^ Named import from module `CommonJS_Named`. This module has no named export called `doesntExist3`.
 
 es6modules.js:83
  83: var j2: string = numberValue2; // Error: number ~> string
@@ -163,8 +163,8 @@ es6modules.js:97
              ^^^^^^ string
 
 es6modules.js:103
-103: import {doesntExist} from "ES6_Default_AnonFunction1"; // Error: Not an exported binding
-             ^^^^^^^^^^^ Named import from module `ES6_Default_AnonFunction1`. This module only has a default export. Did you mean `import doesntExist from ...`?
+103: import {doesntExist4} from "ES6_Default_AnonFunction1"; // Error: Not an exported binding
+             ^^^^^^^^^^^^ Named import from module `ES6_Default_AnonFunction1`. This module only has a default export. Did you mean `import doesntExist4 from ...`?
 
 es6modules.js:107
 107: var n2: string = ES6_Def_AnonFunc1(); // Error: number ~> string
@@ -199,13 +199,13 @@ es6modules.js:119
              ^^^^^^ string
 
 es6modules.js:125
-125: import doesntExist from "ES6_Named1"; // Error: Not an exported binding
-            ^^^^^^^^^^^ Default import from `ES6_Named1`. This module has no default export.
+125: import doesntExist5 from "ES6_Named1"; // Error: Not an exported binding
+            ^^^^^^^^^^^^ Default import from `ES6_Named1`. This module has no default export.
 
 es6modules.js:129
-129: var r2: string = specifierNumber1; // Error: number ~> string
-                      ^^^^^^^^^^^^^^^^ number. This type is incompatible with
-129: var r2: string = specifierNumber1; // Error: number ~> string
+129: var r2: string = specifierNumber1_1; // Error: number ~> string
+                      ^^^^^^^^^^^^^^^^^^ number. This type is incompatible with
+129: var r2: string = specifierNumber1_1; // Error: number ~> string
              ^^^^^^ string
 
 es6modules.js:133

--- a/tests/es6modules/es6modules.js
+++ b/tests/es6modules/es6modules.js
@@ -24,7 +24,7 @@ import DefaultD from "./D"; // Error: No such module
 // == CommonJS Clobbering Literal Exports -> ES6 == //
 // ================================================ //
 
-import {doesntExist} from "CommonJS_Clobbering_Lit"; // Error: Not an exported binding
+import {doesntExist1} from "CommonJS_Clobbering_Lit"; // Error: Not an exported binding
 
 import {numberValue1} from "CommonJS_Clobbering_Lit";
 var c1: number = numberValue1;
@@ -50,7 +50,7 @@ var f4: string = CJS_Clobb_Lit_NS.default.numberValue5; // Error: number ~> stri
 // == CommonJS Clobbering Class Exports -> ES6 == //
 // ============================================== //
 
-import {doesntExist} from "CommonJS_Clobbering_Class"; // Error: Not an exported binding
+import {doesntExist2} from "CommonJS_Clobbering_Class"; // Error: Not an exported binding
 
 // The following import should error because class statics are not turned into
 // named exports for now. This avoids complexities with polymorphic static
@@ -76,7 +76,7 @@ var i3: string = new CJS_Clobb_Class_NS.default().instNumber2(); // Error: numbe
 // == CommonJS Named Exports -> ES6 == //
 // =================================== //
 
-import {doesntExist} from "CommonJS_Named"; // Error: Not an exported binding
+import {doesntExist3} from "CommonJS_Named"; // Error: Not an exported binding
 
 import {numberValue2} from "CommonJS_Named";
 var j1: number = numberValue2;
@@ -100,7 +100,7 @@ var m3: string = CJS_Named_NS.numberValue4; // Error: number ~> string
 // == ES6 Default -> ES6 == //
 //////////////////////////////
 
-import {doesntExist} from "ES6_Default_AnonFunction1"; // Error: Not an exported binding
+import {doesntExist4} from "ES6_Default_AnonFunction1"; // Error: Not an exported binding
 
 import ES6_Def_AnonFunc1 from "ES6_Default_AnonFunction1";
 var n1: number = ES6_Def_AnonFunc1();
@@ -122,11 +122,11 @@ var q2: string = new ES6_Def_NamedClass1().givesANum(); // Error: number ~> stri
 // == ES6 Named -> ES6 == //
 ////////////////////////////
 
-import doesntExist from "ES6_Named1"; // Error: Not an exported binding
+import doesntExist5 from "ES6_Named1"; // Error: Not an exported binding
 
-import {specifierNumber1} from "ES6_Named1";
-var r1: number = specifierNumber1;
-var r2: string = specifierNumber1; // Error: number ~> string
+import {specifierNumber1 as specifierNumber1_1} from "ES6_Named1";
+var r1: number = specifierNumber1_1;
+var r2: string = specifierNumber1_1; // Error: number ~> string
 
 import {specifierNumber2Renamed} from "ES6_Named1";
 var s1: number = specifierNumber2Renamed;

--- a/tests/es_declare_module/es_declare_module.exp
+++ b/tests/es_declare_module/es_declare_module.exp
@@ -71,7 +71,7 @@ es_declare_module.js:39
               ^^ number
 
 es_declare_module.js:41
- 41: import {exports} from "ES"; // Error: Not an export
+ 41: import {exports as nope} from "ES"; // Error: Not an export
              ^^^^^^^ Named import from module `ES`. This module has no named export called `exports`.
 
 

--- a/tests/es_declare_module/es_declare_module.js
+++ b/tests/es_declare_module/es_declare_module.js
@@ -38,4 +38,4 @@ import type {T as T2} from "ES";
 (42: T2);
 ('asdf': T2); // Error: string ~> number
 
-import {exports} from "ES"; // Error: Not an export
+import {exports as nope} from "ES"; // Error: Not an export


### PR DESCRIPTION
Imported bindings can't be assigned to. This just marks `import`s as effectively const.

Fixes #2736