### PR TITLE
Update handling of JSXText to trim and filter empty text

### DIFF
--- a/hack/utils/string_utils.ml
+++ b/hack/utils/string_utils.ml
@@ -91,3 +91,44 @@ let rec is_not_lowercase str i j =
   if is_lowercase_char str.[i] then false
   else if i = j then true
   else is_not_lowercase str (i + 1) j
+
+(* String provides map and iter but not fold. It also is missing a char_list_of
+ * function. Oh well. You can use fold to simulate anything you need, I suppose
+ *)
+let fold_left ~f ~acc str =
+  let acc = ref acc in
+  String.iter (fun c -> acc := f (!acc) c) str;
+  !acc
+
+(* Replaces all instances of the needle character with the replacement character
+ *)
+let replace_char needle replacement =
+  String.map (fun c -> if c = needle then replacement else c)
+
+(* Splits a string into a list of strings using "\n", "\r" or "\r\n" as
+ * delimeters. If the string starts or ends with a delimeter, there WILL be an
+ * empty string at the beginning or end of the list, like Str.split_delim does
+ *)
+let split_into_lines str =
+  (* Fold through the list and break the string into a reversed list of
+   * reversed char lists *)
+  let _, (partial, lines) = fold_left
+    ~f: (fun (idx, (partial, lines)) c ->
+      (* For \r\n, we've already processed the newline *)
+      if c = '\n' && idx > 0 && String.get str (idx-1) = '\r'
+      then idx+1, (partial, lines)
+      else
+        if c = '\n' || c = '\r'
+        then idx+1, ([], partial::lines)
+        else idx+1, (c::partial, lines))
+    ~acc: (0, ([], []))
+    str in
+
+  (* Reverse everything and turn the char lists into strings *)
+  List.fold_left (fun lines chars ->
+    let line = chars
+    |> List.rev
+    |> List.map (String.make 1)
+    |> String.concat "" in
+    line::lines
+  ) [] (partial::lines)

--- a/src/common/reason.ml
+++ b/src/common/reason.ml
@@ -82,6 +82,7 @@ type reason_desc =
   | RJSXIdentifier of string * string
   | RJSXElementProps of string
   | RJSXElement of string option
+  | RJSXText
   | RAnyObject
   | RAnyFunction
   | RUnknownString
@@ -377,6 +378,7 @@ let rec string_of_desc = function
     | Some x -> spf "JSX element `%s`" x
     | None -> "JSX element")
   | RJSXElementProps x -> spf "props of JSX element `%s`" x
+  | RJSXText -> spf "JSX text"
   | RAnyObject -> "any object"
   | RAnyFunction -> "any function"
   | RUnknownString -> "some string with unknown value"

--- a/src/common/reason.mli
+++ b/src/common/reason.mli
@@ -34,6 +34,7 @@ type reason_desc =
   | RJSXIdentifier of string * string
   | RJSXElementProps of string
   | RJSXElement of string option
+  | RJSXText
   | RAnyObject
   | RAnyFunction
   | RUnknownString

--- a/src/typing/statement.ml
+++ b/src/typing/statement.ml
@@ -3464,7 +3464,15 @@ and react_ignore_attribute aname =
 
 and jsx cx = Ast.JSX.(
   function { openingElement; children; _ } ->
-  jsx_title cx openingElement (List.map (jsx_body cx) children)
+  let children =
+    children
+    |> List.map (jsx_body cx)
+    |> List.fold_left (fun children -> function
+      | None -> children
+      | Some child -> child::children) []
+    |> List.rev in
+
+  jsx_title cx openingElement children
 )
 
 and jsx_title cx openingElement children = Ast.JSX.(
@@ -3672,17 +3680,86 @@ and jsx_pragma_expression cx raw_jsx_expr loc = Ast.Expression.(function
 )
 
 and jsx_body cx = Ast.JSX.(function
-  | _, Element e -> jsx cx e
+  | _, Element e -> Some (jsx cx e)
   | _, ExpressionContainer ec -> (
       let open ExpressionContainer in
       let { expression = ex } = ec in
-      match ex with
+      Some (match ex with
         | Expression (loc, e) -> expression cx (loc, e)
         | EmptyExpression loc ->
-          EmptyT (mk_reason (RCustom "empty jsx body") loc)
+          EmptyT (mk_reason (RCustom "empty jsx body") loc))
     )
-  | loc, Text _ -> StrT.at loc (* TODO: create StrT (..., Literal ...)) *)
+  | loc, Text { Text.value; raw=_; } -> jsx_trim_text loc value
 )
