### PR TITLE
Add EventListenerOptions support

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -126,18 +126,24 @@ type KeyboardEventTypes = 'keydown' | 'keyup' | 'keypress';
 type TouchEventTypes = 'touchstart' | 'touchmove' | 'touchend' | 'touchcancel';
 type WheelEventTypes = 'wheel';
 
-declare class EventTarget {
-  addEventListener(type: MouseEventTypes, listener: MouseEventListener, useCapture?: boolean): void;
-  addEventListener(type: KeyboardEventTypes, listener: KeyboardEventListener, useCapture?: boolean): void;
-  addEventListener(type: TouchEventTypes, listener: TouchEventListener, useCapture?: boolean): void;
-  addEventListener(type: WheelEventTypes, listener: WheelEventListener, useCapture?: boolean): void;
-  addEventListener(type: string, listener: EventListener, useCapture?: boolean): void;
+type EventListenerOptions = boolean | {
+  capture?: boolean,
+  once?: boolean,
+  passive?: boolean
+};
 
-  removeEventListener(type: MouseEventTypes, listener: MouseEventListener, useCapture?: boolean): void;
-  removeEventListener(type: KeyboardEventTypes, listener: KeyboardEventListener, useCapture?: boolean): void;
-  removeEventListener(type: TouchEventTypes, listener: TouchEventListener, useCapture?: boolean): void;
-  removeEventListener(type: WheelEventTypes, listener: WheelEventListener, useCapture?: boolean): void;
-  removeEventListener(type: string, listener: EventListener, useCapture?: boolean): void;
+declare class EventTarget {
+  addEventListener(type: MouseEventTypes, listener: MouseEventListener, options?: EventListenerOptions): void;
+  addEventListener(type: KeyboardEventTypes, listener: KeyboardEventListener, options?: EventListenerOptions): void;
+  addEventListener(type: TouchEventTypes, listener: TouchEventListener, options?: EventListenerOptions): void;
+  addEventListener(type: WheelEventTypes, listener: WheelEventListener, options?: EventListenerOptions): void;
+  addEventListener(type: string, listener: EventListener, options?: EventListenerOptions): void;
+
+  removeEventListener(type: MouseEventTypes, listener: MouseEventListener, options?: EventListenerOptions): void;
+  removeEventListener(type: KeyboardEventTypes, listener: KeyboardEventListener, options?: EventListenerOptions): void;
+  removeEventListener(type: TouchEventTypes, listener: TouchEventListener, options?: EventListenerOptions): void;
+  removeEventListener(type: WheelEventTypes, listener: WheelEventListener, options?: EventListenerOptions): void;
+  removeEventListener(type: string, listener: EventListener, options?: EventListenerOptions): void;
 
   attachEvent?: (type: MouseEventTypes, listener: MouseEventListener) => void;
   attachEvent?: (type: KeyboardEventTypes, listener: KeyboardEventListener) => void;

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -126,24 +126,24 @@ type KeyboardEventTypes = 'keydown' | 'keyup' | 'keypress';
 type TouchEventTypes = 'touchstart' | 'touchmove' | 'touchend' | 'touchcancel';
 type WheelEventTypes = 'wheel';
 
-type EventListenerOptions = boolean | {
+type EventListenerOptionsOrUseCapture = boolean | {
   capture?: boolean,
   once?: boolean,
   passive?: boolean
 };
 
 declare class EventTarget {
-  addEventListener(type: MouseEventTypes, listener: MouseEventListener, options?: EventListenerOptions): void;
-  addEventListener(type: KeyboardEventTypes, listener: KeyboardEventListener, options?: EventListenerOptions): void;
-  addEventListener(type: TouchEventTypes, listener: TouchEventListener, options?: EventListenerOptions): void;
-  addEventListener(type: WheelEventTypes, listener: WheelEventListener, options?: EventListenerOptions): void;
-  addEventListener(type: string, listener: EventListener, options?: EventListenerOptions): void;
+  addEventListener(type: MouseEventTypes, listener: MouseEventListener, optionsOrUseCapture?: EventListenerOptionsOrUseCapture): void;
+  addEventListener(type: KeyboardEventTypes, listener: KeyboardEventListener, optionsOrUseCapture?: EventListenerOptionsOrUseCapture): void;
+  addEventListener(type: TouchEventTypes, listener: TouchEventListener, optionsOrUseCapture?: EventListenerOptionsOrUseCapture): void;
+  addEventListener(type: WheelEventTypes, listener: WheelEventListener, optionsOrUseCapture?: EventListenerOptionsOrUseCapture): void;
+  addEventListener(type: string, listener: EventListener, optionsOrUseCapture?: EventListenerOptionsOrUseCapture): void;
 
-  removeEventListener(type: MouseEventTypes, listener: MouseEventListener, options?: EventListenerOptions): void;
-  removeEventListener(type: KeyboardEventTypes, listener: KeyboardEventListener, options?: EventListenerOptions): void;
-  removeEventListener(type: TouchEventTypes, listener: TouchEventListener, options?: EventListenerOptions): void;
-  removeEventListener(type: WheelEventTypes, listener: WheelEventListener, options?: EventListenerOptions): void;
-  removeEventListener(type: string, listener: EventListener, options?: EventListenerOptions): void;
+  removeEventListener(type: MouseEventTypes, listener: MouseEventListener, optionsOrUseCapture?: EventListenerOptionsOrUseCapture): void;
+  removeEventListener(type: KeyboardEventTypes, listener: KeyboardEventListener, optionsOrUseCapture?: EventListenerOptionsOrUseCapture): void;
+  removeEventListener(type: TouchEventTypes, listener: TouchEventListener, optionsOrUseCapture?: EventListenerOptionsOrUseCapture): void;
+  removeEventListener(type: WheelEventTypes, listener: WheelEventListener, optionsOrUseCapture?: EventListenerOptionsOrUseCapture): void;
+  removeEventListener(type: string, listener: EventListener, optionsOrUseCapture?: EventListenerOptionsOrUseCapture): void;
 
   attachEvent?: (type: MouseEventTypes, listener: MouseEventListener) => void;
   attachEvent?: (type: KeyboardEventTypes, listener: KeyboardEventListener) => void;


### PR DESCRIPTION
This PR adds support for EventListenerOptions.
`passive`: https://github.com/WICG/EventListenerOptions/blob/gh-pages/explainer.md
`once` and others: https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener