### PR TITLE
Add import type shorthand syntax

### DIFF
--- a/newtests/import_type_shorthand/_flowconfig
+++ b/newtests/import_type_shorthand/_flowconfig
@@ -1,0 +1,8 @@
+[ignore]
+
+[include]
+
+[libs]
+
+[options]
+all=true

--- a/newtests/import_type_shorthand/esmodule.js
+++ b/newtests/import_type_shorthand/esmodule.js
@@ -1,0 +1,4 @@
+// @flow
+
+export type T = number;
+export class C {};

--- a/newtests/import_type_shorthand/test.js
+++ b/newtests/import_type_shorthand/test.js
@@ -1,0 +1,74 @@
+/* @flow */
+
+
+import {suite, test} from '../../tsrc/test/Tester';
+
+export default suite(({addFile, addFiles, addCode}) => [
+  test('Unaliased type import', [
+    addFile('esmodule.js')
+      .addCode('import {type T, C} from "./esmodule";')
+      .addCode('new C();')
+      .addCode('(42: T);')
+        .noNewErrors(),
+
+    addCode('("str": T);')
+      .newErrors(`
+        test.js:9
+          9: ("str": T);
+              ^^^^^ string. This type is incompatible with
+          9: ("str": T);
+                     ^ number
+      `),
+  ]),
+
+  test('Aliased type import', [
+    addFile('esmodule.js')
+      .addCode('import {type T as U, C} from "./esmodule";')
+      .addCode('new C();')
+      .addCode('(42: U);')
+        .noNewErrors(),
+
+    addCode('("str": U);')
+      .newErrors(`
+        test.js:9
+          9: ("str": U);
+              ^^^^^ string. This type is incompatible with
+          9: ("str": U);
+                     ^ number
+      `),
+  ]),
+
+  test('Unaliased typeof import', [
+    addFile('esmodule.js')
+      .addCode('import {typeof C, C as CImpl} from "./esmodule";')
+      .addCode('new CImpl();')
+      .addCode('(CImpl: C);')
+        .noNewErrors(),
+
+    addCode('("str": C);')
+      .newErrors(`
+        test.js:9
+          9: ("str": C);
+              ^^^^^ string. This type is incompatible with
+          9: ("str": C);
+               ^ class type: C
+      `),
+  ]),
+
+  test('Aliased type import', [
+    addFile('esmodule.js')
+      .addCode('import {typeof C as CPrime, C as CImpl} from "./esmodule";')
+      .addCode('new CImpl();')
+      .addCode('(CImpl: CPrime);')
+        .noNewErrors(),
+
+    addCode('("str": CPrime);')
+      .newErrors(`
+        test.js:9
+          9: ("str": CPrime);
+              ^^^^^ string. This type is incompatible with
+          9: ("str": CPrime);
+                     ^^^^^^ class type: C
+      `),
+  ]),
+]);

--- a/src/parser/estree_translator.ml
+++ b/src/parser/estree_translator.ml
@@ -275,8 +275,8 @@ end with type t = Impl.t) = struct
         let specifiers = import.specifiers |> List.map (function
           | ImportDefaultSpecifier id ->
               import_default_specifier id
-          | ImportNamedSpecifier {local; remote;} ->
-              import_named_specifier local remote
+          | ImportNamedSpecifier {local; remote; kind;} ->
+              import_named_specifier local remote kind
           | ImportNamespaceSpecifier id ->
               import_namespace_specifier id
         ) in
@@ -1275,7 +1275,7 @@ end with type t = Impl.t) = struct
       "local", identifier id;
     |]
 
-  and import_named_specifier local_id remote_id =
+  and import_named_specifier local_id remote_id kind =
     let span_loc =
       match local_id with
       | Some local_id -> Loc.btwn (fst remote_id) (fst local_id)
@@ -1288,6 +1288,12 @@ end with type t = Impl.t) = struct
     node "ImportSpecifier" span_loc [|
       "imported", identifier remote_id;
       "local", identifier local_id;
+      "importKind", (
+        match kind with
+        | Some Statement.ImportDeclaration.ImportType -> string "type"
+        | Some Statement.ImportDeclaration.ImportTypeof -> string "typeof"
+        | Some Statement.ImportDeclaration.ImportValue | None -> null
+      );
     |]
 
   and comment_list comments = array_of_list comment comments

