### PR TITLE
modify `mode?:  any` to `mode?: number`,  and add a new var `constants` for node 6.x.

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -836,8 +836,8 @@ declare module "fs" {
   declare function watch(filename: string, options?: Object, listener?: (event: string, filename: string) => void): FSWatcher;
   declare function exists(path: string, callback?: (exists: boolean) => void): void;
   declare function existsSync(path: string): boolean;
-  declare function access(path: string, mode?: any, callback?: (err: ?ErrnoError) => void): void;
-  declare function accessSync(path: string, mode?: any): void;
+  declare function access(path: string, mode?: number, callback?: (err: ?ErrnoError) => void): void;
+  declare function accessSync(path: string, mode?: number): void;
   declare function createReadStream(path: string, options?: Object): ReadStream;
   declare function createWriteStream(path: string, options?: Object): WriteStream;
 

--- a/lib/node.js
+++ b/lib/node.js
@@ -845,6 +845,48 @@ declare module "fs" {
   declare var R_OK: number;
   declare var W_OK: number;
   declare var X_OK: number;
+  // new var from node 6.x
+  // https://nodejs.org/dist/latest-v6.x/docs/api/fs.html#fs_fs_constants_1
+  declare var constants: {
+    F_OK: number, // 0
+    R_OK: number, // 4
+    W_OK: number, // 2
+    X_OK: number, // 1
+    O_RDONLY: number, // 0
+    O_WRONLY: number, // 1
+    O_RDWR: number, // 2
+    S_IFMT: number, // 61440
+    S_IFREG: number, // 32768
+    S_IFDIR: number, // 16384
+    S_IFCHR: number, // 8192
+    S_IFBLK: number, // 24576
+    S_IFIFO: number, // 4096
+    S_IFLNK: number, // 40960
+    S_IFSOCK: number, // 49152
+    O_CREAT: number, // 64
+    O_EXCL: number, // 128
+    O_NOCTTY: number, // 256
+    O_TRUNC: number, // 512
+    O_APPEND: number, // 1024
+    O_DIRECTORY: number, // 65536
+    O_NOATIME: number, // 262144
+    O_NOFOLLOW: number, // 131072
+    O_SYNC: number, // 4096
+    O_DIRECT: number, // 16384
+    O_NONBLOCK: number, // 2048
+    S_IRWXU: number, // 448
+    S_IRUSR: number, // 256
+    S_IWUSR: number, // 128
+    S_IXUSR: number, // 64
+    S_IRWXG: number, // 56
+    S_IRGRP: number, // 32
+    S_IWGRP: number, // 16
+    S_IXGRP: number, // 8
+    S_IRWXO: number, // 7
+    S_IROTH: number, // 4
+    S_IWOTH: number, // 2
+    S_IXOTH: number, // 1
+  };
 }
 
 declare class http$IncomingMessage extends stream$Readable {


### PR DESCRIPTION
The first commit  modified `mode?:  any` to `mode?: number` for both of `4.x` and `6.x`.

Second commit is for `6.x`. add a new var [`constants`](https://nodejs.org/dist/latest-v6.x/docs/api/fs.html#fs_fs_constants_1) for node 6.x. ( Seems the constansts of fs are collected to `constants` from 6.x). It will not make backward compatibility issues, since both of them are numbers. (`fs.F_OK == fs.constants.F_OK`).

Maybe in the future, when the node defs are separated by versions, we can use number literals to restrict the args.
