### PR TITLE
Add emoji to server status messages

### DIFF
--- a/js/unix.js
+++ b/js/unix.js
@@ -48,6 +48,11 @@ function unix_fork() {
   throw new Error('unix_fork: not implemented in JS');
 }
 
+//Provides: unix_isatty const
+function unix_isatty() {
+  return false;
+}
+
 //Provides: unix_kill
 function unix_kill() {
   throw new Error('unix_kill: not implemented in JS');

--- a/src/commands/commandConnect.ml
+++ b/src/commands/commandConnect.ml
@@ -60,24 +60,25 @@ let is_valid_line s =
 
 let msg_of_tail env tail_env =
   let line = Tail.last_line tail_env in
+  let use_emoji = env.emoji && Utils_js.can_emoji in
   if matches_re parsing_re line then
     Printf.sprintf "[%sparsing]"
-      (if env.emoji then (* Ghost *) "\xf0\x9f\x91\xbb  " else "")
+      (if use_emoji then (* Ghost *) "\xf0\x9f\x91\xbb  " else "")
   else if matches_re infer_re line then
     Printf.sprintf "[%slocal inference]"
-      (if env.emoji then (* Turtle *) "\xf0\x9f\x90\xa2  " else "")
+      (if use_emoji then (* Turtle *) "\xf0\x9f\x90\xa2  " else "")
   else if matches_re calc_deps_re line then
     Printf.sprintf "[%scalculating dependencies]"
-      (if env.emoji then (* Taco *) "\xf0\x9f\x8c\xae  " else "")
+      (if use_emoji then (* Taco *) "\xf0\x9f\x8c\xae  " else "")
   else if matches_re merging_re line then
     Printf.sprintf "[%smerging inference]"
-      (if env.emoji then (* Snail *) "\xf0\x9f\x90\x8c  " else "")
+      (if use_emoji then (* Snail *) "\xf0\x9f\x90\x8c  " else "")
   else if matches_re server_ready_re line then
     Printf.sprintf "[%sserver is ready]"
-      (if env.emoji then (* Unicorn Face *) "\xf0\x9f\xa6\x84  " else "")
+      (if use_emoji then (* Unicorn Face *) "\xf0\x9f\xa6\x84  " else "")
   else
     Printf.sprintf "[%sprocessing]"
-      (if env.emoji then (* Panda Face *) "\xf0\x9f\x90\xbc  " else "")
+      (if use_emoji then (* Panda Face *) "\xf0\x9f\x90\xbc  " else "")
 
 let arg name value arr = match value with
 | None -> arr

--- a/src/commands/commandConnect.ml
+++ b/src/commands/commandConnect.ml
@@ -24,6 +24,7 @@ type env = {
   shm_log_level : int option;
   log_file : string;
   ignore_version : bool;
+  emoji : bool;
   quiet : bool;
 }
 
@@ -57,20 +58,26 @@ let is_valid_line s =
   List.exists (fun re -> matches_re re s) re_list
 
 
-let msg_of_tail tail_env =
+let msg_of_tail env tail_env =
   let line = Tail.last_line tail_env in
   if matches_re parsing_re line then
-    "[parsing]"
+    Printf.sprintf "[%sparsing]"
+      (if env.emoji then (* Ghost *) "\xf0\x9f\x91\xbb  " else "")
   else if matches_re infer_re line then
-    "[local inference]"
+    Printf.sprintf "[%slocal inference]"
+      (if env.emoji then (* Turtle *) "\xf0\x9f\x90\xa2  " else "")
   else if matches_re calc_deps_re line then
-    "[calculating dependencies]"
+    Printf.sprintf "[%scalculating dependencies]"
+      (if env.emoji then (* Taco *) "\xf0\x9f\x8c\xae  " else "")
   else if matches_re merging_re line then
-    "[merging inference]"
+    Printf.sprintf "[%smerging inference]"
+      (if env.emoji then (* Snail *) "\xf0\x9f\x90\x8c  " else "")
   else if matches_re server_ready_re line then
-    "[server is ready]"
+    Printf.sprintf "[%sserver is ready]"
+      (if env.emoji then (* Unicorn Face *) "\xf0\x9f\xa6\x84  " else "")
   else
-    "[processing]"
+    Printf.sprintf "[%sprocessing]"
+      (if env.emoji then (* Panda Face *) "\xf0\x9f\x90\xbc  " else "")
 
 let arg name value arr = match value with
 | None -> arr
@@ -181,7 +188,7 @@ let rec connect env retries start_time tail_env =
   end;
   Tail.update_env is_valid_line tail_env;
   Tail.set_lines tail_env [];
-  let tail_msg = msg_of_tail tail_env in
+  let tail_msg = msg_of_tail env tail_env in
 
   if Tty.spinner_used () then Tty.print_clear_line stderr;
   let retries = reset_retries_if_necessary retries conn in

--- a/src/commands/commandUtils.ml
+++ b/src/commands/commandUtils.ml
@@ -372,6 +372,7 @@ let connect server_flags root =
     shm_log_level = server_flags.shm_log_level;
     log_file;
     ignore_version = server_flags.ignore_version;
+    emoji = config_options.FlowConfig.Opts.emoji;
     quiet = server_flags.quiet;
   } in
   CommandConnect.connect env

