### PR TITLE
Add escape and friends

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -773,6 +773,9 @@ declare class DataView {
 declare function btoa(rawString: string): string;
 declare function atob(encodedString: string): string;
 
+declare function escape(str: string): string;
+declare function unescape(str: string): string;
+
 declare function clearInterval(intervalId?: number): void;
 declare function clearTimeout(timeoutId?: any): void;
 declare function setTimeout(callback: any, ms?: number, ...args: Array<any>): number;


### PR DESCRIPTION
This adds definitions for:

- `escape`
- `unescape`
- ~~`encodeURI`~~
- ~~`encodeURIComponent`~~
- ~~`decodeURI`~~
- ~~`decodeURIComponent`~~

Edit: Oops, never mind about `encodeURI*`/`decodeURI*`, those were already defined. `escape`/`unescape` where really missing though.