### PR TITLE
WeakMap#get can be undefined

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -551,7 +551,7 @@ declare class Map<K, V> {
 declare class WeakMap<K, V> {
     clear(): void;
     delete(key: K): boolean;
-    get(key: K): V;
+    get(key: K): V | void;
     has(key: K): boolean;
     set(key: K, value: V): WeakMap<K, V>;
 }


### PR DESCRIPTION
in current defined types,
`Map#get` returns `V | void`
but
`WeakMap#get` returns `V`
.

It's inconsistent and this PR makes `WeakMap#get` to return `V | void` as well.