### PR TITLE
lib: require.main property added

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -844,6 +844,7 @@ declare var require: {
   (id: string): any;
   resolve: (id: string) => string;
   cache: any;
+  main: typeof module;
 };
 declare var exports: any;
 


### PR DESCRIPTION
Summary:
Added property `main` of object (function) `require`. It allows to
access the main module. [Documentation][1].

[1]: https://nodejs.org/api/modules.html#modules_accessing_the_main_module