+
+(* This is hard for two main reasons:
+ *  1. We can't use Str
+ *  2. It's not enough to trim the text, we also need to figure out the line and
+ *     column for the start and end of the text
+*)
+and jsx_trim_text loc value =
+  let lines = String_utils.split_into_lines value in
+  let trimmed_lines = List.map String.trim lines in
+
+  (* Figure out the first and last non-empty line, if there are any *)
+  let _, first_and_last_non_empty =
+    List.fold_left
+      (fun (idx, first_and_last) line ->
+        let first_and_last =
+          if line <> ""
+          then match first_and_last with
+          | None -> Some (idx, idx)
+          | Some (first, _) -> Some (first, idx)
+          else first_and_last in
+        idx+1, first_and_last)
+      (0, None)
+      trimmed_lines in
+
+  match first_and_last_non_empty with
+  | None -> None
+  | Some (first_line, last_line) ->
+      let trimmed =
+        trimmed_lines
+        |> List.filter (fun line -> line <> "")
+        |> String.concat " "
+        |> String_utils.replace_char '\t' ' ' in
+
+      let open Loc in
+      let start_line = loc.start.line + first_line in
+      let end_line = loc.start.line + last_line in
+
+      (* We want to know the column and offset for the first and last
+       * non-whitespace characters. We can do that by figuring out what those
+       * characters are and using String.index and String.rindex to search for
+       * them *)
+      let first_trimmed_line = List.nth trimmed_lines first_line in
+      let last_trimmed_line = List.nth trimmed_lines last_line in
+      let first_char = String.get first_trimmed_line 0 in
+      let last_char =
+        String.get last_trimmed_line (String.length last_trimmed_line - 1) in
+
+      (* For column we just do a search within the line *)
+      let start_column = String.index (List.nth lines first_line) first_char in
+      let end_column = String.rindex (List.nth lines last_line) last_char + 1 in
+
+      (* For offset, we do a search in the whole JSXText string *)
+      let start_offset = loc.start.offset + (String.index value first_char) in
+      let end_offset = loc.start.offset + (String.rindex value last_char) + 1 in
+
+      let loc = { loc with
+        start = {
+          line = start_line;
+          column = start_column;
+          offset = start_offset;
+        };
+        _end = {
+          line = end_line;
+          column = end_column;
+          offset = end_offset;
+        };
+      } in
+      Some (StrT (mk_reason RJSXText loc, Type.Literal trimmed))
+
 
 (* Native support for React.PropTypes validation functions, which are
    interpreted as type annotations for React props. This strategy is reasonable


### PR DESCRIPTION
The recent support for the `// @jsx Foo` pragma exposed that Flow wasn't properly desugaring JSX.  `JSXText` children are preprocessed and filtered before being passed to `React.createElement` or the custom function. Using babel as reference, this is what should happen

* Each line of the `JSXText` is trimmed of whitespace
* Empty lines are removed
* Tabs are replaces with spaces
* The lines are joined together with spaces.

Furthermore, empty `JSXText` children are thrown away and are not passed to the function. So

```
<Foo> {true} </Foo>
```

is correctly parsed as having 3 children (`" "`, `true`, and `" "`), but should desugar to `React.createElement(Foo, null, true)`;