### PR TITLE
fix: Node.js definitions: supply static & constructor signatures for crypto$Verify & crypto$SIgn

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -442,6 +442,8 @@ type crypto$Sign$private_key = string | {
   passphrase: string,
 }
 declare class crypto$Sign extends stream$Writable {
+  static(algorithm: string, options?: writableStreamOptions): crypto$Sign,
+  constructor(algorithm: string, options?: writableStreamOptions): void;
   sign(
     private_key: crypto$Sign$private_key,
     output_format: 'binary' | 'hex' | 'base64'
@@ -455,6 +457,8 @@ declare class crypto$Sign extends stream$Writable {
 }
 
 declare class crypto$Verify extends stream$Writable {
+  static(algorithm: string, options?: writableStreamOptions): crypto$Verify,
+  constructor(algorithm: string, options?: writableStreamOptions): void;
   update(data: Buffer, input_encoding?: void): crypto$Verify;
   update(data: string, input_encoding?: 'utf8' | 'ascii' | 'binary'): crypto$Verify;
   verify(

--- a/tests/node_tests/node_tests.exp
+++ b/tests/node_tests/node_tests.exp
@@ -49,24 +49,24 @@ crypto/crypto.js:16
          ^^^^^^^^^^^^^^^ call of method `write`
  16:     hmac.write(123); // 2 errors: not a string or a Buffer
                     ^^^ number. This type is incompatible with
-1217:     chunk: Buffer | string,
-                 ^^^^^^^^^^^^^^^ union: Buffer | string. See lib: <BUILTINS>/node.js:1217
+1221:     chunk: Buffer | string,
+                 ^^^^^^^^^^^^^^^ union: Buffer | string. See lib: <BUILTINS>/node.js:1221
   Member 1:
-  1217:     chunk: Buffer | string,
-                   ^^^^^^ Buffer. See lib: <BUILTINS>/node.js:1217
+  1221:     chunk: Buffer | string,
+                   ^^^^^^ Buffer. See lib: <BUILTINS>/node.js:1221
   Error:
    16:     hmac.write(123); // 2 errors: not a string or a Buffer
                       ^^^ number. This type is incompatible with
-  1217:     chunk: Buffer | string,
-                   ^^^^^^ Buffer. See lib: <BUILTINS>/node.js:1217
+  1221:     chunk: Buffer | string,
+                   ^^^^^^ Buffer. See lib: <BUILTINS>/node.js:1221
   Member 2:
-  1217:     chunk: Buffer | string,
-                            ^^^^^^ string. See lib: <BUILTINS>/node.js:1217
+  1221:     chunk: Buffer | string,
+                            ^^^^^^ string. See lib: <BUILTINS>/node.js:1221
   Error:
    16:     hmac.write(123); // 2 errors: not a string or a Buffer
                       ^^^ number. This type is incompatible with
-  1217:     chunk: Buffer | string,
-                            ^^^^^^ string. See lib: <BUILTINS>/node.js:1217
+  1221:     chunk: Buffer | string,
+                            ^^^^^^ string. See lib: <BUILTINS>/node.js:1221
 
 crypto/crypto.js:26
  26:     hmac.update('foo', 'bogus'); // 1 error
@@ -127,14 +127,14 @@ crypto/crypto.js:36
 fs/fs.js:13
  13: fs.readFile("file.exp", { encoding: "blah" }, (_, data) => {
      ^ call of method `readFile`. Could not decide which case to select
-790:   declare function readFile(
-                                ^ intersection type. See lib: <BUILTINS>/node.js:790
+794:   declare function readFile(
+                                ^ intersection type. See lib: <BUILTINS>/node.js:794
   Case 3 may work:
-  799:   declare function readFile(
-                                  ^ function type. See lib: <BUILTINS>/node.js:799
+  803:   declare function readFile(
+                                  ^ function type. See lib: <BUILTINS>/node.js:803
   But if it doesn't, case 4 looks promising too:
-  804:   declare function readFile(
-                                  ^ function type. See lib: <BUILTINS>/node.js:804
+  808:   declare function readFile(
+                                  ^ function type. See lib: <BUILTINS>/node.js:808
   Please provide additional annotation(s) to determine whether case 3 works (or consider merging it with case 4):
    13: fs.readFile("file.exp", { encoding: "blah" }, (_, data) => {
                                                       ^ parameter `_`


### PR DESCRIPTION
The signatures for these class constructors differ very slightly to those of WritableStream. They require an algo as the first argument - and they also can be called without `new`. This PR adds declarations for both of these features.

([Source for verify](https://github.com/nodejs/node/blob/7537718460c7b964ffbbc0910b12eaff9cd8b7a8/lib/crypto.js#L293-L302), [Source for sign](https://github.com/nodejs/node/blob/7537718460c7b964ffbbc0910b12eaff9cd8b7a8/lib/crypto.js#L259-L266))