--- a/src/common/flowConfig.ml
+++ b/src/common/flowConfig.ml
@@ -42,6 +42,7 @@ module Opts = struct
   type moduleSystem = Node | Haste
 
   type t = {
+    emoji: bool;
     enable_const_params: bool;
     enable_unsafe_getters_and_setters: bool;
     enforce_strict_type_args: bool;
@@ -138,6 +139,7 @@ module Opts = struct
     |> SSet.add ".webm"
 
   let default_options = {
+    emoji = false;
     enable_const_params = false;
     enable_unsafe_getters_and_setters = false;
     enforce_strict_type_args = true;
@@ -390,6 +392,15 @@ let parse_ignores config lines =
 let parse_options config lines =
   let open Opts in
   let options = parse config.options lines
+    |> define_opt "emoji" {
+      _initializer = USE_DEFAULT;
+      flags = [];
+      optparser = optparse_boolean;
+      setter = (fun opts v ->
+        {opts with emoji = v;}
+      );
+    }
+
     |> define_opt "esproposal.class_instance_fields" {
       _initializer = USE_DEFAULT;
       flags = [];

--- a/src/common/flowConfig.mli
+++ b/src/common/flowConfig.mli
@@ -11,6 +11,7 @@
 module Opts : sig
   type moduleSystem = Node | Haste
   type t = {
+    emoji: bool;
     enable_const_params: bool;
     enable_unsafe_getters_and_setters: bool;
     enforce_strict_type_args: bool;

--- a/src/common/utils_js.ml
+++ b/src/common/utils_js.ml
@@ -14,6 +14,12 @@ let spf = Printf.sprintf
 let print_endlinef fmt = Printf.ksprintf print_endline fmt
 let prerr_endlinef fmt = Printf.ksprintf prerr_endline fmt
 
+(* See https://github.com/yarnpkg/yarn/issues/405. *)
+let can_emoji =
+  Sys.os_type <> "Win32" &&
+  Unix.isatty Unix.stdout &&
+  Sys.getenv "TERM" <> "dumb"
+
 (* JSON numbers must not end in a `.`, but string_of_float returns things like
    `1.` instead of `1.0`, so we want to truncate the `.` *)
 (* TODO: ocaml's string_of_float in general differs from JavaScript's. once

--- a/website/docs/02-advanced-configuration.md
+++ b/website/docs/02-advanced-configuration.md
@@ -110,6 +110,9 @@ pairs. Any options that are omitted will use their default values. Some options
 can be overridden with command line flags.
 
 - `log.file` (string): the path to the log file (defaults to `/tmp/flow/<escaped root path>.log`)
+
+- `emoji` (boolean): set this to `true` and Flow will use emoji in server status messages. The default value is `false`.
+
 - `module.name_mapper` (regex -> string): specify a regular expression to match against module names, and a replacement pattern, separated by a `->`.
 
   For example:


### PR DESCRIPTION
This change adds emoji to the various server status messages printed by flow. These messages are usually seen in square brackets with labels like "parsing" or "merging inference". The new behavior is configurable via the `emoji` option in `.flowconfig`, but will only be used in non-Windows platforms. It's disabled by default, so to opt-in you must add:

```
[options]
emoji=true
```

![flow-emoji](https://cloud.githubusercontent.com/assets/830952/21086430/895c245e-bfea-11e6-8b92-d1c85268bd46.gif)


Test plan (on a Mac):

* `make test`
* Started `flow` with an empty flowconfig and didn't see emoji.
* Started `flow` with a `.flowconfig` that had `emoji=true` under `[options]`, and saw emoji.
* Made a js change after the flow server had started, ran `flow` again, and saw the appropriate emoji given the config.
* Ran `flow | cat` with emoji enabled and didn't see any emoji.
* `make js` and `node -p 'require("./bin/flow.js").checkContent("-", "// @flow\n(1: string);")'` - this showed the correct error.