### PR TITLE
[RFC] Use ocp-build + watchman for oss build.

### DIFF
--- a/.merlin
+++ b/.merlin
@@ -1,4 +1,4 @@
 S hack/**
 S src/**
 
-B _build/**
+B _obuild/*

--- a/Makefile
+++ b/Makefile
@@ -103,6 +103,15 @@ OCP_BUILD_FILES=\
   ocp_build_flow.ocp\
   ocp_build_hack.ocp
 
+WATCH_FILES=\
+  'Makefile'\
+  'src/**/*.ml'\
+  'src/**/*.mli'\
+  'src/**/*.mll'\
+  'src/**/*.mly'\
+  'hack/**/*.ml'\
+  'hack/**/*.mli'
+
 FILES_TO_COPY=\
   $(wildcard lib/*.js)
 
@@ -171,6 +180,15 @@ build-flow-debug: $(BUILT_OBJECT_FILES) $(FLOWLIB)
 	ocamlbuild -lflags -custom -no-links $(INCLUDE_OPTS) $(LIB_OPTS) -lflags "$(LINKER_FLAGS)" src/flow.d.byte
 	mkdir -p bin
 	cp _build/src/flow.d.byte bin/flow
+
+fast-build: $(OCP_BUILD_FILES) hack/utils/get_build_id.gen.c
+	[ -d _obuild ] || ocp-build init
+	ocp-build make flow -njobs 8 -byte flow
+	rm -f $(OCP_BUILD_FILES)
+	cp _obuild/flow/flow.byte bin/flow
+
+watchman: fast-build
+	watchman-make -p $(WATCH_FILES) -t fast-build
 
 %.h: $(subst _build/,,$@)
 	mkdir -p $(dir $@)

--- a/Makefile
+++ b/Makefile
@@ -181,7 +181,7 @@ build-flow-debug: $(BUILT_OBJECT_FILES) $(FLOWLIB)
 	mkdir -p bin
 	cp _build/src/flow.d.byte bin/flow
 
-fast-build: $(OCP_BUILD_FILES) hack/utils/get_build_id.gen.c
+fast-build: $(OCP_BUILD_FILES) random-build-id
 	[ -d _obuild ] || ocp-build init
 	ocp-build make flow -njobs 8 -byte flow
 	rm -f $(OCP_BUILD_FILES)
@@ -204,6 +204,10 @@ $(BUILT_OBJECT_FILES): %.o: %.c $(ALL_HEADER_FILES)
 
 hack/utils/get_build_id.gen.c: FORCE scripts/utils.ml scripts/gen_build_id.ml
 	ocaml -I scripts -w -3 unix.cma scripts/gen_build_id.ml $@
+
+random-build-id: FORCE scripts/utils.ml scripts/gen_build_id.ml
+	ocaml -I scripts -w -3 unix.cma scripts/gen_build_id.ml\
+	  hack/utils/get_build_id.gen.c random
 
 _build/hack/utils/get_build_id.gen.c: FORCE scripts/utils.ml scripts/gen_build_id.ml
 	ocaml -I scripts -w -3 unix.cma scripts/gen_build_id.ml $@

--- a/scripts/gen_build_id.ml
+++ b/scripts/gen_build_id.ml
@@ -23,11 +23,15 @@
  *)
 let () =
   let out_file = Sys.argv.(1) in
-  let rev =
-    try read_process_output "git" [|"git"; "rev-parse"; "HEAD"|]
-    with Failure _ ->
-      try read_process_output "hg" [|"hg"; "id"; "-i"|]
-      with Failure _ -> ""
+  let rev = if (Array.length Sys.argv) > 2 && Sys.argv.(2) = "random"
+    then begin
+      Random.self_init ();
+      Random.bits () |> string_of_int
+    end else
+      try read_process_output "git" [|"git"; "rev-parse"; "HEAD"|]
+      with Failure _ ->
+        try read_process_output "hg" [|"hg"; "id"; "-i"|]
+        with Failure _ -> ""
   in
   let time =
     try read_process_output "git" [|"git"; "log"; "-1"; "--pretty=tformat:%ct"|]


### PR DESCRIPTION
How about building with ocp-build by default? It's much faster and is the same build system as in travis.

Timings on my machine after touching `statement.ml`:
- `make fast-build` - 1.5s
- `make build-flow-debug` - 6.5s

Also, I think it would be convenient to have a watch command. So I added it via watchman.

If you are ok with this, I'll add docs and can remove building with ocamlbuild.

Related: #1106