### PR TITLE
Forward abnormal-return for `while(true) { return ; }`

### DIFF
--- a/newtests/while_true_return/_flowconfig
+++ b/newtests/while_true_return/_flowconfig
@@ -1,0 +1,8 @@
+[ignore]
+
+[include]
+
+[libs]
+
+[options]
+all=true

--- a/newtests/while_true_return/test.js
+++ b/newtests/while_true_return/test.js
@@ -1,0 +1,29 @@
+/* @flow */
+
+
+import {suite, test} from '../../tsrc/test/Tester';
+
+export default suite(({addFile, addFiles, addCode}) => [
+  test('while(true) { return; } forwards the return abnormal', [
+    addCode(`
+      function a(): string {
+        while (true) {
+          return '';
+        }
+      }
+    `).noNewErrors(),
+
+    addCode(`
+      function b(): string {
+        while (true) {
+          return '';
+        }
+        return '';
+      }
+    `).newErrors(`
+      test.js:16
+       16:         return '';
+                   ^^^^^^^^^^ unreachable code
+    `),
+  ]),
+]);

--- a/src/typing/statement.ml
+++ b/src/typing/statement.ml
@@ -1187,7 +1187,15 @@ and statement cx = Ast.Statement.(
 
       (* if we broke out of the loop, havoc vars changed by loop body *)
       if Abnormal.swap_saved (Abnormal.Break None) save_break <> None
-      then Env.havoc_vars newset
+      then Env.havoc_vars newset;
+
+      Ast.(
+        match test with
+        | (_, Ast.Expression.Literal { Literal.value = Literal.Boolean true; _; }) ->
+          if Abnormal.swap_saved Abnormal.Return save_break <> None
+          then Abnormal.throw_control_flow_exception Abnormal.Return
+        | _ -> ()
+      );
 
   (***************************************************************************)
   (* Refinements for `do-while` are derived by the following Hoare logic rule:


### PR DESCRIPTION
Before this change, the following would error stating that the function could implicitly return `undefined` (incompatible with the stated `string` return type):

```js
function f(): string {
  while (true) {
    return '';
  }
}
```

This change fixes the problem only for exact `while (true)` syntactic scenarios. There's a lot more work to be done to fix it for indirect scenarios (i.e. `let t = true; while (t)`), so we punt on fixing that for now.