### PR TITLE
Fix build issue with LZ4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ NATIVE_C_FILES=\
   hack/utils/win32_support.c\
   hack/hhi/hhi_win32res_stubs.c\
   src/embedded/flowlib_elf.c\
-  $(wildcard src/third-party/lz4/*.c)
+  $(sort $(wildcard src/third-party/lz4/*.c))
 
 OCAML_LIBRARIES=\
   unix\


### PR DESCRIPTION
Because the Makefile builds C files in the order given by `NATIVE_C_FILES`, and the ordering of `$(wildcard ...)` is non-deterministic, it's possible for the build to compile C files from LZ4 before files they `#include` are present.

This was happening to our build, causing a failure where building `lz4hc.c` would be attempted before `lz4.c` was even present. The solution proposed is a hack. A better solution would probably be an explicit target for LZ4 that uses it's Makefile, but for the moment I just wanted to highlight the issue and show _a_ solution for others who might be experiencing this problem.