### PR TITLE
Adding annotation in Constructor Parameter

### DIFF
--- a/website/docs/ref/classes.doc.js
+++ b/website/docs/ref/classes.doc.js
@@ -162,7 +162,7 @@ var n: number = takesAnXY(c);
 class PolyC<X> {
   x: X;
   y: number;
-  constructor(x) { this.x = x; }
+  constructor(x: X) { this.x = x; }
   foo() { return this.x; }
   bar(y) { this.y = y; }
 }


### PR DESCRIPTION
Polymorphic classes constructor without annotation was throwing following error.

```
4:   constructor(x) { this.x = x; }
                               ^ number. This type is incompatible with
2: class PolyC<X> {
         ^ some incompatible instantiation of `X' 
```

After adding annotation it works fine.

I tried following code from the flow docs but it keeps on throwing error

```
/* @flow */
class PolyC<X> {
  x: X;
  constructor(x) { this.x = x; }
}

class abc extends PolyC<number> {
}


const x=new abc(5)

console.log(x)
```

Following code seems to work:-

```
/* @flow */
class PolyC<X> {
  x: X;
  constructor(x:X) { this.x = x; }
}

class abc extends PolyC<number> {
}


const x=new abc(5)

console.log(x)
```