### PR TITLE
Add vendor specific properties for Error

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -447,6 +447,16 @@ declare class Error {
     stack: string;
     toString(): string;
 
+    // note: microsoft only
+    description?: string;
+    number?: number;
+
+    // note: mozilla only
+    fileName?: string;
+    lineNumber?: number;
+    columnNumber?: number;
+    stack?: string
+
     // note: v8 only (node/chrome)
     static captureStackTrace(target: Object, constructor?: Function): void;
 


### PR DESCRIPTION
Note sure this is wanted but since the v8 specific `captureStackTrace` is already there, this PR fills out the other vendor-specific properties of `Error`.