### PR TITLE
Windows issues

### DIFF
--- a/src/common/files.ml
+++ b/src/common/files.ml
@@ -253,7 +253,8 @@ let is_ignored options =
     List.exists (fun rx -> Str.string_match rx path 0) list
 
 (* true if a file path matches an [include] path in config *)
-let is_included options f = Path_matcher.matches (Options.includes options) f
+let is_included options f =
+  Path_matcher.matches (Options.includes options) f
 
 let wanted ~options lib_fileset =
   let is_ignored_ = is_ignored options in

--- a/src/common/path_matcher.ml
+++ b/src/common/path_matcher.ml
@@ -48,7 +48,8 @@ let path_patt =
   let star2 = Str.regexp_string "**" in
   let qmark = Str.regexp_string "?" in
   fun path ->
-    let str = Path.to_string path in
+    let str = Path.to_string path 
+      |> Sys_utils.normalize_filename_dir_sep in
     (* because we accept both * and **, convert in 2 steps *)
     let results = Str.full_split star2 str in
     let results = List.map (fun r -> match r with
@@ -120,7 +121,8 @@ let rec match_patt f = function
 
 let matches path_matcher f =
   let matching_stems = find_prefixes f path_matcher.stems in
+  let normalized_f = Sys_utils.normalize_filename_dir_sep f in
   List.exists (fun stem ->
     let patts = PathMap.find_unsafe stem path_matcher.stem_map in
-    match_patt f patts != None
+    match_patt normalized_f patts != None
   ) matching_stems

--- a/tsrc/test/builder.js
+++ b/tsrc/test/builder.js
@@ -111,9 +111,9 @@ export class TestBuilder {
     } else {
       await exec(
         format(
-          "%s init --options 'all=true;temp_dir=%s' %s",
+          '%s init --options "all=true;temp_dir=%s" %s',
           this.bin,
-          this.tmpDir,
+          this.normalizeForFlowconfig(this.tmpDir),
           this.dir,
         ),
         {cwd: __dirname},


### PR DESCRIPTION
The `ls_command` test was failing on Windows. I found two things that were wrong:

1. `./tool test` was exec'ing a command with single quotes, which don't work on Windows
2. Includes on Windows were broken. This fixes them enough for the ls command to work, but we probably should finally port all our bash tests to `./tool` and make sure they pass on Windows.