### PR TITLE
Add type safe version of `process.nextTick` w/args

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -1572,7 +1572,8 @@ declare class Process extends events$EventEmitter {
     heapTotal : number;
     heapUsed : number;
   };
-  nextTick(cb : Function) : void;
+  nextTick<A, B, C, D, E, F>(cb: (A, B, C, D, E, F) => mixed, A, B, C, D, E, F) : void;
+  nextTick(cb : Function, ...Array<void>) : void;
   pid : number;
   platform : string;
   release : {


### PR DESCRIPTION
Adds a type safe version for calls to `process.nextTick` with a function with known parameter types, and passed arguments. Works for functions that take up to six arguments.

E.g.:

```js
function repeat(what: string, n: number): string {
  return Array(n + 1).join(what);
}

process.nextTick(repeat, 'foo', 3); // passes
process.nextTick((a, b) => {}, 1); // passes, unknown types
process.nextTick(repeat, 123, 2); // fails, `123` has the wrong type
```

The `...Array<void>` technique has been taken [from the flow docs](https://flowtype.org/docs/functions.html#too-many-arguments)