### PR TITLE
fix: add node.js crypto.Sign and crypto.Verify exports

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -465,6 +465,9 @@ declare class crypto$Verify extends stream$Writable {
 
 declare module "crypto" {
   declare var DEFAULT_ENCODING: string;
+  
+  declare class Sign extends crypo$Sign {};
+  declare class Verify extends crypo$Verify {};
 
   declare function createCipher(algorithm: string, password: string | Buffer): crypto$Cipher;
   declare function createCipheriv(

--- a/lib/node.js
+++ b/lib/node.js
@@ -465,9 +465,9 @@ declare class crypto$Verify extends stream$Writable {
 
 declare module "crypto" {
   declare var DEFAULT_ENCODING: string;
-  
-  declare class Sign extends crypo$Sign {};
-  declare class Verify extends crypo$Verify {};
+
+  declare class Sign extends crypto$Sign {}
+  declare class Verify extends crypto$Verify {}
 
   declare function createCipher(algorithm: string, password: string | Buffer): crypto$Cipher;
   declare function createCipheriv(

--- a/tests/node_tests/node_tests.exp
+++ b/tests/node_tests/node_tests.exp
@@ -49,24 +49,24 @@ crypto/crypto.js:16
          ^^^^^^^^^^^^^^^ call of method `write`
  16:     hmac.write(123); // 2 errors: not a string or a Buffer
                     ^^^ number. This type is incompatible with
-1212:     chunk: Buffer | string,
-                 ^^^^^^^^^^^^^^^ union: Buffer | string. See lib: <BUILTINS>/node.js:1212
+1215:     chunk: Buffer | string,
+                 ^^^^^^^^^^^^^^^ union: Buffer | string. See lib: <BUILTINS>/node.js:1215
   Member 1:
-  1212:     chunk: Buffer | string,
-                   ^^^^^^ Buffer. See lib: <BUILTINS>/node.js:1212
+  1215:     chunk: Buffer | string,
+                   ^^^^^^ Buffer. See lib: <BUILTINS>/node.js:1215
   Error:
    16:     hmac.write(123); // 2 errors: not a string or a Buffer
                       ^^^ number. This type is incompatible with
-  1212:     chunk: Buffer | string,
-                   ^^^^^^ Buffer. See lib: <BUILTINS>/node.js:1212
+  1215:     chunk: Buffer | string,
+                   ^^^^^^ Buffer. See lib: <BUILTINS>/node.js:1215
   Member 2:
-  1212:     chunk: Buffer | string,
-                            ^^^^^^ string. See lib: <BUILTINS>/node.js:1212
+  1215:     chunk: Buffer | string,
+                            ^^^^^^ string. See lib: <BUILTINS>/node.js:1215
   Error:
    16:     hmac.write(123); // 2 errors: not a string or a Buffer
                       ^^^ number. This type is incompatible with
-  1212:     chunk: Buffer | string,
-                            ^^^^^^ string. See lib: <BUILTINS>/node.js:1212
+  1215:     chunk: Buffer | string,
+                            ^^^^^^ string. See lib: <BUILTINS>/node.js:1215
 
 crypto/crypto.js:26
  26:     hmac.update('foo', 'bogus'); // 1 error
@@ -127,14 +127,14 @@ crypto/crypto.js:36
 fs/fs.js:13
  13: fs.readFile("file.exp", { encoding: "blah" }, (_, data) => {
      ^ call of method `readFile`. Could not decide which case to select
-785:   declare function readFile(
-                                ^ intersection type. See lib: <BUILTINS>/node.js:785
+788:   declare function readFile(
+                                ^ intersection type. See lib: <BUILTINS>/node.js:788
   Case 3 may work:
-  794:   declare function readFile(
-                                  ^ function type. See lib: <BUILTINS>/node.js:794
+  797:   declare function readFile(
+                                  ^ function type. See lib: <BUILTINS>/node.js:797
   But if it doesn't, case 4 looks promising too:
-  799:   declare function readFile(
-                                  ^ function type. See lib: <BUILTINS>/node.js:799
+  802:   declare function readFile(
+                                  ^ function type. See lib: <BUILTINS>/node.js:802
   Please provide additional annotation(s) to determine whether case 3 works (or consider merging it with case 4):
    13: fs.readFile("file.exp", { encoding: "blah" }, (_, data) => {
                                                       ^ parameter `_`


### PR DESCRIPTION
Since Node 0.1.92, one has been able to `require('crypto').Sign` which gives you the class that the factory `createSign` instantiates. Same for `Verify`.

This adds the two classes in the type signature for the crypto module. Meaning `require('crypto').Sign` validates properly for flow users who chose to use it over `createSign` (and again, same for Verify).