### PR TITLE
Improve lib def for WebSocket 'close', 'message' event handlers

### DIFF
--- a/lib/bom.js
+++ b/lib/bom.js
@@ -368,6 +368,11 @@ declare class CloseEvent extends Event {
     wasClean: boolean;
 }
 
+type MessageEventHandler = (event: MessageEvent) => mixed;
+type CloseEventHandler = (event: CloseEvent) => mixed;
+type MessageEventListener = {handleEvent: MessageEventHandler} | MessageEventHandler;
+type CloseEventListener = {handleEvent: CloseEventHandler} | CloseEventHandler;
+
 declare class WebSocket extends EventTarget {
     static CONNECTING: 0;
     static OPEN: 1;
@@ -379,8 +384,10 @@ declare class WebSocket extends EventTarget {
     bufferedAmount: number;
     onopen: (ev: Event) => any;
     extensions: string;
-    onmessage: (ev: MessageEvent) => any;
-    onclose: (ev: CloseEvent) => any;
+    addEventListener(type: 'message', listener: MessageEventListener): void;
+    addEventListener(type: 'close', listener: CloseEventListener): void;
+    onmessage: MessageEventHandler;
+    onclose: CloseEventHandler;
     onerror: (ev: Event) => any;
     binaryType: string;
     url: string;
@@ -395,7 +402,7 @@ declare class WebSocket extends EventTarget {
 declare class Worker extends EventTarget {
     constructor(stringUrl: string): void;
     onerror: (ev: Event) => any;
-    onmessage: (ev: MessageEvent) => any;
+    onmessage: MessageEventHandler;
     postMessage(message: any, ports?: any): void;
     terminate(): void;
 }

--- a/tests/fetch/fetch.exp
+++ b/tests/fetch/fetch.exp
@@ -1,106 +1,106 @@
 fetch.js:12
  12: const b: Promise<string> = fetch(myRequest); // incorrect
                       ^^^^^^ string. This type is incompatible with
-888: declare function fetch(input: string | Request, init?: RequestOptions): Promise<Response>;
-                                                                                     ^^^^^^^^ Response. See lib: <BUILTINS>/bom.js:888
+895: declare function fetch(input: string | Request, init?: RequestOptions): Promise<Response>;
+                                                                                     ^^^^^^^^ Response. See lib: <BUILTINS>/bom.js:895
 
 fetch.js:25
  25: const d: Promise<Blob> = fetch('image.png'); // incorrect
                       ^^^^ Blob. This type is incompatible with
-888: declare function fetch(input: string | Request, init?: RequestOptions): Promise<Response>;
-                                                                                     ^^^^^^^^ Response. See lib: <BUILTINS>/bom.js:888
+895: declare function fetch(input: string | Request, init?: RequestOptions): Promise<Response>;
+                                                                                     ^^^^^^^^ Response. See lib: <BUILTINS>/bom.js:895
 
 headers.js:3
   3: const a = new Headers("'Content-Type': 'image/jpeg'"); // not correct
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructor call
   3: const a = new Headers("'Content-Type': 'image/jpeg'"); // not correct
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string. This type is incompatible with
-781:     constructor(init?: HeadersInit): void;
-                            ^^^^^^^^^^^ union: Headers | object type. See lib: <BUILTINS>/bom.js:781
+788:     constructor(init?: HeadersInit): void;
+                            ^^^^^^^^^^^ union: Headers | object type. See lib: <BUILTINS>/bom.js:788
   Member 1:
-  774: type HeadersInit = Headers | {[key: string]: string};
-                          ^^^^^^^ Headers. See lib: <BUILTINS>/bom.js:774
+  781: type HeadersInit = Headers | {[key: string]: string};
+                          ^^^^^^^ Headers. See lib: <BUILTINS>/bom.js:781
   Error:
     3: const a = new Headers("'Content-Type': 'image/jpeg'"); // not correct
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string. This type is incompatible with
-  774: type HeadersInit = Headers | {[key: string]: string};
-                          ^^^^^^^ Headers. See lib: <BUILTINS>/bom.js:774
+  781: type HeadersInit = Headers | {[key: string]: string};
+                          ^^^^^^^ Headers. See lib: <BUILTINS>/bom.js:781
   Member 2:
-  774: type HeadersInit = Headers | {[key: string]: string};
-                                    ^^^^^^^^^^^^^^^^^^^^^^^ object type. See lib: <BUILTINS>/bom.js:774
+  781: type HeadersInit = Headers | {[key: string]: string};
+                                    ^^^^^^^^^^^^^^^^^^^^^^^ object type. See lib: <BUILTINS>/bom.js:781
   Error:
     3: const a = new Headers("'Content-Type': 'image/jpeg'"); // not correct
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string. This type is incompatible with
-  774: type HeadersInit = Headers | {[key: string]: string};
-                                    ^^^^^^^^^^^^^^^^^^^^^^^ object type. See lib: <BUILTINS>/bom.js:774
+  781: type HeadersInit = Headers | {[key: string]: string};
+                                    ^^^^^^^^^^^^^^^^^^^^^^^ object type. See lib: <BUILTINS>/bom.js:781
 
 headers.js:4
   4: const b = new Headers(['Content-Type', 'image/jpeg']); // not correct
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructor call
   4: const b = new Headers(['Content-Type', 'image/jpeg']); // not correct
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ array literal. This type is incompatible with
-781:     constructor(init?: HeadersInit): void;
-                            ^^^^^^^^^^^ union: Headers | object type. See lib: <BUILTINS>/bom.js:781
+788:     constructor(init?: HeadersInit): void;
+                            ^^^^^^^^^^^ union: Headers | object type. See lib: <BUILTINS>/bom.js:788
   Member 1:
-  774: type HeadersInit = Headers | {[key: string]: string};
-                          ^^^^^^^ Headers. See lib: <BUILTINS>/bom.js:774
+  781: type HeadersInit = Headers | {[key: string]: string};
+                          ^^^^^^^ Headers. See lib: <BUILTINS>/bom.js:781
   Error:
     4: const b = new Headers(['Content-Type', 'image/jpeg']); // not correct
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ array literal. This type is incompatible with
-  774: type HeadersInit = Headers | {[key: string]: string};
-                          ^^^^^^^ Headers. See lib: <BUILTINS>/bom.js:774
+  781: type HeadersInit = Headers | {[key: string]: string};
+                          ^^^^^^^ Headers. See lib: <BUILTINS>/bom.js:781
   Member 2:
-  774: type HeadersInit = Headers | {[key: string]: string};
-                                    ^^^^^^^^^^^^^^^^^^^^^^^ object type. See lib: <BUILTINS>/bom.js:774
+  781: type HeadersInit = Headers | {[key: string]: string};
+                                    ^^^^^^^^^^^^^^^^^^^^^^^ object type. See lib: <BUILTINS>/bom.js:781
   Error:
     4: const b = new Headers(['Content-Type', 'image/jpeg']); // not correct
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ array literal. This type is incompatible with
-  774: type HeadersInit = Headers | {[key: string]: string};
-                                    ^^^^^^^^^^^^^^^^^^^^^^^ object type. See lib: <BUILTINS>/bom.js:774
+  781: type HeadersInit = Headers | {[key: string]: string};
+                                    ^^^^^^^^^^^^^^^^^^^^^^^ object type. See lib: <BUILTINS>/bom.js:781
 
 headers.js:9
   9: e.append('Content-Type'); // not correct
      ^^^^^^^^^^^^^^^^^^^^^^^^ call of method `append`
   9: e.append('Content-Type'); // not correct
      ^^^^^^^^^^^^^^^^^^^^^^^^ undefined (too few arguments, expected default/rest parameters). This type is incompatible with
-782:     append(name: string, value: string): void;
-                                     ^^^^^^ string. See lib: <BUILTINS>/bom.js:782
+789:     append(name: string, value: string): void;
+                                     ^^^^^^ string. See lib: <BUILTINS>/bom.js:789
 
 headers.js:10
  10: e.append({'Content-Type', 'image/jpeg'}); // not correct
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call of method `append`
  10: e.append({'Content-Type', 'image/jpeg'}); // not correct
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ undefined (too few arguments, expected default/rest parameters). This type is incompatible with
-782:     append(name: string, value: string): void;
-                                     ^^^^^^ string. See lib: <BUILTINS>/bom.js:782
+789:     append(name: string, value: string): void;
+                                     ^^^^^^ string. See lib: <BUILTINS>/bom.js:789
 
 headers.js:10
  10: e.append({'Content-Type', 'image/jpeg'}); // not correct
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ object literal. This type is incompatible with the expected param type of
-782:     append(name: string, value: string): void;
-                      ^^^^^^ string. See lib: <BUILTINS>/bom.js:782
+789:     append(name: string, value: string): void;
+                      ^^^^^^ string. See lib: <BUILTINS>/bom.js:789
 
 headers.js:12
  12: e.set('Content-Type'); // not correct
      ^^^^^^^^^^^^^^^^^^^^^ call of method `set`
  12: e.set('Content-Type'); // not correct
      ^^^^^^^^^^^^^^^^^^^^^ undefined (too few arguments, expected default/rest parameters). This type is incompatible with
-789:     set(name: string, value: string): void;
-                                  ^^^^^^ string. See lib: <BUILTINS>/bom.js:789
+796:     set(name: string, value: string): void;
+                                  ^^^^^^ string. See lib: <BUILTINS>/bom.js:796
 
 headers.js:13
  13: e.set({'Content-Type', 'image/jpeg'}); // not correct
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call of method `set`
  13: e.set({'Content-Type', 'image/jpeg'}); // not correct
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ undefined (too few arguments, expected default/rest parameters). This type is incompatible with
-789:     set(name: string, value: string): void;
-                                  ^^^^^^ string. See lib: <BUILTINS>/bom.js:789
+796:     set(name: string, value: string): void;
+                                  ^^^^^^ string. See lib: <BUILTINS>/bom.js:796
 
 headers.js:13
  13: e.set({'Content-Type', 'image/jpeg'}); // not correct
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ object literal. This type is incompatible with the expected param type of
-789:     set(name: string, value: string): void;
-                   ^^^^^^ string. See lib: <BUILTINS>/bom.js:789
+796:     set(name: string, value: string): void;
+                   ^^^^^^ string. See lib: <BUILTINS>/bom.js:796
 
 headers.js:15
  15: const f: Headers = e.append('Content-Type', 'image/jpeg'); // not correct
@@ -119,449 +119,449 @@ request.js:2
                         ^^^^^^^^^^^^^ constructor call
   2: const a: Request = new Request(); // incorrect
                         ^^^^^^^^^^^^^ undefined (too few arguments, expected default/rest parameters). This type is incompatible with
-863:     constructor(input: string | Request, init?: RequestOptions): void;
-                            ^^^^^^^^^^^^^^^^ union: string | Request. See lib: <BUILTINS>/bom.js:863
+870:     constructor(input: string | Request, init?: RequestOptions): void;
+                            ^^^^^^^^^^^^^^^^ union: string | Request. See lib: <BUILTINS>/bom.js:870
   Member 1:
-  863:     constructor(input: string | Request, init?: RequestOptions): void;
-                              ^^^^^^ string. See lib: <BUILTINS>/bom.js:863
+  870:     constructor(input: string | Request, init?: RequestOptions): void;
+                              ^^^^^^ string. See lib: <BUILTINS>/bom.js:870
   Error:
     2: const a: Request = new Request(); // incorrect
                           ^^^^^^^^^^^^^ undefined (too few arguments, expected default/rest parameters). This type is incompatible with
-  863:     constructor(input: string | Request, init?: RequestOptions): void;
-                              ^^^^^^ string. See lib: <BUILTINS>/bom.js:863
+  870:     constructor(input: string | Request, init?: RequestOptions): void;
+                              ^^^^^^ string. See lib: <BUILTINS>/bom.js:870
   Member 2:
-  863:     constructor(input: string | Request, init?: RequestOptions): void;
-                                       ^^^^^^^ Request. See lib: <BUILTINS>/bom.js:863
+  870:     constructor(input: string | Request, init?: RequestOptions): void;
+                                       ^^^^^^^ Request. See lib: <BUILTINS>/bom.js:870
   Error:
     2: const a: Request = new Request(); // incorrect
                           ^^^^^^^^^^^^^ undefined (too few arguments, expected default/rest parameters). This type is incompatible with
-  863:     constructor(input: string | Request, init?: RequestOptions): void;
-                                       ^^^^^^^ Request. See lib: <BUILTINS>/bom.js:863
+  870:     constructor(input: string | Request, init?: RequestOptions): void;
+                                       ^^^^^^^ Request. See lib: <BUILTINS>/bom.js:870
 
 request.js:6
   6: const e: Request = new Request(b, c); // incorrect
                         ^^^^^^^^^^^^^^^^^ constructor call
 inconsistent use of library definitions
-868:     cache: CacheType;
-                ^^^^^^^^^ string enum. This type is incompatible with an argument type of. See lib: <BUILTINS>/bom.js:868
-820:     cache?: ?CacheType;
-                  ^^^^^^^^^ null. See lib: <BUILTINS>/bom.js:820
+875:     cache: CacheType;
+                ^^^^^^^^^ string enum. This type is incompatible with an argument type of. See lib: <BUILTINS>/bom.js:875
+827:     cache?: ?CacheType;
+                  ^^^^^^^^^ null. See lib: <BUILTINS>/bom.js:827
 
 request.js:6
   6: const e: Request = new Request(b, c); // incorrect
                         ^^^^^^^^^^^^^^^^^ constructor call
 inconsistent use of library definitions
-868:     cache: CacheType;
-                ^^^^^^^^^ string enum. This type is incompatible with an argument type of. See lib: <BUILTINS>/bom.js:868
-820:     cache?: ?CacheType;
-                  ^^^^^^^^^ undefined. See lib: <BUILTINS>/bom.js:820
+875:     cache: CacheType;
+                ^^^^^^^^^ string enum. This type is incompatible with an argument type of. See lib: <BUILTINS>/bom.js:875
+827:     cache?: ?CacheType;
+                  ^^^^^^^^^ undefined. See lib: <BUILTINS>/bom.js:827
 
 request.js:6
   6: const e: Request = new Request(b, c); // incorrect
                         ^^^^^^^^^^^^^^^^^ constructor call
 inconsistent use of library definitions
-869:     credentials: CredentialsType;
-                      ^^^^^^^^^^^^^^^ string enum. This type is incompatible with an argument type of. See lib: <BUILTINS>/bom.js:869
-821:     credentials?: ?CredentialsType;
-                        ^^^^^^^^^^^^^^^ null. See lib: <BUILTINS>/bom.js:821
+876:     credentials: CredentialsType;
+                      ^^^^^^^^^^^^^^^ string enum. This type is incompatible with an argument type of. See lib: <BUILTINS>/bom.js:876
+828:     credentials?: ?CredentialsType;
+                        ^^^^^^^^^^^^^^^ null. See lib: <BUILTINS>/bom.js:828
 
 request.js:6
   6: const e: Request = new Request(b, c); // incorrect
                         ^^^^^^^^^^^^^^^^^ constructor call
 inconsistent use of library definitions
-869:     credentials: CredentialsType;
-                      ^^^^^^^^^^^^^^^ string enum. This type is incompatible with an argument type of. See lib: <BUILTINS>/bom.js:869
-821:     credentials?: ?CredentialsType;
-                        ^^^^^^^^^^^^^^^ undefined. See lib: <BUILTINS>/bom.js:821
+876:     credentials: CredentialsType;
+                      ^^^^^^^^^^^^^^^ string enum. This type is incompatible with an argument type of. See lib: <BUILTINS>/bom.js:876
+828:     credentials?: ?CredentialsType;
+                        ^^^^^^^^^^^^^^^ undefined. See lib: <BUILTINS>/bom.js:828
 
 request.js:6
   6: const e: Request = new Request(b, c); // incorrect
                         ^^^^^^^^^^^^^^^^^ constructor call
 inconsistent use of library definitions
-870:     headers: Headers;
-                  ^^^^^^^ Headers. This type is incompatible with an argument type of. See lib: <BUILTINS>/bom.js:870
-822:     headers?: ?HeadersInit;
-                    ^^^^^^^^^^^ null. See lib: <BUILTINS>/bom.js:822
+877:     headers: Headers;
+                  ^^^^^^^ Headers. This type is incompatible with an argument type of. See lib: <BUILTINS>/bom.js:877
+829:     headers?: ?HeadersInit;
+                    ^^^^^^^^^^^ null. See lib: <BUILTINS>/bom.js:829
 
 request.js:6
   6: const e: Request = new Request(b, c); // incorrect
                         ^^^^^^^^^^^^^^^^^ constructor call
 inconsistent use of library definitions
-870:     headers: Headers;
-                  ^^^^^^^ Headers. This type is incompatible with an argument type of. See lib: <BUILTINS>/bom.js:870
-822:     headers?: ?HeadersInit;
-                    ^^^^^^^^^^^ object type. See lib: <BUILTINS>/bom.js:822
+877:     headers: Headers;
+                  ^^^^^^^ Headers. This type is incompatible with an argument type of. See lib: <BUILTINS>/bom.js:877
+829:     headers?: ?HeadersInit;
+                    ^^^^^^^^^^^ object type. See lib: <BUILTINS>/bom.js:829
 
 request.js:6
   6: const e: Request = new Request(b, c); // incorrect
                         ^^^^^^^^^^^^^^^^^ constructor call
 inconsistent use of library definitions
-870:     headers: Headers;
-                  ^^^^^^^ Headers. This type is incompatible with an argument type of. See lib: <BUILTINS>/bom.js:870
-822:     headers?: ?HeadersInit;
-                    ^^^^^^^^^^^ undefined. See lib: <BUILTINS>/bom.js:822
+877:     headers: Headers;
+                  ^^^^^^^ Headers. This type is incompatible with an argument type of. See lib: <BUILTINS>/bom.js:877
+829:     headers?: ?HeadersInit;
+                    ^^^^^^^^^^^ undefined. See lib: <BUILTINS>/bom.js:829
 
 request.js:6
   6: const e: Request = new Request(b, c); // incorrect
                         ^^^^^^^^^^^^^^^^^ constructor call
 inconsistent use of library definitions
-871:     integrity: string;
-                    ^^^^^^ string. This type is incompatible with an argument type of. See lib: <BUILTINS>/bom.js:871
-823:     integrity?: ?string;
-                      ^^^^^^ null. See lib: <BUILTINS>/bom.js:823
+878:     integrity: string;
+                    ^^^^^^ string. This type is incompatible with an argument type of. See lib: <BUILTINS>/bom.js:878
+830:     integrity?: ?string;
+                      ^^^^^^ null. See lib: <BUILTINS>/bom.js:830
 
 request.js:6
   6: const e: Request = new Request(b, c); // incorrect
                         ^^^^^^^^^^^^^^^^^ constructor call
 inconsistent use of library definitions
-871:     integrity: string;
-                    ^^^^^^ string. This type is incompatible with an argument type of. See lib: <BUILTINS>/bom.js:871
-823:     integrity?: ?string;
-                      ^^^^^^ undefined. See lib: <BUILTINS>/bom.js:823
+878:     integrity: string;
+                    ^^^^^^ string. This type is incompatible with an argument type of. See lib: <BUILTINS>/bom.js:878
+830:     integrity?: ?string;
+                      ^^^^^^ undefined. See lib: <BUILTINS>/bom.js:830
 
 request.js:6
   6: const e: Request = new Request(b, c); // incorrect
                         ^^^^^^^^^^^^^^^^^ constructor call
 inconsistent use of library definitions
-872:     method: MethodType;
-                 ^^^^^^^^^^ string enum. This type is incompatible with an argument type of. See lib: <BUILTINS>/bom.js:872
-824:     method?: ?MethodType;
-                   ^^^^^^^^^^ null. See lib: <BUILTINS>/bom.js:824
+879:     method: MethodType;
+                 ^^^^^^^^^^ string enum. This type is incompatible with an argument type of. See lib: <BUILTINS>/bom.js:879
+831:     method?: ?MethodType;
+                   ^^^^^^^^^^ null. See lib: <BUILTINS>/bom.js:831
 
 request.js:6
   6: const e: Request = new Request(b, c); // incorrect
                         ^^^^^^^^^^^^^^^^^ constructor call
 inconsistent use of library definitions
-872:     method: MethodType;
-                 ^^^^^^^^^^ string enum. This type is incompatible with an argument type of. See lib: <BUILTINS>/bom.js:872
-824:     method?: ?MethodType;
-                   ^^^^^^^^^^ undefined. See lib: <BUILTINS>/bom.js:824
+879:     method: MethodType;
+                 ^^^^^^^^^^ string enum. This type is incompatible with an argument type of. See lib: <BUILTINS>/bom.js:879
+831:     method?: ?MethodType;
+                   ^^^^^^^^^^ undefined. See lib: <BUILTINS>/bom.js:831
 
 request.js:6
   6: const e: Request = new Request(b, c); // incorrect
                         ^^^^^^^^^^^^^^^^^ constructor call
 inconsistent use of library definitions
-873:     mode: ModeType;
-               ^^^^^^^^ string enum. This type is incompatible with an argument type of. See lib: <BUILTINS>/bom.js:873
-825:     mode?: ?ModeType;
-                 ^^^^^^^^ null. See lib: <BUILTINS>/bom.js:825
+880:     mode: ModeType;
+               ^^^^^^^^ string enum. This type is incompatible with an argument type of. See lib: <BUILTINS>/bom.js:880
+832:     mode?: ?ModeType;
+                 ^^^^^^^^ null. See lib: <BUILTINS>/bom.js:832
 
 request.js:6
   6: const e: Request = new Request(b, c); // incorrect
                         ^^^^^^^^^^^^^^^^^ constructor call
 inconsistent use of library definitions
-873:     mode: ModeType;
-               ^^^^^^^^ string enum. This type is incompatible with an argument type of. See lib: <BUILTINS>/bom.js:873
-825:     mode?: ?ModeType;
-                 ^^^^^^^^ undefined. See lib: <BUILTINS>/bom.js:825
+880:     mode: ModeType;
+               ^^^^^^^^ string enum. This type is incompatible with an argument type of. See lib: <BUILTINS>/bom.js:880
+832:     mode?: ?ModeType;
+                 ^^^^^^^^ undefined. See lib: <BUILTINS>/bom.js:832
 
 request.js:6
   6: const e: Request = new Request(b, c); // incorrect
                         ^^^^^^^^^^^^^^^^^ constructor call
 inconsistent use of library definitions
-874:     redirect: RedirectType;
-                   ^^^^^^^^^^^^ string enum. This type is incompatible with an argument type of. See lib: <BUILTINS>/bom.js:874
-826:     redirect?: ?RedirectType;
-                     ^^^^^^^^^^^^ null. See lib: <BUILTINS>/bom.js:826
+881:     redirect: RedirectType;
+                   ^^^^^^^^^^^^ string enum. This type is incompatible with an argument type of. See lib: <BUILTINS>/bom.js:881
+833:     redirect?: ?RedirectType;
+                     ^^^^^^^^^^^^ null. See lib: <BUILTINS>/bom.js:833
 
 request.js:6
   6: const e: Request = new Request(b, c); // incorrect
                         ^^^^^^^^^^^^^^^^^ constructor call
 inconsistent use of library definitions
-874:     redirect: RedirectType;
-                   ^^^^^^^^^^^^ string enum. This type is incompatible with an argument type of. See lib: <BUILTINS>/bom.js:874
-826:     redirect?: ?RedirectType;
-                     ^^^^^^^^^^^^ undefined. See lib: <BUILTINS>/bom.js:826
+881:     redirect: RedirectType;
+                   ^^^^^^^^^^^^ string enum. This type is incompatible with an argument type of. See lib: <BUILTINS>/bom.js:881
+833:     redirect?: ?RedirectType;
+                     ^^^^^^^^^^^^ undefined. See lib: <BUILTINS>/bom.js:833
 
 request.js:6
   6: const e: Request = new Request(b, c); // incorrect
                         ^^^^^^^^^^^^^^^^^ constructor call
 inconsistent use of library definitions
-875:     referrer: string;
-                   ^^^^^^ string. This type is incompatible with an argument type of. See lib: <BUILTINS>/bom.js:875
-827:     referrer?: ?string;
-                     ^^^^^^ null. See lib: <BUILTINS>/bom.js:827
+882:     referrer: string;
+                   ^^^^^^ string. This type is incompatible with an argument type of. See lib: <BUILTINS>/bom.js:882
+834:     referrer?: ?string;
+                     ^^^^^^ null. See lib: <BUILTINS>/bom.js:834
 
 request.js:6
   6: const e: Request = new Request(b, c); // incorrect
                         ^^^^^^^^^^^^^^^^^ constructor call
 inconsistent use of library definitions
-875:     referrer: string;
-                   ^^^^^^ string. This type is incompatible with an argument type of. See lib: <BUILTINS>/bom.js:875
-827:     referrer?: ?string;
-                     ^^^^^^ undefined. See lib: <BUILTINS>/bom.js:827
+882:     referrer: string;
+                   ^^^^^^ string. This type is incompatible with an argument type of. See lib: <BUILTINS>/bom.js:882
+834:     referrer?: ?string;
+                     ^^^^^^ undefined. See lib: <BUILTINS>/bom.js:834
 
 request.js:6
   6: const e: Request = new Request(b, c); // incorrect
                         ^^^^^^^^^^^^^^^^^ constructor call
 inconsistent use of library definitions
-876:     referrerPolicy: ReferrerPolicyType;
-                         ^^^^^^^^^^^^^^^^^^ string enum. This type is incompatible with an argument type of. See lib: <BUILTINS>/bom.js:876
-828:     referrerPolicy?: ?ReferrerPolicyType;
-                           ^^^^^^^^^^^^^^^^^^ null. See lib: <BUILTINS>/bom.js:828
+883:     referrerPolicy: ReferrerPolicyType;
+                         ^^^^^^^^^^^^^^^^^^ string enum. This type is incompatible with an argument type of. See lib: <BUILTINS>/bom.js:883
+835:     referrerPolicy?: ?ReferrerPolicyType;
+                           ^^^^^^^^^^^^^^^^^^ null. See lib: <BUILTINS>/bom.js:835
 
 request.js:6
   6: const e: Request = new Request(b, c); // incorrect
                         ^^^^^^^^^^^^^^^^^ constructor call
 inconsistent use of library definitions
-876:     referrerPolicy: ReferrerPolicyType;
-                         ^^^^^^^^^^^^^^^^^^ string enum. This type is incompatible with an argument type of. See lib: <BUILTINS>/bom.js:876
-828:     referrerPolicy?: ?ReferrerPolicyType;
-                           ^^^^^^^^^^^^^^^^^^ undefined. See lib: <BUILTINS>/bom.js:828
+883:     referrerPolicy: ReferrerPolicyType;
+                         ^^^^^^^^^^^^^^^^^^ string enum. This type is incompatible with an argument type of. See lib: <BUILTINS>/bom.js:883
+835:     referrerPolicy?: ?ReferrerPolicyType;
+                           ^^^^^^^^^^^^^^^^^^ undefined. See lib: <BUILTINS>/bom.js:835
 
 request.js:8
   8: const f: Request = new Request({}) // incorrect
                         ^^^^^^^^^^^^^^^ constructor call
   8: const f: Request = new Request({}) // incorrect
                                     ^^ object literal. This type is incompatible with
-863:     constructor(input: string | Request, init?: RequestOptions): void;
-                            ^^^^^^^^^^^^^^^^ union: string | Request. See lib: <BUILTINS>/bom.js:863
+870:     constructor(input: string | Request, init?: RequestOptions): void;
+                            ^^^^^^^^^^^^^^^^ union: string | Request. See lib: <BUILTINS>/bom.js:870
   Member 1:
-  863:     constructor(input: string | Request, init?: RequestOptions): void;
-                              ^^^^^^ string. See lib: <BUILTINS>/bom.js:863
+  870:     constructor(input: string | Request, init?: RequestOptions): void;
+                              ^^^^^^ string. See lib: <BUILTINS>/bom.js:870
   Error:
     8: const f: Request = new Request({}) // incorrect
                                       ^^ object literal. This type is incompatible with
-  863:     constructor(input: string | Request, init?: RequestOptions): void;
-                              ^^^^^^ string. See lib: <BUILTINS>/bom.js:863
+  870:     constructor(input: string | Request, init?: RequestOptions): void;
+                              ^^^^^^ string. See lib: <BUILTINS>/bom.js:870
   Member 2:
-  863:     constructor(input: string | Request, init?: RequestOptions): void;
-                                       ^^^^^^^ Request. See lib: <BUILTINS>/bom.js:863
+  870:     constructor(input: string | Request, init?: RequestOptions): void;
+                                       ^^^^^^^ Request. See lib: <BUILTINS>/bom.js:870
   Error:
     8: const f: Request = new Request({}) // incorrect
                                       ^^ object literal. This type is incompatible with
-  863:     constructor(input: string | Request, init?: RequestOptions): void;
-                                       ^^^^^^^ Request. See lib: <BUILTINS>/bom.js:863
+  870:     constructor(input: string | Request, init?: RequestOptions): void;
+                                       ^^^^^^^ Request. See lib: <BUILTINS>/bom.js:870
 
 request.js:30
  30: const j: Request = new Request('http://example.org', {
                         ^ constructor call
  32:   headers: 'Content-Type: image/jpeg',
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^ string. This type is incompatible with
-822:     headers?: ?HeadersInit;
-                    ^^^^^^^^^^^ union: Headers | object type. See lib: <BUILTINS>/bom.js:822
+829:     headers?: ?HeadersInit;
+                    ^^^^^^^^^^^ union: Headers | object type. See lib: <BUILTINS>/bom.js:829
   Member 1:
-  774: type HeadersInit = Headers | {[key: string]: string};
-                          ^^^^^^^ Headers. See lib: <BUILTINS>/bom.js:774
+  781: type HeadersInit = Headers | {[key: string]: string};
+                          ^^^^^^^ Headers. See lib: <BUILTINS>/bom.js:781
   Error:
    32:   headers: 'Content-Type: image/jpeg',
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^ string. This type is incompatible with
-  774: type HeadersInit = Headers | {[key: string]: string};
-                          ^^^^^^^ Headers. See lib: <BUILTINS>/bom.js:774
+  781: type HeadersInit = Headers | {[key: string]: string};
+                          ^^^^^^^ Headers. See lib: <BUILTINS>/bom.js:781
   Member 2:
-  774: type HeadersInit = Headers | {[key: string]: string};
-                                    ^^^^^^^^^^^^^^^^^^^^^^^ object type. See lib: <BUILTINS>/bom.js:774
+  781: type HeadersInit = Headers | {[key: string]: string};
+                                    ^^^^^^^^^^^^^^^^^^^^^^^ object type. See lib: <BUILTINS>/bom.js:781
   Error:
    32:   headers: 'Content-Type: image/jpeg',
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^ string. This type is incompatible with
-  774: type HeadersInit = Headers | {[key: string]: string};
-                                    ^^^^^^^^^^^^^^^^^^^^^^^ object type. See lib: <BUILTINS>/bom.js:774
+  781: type HeadersInit = Headers | {[key: string]: string};
+                                    ^^^^^^^^^^^^^^^^^^^^^^^ object type. See lib: <BUILTINS>/bom.js:781
 
 request.js:37
  37: const k: Request = new Request('http://example.org', {
                                                           ^ object literal. This type is incompatible with the expected param type of
-863:     constructor(input: string | Request, init?: RequestOptions): void;
-                                                     ^^^^^^^^^^^^^^ object type. See lib: <BUILTINS>/bom.js:863
+870:     constructor(input: string | Request, init?: RequestOptions): void;
+                                                     ^^^^^^^^^^^^^^ object type. See lib: <BUILTINS>/bom.js:870
   Property `method` is incompatible:
      38:   method: 'CONNECT',
                    ^^^^^^^^^ string. This type is incompatible with
-    824:     method?: ?MethodType;
-                       ^^^^^^^^^^ string enum. See lib: <BUILTINS>/bom.js:824
+    831:     method?: ?MethodType;
+                       ^^^^^^^^^^ string enum. See lib: <BUILTINS>/bom.js:831
 
 request.js:49
  49: h.text().then((t: Buffer) => t); // incorrect
                        ^^^^^^ Buffer. This type is incompatible with an argument type of
-885:     text(): Promise<string>;
-                         ^^^^^^ string. See lib: <BUILTINS>/bom.js:885
+892:     text(): Promise<string>;
+                         ^^^^^^ string. See lib: <BUILTINS>/bom.js:892
 
 request.js:51
  51: h.arrayBuffer().then((ab: Buffer) => ab); // incorrect
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call of method `then`
  51: h.arrayBuffer().then((ab: Buffer) => ab); // incorrect
                                ^^^^^^ Buffer. This type is incompatible with
-881:     arrayBuffer(): Promise<ArrayBuffer>;
-                                ^^^^^^^^^^^ ArrayBuffer. See lib: <BUILTINS>/bom.js:881
+888:     arrayBuffer(): Promise<ArrayBuffer>;
+                                ^^^^^^^^^^^ ArrayBuffer. See lib: <BUILTINS>/bom.js:888
 
 response.js:10
  10: const e: Response = new Response("responsebody", {
                                                       ^ object literal. This type is incompatible with the expected param type of
-838:     constructor(input?: string | URLSearchParams | FormData | Blob, init?: ResponseOptions): void;
-                                                                                ^^^^^^^^^^^^^^^ object type. See lib: <BUILTINS>/bom.js:838
+845:     constructor(input?: string | URLSearchParams | FormData | Blob, init?: ResponseOptions): void;
+                                                                                ^^^^^^^^^^^^^^^ object type. See lib: <BUILTINS>/bom.js:845
   Property `status` is incompatible:
      11:     status: "404"
                      ^^^^^ string. This type is incompatible with
-    832:     status?: ?number;
-                       ^^^^^^ number. See lib: <BUILTINS>/bom.js:832
+    839:     status?: ?number;
+                       ^^^^^^ number. See lib: <BUILTINS>/bom.js:839
 
 response.js:14
  14: const f: Response = new Response("responsebody", {
                          ^ constructor call
  16:     headers: "'Content-Type': 'image/jpeg'"
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string. This type is incompatible with
-834:     headers?: ?HeadersInit
-                    ^^^^^^^^^^^ union: Headers | object type. See lib: <BUILTINS>/bom.js:834
+841:     headers?: ?HeadersInit
+                    ^^^^^^^^^^^ union: Headers | object type. See lib: <BUILTINS>/bom.js:841
   Member 1:
-  774: type HeadersInit = Headers | {[key: string]: string};
-                          ^^^^^^^ Headers. See lib: <BUILTINS>/bom.js:774
+  781: type HeadersInit = Headers | {[key: string]: string};
+                          ^^^^^^^ Headers. See lib: <BUILTINS>/bom.js:781
   Error:
    16:     headers: "'Content-Type': 'image/jpeg'"
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string. This type is incompatible with
-  774: type HeadersInit = Headers | {[key: string]: string};
-                          ^^^^^^^ Headers. See lib: <BUILTINS>/bom.js:774
+  781: type HeadersInit = Headers | {[key: string]: string};
+                          ^^^^^^^ Headers. See lib: <BUILTINS>/bom.js:781
   Member 2:
-  774: type HeadersInit = Headers | {[key: string]: string};
-                                    ^^^^^^^^^^^^^^^^^^^^^^^ object type. See lib: <BUILTINS>/bom.js:774
+  781: type HeadersInit = Headers | {[key: string]: string};
+                                    ^^^^^^^^^^^^^^^^^^^^^^^ object type. See lib: <BUILTINS>/bom.js:781
   Error:
    16:     headers: "'Content-Type': 'image/jpeg'"
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string. This type is incompatible with
-  774: type HeadersInit = Headers | {[key: string]: string};
-                                    ^^^^^^^^^^^^^^^^^^^^^^^ object type. See lib: <BUILTINS>/bom.js:774
+  781: type HeadersInit = Headers | {[key: string]: string};
+                                    ^^^^^^^^^^^^^^^^^^^^^^^ object type. See lib: <BUILTINS>/bom.js:781
 
 response.js:33
  33: const i: Response = new Response({
                          ^ constructor call
  33: const i: Response = new Response({
                                       ^ object literal. This type is incompatible with
-838:     constructor(input?: string | URLSearchParams | FormData | Blob, init?: ResponseOptions): void;
-                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ union: string | URLSearchParams | FormData | Blob. See lib: <BUILTINS>/bom.js:838
+845:     constructor(input?: string | URLSearchParams | FormData | Blob, init?: ResponseOptions): void;
+                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ union: string | URLSearchParams | FormData | Blob. See lib: <BUILTINS>/bom.js:845
   Member 1:
-  838:     constructor(input?: string | URLSearchParams | FormData | Blob, init?: ResponseOptions): void;
-                               ^^^^^^ string. See lib: <BUILTINS>/bom.js:838
+  845:     constructor(input?: string | URLSearchParams | FormData | Blob, init?: ResponseOptions): void;
+                               ^^^^^^ string. See lib: <BUILTINS>/bom.js:845
   Error:
    33: const i: Response = new Response({
                                         ^ object literal. This type is incompatible with
-  838:     constructor(input?: string | URLSearchParams | FormData | Blob, init?: ResponseOptions): void;
-                               ^^^^^^ string. See lib: <BUILTINS>/bom.js:838
+  845:     constructor(input?: string | URLSearchParams | FormData | Blob, init?: ResponseOptions): void;
+                               ^^^^^^ string. See lib: <BUILTINS>/bom.js:845
   Member 2:
-  838:     constructor(input?: string | URLSearchParams | FormData | Blob, init?: ResponseOptions): void;
-                                        ^^^^^^^^^^^^^^^ URLSearchParams. See lib: <BUILTINS>/bom.js:838
+  845:     constructor(input?: string | URLSearchParams | FormData | Blob, init?: ResponseOptions): void;
+                                        ^^^^^^^^^^^^^^^ URLSearchParams. See lib: <BUILTINS>/bom.js:845
   Error:
    33: const i: Response = new Response({
                                         ^ object literal. This type is incompatible with
-  838:     constructor(input?: string | URLSearchParams | FormData | Blob, init?: ResponseOptions): void;
-                                        ^^^^^^^^^^^^^^^ URLSearchParams. See lib: <BUILTINS>/bom.js:838
+  845:     constructor(input?: string | URLSearchParams | FormData | Blob, init?: ResponseOptions): void;
+                                        ^^^^^^^^^^^^^^^ URLSearchParams. See lib: <BUILTINS>/bom.js:845
   Member 3:
-  838:     constructor(input?: string | URLSearchParams | FormData | Blob, init?: ResponseOptions): void;
-                                                          ^^^^^^^^ FormData. See lib: <BUILTINS>/bom.js:838
+  845:     constructor(input?: string | URLSearchParams | FormData | Blob, init?: ResponseOptions): void;
+                                                          ^^^^^^^^ FormData. See lib: <BUILTINS>/bom.js:845
   Error:
    33: const i: Response = new Response({
                                         ^ object literal. This type is incompatible with
-  838:     constructor(input?: string | URLSearchParams | FormData | Blob, init?: ResponseOptions): void;
-                                                          ^^^^^^^^ FormData. See lib: <BUILTINS>/bom.js:838
+  845:     constructor(input?: string | URLSearchParams | FormData | Blob, init?: ResponseOptions): void;
+                                                          ^^^^^^^^ FormData. See lib: <BUILTINS>/bom.js:845
   Member 4:
-  838:     constructor(input?: string | URLSearchParams | FormData | Blob, init?: ResponseOptions): void;
-                                                                     ^^^^ Blob. See lib: <BUILTINS>/bom.js:838
+  845:     constructor(input?: string | URLSearchParams | FormData | Blob, init?: ResponseOptions): void;
+                                                                     ^^^^ Blob. See lib: <BUILTINS>/bom.js:845
   Error:
    33: const i: Response = new Response({
                                         ^ object literal. This type is incompatible with
-  838:     constructor(input?: string | URLSearchParams | FormData | Blob, init?: ResponseOptions): void;
-                                                                     ^^^^ Blob. See lib: <BUILTINS>/bom.js:838
+  845:     constructor(input?: string | URLSearchParams | FormData | Blob, init?: ResponseOptions): void;
+                                                                     ^^^^ Blob. See lib: <BUILTINS>/bom.js:845
 
 response.js:44
  44: h.text().then((t: Buffer) => t); // incorrect
                        ^^^^^^ Buffer. This type is incompatible with an argument type of
-859:     text(): Promise<string>;
-                         ^^^^^^ string. See lib: <BUILTINS>/bom.js:859
+866:     text(): Promise<string>;
+                         ^^^^^^ string. See lib: <BUILTINS>/bom.js:866
 
 response.js:46
  46: h.arrayBuffer().then((ab: Buffer) => ab); // incorrect
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call of method `then`
  46: h.arrayBuffer().then((ab: Buffer) => ab); // incorrect
                                ^^^^^^ Buffer. This type is incompatible with
-855:     arrayBuffer(): Promise<ArrayBuffer>;
-                                ^^^^^^^^^^^ ArrayBuffer. See lib: <BUILTINS>/bom.js:855
+862:     arrayBuffer(): Promise<ArrayBuffer>;
+                                ^^^^^^^^^^^ ArrayBuffer. See lib: <BUILTINS>/bom.js:862
 
 urlsearchparams.js:4
   4: const b = new URLSearchParams(['key1', 'value1']); // not correct
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructor call
   4: const b = new URLSearchParams(['key1', 'value1']); // not correct
                                    ^^^^^^^^^^^^^^^^^^ array literal. This type is incompatible with
-795:     constructor(query?: string | URLSearchParams): void;
-                             ^^^^^^^^^^^^^^^^^^^^^^^^ union: string | URLSearchParams. See lib: <BUILTINS>/bom.js:795
+802:     constructor(query?: string | URLSearchParams): void;
+                             ^^^^^^^^^^^^^^^^^^^^^^^^ union: string | URLSearchParams. See lib: <BUILTINS>/bom.js:802
   Member 1:
-  795:     constructor(query?: string | URLSearchParams): void;
-                               ^^^^^^ string. See lib: <BUILTINS>/bom.js:795
+  802:     constructor(query?: string | URLSearchParams): void;
+                               ^^^^^^ string. See lib: <BUILTINS>/bom.js:802
   Error:
     4: const b = new URLSearchParams(['key1', 'value1']); // not correct
                                      ^^^^^^^^^^^^^^^^^^ array literal. This type is incompatible with
-  795:     constructor(query?: string | URLSearchParams): void;
-                               ^^^^^^ string. See lib: <BUILTINS>/bom.js:795
+  802:     constructor(query?: string | URLSearchParams): void;
+                               ^^^^^^ string. See lib: <BUILTINS>/bom.js:802
   Member 2:
-  795:     constructor(query?: string | URLSearchParams): void;
-                                        ^^^^^^^^^^^^^^^ URLSearchParams. See lib: <BUILTINS>/bom.js:795
+  802:     constructor(query?: string | URLSearchParams): void;
+                                        ^^^^^^^^^^^^^^^ URLSearchParams. See lib: <BUILTINS>/bom.js:802
   Error:
     4: const b = new URLSearchParams(['key1', 'value1']); // not correct
                                      ^^^^^^^^^^^^^^^^^^ array literal. This type is incompatible with
-  795:     constructor(query?: string | URLSearchParams): void;
-                                        ^^^^^^^^^^^^^^^ URLSearchParams. See lib: <BUILTINS>/bom.js:795
+  802:     constructor(query?: string | URLSearchParams): void;
+                                        ^^^^^^^^^^^^^^^ URLSearchParams. See lib: <BUILTINS>/bom.js:802
 
 urlsearchparams.js:5
   5: const c = new URLSearchParams({'key1', 'value1'}); // not correct
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructor call
   5: const c = new URLSearchParams({'key1', 'value1'}); // not correct
                                    ^^^^^^^^^^^^^^^^^^ object literal. This type is incompatible with
-795:     constructor(query?: string | URLSearchParams): void;
-                             ^^^^^^^^^^^^^^^^^^^^^^^^ union: string | URLSearchParams. See lib: <BUILTINS>/bom.js:795
+802:     constructor(query?: string | URLSearchParams): void;
+                             ^^^^^^^^^^^^^^^^^^^^^^^^ union: string | URLSearchParams. See lib: <BUILTINS>/bom.js:802
   Member 1:
-  795:     constructor(query?: string | URLSearchParams): void;
-                               ^^^^^^ string. See lib: <BUILTINS>/bom.js:795
+  802:     constructor(query?: string | URLSearchParams): void;
+                               ^^^^^^ string. See lib: <BUILTINS>/bom.js:802
   Error:
     5: const c = new URLSearchParams({'key1', 'value1'}); // not correct
                                      ^^^^^^^^^^^^^^^^^^ object literal. This type is incompatible with
-  795:     constructor(query?: string | URLSearchParams): void;
-                               ^^^^^^ string. See lib: <BUILTINS>/bom.js:795
+  802:     constructor(query?: string | URLSearchParams): void;
+                               ^^^^^^ string. See lib: <BUILTINS>/bom.js:802
   Member 2:
-  795:     constructor(query?: string | URLSearchParams): void;
-                                        ^^^^^^^^^^^^^^^ URLSearchParams. See lib: <BUILTINS>/bom.js:795
+  802:     constructor(query?: string | URLSearchParams): void;
+                                        ^^^^^^^^^^^^^^^ URLSearchParams. See lib: <BUILTINS>/bom.js:802
   Error:
     5: const c = new URLSearchParams({'key1', 'value1'}); // not correct
                                      ^^^^^^^^^^^^^^^^^^ object literal. This type is incompatible with
-  795:     constructor(query?: string | URLSearchParams): void;
-                                        ^^^^^^^^^^^^^^^ URLSearchParams. See lib: <BUILTINS>/bom.js:795
+  802:     constructor(query?: string | URLSearchParams): void;
+                                        ^^^^^^^^^^^^^^^ URLSearchParams. See lib: <BUILTINS>/bom.js:802
 
 urlsearchparams.js:9
   9: e.append('key1'); // not correct
      ^^^^^^^^^^^^^^^^ call of method `append`
   9: e.append('key1'); // not correct
      ^^^^^^^^^^^^^^^^ undefined (too few arguments, expected default/rest parameters). This type is incompatible with
-796:     append(name: string, value: string): void;
-                                     ^^^^^^ string. See lib: <BUILTINS>/bom.js:796
+803:     append(name: string, value: string): void;
+                                     ^^^^^^ string. See lib: <BUILTINS>/bom.js:803
 
 urlsearchparams.js:10
  10: e.append({'key1', 'value1'}); // not correct
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call of method `append`
  10: e.append({'key1', 'value1'}); // not correct
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ undefined (too few arguments, expected default/rest parameters). This type is incompatible with
-796:     append(name: string, value: string): void;
-                                     ^^^^^^ string. See lib: <BUILTINS>/bom.js:796
+803:     append(name: string, value: string): void;
+                                     ^^^^^^ string. See lib: <BUILTINS>/bom.js:803
 
 urlsearchparams.js:10
  10: e.append({'key1', 'value1'}); // not correct
               ^^^^^^^^^^^^^^^^^^ object literal. This type is incompatible with the expected param type of
-796:     append(name: string, value: string): void;
-                      ^^^^^^ string. See lib: <BUILTINS>/bom.js:796
+803:     append(name: string, value: string): void;
+                      ^^^^^^ string. See lib: <BUILTINS>/bom.js:803
 
 urlsearchparams.js:12
  12: e.set('key1'); // not correct
      ^^^^^^^^^^^^^ call of method `set`
  12: e.set('key1'); // not correct
      ^^^^^^^^^^^^^ undefined (too few arguments, expected default/rest parameters). This type is incompatible with
-803:     set(name: string, value: string): void;
-                                  ^^^^^^ string. See lib: <BUILTINS>/bom.js:803
+810:     set(name: string, value: string): void;
+                                  ^^^^^^ string. See lib: <BUILTINS>/bom.js:810
 
 urlsearchparams.js:13
  13: e.set({'key1', 'value1'}); // not correct
      ^^^^^^^^^^^^^^^^^^^^^^^^^ call of method `set`
  13: e.set({'key1', 'value1'}); // not correct
      ^^^^^^^^^^^^^^^^^^^^^^^^^ undefined (too few arguments, expected default/rest parameters). This type is incompatible with
-803:     set(name: string, value: string): void;
-                                  ^^^^^^ string. See lib: <BUILTINS>/bom.js:803
+810:     set(name: string, value: string): void;
+                                  ^^^^^^ string. See lib: <BUILTINS>/bom.js:810
 
 urlsearchparams.js:13
  13: e.set({'key1', 'value1'}); // not correct
            ^^^^^^^^^^^^^^^^^^ object literal. This type is incompatible with the expected param type of
-803:     set(name: string, value: string): void;
-                   ^^^^^^ string. See lib: <BUILTINS>/bom.js:803
+810:     set(name: string, value: string): void;
+                   ^^^^^^ string. See lib: <BUILTINS>/bom.js:810
 
 urlsearchparams.js:15
  15: const f: URLSearchParams = e.append('key1', 'value1'); // not correct

--- a/tests/websocket/.flowconfig
+++ b/tests/websocket/.flowconfig
@@ -1,0 +1,1 @@
+[options]

--- a/tests/websocket/events.js
+++ b/tests/websocket/events.js
@@ -1,0 +1,14 @@
+const ws = new WebSocket('http://foo/bar');
+
+function handleClose(event: CloseEvent) {
+  console.log('WebSocket closed with code', event.code);
+}
+
+function handleMessage(event: MessageEvent) {
+  console.log('WebSocket received message', event.data);
+}
+
+ws.addEventListener('message', handleMessage);
+ws.addEventListener('close', handleClose);
+ws.onmessage = handleMessage;
+ws.onclose = handleClose;

--- a/tests/websocket/websocket.exp
+++ b/tests/websocket/websocket.exp
@@ -1,0 +1,1 @@
+Found 0 errors


### PR DESCRIPTION
Handlers registered via `addEventListener('close' | 'message', ...)` now have their `event` argument spec'ed the same way that `onclose` and `onmessage` handlers have.