### PR TITLE
Remove unused modules

### DIFF
--- a/src/common/errors.ml
+++ b/src/common/errors.ml
@@ -507,7 +507,6 @@ module ErrorSet = Set.Make(Error)
  *)
 module ErrorSuppressions = struct
   open Span
-  module Ast = Spider_monkey_ast
 
   type error_suppressions = Loc.t SpanMap.t
   type t = {

--- a/src/common/reason.ml
+++ b/src/common/reason.ml
@@ -21,7 +21,6 @@
 
 open Utils_js
 open String_utils
-module Ast = Spider_monkey_ast
 
 let mk_id () = Ident.make ""
 

--- a/src/parser/parser_env.ml
+++ b/src/parser/parser_env.ml
@@ -14,7 +14,6 @@ module Lex_result = Lexer_flow.Lex_result
 open Ast
 module Error = Parse_error
 module SSet = Set.Make(String)
-module SMap = Map.Make(String)
 
 module Lex_mode = struct
   type t =

--- a/src/services/inference/module_js.ml
+++ b/src/services/inference/module_js.ml
@@ -19,7 +19,6 @@
 open Utils_js
 
 module Ast = Spider_monkey_ast
-module Flow = Flow_js
 module ErrorSet = Errors.ErrorSet
 module FlowError = Flow_error
 

--- a/src/typing/func_params.ml
+++ b/src/typing/func_params.ml
@@ -1,7 +1,6 @@
 module Ast = Spider_monkey_ast
 module Anno = Type_annotation
 module Flow = Flow_js
-module Utils = Utils_js
 
 open Reason
 open Type


### PR DESCRIPTION
Tried to compile with 4.04 on a lark, which adds a new warning for unused modules.

Fixes #2870