### PR TITLE
Support computed properties for instances.

### DIFF
--- a/src/common/reason.ml
+++ b/src/common/reason.ml
@@ -67,6 +67,7 @@ type reason_desc =
   | RObjectLit
   | RObjectType
   | RObjectClassName
+  | RObjectIndexer
   | RArray
   | RArrayLit
   | REmptyArrayLit
@@ -358,6 +359,7 @@ let rec string_of_desc = function
   | RObjectLit -> "object literal"
   | RObjectType -> "object type"
   | RObjectClassName -> "Object"
+  | RObjectIndexer -> "object indexer"
   | RArray -> "array"
   | RArrayLit -> "array literal"
   | REmptyArrayLit -> "empty array literal"

--- a/src/common/reason.mli
+++ b/src/common/reason.mli
@@ -19,6 +19,7 @@ type reason_desc =
   | RObjectLit
   | RObjectType
   | RObjectClassName
+  | RObjectIndexer
   | RArray
   | RArrayLit
   | REmptyArrayLit

--- a/tests/computed_props/computed_props.exp
+++ b/tests/computed_props/computed_props.exp
@@ -1,3 +1,63 @@
+instance.js:8
+  8:   [index: number]: () => string;
+                              ^^^^^^ string. This type is incompatible with
+ 35: (sub[num]: () => bool);
+                      ^^^^ boolean
+
+instance.js:26
+ 26: (sub['x']: string); // string ~> number
+      ^^^^^^^^ number. This type is incompatible with
+ 26: (sub['x']: string); // string ~> number
+                ^^^^^^ string
+
+instance.js:29
+ 29: (sub['meth'](): string); // string ~> number
+      ^^^^^^^^^^^^^ number. This type is incompatible with
+ 29: (sub['meth'](): string); // string ~> number
+                     ^^^^^^ string
+
+instance.js:36
+ 36: (sub[num](): bool); // string ~> bool
+      ^^^^^^^^^^ string. This type is incompatible with
+ 36: (sub[num](): bool); // string ~> bool
+                  ^^^^ boolean
+
+instance.js:39
+ 39: (sub.a: () => string); // key: string ~> number
+      ^^^^^ property `a` is a string. This type is incompatible with
+  8:   [index: number]: () => string;
+               ^^^^^^ number
+
+instance.js:40
+ 40: (sub['a']: () => string); // key: string ~> number
+      ^^^^^^^^ property `a` is a string. This type is incompatible with
+  8:   [index: number]: () => string;
+               ^^^^^^ number
+
+instance.js:41
+ 41: (sub[true](): () => bool); // key: bool ~> number, value: bool ~> string
+      ^^^^^^^^^^^ string. This type is incompatible with
+ 41: (sub[true](): () => bool); // key: bool ~> number, value: bool ~> string
+                   ^^^^^^^^^^ function type
+
+instance.js:41
+ 41: (sub[true](): () => bool); // key: bool ~> number, value: bool ~> string
+          ^^^^ boolean. This type is incompatible with
+  8:   [index: number]: () => string;
+               ^^^^^^ number
+
+instance.js:46
+ 46: (map[num](): bool); // bool ~> string
+      ^^^^^^^^^^ string. This type is incompatible with
+ 46: (map[num](): bool); // bool ~> string
+                  ^^^^ boolean
+
+instance.js:50
+ 50: map[0] = () => 1; // number ~> string
+                    ^ number. This type is incompatible with
+  8:   [index: number]: () => string;
+                              ^^^^^^ string
+
 test.js:19
  19: (ColorIdToNumber[ColorId.RED]: 'ffffff'); // oops
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string. Expected string literal `ffffff`, got `ff0000` instead
@@ -41,4 +101,4 @@ test7.js:5
             ^^^^^^ string
 
 
-Found 7 errors
+Found 17 errors

--- a/tests/computed_props/instance.js
+++ b/tests/computed_props/instance.js
@@ -1,0 +1,50 @@
+// @flow
+
+declare class Parent {
+  top: true;
+}
+
+declare class Map extends Parent {
+  [index: number]: () => string;
+}
+
+declare class Sub extends Map {
+  x: number;
+  meth(): number;
+}
+
+declare var map: Map;
+declare var sub: Sub;
+declare var str: string;
+declare var num: number;
+
+// Lookup prop in parent classes before the dict
+(sub.top: true);
+(sub['top']: true);
+
+(sub['x']: number);
+(sub['x']: string); // string ~> number
+
+(sub['meth'](): number);
+(sub['meth'](): string); // string ~> number
+
+// Correct key type
+(sub[num]: () => any);
+(sub[123]: () => string);
+(sub[num](): string);
+(sub[num]: () => bool);
+(sub[num](): bool); // string ~> bool
+
+// Incorrect key type
+(sub.a: () => string); // key: string ~> number
+(sub['a']: () => string); // key: string ~> number
+(sub[true](): () => bool); // key: bool ~> number, value: bool ~> string
+
+// Indexer on class (not parent)
+(map[num]: () => string);
+(map[1](): string);
+(map[num](): bool); // bool ~> string
+
+// Write prop
+map[0] = () => '';
+map[0] = () => 1; // number ~> string

--- a/tests/refinements/refinements.exp
+++ b/tests/refinements/refinements.exp
@@ -718,6 +718,12 @@ tagged_union.js:100
 
 tagged_union.js:109
 109:     if (x.legnth === 0) {} // error, typo
+             ^^^^^^^^ property `legnth` is a string. This type is incompatible with
+228:     [key: number]: T;
+               ^^^^^^ number. See lib: <BUILTINS>/core.js:228
+
+tagged_union.js:109
+109:     if (x.legnth === 0) {} // error, typo
                ^^^^^^ property `legnth`. Property not found in
 109:     if (x.legnth === 0) {} // error, typo
              ^ Array
@@ -887,4 +893,4 @@ void.js:85
            ^^^^^^ undefined. The operand of an arithmetic operation must be a number.
 
 
-Found 153 errors
+Found 154 errors


### PR DESCRIPTION
This is needed before #2952 can be merged.

Lookup rules:
1. If prop is a string literal (either computed or named), we look it up the prototype chain.
2. If class has an indexer, we add it to `try_ts_on_failure` of `LookupT` (only if there is no indexer queued yet, we distinguish by the reason `RObjectIndexer`).

We can't check indexer earlier because some classes like node's `Buffer` define indexer but has a parent class.

If this PR works, we can get rid of `$key` and `$value` props and use `dicttype` like in `ObjT`.

cc @samwgoldman 