### PR TITLE
Fix Element type's requestFullscreen

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -941,7 +941,7 @@ declare class Element extends Node {
   removeAttribute(name?: string): void;
   removeAttributeNode(attributeNode: Attr): Attr;
   removeAttributeNS(namespaceURI: string | null, localName: string): void;
-  requestFullscren(): void;
+  requestFullscreen(): void;
   requestPointerLock(): void;
   scrollIntoView(arg?: (boolean | { behavior?: ('auto' | 'instant' | 'smooth'), block?: ('start' | 'end') })): void;
   setAttribute(name?: string, value?: string): void;


### PR DESCRIPTION
This fixes a typo found in #3017.

Changing `requestFullscren` to `requestFullscreen`.