### PR TITLE
Fix tls module definition

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -1379,9 +1379,9 @@ declare module "tls" {
   declare var SecureContext: Object;
   declare var TLSSocket: typeof tls$TLSSocket;
   declare var Server: typeof tls$Server;
-  declare function createServer(options: Object, secureConnectionListener?: function): typeof tls$Server;
-  declare function connect(options: Object, callback?: function): typeof tls$TLSSocket;
-  declare function connect(port: number, host?: string, options?: Object, callback?: function): typeof tls$TLSSocket;
+  declare function createServer(options: Object, secureConnectionListener?: function): tls$Server;
+  declare function connect(options: Object, callback?: function): tls$TLSSocket;
+  declare function connect(port: number, host?: string, options?: Object, callback?: function): tls$TLSSocket;
   declare function createSecurePair(context?: Object, isServer?: boolean, requestCert?: boolean, rejectUnauthorized?: boolean, options?: Object): Object;
 }
 


### PR DESCRIPTION
Previous definition had the factory method return the wrong type.

Specifically, this completely valid code:
`
let socket: tls.TLSSocket = tls.connect({...});
`

Was marked as:
```
class type: tls$TLSSocket: test.js:1
This type is incompatible with
tls$TLSSocket: test.js:1
```
