### PR TITLE
lib: fix typedef for `crypto$Decipher`.

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -22,7 +22,7 @@ type buffer$NonBufferEncoding =
   'binary' | 'BINARY' |
   'base64' | 'BASE64' |
   'ucs2' | 'UCS2' | 'ucs-2' | 'UCS-2' |
-  'utf16le' | 'UTF16LE' | 'utf-16le' | 'UTF-16LE';
+  'utf16le' | 'UTF16LE' | 'utf-16le' | 'UTF-16LE' | 'latin1';
 type buffer$Encoding = buffer$NonBufferEncoding | 'buffer'
 type buffer$ToJSONRet = { type: string, data: Array<number> }
 
@@ -347,7 +347,7 @@ declare module "cluster" {
 type crypto$createCredentialsDetails = any; // TODO
 
 declare class crypto$Cipher extends stream$Duplex {
-  final(output_encoding: 'binary' | 'base64' | 'hex'): string;
+  final(output_encoding: 'latin1' | 'base64' | 'hex'): string;
   final(output_encoding: void): Buffer;
   getAuthTag(): Buffer;
   setAAD(buffer: Buffer): void;
@@ -355,18 +355,18 @@ declare class crypto$Cipher extends stream$Duplex {
   setAutoPadding(auto_padding?: boolean): crypto$Cipher;
   update(
     data: string,
-    input_encoding: 'utf8'| 'ascii' | 'binary',
-    output_encoding: 'binary' | 'base64' | 'hex'
+    input_encoding: 'utf8'| 'ascii' | 'latin1',
+    output_encoding: 'latin1' | 'base64' | 'hex'
   ): string;
   update(
     data: string,
-    input_encoding: 'utf8'| 'ascii' | 'binary',
+    input_encoding: 'utf8'| 'ascii' | 'latin1',
     output_encoding: void
   ): Buffer;
   update(
     data: Buffer,
     input_encoding: void,
-    output_encoding: 'binary' | 'base64' | 'hex'
+    output_encoding: 'latin1' | 'base64' | 'hex'
   ): string;
   update(
     data: Buffer,
@@ -395,7 +395,7 @@ type crypto$DiffieHellman = {
 }
 
 declare class crypto$Decipher extends stream$Duplex {
-  final(output_encoding: 'binary' | 'base64' | 'hex'): string;
+  final(output_encoding: 'latin1' | 'ascii' | 'utf8'): string;
   final(output_encoding: void): Buffer;
   getAuthTag(): Buffer;
   setAAD(buffer: Buffer): void;
@@ -403,18 +403,18 @@ declare class crypto$Decipher extends stream$Duplex {
   setAutoPadding(auto_padding?: boolean): crypto$Cipher;
   update(
     data: string,
-    input_encoding: 'utf8'| 'ascii' | 'binary',
-    output_encoding: 'binary' | 'base64' | 'hex'
+    input_encoding: 'latin1'| 'base64' | 'hex',
+    output_encoding: 'latin1' | 'ascii' | 'utf8',
   ): string;
   update(
     data: string,
-    input_encoding: 'utf8'| 'ascii' | 'binary',
+    input_encoding: 'latin1'| 'base64' | 'hex',
     output_encoding: void
   ): Buffer;
   update(
     data: Buffer,
     input_encoding: void,
-    output_encoding: 'binary' | 'base64' | 'hex'
+    output_encoding: 'latin1' | 'ascii' | 'utf8',
   ): string;
   update(
     data: Buffer,
@@ -424,17 +424,17 @@ declare class crypto$Decipher extends stream$Duplex {
 }
 
 declare class crypto$Hash extends stream$Duplex {
-  digest(encoding: 'hex' | 'binary' | 'base64'): string;
+  digest(encoding: 'hex' | 'latin1' | 'base64'): string;
   digest(encoding: void): Buffer;
   update(data: Buffer, input_encoding?: void): crypto$Hash;
-  update(data: string, input_encoding?: 'utf8' | 'ascii' | 'binary'): crypto$Hash;
+  update(data: string, input_encoding?: 'utf8' | 'ascii' | 'latin1'): crypto$Hash;
 }
 
 declare class crypto$Hmac extends stream$Duplex {
-  digest(encoding: 'hex' | 'binary' | 'base64'): string;
+  digest(encoding: 'hex' | 'latin1' | 'base64'): string;
   digest(encoding: void): Buffer;
   update(data: Buffer, input_encoding?: void): crypto$Hmac;
-  update(data: string, input_encoding?: 'utf8' | 'ascii' | 'binary'): crypto$Hmac;
+  update(data: string, input_encoding?: 'utf8' | 'ascii' | 'latin1'): crypto$Hmac;
 }
 
 type crypto$Sign$private_key = string | {
@@ -446,25 +446,25 @@ declare class crypto$Sign extends stream$Writable {
   constructor(algorithm: string, options?: writableStreamOptions): void;
   sign(
     private_key: crypto$Sign$private_key,
-    output_format: 'binary' | 'hex' | 'base64'
+    output_format: 'latin1' | 'hex' | 'base64'
   ): string;
   sign(
     private_key: crypto$Sign$private_key,
     output_format: void
   ): Buffer;
   update(data: Buffer, input_encoding?: void): crypto$Sign;
-  update(data: string, input_encoding?: 'utf8' | 'ascii' | 'binary'): crypto$Sign;
+  update(data: string, input_encoding?: 'utf8' | 'ascii' | 'latin1'): crypto$Sign;
 }
 
 declare class crypto$Verify extends stream$Writable {
   static(algorithm: string, options?: writableStreamOptions): crypto$Verify,
   constructor(algorithm: string, options?: writableStreamOptions): void;
   update(data: Buffer, input_encoding?: void): crypto$Verify;
-  update(data: string, input_encoding?: 'utf8' | 'ascii' | 'binary'): crypto$Verify;
+  update(data: string, input_encoding?: 'utf8' | 'ascii' | 'latin1'): crypto$Verify;
   verify(
     object: string,
     signature: string,
-    signature_format: 'binary' | 'hex' | 'base64'
+    signature_format: 'latin1' | 'hex' | 'base64'
   ): boolean;
   verify(object: string, signature: Buffer, signature_format: void): boolean;
 }

--- a/lib/node.js
+++ b/lib/node.js
@@ -347,7 +347,7 @@ declare module "cluster" {
 type crypto$createCredentialsDetails = any; // TODO
 
 declare class crypto$Cipher extends stream$Duplex {
-  final(output_encoding: 'latin1' | 'base64' | 'hex'): string;
+  final(output_encoding: 'latin1' | 'binary' | 'base64' | 'hex'): string;
   final(output_encoding: void): Buffer;
   getAuthTag(): Buffer;
   setAAD(buffer: Buffer): void;
@@ -355,18 +355,18 @@ declare class crypto$Cipher extends stream$Duplex {
   setAutoPadding(auto_padding?: boolean): crypto$Cipher;
   update(
     data: string,
-    input_encoding: 'utf8'| 'ascii' | 'latin1',
-    output_encoding: 'latin1' | 'base64' | 'hex'
+    input_encoding: 'utf8'| 'ascii' | 'latin1' | 'binary',
+    output_encoding: 'latin1' | 'binary'| 'base64' | 'hex'
   ): string;
   update(
     data: string,
-    input_encoding: 'utf8'| 'ascii' | 'latin1',
+    input_encoding: 'utf8'| 'ascii' | 'latin1' | 'binary',
     output_encoding: void
   ): Buffer;
   update(
     data: Buffer,
     input_encoding: void,
-    output_encoding: 'latin1' | 'base64' | 'hex'
+    output_encoding: 'latin1' | 'binary' | 'base64' | 'hex'
   ): string;
   update(
     data: Buffer,
@@ -395,7 +395,7 @@ type crypto$DiffieHellman = {
 }
 
 declare class crypto$Decipher extends stream$Duplex {
-  final(output_encoding: 'latin1' | 'ascii' | 'utf8'): string;
+  final(output_encoding: 'latin1' | 'binary' | 'ascii' | 'utf8'): string;
   final(output_encoding: void): Buffer;
   getAuthTag(): Buffer;
   setAAD(buffer: Buffer): void;
@@ -403,18 +403,18 @@ declare class crypto$Decipher extends stream$Duplex {
   setAutoPadding(auto_padding?: boolean): crypto$Cipher;
   update(
     data: string,
-    input_encoding: 'latin1'| 'base64' | 'hex',
-    output_encoding: 'latin1' | 'ascii' | 'utf8',
+    input_encoding: 'latin1' | 'binary' | 'base64' | 'hex',
+    output_encoding: 'latin1' | 'binary' | 'ascii' | 'utf8',
   ): string;
   update(
     data: string,
-    input_encoding: 'latin1'| 'base64' | 'hex',
+    input_encoding: 'latin1' | 'binary' | 'base64' | 'hex',
     output_encoding: void
   ): Buffer;
   update(
     data: Buffer,
     input_encoding: void,
-    output_encoding: 'latin1' | 'ascii' | 'utf8',
+    output_encoding: 'latin1' | 'binary' | 'ascii' | 'utf8',
   ): string;
   update(
     data: Buffer,
@@ -424,17 +424,19 @@ declare class crypto$Decipher extends stream$Duplex {
 }
 
 declare class crypto$Hash extends stream$Duplex {
-  digest(encoding: 'hex' | 'latin1' | 'base64'): string;
+  digest(encoding: 'hex' | 'latin1' | 'binary' | 'base64'): string;
   digest(encoding: void): Buffer;
   update(data: Buffer, input_encoding?: void): crypto$Hash;
-  update(data: string, input_encoding?: 'utf8' | 'ascii' | 'latin1'): crypto$Hash;
+  update(data: string, input_encoding?: 'utf8' | 'ascii' | 'latin1' |
+  'binary'): crypto$Hash;
 }
 
 declare class crypto$Hmac extends stream$Duplex {
-  digest(encoding: 'hex' | 'latin1' | 'base64'): string;
+  digest(encoding: 'hex' | 'latin1' | 'binary' | 'base64'): string;
   digest(encoding: void): Buffer;
   update(data: Buffer, input_encoding?: void): crypto$Hmac;
-  update(data: string, input_encoding?: 'utf8' | 'ascii' | 'latin1'): crypto$Hmac;
+  update(data: string, input_encoding?: 'utf8' | 'ascii' | 'latin1' |
+  'binary'): crypto$Hmac;
 }
 
 type crypto$Sign$private_key = string | {
@@ -446,25 +448,27 @@ declare class crypto$Sign extends stream$Writable {
   constructor(algorithm: string, options?: writableStreamOptions): void;
   sign(
     private_key: crypto$Sign$private_key,
-    output_format: 'latin1' | 'hex' | 'base64'
+    output_format: 'latin1' | 'binary' | 'hex' | 'base64'
   ): string;
   sign(
     private_key: crypto$Sign$private_key,
     output_format: void
   ): Buffer;
   update(data: Buffer, input_encoding?: void): crypto$Sign;
-  update(data: string, input_encoding?: 'utf8' | 'ascii' | 'latin1'): crypto$Sign;
+  update(data: string, input_encoding?: 'utf8' | 'ascii' | 'latin1'|
+  'binary' ): crypto$Sign;
 }
 
 declare class crypto$Verify extends stream$Writable {
   static(algorithm: string, options?: writableStreamOptions): crypto$Verify,
   constructor(algorithm: string, options?: writableStreamOptions): void;
   update(data: Buffer, input_encoding?: void): crypto$Verify;
-  update(data: string, input_encoding?: 'utf8' | 'ascii' | 'latin1'): crypto$Verify;
+  update(data: string, input_encoding?: 'utf8' | 'ascii' | 'latin1' |
+  'binary' ): crypto$Verify;
   verify(
     object: string,
     signature: string,
-    signature_format: 'latin1' | 'hex' | 'base64'
+    signature_format: 'latin1' | 'binary' | 'hex' | 'base64'
   ): boolean;
   verify(object: string, signature: Buffer, signature_format: void): boolean;
 }


### PR DESCRIPTION
[decipher.update api](https://nodejs.org/api/crypto.html#crypto_decipher_update_data_input_encoding_output_encoding)
The `input_encoding` should be `'latin1'| 'base64' | 'hex'`.
and `output_encoding` should be `'latin1' | 'ascii' | 'utf8'`.

Also modified all `binary` to `latin1`, for keeping synchronized with `Nodejs` docs.
The `binary` in `buffer$NonBufferEncoding` is retained, i'm not sure if there is someone need it.