### PR TITLE
Make node's Buffer class extend Uint8Array

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -626,7 +626,7 @@ type $ArrayBufferView = $TypedArray | DataView;
 // http://www.ecma-international.org/ecma-262/6.0/#sec-%typedarray%-intrinsic-object
 declare class $TypedArray {
     static BYTES_PER_ELEMENT: number;
-    static from(iterable: Iterable<number>): this;
+    static from(iterable: Iterable<number>, mapFn?: (element: number) => number, thisArg?: any): this;
     static of(...values: number[]): this;
 
     constructor(length: number): void;
@@ -644,17 +644,17 @@ declare class $TypedArray {
     length: number;
 
     copyWithin(target: number, start: number, end?: number): void;
-    entries(): Iterator<number>;
+    entries(): Iterator<[number, number]>;
     every(callback: (value: number, index: number, array: this) => mixed, thisArg?: any): boolean;
-    fill(value: number, start?: number, end?: number): void;
+    fill(value: number, start?: number, end?: number): this;
     filter(callback: (value: number, index: number, array: this) => mixed, thisArg?: any): this;
     find(callback: (value: number, index: number, array: this) => mixed, thisArg?: any): number | void;
-    findIndex(callback: (value: number, index: number, array: this) => mixed, thisArg?: any): number | void;
+    findIndex(callback: (value: number, index: number, array: this) => mixed, thisArg?: any): number;
     forEach(callback: (value: number, index: number, array: this) => mixed, thisArg?: any): void;
     includes(searchElement: number, fromIndex?: number): boolean;
     indexOf(searchElement: number, fromIndex?: number): number; // -1 if not present
     join(separator?: string): string;
-    keys(): Array<number>;
+    keys(): Iterator<number>;
     lastIndexOf(searchElement: number, fromIndex?: number): number; // -1 if not present
     map(callback: (currentValue: number, index: number, array: this) => number, thisArg?: any): this;
     reduce(

--- a/lib/node.js
+++ b/lib/node.js
@@ -26,7 +26,7 @@ type buffer$NonBufferEncoding =
 type buffer$Encoding = buffer$NonBufferEncoding | 'buffer'
 type buffer$ToJSONRet = { type: string, data: Array<number> }
 
-declare class Buffer {
+declare class Buffer extends Uint8Array {
   constructor(
     value: Array<number> | number | string | Buffer | ArrayBuffer,
     encoding?: buffer$Encoding
@@ -38,7 +38,8 @@ declare class Buffer {
   copy(targetBuffer: Buffer, targetStart?: number, sourceStart?: number, sourceEnd?: number): number;
   entries(): Iterator<[number, number]>;
   equals(otherBuffer: Buffer): boolean;
-  fill(value: string | number, offset?: number, end?: number): this;
+  fill(value: string | number, offset?: number, end?: number, encoding?: string): this;
+  fill(value: string, encoding?: string): this;
   includes(
     value: string | Buffer | number,
     offsetOrEncoding?: number | buffer$Encoding,
@@ -74,7 +75,7 @@ declare class Buffer {
   readUInt8(offset: number, noAssert?: boolean): number;
   readUIntBE(offset: number, byteLength: number, noAssert?: boolean): number;
   readUIntLE(offset: number, byteLength: number, noAssert?: boolean): number;
-  slice(start?: number, end?: number): Buffer;
+  slice(start?: number, end?: number): this;
   swap16(): Buffer;
   swap32(): Buffer;
   toJSON(): buffer$ToJSONRet;
@@ -106,10 +107,9 @@ declare class Buffer {
   static byteLength(string: string | Buffer | $TypedArray | DataView | ArrayBuffer, encoding?: buffer$Encoding): number;
   static compare(buf1: Buffer, buf2: Buffer): number;
   static concat(list: Array<Buffer>, totalLength?: number): Buffer;
-  // `UNUSED` argument strictly enforces arity to enable overloading this
-  // function with 1-arg and 2-arg variants.
-  static from(value: Array<number>, UNUSED: void): Buffer;
-  static from(value: Buffer, UNUSED: void): Buffer;
+
+  static from(value: Iterable<number>): this;
+  static from(value: Buffer): Buffer;
   static from(value: string, encoding?: buffer$Encoding): Buffer;
   static from(value: ArrayBuffer, byteOffset?: number, length?: number): Buffer;
   static isBuffer(obj: any): boolean;

--- a/tests/node_tests/buffer/buffer.js
+++ b/tests/node_tests/buffer/buffer.js
@@ -1,0 +1,57 @@
+/* @flow */
+
+let bool: boolean = false;
+let buffer: Buffer = new Buffer(0);
+let num: number = 0;
+let maybeNum: ?number;
+
+// Uint8Array properties. All of these should type check ok.
+buffer.length;
+buffer.buffer;
+buffer.byteOffset;
+buffer.byteLength;
+buffer[1];
+
+// A few Uint8Array instance methods. All of these should type check ok.
+buffer.copyWithin(0, 0);
+buffer.copyWithin(0, 0, 0);
+
+const it1: Iterator<[number, number]> = buffer.entries();
+
+bool = buffer.every((element: number) => false);
+bool = buffer.every((element: number) => false, buffer);
+
+buffer = buffer.fill(1);
+buffer = buffer.fill(1, 0, 0);
+buffer = buffer.fill("a");
+buffer = buffer.fill("a", 0, 0);
+buffer = buffer.fill("a", 0, 0, "utf8");
+buffer = buffer.fill("a", "utf8");
+
+maybeNum = buffer.find((element: number, index: number, array:Uint8Array) => false);
+maybeNum = buffer.find((element: number, index: number, array:Uint8Array) => false, buffer);
+
+num = buffer.findIndex((element: number, index: number, array:Uint8Array) => false);
+num = buffer.findIndex((element: number, index: number, array:Uint8Array) => false, buffer);
+
+buffer.forEach((value: number) => console.log(value), buffer);
+buffer.forEach((value: number, index:number, array:Uint8Array) => console.log(value), buffer);
+
+bool = buffer.includes(3);
+bool = buffer.includes(3, 4);
+
+num = buffer.indexOf(3);
+num = buffer.indexOf(3, 4);
+
+// static methods
+buffer = Buffer.from([0x62, 0x75, 0x66, 0x66, 0x65, 0x72]);
+const typedArray = new Uint8Array([0x34]);
+buffer = Buffer.from(typedArray.buffer, typedArray.byteOffset, typedArray.byteLength);
+buffer = Buffer.from(new Buffer(0));
+buffer = Buffer.from("foo", "utf8");
+
+// This call to from() does type check ok, but should not. Unfortunately, Buffer
+// extends Uint8Array but gets rid of this signature to .from(). Understandably,
+// flow doesn't support a subclass hiding a superclass member, so this checks out as
+// ok, even though it is not correct.
+buffer = Buffer.from([0x62, 0x75, 0x66, 0x66, 0x65, 0x72], (a:number) => a + 1, {}); // should error but doesn't


### PR DESCRIPTION
Node's `Buffer` class is now a `Uint8Array`, but the current flow builtins don't recognize that fact. This results in two problems:

1. There are a bunch of methods on `Buffer` that flow doesn't know about, like `forEach` and `reduce`.
2. Methods that take a `Uint8Array` can't take a `Buffer`, even though `(new Buffer(0)).__proto__.__proto__` returns `Uint8Array {}`.

I've tried to fix that in this PR, but it's a little hairy, because `Buffer` changes the signature of `Uint8Array.from`. From [the Node 6.9.1 documentation](https://nodejs.org/dist/latest-v6.x/docs/api/buffer.html#buffer_buffers_and_typedarray):

> The Buffer.from() and TypedArray.from() have different signatures and implementations. Specifically, the TypedArray variants accept a second argument that is a mapping function that is invoked on every element of the typed array

This PR defines `TypedArray.from` with the optional mapping function & this argument, which means that `Buffer` incorrectly inherits that function signature. Also, `Buffer.from(Array<number>)` has to be changed to `Buffer.from(Iterable<number>)` because the former is not compatible with `TypedArray.from(Iterable<number>)`. This means that `Buffer.from` will pass type checks incorrectly when passed an Iterable that is not an array. These effects are unfortunate, as they will allow some code to pass type checks incorrectly, but I don't see another way to do it. If there is a better way, please let me know.

Note also that there are a few fixes to function signatures that are just simple correctness fixes but are required to allow `Buffer` to extend `Uint8Array`: `TypedArray.entries`, `TypedArray.fill`, `TypedArray.findIndex`, `TypedArray.keys`, and `Buffer.slice`. I used the [MDN TypedArray page](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray) and [the Node 6.9.1 Buffer page](https://nodejs.org/dist/latest-v6.x/docs/api/buffer.html) as my references when trying to determine the true function signatures.

I believe this PR should fix issue #1514.

Thanks for all the work you do, and let me know what you think. Thanks!