### PR TITLE
Add overload for setState to support function as argument

### DIFF
--- a/lib/react.js
+++ b/lib/react.js
@@ -22,8 +22,8 @@ declare class React$Component<DefaultProps, Props, State> {
 
   // action methods
 
-  // TODO: partialState could be a function as well
   setState(partialState: $Shape<State>, callback?: () => mixed): void;
+  setState(mapState: (prevState: State, props: Props ) => $Shape<State>, callback?: () => mixed): void;
 
   forceUpdate(callback?: () => void): void;
 

--- a/tests/new_react/new_react.exp
+++ b/tests/new_react/new_react.exp
@@ -45,6 +45,12 @@ classes.js:25
   9:   state: State;
               ^^^^^ object type
 
+classes.js:25
+ 25:   setState(o: { y_: string }): void { }
+                   ^^^^^^^^^^^^^^ property `y_` of object type. Property not found in
+ 26:   setState(mapState: (prevState: State, props: Props ) => $Shape<State>, callback?: () => mixed): void;
+                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function type. See lib: <BUILTINS>/react.js:26
+
 classes.js:40
  40: Foo.defaultProps = 0;
      ^^^^^^^^^^^^^^^^ assignment of property `defaultProps`
@@ -83,6 +89,12 @@ classes.js:66
  63:     return { y: "" };
  64:   },
        ^ object type
+
+classes.js:66
+ 66:   setState(o: { y_: string }): void { },
+                   ^^^^^^^^^^^^^^ property `y_` of object type. Property not found in
+ 26:   setState(mapState: (prevState: State, props: Props ) => $Shape<State>, callback?: () => mixed): void;
+                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function type. See lib: <BUILTINS>/react.js:26
 
 classes.js:81
  81: var foo_legacy: $jsx<number> = <FooLegacy/>;
@@ -377,22 +389,53 @@ state3.js:13
  13:         this.setState({
  14:             x: false // error
  15:         })