--- a/src/parser/parse_error.ml
+++ b/src/parser/parse_error.ml
@@ -82,6 +82,8 @@ type t =
   | GetterArity
   | SetterArity
   | InvalidNonTypeImportInDeclareModule
+  | ImportTypeShorthandOnlyInPureImport
+  | ImportSpecifierMissingComma
 
 exception Error of (Loc.t * t) list
 
@@ -192,4 +194,10 @@ module PP =
       | InvalidNonTypeImportInDeclareModule ->
           "Imports within a `declare module` body must always be " ^
           "`import type` or `import typeof`!"
+      | ImportTypeShorthandOnlyInPureImport ->
+        "The `type` and `typeof` keywords on named imports can only be used on \
+        regular `import` statements. It cannot be used with `import type` or \
+        `import typeof` statements"
+      | ImportSpecifierMissingComma ->
+        "Missing comma between import specifiers"
   end

--- a/src/parser/spider_monkey_ast.ml
+++ b/src/parser/spider_monkey_ast.ml
@@ -443,25 +443,21 @@ and Statement : sig
     }
   end
   module ImportDeclaration : sig
-    module NamedSpecifier : sig
-      type t = Loc.t * t'
-      and t' = {
-        id: Identifier.t;
-        name: Identifier.t option;
-      }
-    end
-    type named_specifier = {
-      local: Identifier.t option;
-      remote: Identifier.t;
-    }
-    type specifier =
-      | ImportNamedSpecifier of named_specifier
-      | ImportDefaultSpecifier of Identifier.t
-      | ImportNamespaceSpecifier of (Loc.t * Identifier.t)
     type importKind =
       | ImportType
       | ImportTypeof
       | ImportValue
+
+    type specifier =
+      | ImportNamedSpecifier of named_specifier
+      | ImportDefaultSpecifier of Identifier.t
+      | ImportNamespaceSpecifier of (Loc.t * Identifier.t)
+    and named_specifier = {
+      kind: importKind option;
+      local: Identifier.t option;
+      remote: Identifier.t;
+    }
+
     type t = {
       importKind: importKind;
       source: (Loc.t * Literal.t); (* Always a string literal *)

--- a/src/parser/test/esprima_tests.js
+++ b/src/parser/test/esprima_tests.js
@@ -4650,8 +4650,8 @@ module.exports = {
         'import * as namespace from "MyModule";',
         'import {} from "MyModule";',
         'import defaultbinding, {} from "MyModule";',
-        /* TODO Esprima should support these
         'import {x,} from "MyModule";',
+        /* TODO Esprima should support these
         'import defaultbinding, {x,} from "MyModule";',
         */
         'import {x} from "MyModule";',

--- a/src/parser/test/hardcoded_tests.js
+++ b/src/parser/test/hardcoded_tests.js
@@ -5083,5 +5083,138 @@ module.exports = {
         ]
       },
     },
