### PR TITLE
`Buffer#fill` returns `this`

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -38,7 +38,7 @@ declare class Buffer {
   copy(targetBuffer: Buffer, targetStart?: number, sourceStart?: number, sourceEnd?: number): number;
   entries(): Iterator<[number, number]>;
   equals(otherBuffer: Buffer): boolean;
-  fill(value: string | number, offset?: number, end?: number): void;
+  fill(value: string | number, offset?: number, end?: number): this;
   includes(
     value: string | Buffer | number,
     offsetOrEncoding?: number | buffer$Encoding,


### PR DESCRIPTION
The `fill` method of Buffer objects returns `this` rather than `void`.