-             -^ call of method `setState`
- 14:             x: false // error
-                    ^^^^^ boolean. This type is incompatible with
-  4:     getInitialState: function(): { x: string; } {
-                                           ^^^^^^ string
+             -^ call of method `setState`. Function cannot be called on any member of intersection type
+ 13:         this.setState({
+             ^^^^^^^^^^^^^ intersection
+  Member 1:
+   25:   setState(partialState: $Shape<State>, callback?: () => mixed): void;
+         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function type. See lib: <BUILTINS>/react.js:25
+  Error:
+   14:             x: false // error
+                      ^^^^^ boolean. This type is incompatible with
+    4:     getInitialState: function(): { x: string; } {
+                                             ^^^^^^ string
+  Member 2:
+   26:   setState(mapState: (prevState: State, props: Props ) => $Shape<State>, callback?: () => mixed): void;
+         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function type. See lib: <BUILTINS>/react.js:26
+  Error:
+   26:   setState(mapState: (prevState: State, props: Props ) => $Shape<State>, callback?: () => mixed): void;
+                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function type. Callable signature not found in. See lib: <BUILTINS>/react.js:26
+                             v
+   13:         this.setState({
+   14:             x: false // error
+   15:         })
+               ^ object literal
 
 state4.js:9
   9:     this.setState({ y: 0 });
-         ^^^^^^^^^^^^^^^^^^^^^^^ call of method `setState`
+         ^^^^^^^^^^^^^^^^^^^^^^^ call of method `setState`. Function cannot be called on any member of intersection type
   9:     this.setState({ y: 0 });
-                       ^^^^^^^^ property `y` of object literal. Property not found in
-                        v--------------------------
-  4:   getInitialState: function(): { x: number } {
-  5:     return { x: 0 };
-  6:   },
-       ^ object type
+         ^^^^^^^^^^^^^ intersection
+  Member 1:
+   25:   setState(partialState: $Shape<State>, callback?: () => mixed): void;
+         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function type. See lib: <BUILTINS>/react.js:25
+  Error:
+    9:     this.setState({ y: 0 });
+                         ^^^^^^^^ property `y` of object literal. Property not found in
+                          v--------------------------
+    4:   getInitialState: function(): { x: number } {
+    5:     return { x: 0 };
+    6:   },
+         ^ object type
+  Member 2:
+   26:   setState(mapState: (prevState: State, props: Props ) => $Shape<State>, callback?: () => mixed): void;
+         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function type. See lib: <BUILTINS>/react.js:26
+  Error:
+   26:   setState(mapState: (prevState: State, props: Props ) => $Shape<State>, callback?: () => mixed): void;
+                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function type. Callable signature not found in. See lib: <BUILTINS>/react.js:26
+    9:     this.setState({ y: 0 });
+                         ^^^^^^^^ object literal
 
 state4.js:10
  10:     return <div>{this.state.z}</div>
@@ -407,4 +450,4 @@ state5.js:5
                 ^^^^^^^^^^ undefined. Did you forget to declare type parameter `State` of property `Component`?
 
 
-Found 50 errors
+Found 52 errors

--- a/tests/react/react.exp
+++ b/tests/react/react.exp
@@ -257,14 +257,28 @@ create_class_initial_state_sealed.js:35
 
 create_class_initial_state_sealed.js:45
  45:     this.setState({ q: 0 }); // property `q` not found
-         ^^^^^^^^^^^^^^^^^^^^^^^ call of method `setState`
+         ^^^^^^^^^^^^^^^^^^^^^^^ call of method `setState`. Function cannot be called on any member of intersection type
  45:     this.setState({ q: 0 }); // property `q` not found
-                       ^^^^^^^^ property `q` of object literal. Property not found in
-                      v------------------
- 41:   getInitialState(): { p: number } {
- 42:     return { p: 0 };
- 43:   },
-       ^ object type
+         ^^^^^^^^^^^^^ intersection
+  Member 1:
+   25:   setState(partialState: $Shape<State>, callback?: () => mixed): void;
+         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function type. See lib: <BUILTINS>/react.js:25
+  Error:
+   45:     this.setState({ q: 0 }); // property `q` not found
+                         ^^^^^^^^ property `q` of object literal. Property not found in
+                        v------------------
+   41:   getInitialState(): { p: number } {
+   42:     return { p: 0 };
+   43:   },
+         ^ object type
+  Member 2:
+   26:   setState(mapState: (prevState: State, props: Props ) => $Shape<State>, callback?: () => mixed): void;
+         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function type. See lib: <BUILTINS>/react.js:26
+  Error:
+   26:   setState(mapState: (prevState: State, props: Props ) => $Shape<State>, callback?: () => mixed): void;
+                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function type. Callable signature not found in. See lib: <BUILTINS>/react.js:26
+   45:     this.setState({ q: 0 }); // property `q` not found
+                         ^^^^^^^^ object literal
 
 create_class_initial_state_sealed.js:48
  48:     (this.state.q: empty); // property `q` not found
@@ -280,14 +294,28 @@ create_class_initial_state_sealed.js:66
 
 create_class_initial_state_sealed.js:81
  81:     this.setState({ baz: 0 }); // property `baz`  not found
-         ^^^^^^^^^^^^^^^^^^^^^^^^^ call of method `setState`
+         ^^^^^^^^^^^^^^^^^^^^^^^^^ call of method `setState`. Function cannot be called on any member of intersection type
  81:     this.setState({ baz: 0 }); // property `baz`  not found
-                       ^^^^^^^^^^ property `baz` of object literal. Property not found in
-                        v--------------------
- 73:     getInitialState(): { foo: number } {
- 74:       return { foo: 0 };
- 75:     },
-         ^ object type
+         ^^^^^^^^^^^^^ intersection
+  Member 1:
+   25:   setState(partialState: $Shape<State>, callback?: () => mixed): void;
+         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function type. See lib: <BUILTINS>/react.js:25
+  Error:
+   81:     this.setState({ baz: 0 }); // property `baz`  not found
+                         ^^^^^^^^^^ property `baz` of object literal. Property not found in
+                          v--------------------
+   73:     getInitialState(): { foo: number } {
+   74:       return { foo: 0 };
+   75:     },
+           ^ object type
+  Member 2:
+   26:   setState(mapState: (prevState: State, props: Props ) => $Shape<State>, callback?: () => mixed): void;
+         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function type. See lib: <BUILTINS>/react.js:26
+  Error:
+   26:   setState(mapState: (prevState: State, props: Props ) => $Shape<State>, callback?: () => mixed): void;
+                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function type. Callable signature not found in. See lib: <BUILTINS>/react.js:26
+   81:     this.setState({ baz: 0 }); // property `baz`  not found
+                         ^^^^^^^^^^ object literal
 
 create_class_initial_state_sealed.js:84
  84:     (this.state.baz: empty); // property `baz` not found


### PR DESCRIPTION
Hi! I'm a junior developer and this is my first open source PR so please be gentle.

I have updated setState so that it can also take a function as per the React.js docs: https://facebook.github.io/react/docs/state-and-lifecycle.html

I'm not sure if I should add another test scenario to catch this change or if updating the test expectations as I have done is enough.

