### PR TITLE
Type-preserving versions of `Object.entries`/`Object.values`

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -35,6 +35,7 @@ declare class Object {
     static create(o: any, properties?: any): any; // compiler magic
     static defineProperties(o: any, properties: any): any;
     static defineProperty(o: any, p: any, attributes: any): any;
+    static entries<T>(object: {[key: string]: T}): Array<[string, T]>,
     static entries(object: any): Array<[string, mixed]>;
     static freeze<T>(o: T): T;
     static getOwnPropertyDescriptor(o: any, p: any): any;
@@ -49,6 +50,7 @@ declare class Object {
     static preventExtensions(o: any): any;
     static seal(o: any): any;
     static setPrototypeOf(o: any, proto: ?Object): bool;
+    static values<T>(object: {[key: string]: T}): Array<T>,
     static values(object: any): Array<mixed>;
     hasOwnProperty(prop: any): boolean;
     isPrototypeOf(o: any): boolean;


### PR DESCRIPTION
This adds signatures for `Object.entries` and `Object.values` that take a `{[key: string]: T}` and return `Array<[string, T]>` and `Array<T>`, respectively.