+    'import type shorthand': {
+      'import {type} from "foo";': {
+        'body.0': {
+          'type': 'ImportDeclaration',
+          'importKind': 'value',
+          'specifiers': [{
+            'type': 'ImportSpecifier',
+            'imported.name': 'type',
+            'local.name': 'type',
+            'importKind': null,
+          }]
+        }
+      },
+      'import {type t} from "foo";': {
+        'body.0': {
+          'type': 'ImportDeclaration',
+          'importKind': 'value',
+          'specifiers': [{
+            'type': 'ImportSpecifier',
+            'imported.name': 't',
+            'local.name': 't',
+            'importKind': 'type',
+          }]
+        }
+      },
+      'import {type as} from "foo";': {
+        'body.0': {
+          'type': 'ImportDeclaration',
+          'importKind': 'value',
+          'specifiers': [{
+            'type': 'ImportSpecifier',
+            'imported.name': 'as',
+            'local.name': 'as',
+            'importKind': 'type',
+          }]
+        }
+      },
+      'import {type t as u} from "foo";': {
+        'body.0': {
+          'type': 'ImportDeclaration',
+          'importKind': 'value',
+          'specifiers': [{
+            'type': 'ImportSpecifier',
+            'imported.name': 't',
+            'local.name': 'u',
+            'importKind': 'type',
+          }]
+        }
+      },
+
+      'import {typeof t} from "foo";': {
+        'body.0': {
+          'type': 'ImportDeclaration',
+          'importKind': 'value',
+          'specifiers': [{
+            'type': 'ImportSpecifier',
+            'imported.name': 't',
+            'local.name': 't',
+            'importKind': 'typeof',
+          }]
+        }
+      },
+      'import {typeof as} from "foo";': {
+        'body.0': {
+          'type': 'ImportDeclaration',
+          'importKind': 'value',
+          'specifiers': [{
+            'type': 'ImportSpecifier',
+            'imported.name': 'as',
+            'local.name': 'as',
+            'importKind': 'typeof',
+          }]
+        }
+      },
+      'import {typeof t as u} from "foo";': {
+        'body.0': {
+          'type': 'ImportDeclaration',
+          'importKind': 'value',
+          'specifiers': [{
+            'type': 'ImportSpecifier',
+            'imported.name': 't',
+            'local.name': 'u',
+            'importKind': 'typeof',
+          }]
+        }
+      },
+
+      'import {type t as} from "foo";': {
+        'errors.0.message': 'Unexpected token }'
+      },
+      'import {typeof} from "foo";': {
+        'errors.0.message': 'Unexpected token typeof'
+      },
+      'import type {type t} from "foo";': {
+        'errors.0.message': 'The `type` and `typeof` keywords on named imports can only be used on regular `import` statements. It cannot be used with `import type` or `import typeof` statements'
+      },
+      'import typeof {typeof t} from "foo";': {
+        'errors.0.message': 'The `type` and `typeof` keywords on named imports can only be used on regular `import` statements. It cannot be used with `import type` or `import typeof` statements'
+      },
+    },
+    'import statements': {
+      'import {x,} from "MyModule";': {
+        'body.0': {
+          'type': 'ImportDeclaration',
+          'importKind': 'value',
+          'specifiers': [{
+            'type': 'ImportSpecifier',
+            'imported.name': 'x',
+            'local.name': 'x',
+          }]
+        }
+      },
+      'import defexp, {x,} from "MyModule";': {
+        'body.0': {
+          'type': 'ImportDeclaration',
+          'importKind': 'value',
+          'specifiers': [
+            {
+              'type': 'ImportDefaultSpecifier',
+              'local.name': 'defexp',
+            },
+            {
+              'type': 'ImportSpecifier',
+              'imported.name': 'x',
+              'local.name': 'x',
+            }
+          ]
+        }
+      },
+      'import {a nopeNeedsAPrecedingComma} from "MyModule";': {
+        'errors.0.message': 'Missing comma between import specifiers'
+      },
+    },
   }
 };

--- a/src/services/flowFileGen/flowFileGen.ml
+++ b/src/services/flowFileGen/flowFileGen.ml
@@ -95,10 +95,16 @@ let gen_imports env =
     let env = if List.length named = 0 then env else (
       let env = Codegen.add_str "{" env in
       let env =
-        Codegen.gen_separated_list named ", " (fun {local; remote} env ->
+        Codegen.gen_separated_list named ", " (fun {local; remote; kind;} env ->
           let (_, remote) = remote in
           match local with
           | Some (_, local) when local <> remote ->
+            let env =
+              match kind with
+              | Some ImportType -> Codegen.add_str "type " env
+              | Some ImportTypeof -> Codegen.add_str "typeof " env
+              | Some ImportValue | None -> env
+            in
             Codegen.add_str remote env
               |> Codegen.add_str " as "
               |> Codegen.add_str local

--- a/tests/union_new/union_new.exp
+++ b/tests/union_new/union_new.exp
@@ -309,4 +309,4 @@ test9.js:12
                   ^ null. The operand of an arithmetic operation must be a number.
 
 
-Found 22 errors
+Found 23 errors


### PR DESCRIPTION
Currently, importing both types and values from the same modules requires two statements with most of the same boilerplate in both statements:

```js
import {someValue} from "blah";
import type {someType} from "blah";
import typeof {someOtherValue} from "blah";
```

This gets tediously repetitive and adds a lot of boilerplate to JS files.

This PR implements a proposal from @leebyron to add an additional `type`/`typeof` shorthand to vanilla-`import` statements for individual named specifiers so that the above code can be written more concisely as:

```js
import {
  someValue,
  type someType,
  typeof someOtherValue,
} from "blah";
```

This PR does not remove `import type` or `import typeof` statements -- it only adds the shorthand to vanilla `import` statements.

Note also that I've banned usage of the shorthand with `import type` and `import typeof` statements since the need for shorthand in those is far less common and often combinatorially confusing:

```js
import type { type T } from "foo"; // <-- parse error
import typeof { type T } from "foo"; // <-- parse error
```