### PR TITLE
Add `make ocamlfind-install` to parser Makefile

### DIFF
--- a/src/parser/META
+++ b/src/parser/META
@@ -1,0 +1,5 @@
+name="parser_flow"
+version="0.35.0"
+description="flow parser ocamlfind package"
+archive(byte)="parser_flow.cma"
+archive(native)="parser_flow.cmxa"

--- a/src/parser/Makefile
+++ b/src/parser/Makefile
@@ -110,3 +110,11 @@ npm-publish:
 	-npm publish
 	mv README.md README-npm.md
 	mv README-backup.md README.md
+
+ocamlfind-install:
+	ocamlbuild parser_flow.cma parser_flow.cmxa
+	ocamlfind install flow_parser META \
+		_build/parser_flow.a \
+		_build/parser_flow.cma \
+		_build/parser_flow.cmxa \
+		_build/*.cmi


### PR DESCRIPTION
When I added flow_parser.0.32.0 to opam (https://github.com/ocaml/opam-repository/pull/7348), I promised that I would add do this in time for 0.33.0. Then I forgot. Whoops.

Basically, this saves us from having a really gross [opam file](https://github.com/gabelevi/opam-repository/blob/master/packages/flow_parser/flow_parser.0.32.0/opam). The small downside is that this is one more place where we need to bump the version.

To test I did

```
$ make ocamlfind-install
ocamlbuild parser_flow.cma parser_flow.cmxa
Finished, 25 targets (25 cached) in 00:00:00.
ocamlfind install flow_parser META \
		_build/parser_flow.a \
		_build/parser_flow.cma \
		_build/parser_flow.cmxa \
		_build/*.cmi
Installed /Users/glevi/.opam/4.02.1/lib/flow_parser/spider_monkey_ast.cmi
Installed /Users/glevi/.opam/4.02.1/lib/flow_parser/parser_flow.cmi
Installed /Users/glevi/.opam/4.02.1/lib/flow_parser/parser_env.cmi
Installed /Users/glevi/.opam/4.02.1/lib/flow_parser/parse_error.cmi
Installed /Users/glevi/.opam/4.02.1/lib/flow_parser/loc.cmi
Installed /Users/glevi/.opam/4.02.1/lib/flow_parser/lexer_flow.cmi
Installed /Users/glevi/.opam/4.02.1/lib/flow_parser/parser_flow.cmxa
Installed /Users/glevi/.opam/4.02.1/lib/flow_parser/parser_flow.cma
Installed /Users/glevi/.opam/4.02.1/lib/flow_parser/parser_flow.a
Installed /Users/glevi/.opam/4.02.1/lib/flow_parser/META
glevi-mbp15r:parser glevi$ ocaml
        OCaml version 4.02.1

# #use "topfind";;
- : unit = ()
Findlib has been successfully loaded. Additional directives:
  #require "package";;      to load a package
  #list;;                   to list the available packages
  #camlp4o;;                to load camlp4 (standard syntax)
  #camlp4r;;                to load camlp4 (revised syntax)
  #predicates "p,q,...";;   to set these predicates
  Topfind.reset();;         to force that packages will be reloaded
  #thread;;                 to enable threads

- : unit = ()
# #require "flow_parser";;
/Users/glevi/.opam/4.02.1/lib/flow_parser: added to search path
/Users/glevi/.opam/4.02.1/lib/flow_parser/parser_flow.cma: loaded
# Parser_flow.program "1+1";;
- : Parser_flow.Ast.program * (Loc.t * Parser_flow.Error.t) list =
(({Loc.source = None; start = {Loc.line = 1; column = 0; offset = 0};
   _end = {Loc.line = 1; column = 3; offset = 3}},
  [({Loc.source = None; start = {Loc.line = 1; column = 0; offset = 0};
     _end = {Loc.line = 1; column = 3; offset = 3}},
    Parser_flow.Ast.Statement.Expression
     {Parser_flow.Ast.Statement.Expression.expression =
       ({Loc.source = None; start = {Loc.line = 1; column = 0; offset = 0};
         _end = {Loc.line = 1; column = 3; offset = 3}},
        Parser_flow.Ast.Expression.Binary
         {Parser_flow.Ast.Expression.Binary.operator =
           Parser_flow.Ast.Expression.Binary.Plus;
          left =
           ({Loc.source = None;
             start = {Loc.line = 1; column = 0; offset = 0};
             _end = {Loc.line = 1; column = 1; offset = 1}},
            Parser_flow.Ast.Expression.Literal
             {Parser_flow.Ast.Literal.value =
               Parser_flow.Ast.Literal.Number 1.;
              raw = "1"});
          right =
           ({Loc.source = None;
             start = {Loc.line = 1; column = 2; offset = 2};
             _end = {Loc.line = 1; column = 3; offset = 3}},
            Parser_flow.Ast.Expression.Literal
             {Parser_flow.Ast.Literal.value =
               Parser_flow.Ast.Literal.Number 1.;
              raw = "1"})})})],
  []),
 [])
# ^D
```