### PR TITLE
Mark defaultProps as covariant in React libs

### DIFF
--- a/lib/react.js
+++ b/lib/react.js
@@ -16,7 +16,7 @@
 declare class React$Component<DefaultProps, Props, State> {
   // fields
 
-  static defaultProps: $Abstract<DefaultProps>;
+  static +defaultProps: $Abstract<DefaultProps>;
   props: Props;
   state: $Abstract<State>;
 

--- a/tests/react_defaultProps/.flowconfig
+++ b/tests/react_defaultProps/.flowconfig
@@ -1,0 +1,2 @@
+[options]
+unsafe.enable_getters_and_setters=true

--- a/tests/react_defaultProps/react_defaultProps.exp
+++ b/tests/react_defaultProps/react_defaultProps.exp
@@ -1,0 +1,1 @@
+Found 0 errors

--- a/tests/react_defaultProps/test.js
+++ b/tests/react_defaultProps/test.js
@@ -1,0 +1,35 @@
+/* @flow */
+
+import React from 'react';
+
+type DefaultProps = {
+    foo: number
+}
+
+class OnlyGetter extends React.Component {
+    static get defaultProps(): DefaultProps {
+        return {
+            foo: 3
+        }
+    }
+}
+
+
+class GetterAndSetter extends React.Component {
+    static set defaultProps(props: DefaultProps) {
+        // do nothing
+    }
+
+    static get defaultProps(): DefaultProps {
+        return {
+            foo: 3
+        }
+    }
+}
+
+
+class StaticDefaultProps extends React.Component {
+    static defaultProps: DefaultProps = {
+        foo: 3
+    }
+}

--- a/tests/react_defaultProps/test.js
+++ b/tests/react_defaultProps/test.js
@@ -33,3 +33,11 @@ class StaticDefaultProps extends React.Component {
         foo: 3
     }
 }
+
+class LaterDefaultProps extends React.Component {
+    static defaultProps: DefaultProps
+}
+
+LaterDefaultProps.defaultProps = {
+    foo: 3
+}


### PR DESCRIPTION
This is so we don't have to include a dummy setter to satisfy Flow when using a getter to dynamically construct defaultProps

This resolves #3008, avoiding the `Covariant property `defaultProps` incompatible with invariant use in statics of React$Component` error and adds a test to ensure that future getters for defaultProps will typecheck properly.