### PR TITLE
Add nullability to return of Element::getAttribute

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -809,7 +809,7 @@ declare class Element extends Node {
 
   closest(selectors: string): ?Element;
   dispatchEvent(event: Event): bool;
-  getAttribute(name?: string): string;
+  getAttribute(name?: string): ?string;
   getAttributeNS(namespaceURI: string, localName: string): string;
   getAttributeNode(name: string): Attr;
   getAttributeNodeNS(namespaceURI: string, localName: string): Attr;


### PR DESCRIPTION
`Element::getAttribute` returns `null` when the attribute does not exist ([spec](https://dom.spec.whatwg.org/#dom-element-getattribute) and browsers agree).