### PR TITLE
Adding WebUSB API

### DIFF
--- a/lib/bom.js
+++ b/lib/bom.js
@@ -113,6 +113,7 @@ declare class Navigator mixins NavigatorCommon {
     vibrate?: (pattern: number|number[]) => bool;
     mozVibrate?: (pattern: number|number[]) => bool;
     webkitVibrate?: (pattern: number|number[]) => bool;
+    usb: USB;
 }
 
 declare var navigator: Navigator;
@@ -1135,4 +1136,140 @@ declare class MessagePort extends EventTarget {
 declare class MessageChannel {
   port1: MessagePort;
   port2: MessagePort;
+}
+
+declare class USBConnectionEvent extends Event {
+  device: USBDevice;
+}
+
+declare type USBConnectionEventHandler = (event: USBConnectionEvent) => mixed;
+
+declare type $USB$BufferSource = ArrayBuffer | DataView | $TypedArray;
+
+declare class USB extends EventTarget {
+  onconnect: ?USBConnectionEventHandler;
+  ondisconnect: ?USBConnectionEventHandler;
+  getDevices: () => Promise<Array<USBDevice>>;
+  requestDevice: (options?: USBDeviceRequestOptions) => Promise<USBDevice>;
+}
+
+declare type USBDeviceRequestOptions = {
+  filters: Array<USBDeviceFilter>;
+};
+
+declare type USBDeviceFilter = {
+  vendorId?: number;
+  productId?: number;
+  classCode?: number;
+  subclassCode?: number;
+  protocolCode?: number;
+  serialNumber?: string;
+};
+
+declare class USBDevice {
+  usbVersionMajor: number;
+  usbVersionMinor: number;
+  usbVersionSubminor: number;
+  deviceClass: number;
+  deviceSubclass: number;
+  deviceProtocol: number;
+  vendorId: number;
+  productId: number;
+  deviceVersionMajor: number;
+  deviceVersionMinor: number;
+  deviceVersionSubminor: number;
+  manufacturerName: ?string;
+  productName: ?string;
+  serialNumber: ?string;
+  configuration: ?USBConfiguration;
+  configurations: Array<USBConfiguration>;
+  opened: boolean;
+  open: () => Promise<void>;
+  close: () => Promise<void>;
+  selectConfiguration: (configurationValue: number) => Promise<void>;
+  claimInterface: (interfaceNumber: number) => Promise<void>;
+  releaseInterface: (interfaceNumber: number) => Promise<void>;
+  selectAlternateInterface: (interfaceNumber: number, alternateSetting: number) => Promise<void>;
+  controlTransferIn: (setup: USBControlTransferParameters, length: number) => Promise<USBInTransferResult>;
+  controlTransferOut: (setup: USBControlTransferParameters, data?: $USB$BufferSource) => Promise<USBOutTransferResult>;
+  clearHalt: (direction: USBDirection, endpointNumber: number) => Promise<void>;
+  transferIn: (endpointNumber: number, length: number) => Promise<USBInTransferResult>;
+  transferOut: (endpointNumber: number, data: $USB$BufferSource) => Promise<USBOutTransferResult>;
+  isochronousTransferIn: (endpointNumber: number, packetLengths: Array<number>) => Promise<USBIsochronousInTransferResult>;
+  isochronousTransferOut: (endpointNumber: number, data: $USB$BufferSource, packetLengths: Array<number>) => Promise<USBIsochronousOutTransferResult>;
+  reset: () => Promise<void>;
+}
+
+declare type USBDirection = 'in' | 'out';
+
+declare class USBConfiguration {
+  configurationValue: number;
+  configurationName: ?string;
+  interfaces: Array<USBInterface>;
+}
+
+declare class USBInterface {
+  interfaceNumber: number;
+  alternate: USBAlternateInterface;
+  alternates: Array<USBAlternateInterface>;
+  claimed: boolean;
+}
+
+declare class USBAlternateInterface {
+  alternateSetting: number;
+  interfaceClass: number;
+  interfaceSubclass: number;
+  interfaceProtocol: number;
+  interfaceName: ?string;
+  endpoints: Array<USBEndpoint>;
+}
+
+declare class USBEndpoint {
+  endpointNumber: number;
+  direction: USBDirection;
+  type: 'bulk' | 'interrupt' |  'isochronous';
+  packetSize: number;
+}
+
+declare type USBRequestType = 'standard' | 'class' | 'vendor';
+declare type USBRecipient = 'device' | 'interface' | 'endpoint' | 'other';
+
+declare type USBControlTransferParameters = {
+  requestType: USBRequestType;
+  recipient: USBRecipient;
+  request: number;
+  value: number;
+  index: number;
+}
+
+declare type USBTransferStatus = 'ok' | 'stall' | 'babble';
+
+declare class USBInTransferResult {
+  data: DataView;
+  status: USBTransferStatus;
+}
+
+declare class USBOutTransferResult {
+  bytesWritten: number;
+  status: USBTransferStatus;
+}
+
+declare class USBIsochronousInTransferPacket {
+  data: DataView;
+  status: USBTransferStatus;
+}
+
+declare class USBIsochronousInTransferResult {
+  data: DataView;
+  packets: Array<USBIsochronousInTransferPacket>;
+}
+
+declare class USBIsochronousOutTransferPacket {
+  protocolCode?: number,
+  bytesWritten: number;
+  status: USBTransferStatus;
+}
+
+declare class USBIsochronousOutTransferResult {
+  packets: Array<USBIsochronousOutTransferPacket>;
 }

--- a/tests/bom/bom.exp
+++ b/tests/bom/bom.exp
@@ -1,14 +1,14 @@
 FormData.js:5
   5: new FormData(''); // incorrect
                   ^^ string. This type is incompatible with the expected param type of
-293:     constructor(form?: HTMLFormElement): void;
-                            ^^^^^^^^^^^^^^^ HTMLFormElement. See lib: <BUILTINS>/bom.js:293
+294:     constructor(form?: HTMLFormElement): void;
+                            ^^^^^^^^^^^^^^^ HTMLFormElement. See lib: <BUILTINS>/bom.js:294
 
 FormData.js:6
   6: new FormData(document.createElement('input')); // incorrect
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ HTMLInputElement. This type is incompatible with
-293:     constructor(form?: HTMLFormElement): void;
-                            ^^^^^^^^^^^^^^^ HTMLFormElement. See lib: <BUILTINS>/bom.js:293
+294:     constructor(form?: HTMLFormElement): void;
+                            ^^^^^^^^^^^^^^^ HTMLFormElement. See lib: <BUILTINS>/bom.js:294
 
 FormData.js:14
  14: const d: string = a.get('foo'); // incorrect
@@ -49,58 +49,58 @@ FormData.js:15
 FormData.js:17
  17: a.get(2); // incorrect
            ^ number. This type is incompatible with the expected param type of
-296:     get(name: string): ?FormDataEntryValue;
-                   ^^^^^^ string. See lib: <BUILTINS>/bom.js:296
+297:     get(name: string): ?FormDataEntryValue;
+                   ^^^^^^ string. See lib: <BUILTINS>/bom.js:297
 
 FormData.js:21
  21: const a2: Array<string | File | number> = a.getAll('foo'); // incorrect
                                      ^^^^^^ number. This type is incompatible with
-297:     getAll(name: string): Array<FormDataEntryValue>;
-                                     ^^^^^^^^^^^^^^^^^^ union: string | File. See lib: <BUILTINS>/bom.js:297
+298:     getAll(name: string): Array<FormDataEntryValue>;
+                                     ^^^^^^^^^^^^^^^^^^ union: string | File. See lib: <BUILTINS>/bom.js:298
   Member 1:
-  290: type FormDataEntryValue = string | File
-                                 ^^^^^^ string. See lib: <BUILTINS>/bom.js:290
+  291: type FormDataEntryValue = string | File
+                                 ^^^^^^ string. See lib: <BUILTINS>/bom.js:291
   Error:
    21: const a2: Array<string | File | number> = a.getAll('foo'); // incorrect
                                        ^^^^^^ number. This type is incompatible with
-  290: type FormDataEntryValue = string | File
-                                 ^^^^^^ string. See lib: <BUILTINS>/bom.js:290
+  291: type FormDataEntryValue = string | File
+                                 ^^^^^^ string. See lib: <BUILTINS>/bom.js:291
   Member 2:
-  290: type FormDataEntryValue = string | File
-                                          ^^^^ File. See lib: <BUILTINS>/bom.js:290
+  291: type FormDataEntryValue = string | File
+                                          ^^^^ File. See lib: <BUILTINS>/bom.js:291
   Error:
    21: const a2: Array<string | File | number> = a.getAll('foo'); // incorrect
                                        ^^^^^^ number. This type is incompatible with
-  290: type FormDataEntryValue = string | File
-                                          ^^^^ File. See lib: <BUILTINS>/bom.js:290
+  291: type FormDataEntryValue = string | File
+                                          ^^^^ File. See lib: <BUILTINS>/bom.js:291
 
 FormData.js:22
  22: const a3: Array<string | Blob | File> = a.getAll('foo'); // incorrect
                               ^^^^ Blob. This type is incompatible with
-297:     getAll(name: string): Array<FormDataEntryValue>;
-                                     ^^^^^^^^^^^^^^^^^^ union: string | File. See lib: <BUILTINS>/bom.js:297
+298:     getAll(name: string): Array<FormDataEntryValue>;
+                                     ^^^^^^^^^^^^^^^^^^ union: string | File. See lib: <BUILTINS>/bom.js:298
   Member 1:
-  290: type FormDataEntryValue = string | File
-                                 ^^^^^^ string. See lib: <BUILTINS>/bom.js:290
+  291: type FormDataEntryValue = string | File
+                                 ^^^^^^ string. See lib: <BUILTINS>/bom.js:291
   Error:
    22: const a3: Array<string | Blob | File> = a.getAll('foo'); // incorrect
                                 ^^^^ Blob. This type is incompatible with
-  290: type FormDataEntryValue = string | File
-                                 ^^^^^^ string. See lib: <BUILTINS>/bom.js:290
+  291: type FormDataEntryValue = string | File
+                                 ^^^^^^ string. See lib: <BUILTINS>/bom.js:291
   Member 2:
-  290: type FormDataEntryValue = string | File
-                                          ^^^^ File. See lib: <BUILTINS>/bom.js:290
+  291: type FormDataEntryValue = string | File
+                                          ^^^^ File. See lib: <BUILTINS>/bom.js:291
   Error:
    22: const a3: Array<string | Blob | File> = a.getAll('foo'); // incorrect
                                 ^^^^ Blob. This type is incompatible with
-  290: type FormDataEntryValue = string | File
-                                          ^^^^ File. See lib: <BUILTINS>/bom.js:290
+  291: type FormDataEntryValue = string | File
+                                          ^^^^ File. See lib: <BUILTINS>/bom.js:291
 
 FormData.js:23
  23: a.getAll(23); // incorrect
               ^^ number. This type is incompatible with the expected param type of
-297:     getAll(name: string): Array<FormDataEntryValue>;
-                      ^^^^^^ string. See lib: <BUILTINS>/bom.js:297
+298:     getAll(name: string): Array<FormDataEntryValue>;
+                      ^^^^^^ string. See lib: <BUILTINS>/bom.js:298
 
 FormData.js:27
  27: a.set('foo', {}); // incorrect
@@ -108,29 +108,29 @@ FormData.js:27
  27: a.set('foo', {}); // incorrect
      ^^^^^ intersection
   Member 1:
-  299:     set(name: string, value: string): void;
-           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function type. See lib: <BUILTINS>/bom.js:299
+  300:     set(name: string, value: string): void;
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function type. See lib: <BUILTINS>/bom.js:300
   Error:
    27: a.set('foo', {}); // incorrect
                     ^^ object literal. This type is incompatible with the expected param type of
-  299:     set(name: string, value: string): void;
-                                    ^^^^^^ string. See lib: <BUILTINS>/bom.js:299
+  300:     set(name: string, value: string): void;
+                                    ^^^^^^ string. See lib: <BUILTINS>/bom.js:300
   Member 2:
-  300:     set(name: string, value: Blob, filename?: string): void;
-           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function type. See lib: <BUILTINS>/bom.js:300
-  Error:
-   27: a.set('foo', {}); // incorrect
-                    ^^ object literal. This type is incompatible with the expected param type of
-  300:     set(name: string, value: Blob, filename?: string): void;
-                                    ^^^^ Blob. See lib: <BUILTINS>/bom.js:300
-  Member 3:
-  301:     set(name: string, value: File, filename?: string): void;
+  301:     set(name: string, value: Blob, filename?: string): void;
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function type. See lib: <BUILTINS>/bom.js:301
   Error:
    27: a.set('foo', {}); // incorrect
                     ^^ object literal. This type is incompatible with the expected param type of
-  301:     set(name: string, value: File, filename?: string): void;
-                                    ^^^^ File. See lib: <BUILTINS>/bom.js:301
+  301:     set(name: string, value: Blob, filename?: string): void;
+                                    ^^^^ Blob. See lib: <BUILTINS>/bom.js:301
+  Member 3:
+  302:     set(name: string, value: File, filename?: string): void;
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function type. See lib: <BUILTINS>/bom.js:302
+  Error:
+   27: a.set('foo', {}); // incorrect
+                    ^^ object literal. This type is incompatible with the expected param type of
+  302:     set(name: string, value: File, filename?: string): void;
+                                    ^^^^ File. See lib: <BUILTINS>/bom.js:302
 
 FormData.js:28
  28: a.set(2, 'bar'); // incorrect
@@ -138,29 +138,29 @@ FormData.js:28
  28: a.set(2, 'bar'); // incorrect
      ^^^^^ intersection
   Member 1:
-  299:     set(name: string, value: string): void;
-           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function type. See lib: <BUILTINS>/bom.js:299
+  300:     set(name: string, value: string): void;
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function type. See lib: <BUILTINS>/bom.js:300
   Error:
    28: a.set(2, 'bar'); // incorrect
              ^ number. This type is incompatible with the expected param type of
-  299:     set(name: string, value: string): void;
-                     ^^^^^^ string. See lib: <BUILTINS>/bom.js:299
-  Member 2:
-  300:     set(name: string, value: Blob, filename?: string): void;
-           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function type. See lib: <BUILTINS>/bom.js:300
-  Error:
-   28: a.set(2, 'bar'); // incorrect
-             ^ number. This type is incompatible with the expected param type of
-  300:     set(name: string, value: Blob, filename?: string): void;
+  300:     set(name: string, value: string): void;
                      ^^^^^^ string. See lib: <BUILTINS>/bom.js:300
-  Member 3:
-  301:     set(name: string, value: File, filename?: string): void;
+  Member 2:
+  301:     set(name: string, value: Blob, filename?: string): void;
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function type. See lib: <BUILTINS>/bom.js:301
   Error:
    28: a.set(2, 'bar'); // incorrect
              ^ number. This type is incompatible with the expected param type of
-  301:     set(name: string, value: File, filename?: string): void;
+  301:     set(name: string, value: Blob, filename?: string): void;
                      ^^^^^^ string. See lib: <BUILTINS>/bom.js:301
+  Member 3:
+  302:     set(name: string, value: File, filename?: string): void;
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function type. See lib: <BUILTINS>/bom.js:302
+  Error:
+   28: a.set(2, 'bar'); // incorrect
+             ^ number. This type is incompatible with the expected param type of
+  302:     set(name: string, value: File, filename?: string): void;
+                     ^^^^^^ string. See lib: <BUILTINS>/bom.js:302
 
 FormData.js:32
  32: a.set('bar', new File([], 'q'), 2) // incorrect
@@ -168,29 +168,29 @@ FormData.js:32
  32: a.set('bar', new File([], 'q'), 2) // incorrect
      ^^^^^ intersection
   Member 1:
-  299:     set(name: string, value: string): void;
-           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function type. See lib: <BUILTINS>/bom.js:299
+  300:     set(name: string, value: string): void;
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function type. See lib: <BUILTINS>/bom.js:300
   Error:
    32: a.set('bar', new File([], 'q'), 2) // incorrect
                     ^^^^^^^^^^^^^^^^^ File. This type is incompatible with the expected param type of
-  299:     set(name: string, value: string): void;
-                                    ^^^^^^ string. See lib: <BUILTINS>/bom.js:299
+  300:     set(name: string, value: string): void;
+                                    ^^^^^^ string. See lib: <BUILTINS>/bom.js:300
   Member 2:
-  300:     set(name: string, value: Blob, filename?: string): void;
-           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function type. See lib: <BUILTINS>/bom.js:300
-  Error:
-   32: a.set('bar', new File([], 'q'), 2) // incorrect
-                                       ^ number. This type is incompatible with the expected param type of
-  300:     set(name: string, value: Blob, filename?: string): void;
-                                                     ^^^^^^ string. See lib: <BUILTINS>/bom.js:300
-  Member 3:
-  301:     set(name: string, value: File, filename?: string): void;
+  301:     set(name: string, value: Blob, filename?: string): void;
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function type. See lib: <BUILTINS>/bom.js:301
   Error:
    32: a.set('bar', new File([], 'q'), 2) // incorrect
                                        ^ number. This type is incompatible with the expected param type of
-  301:     set(name: string, value: File, filename?: string): void;
+  301:     set(name: string, value: Blob, filename?: string): void;
                                                      ^^^^^^ string. See lib: <BUILTINS>/bom.js:301
+  Member 3:
+  302:     set(name: string, value: File, filename?: string): void;
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function type. See lib: <BUILTINS>/bom.js:302
+  Error:
+   32: a.set('bar', new File([], 'q'), 2) // incorrect
+                                       ^ number. This type is incompatible with the expected param type of
+  302:     set(name: string, value: File, filename?: string): void;
+                                                     ^^^^^^ string. See lib: <BUILTINS>/bom.js:302
 
 FormData.js:35
  35: a.set('bar', new Blob, 2) // incorrect
@@ -198,29 +198,29 @@ FormData.js:35
  35: a.set('bar', new Blob, 2) // incorrect
      ^^^^^ intersection
   Member 1:
-  299:     set(name: string, value: string): void;
-           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function type. See lib: <BUILTINS>/bom.js:299
+  300:     set(name: string, value: string): void;
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function type. See lib: <BUILTINS>/bom.js:300
   Error:
    35: a.set('bar', new Blob, 2) // incorrect
                     ^^^^^^^^ Blob. This type is incompatible with the expected param type of
-  299:     set(name: string, value: string): void;
-                                    ^^^^^^ string. See lib: <BUILTINS>/bom.js:299
+  300:     set(name: string, value: string): void;
+                                    ^^^^^^ string. See lib: <BUILTINS>/bom.js:300
   Member 2:
-  300:     set(name: string, value: Blob, filename?: string): void;
-           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function type. See lib: <BUILTINS>/bom.js:300
-  Error:
-   35: a.set('bar', new Blob, 2) // incorrect
-                              ^ number. This type is incompatible with the expected param type of
-  300:     set(name: string, value: Blob, filename?: string): void;
-                                                     ^^^^^^ string. See lib: <BUILTINS>/bom.js:300
-  Member 3:
-  301:     set(name: string, value: File, filename?: string): void;
+  301:     set(name: string, value: Blob, filename?: string): void;
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function type. See lib: <BUILTINS>/bom.js:301
   Error:
    35: a.set('bar', new Blob, 2) // incorrect
+                              ^ number. This type is incompatible with the expected param type of
+  301:     set(name: string, value: Blob, filename?: string): void;
+                                                     ^^^^^^ string. See lib: <BUILTINS>/bom.js:301
+  Member 3:
+  302:     set(name: string, value: File, filename?: string): void;
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function type. See lib: <BUILTINS>/bom.js:302
+  Error:
+   35: a.set('bar', new Blob, 2) // incorrect
                     ^^^^^^^^ Blob. This type is incompatible with
-  301:     set(name: string, value: File, filename?: string): void;
-                                    ^^^^ File. See lib: <BUILTINS>/bom.js:301
+  302:     set(name: string, value: File, filename?: string): void;
+                                    ^^^^ File. See lib: <BUILTINS>/bom.js:302
 
 FormData.js:39
  39: a.append('foo', {}); // incorrect
@@ -228,29 +228,29 @@ FormData.js:39
  39: a.append('foo', {}); // incorrect
      ^^^^^^^^ intersection
   Member 1:
-  303:     append(name: string, value: string): void;
-           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function type. See lib: <BUILTINS>/bom.js:303
+  304:     append(name: string, value: string): void;
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function type. See lib: <BUILTINS>/bom.js:304
   Error:
    39: a.append('foo', {}); // incorrect
                        ^^ object literal. This type is incompatible with the expected param type of
-  303:     append(name: string, value: string): void;
-                                       ^^^^^^ string. See lib: <BUILTINS>/bom.js:303
+  304:     append(name: string, value: string): void;
+                                       ^^^^^^ string. See lib: <BUILTINS>/bom.js:304
   Member 2:
-  304:     append(name: string, value: Blob, filename?: string): void;
-           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function type. See lib: <BUILTINS>/bom.js:304
-  Error:
-   39: a.append('foo', {}); // incorrect
-                       ^^ object literal. This type is incompatible with the expected param type of
-  304:     append(name: string, value: Blob, filename?: string): void;
-                                       ^^^^ Blob. See lib: <BUILTINS>/bom.js:304
-  Member 3:
-  305:     append(name: string, value: File, filename?: string): void;
+  305:     append(name: string, value: Blob, filename?: string): void;
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function type. See lib: <BUILTINS>/bom.js:305
   Error:
    39: a.append('foo', {}); // incorrect
                        ^^ object literal. This type is incompatible with the expected param type of
-  305:     append(name: string, value: File, filename?: string): void;
-                                       ^^^^ File. See lib: <BUILTINS>/bom.js:305
+  305:     append(name: string, value: Blob, filename?: string): void;
+                                       ^^^^ Blob. See lib: <BUILTINS>/bom.js:305
+  Member 3:
+  306:     append(name: string, value: File, filename?: string): void;
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function type. See lib: <BUILTINS>/bom.js:306
+  Error:
+   39: a.append('foo', {}); // incorrect
+                       ^^ object literal. This type is incompatible with the expected param type of
+  306:     append(name: string, value: File, filename?: string): void;
+                                       ^^^^ File. See lib: <BUILTINS>/bom.js:306
 
 FormData.js:40
  40: a.append(2, 'bar'); // incorrect
@@ -258,29 +258,29 @@ FormData.js:40
  40: a.append(2, 'bar'); // incorrect
      ^^^^^^^^ intersection
   Member 1:
-  303:     append(name: string, value: string): void;
-           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function type. See lib: <BUILTINS>/bom.js:303
+  304:     append(name: string, value: string): void;
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function type. See lib: <BUILTINS>/bom.js:304
   Error:
    40: a.append(2, 'bar'); // incorrect
                 ^ number. This type is incompatible with the expected param type of
-  303:     append(name: string, value: string): void;
-                        ^^^^^^ string. See lib: <BUILTINS>/bom.js:303
-  Member 2:
-  304:     append(name: string, value: Blob, filename?: string): void;
-           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function type. See lib: <BUILTINS>/bom.js:304
-  Error:
-   40: a.append(2, 'bar'); // incorrect
-                ^ number. This type is incompatible with the expected param type of
-  304:     append(name: string, value: Blob, filename?: string): void;
+  304:     append(name: string, value: string): void;
                         ^^^^^^ string. See lib: <BUILTINS>/bom.js:304
-  Member 3:
-  305:     append(name: string, value: File, filename?: string): void;
+  Member 2:
+  305:     append(name: string, value: Blob, filename?: string): void;
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function type. See lib: <BUILTINS>/bom.js:305
   Error:
    40: a.append(2, 'bar'); // incorrect
                 ^ number. This type is incompatible with the expected param type of
-  305:     append(name: string, value: File, filename?: string): void;
+  305:     append(name: string, value: Blob, filename?: string): void;
                         ^^^^^^ string. See lib: <BUILTINS>/bom.js:305
+  Member 3:
+  306:     append(name: string, value: File, filename?: string): void;
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function type. See lib: <BUILTINS>/bom.js:306
+  Error:
+   40: a.append(2, 'bar'); // incorrect
+                ^ number. This type is incompatible with the expected param type of
+  306:     append(name: string, value: File, filename?: string): void;
+                        ^^^^^^ string. See lib: <BUILTINS>/bom.js:306
 
 FormData.js:45
  45: a.append('bar', new File([], 'q'), 2) // incorrect
@@ -288,29 +288,29 @@ FormData.js:45
  45: a.append('bar', new File([], 'q'), 2) // incorrect
      ^^^^^^^^ intersection
   Member 1:
-  303:     append(name: string, value: string): void;
-           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function type. See lib: <BUILTINS>/bom.js:303
+  304:     append(name: string, value: string): void;
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function type. See lib: <BUILTINS>/bom.js:304
   Error:
    45: a.append('bar', new File([], 'q'), 2) // incorrect
                        ^^^^^^^^^^^^^^^^^ File. This type is incompatible with the expected param type of
-  303:     append(name: string, value: string): void;
-                                       ^^^^^^ string. See lib: <BUILTINS>/bom.js:303
+  304:     append(name: string, value: string): void;
+                                       ^^^^^^ string. See lib: <BUILTINS>/bom.js:304
   Member 2:
-  304:     append(name: string, value: Blob, filename?: string): void;
-           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function type. See lib: <BUILTINS>/bom.js:304
-  Error:
-   45: a.append('bar', new File([], 'q'), 2) // incorrect
-                                          ^ number. This type is incompatible with the expected param type of
-  304:     append(name: string, value: Blob, filename?: string): void;
-                                                        ^^^^^^ string. See lib: <BUILTINS>/bom.js:304
-  Member 3:
-  305:     append(name: string, value: File, filename?: string): void;
+  305:     append(name: string, value: Blob, filename?: string): void;
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function type. See lib: <BUILTINS>/bom.js:305
   Error:
    45: a.append('bar', new File([], 'q'), 2) // incorrect
                                           ^ number. This type is incompatible with the expected param type of
-  305:     append(name: string, value: File, filename?: string): void;
+  305:     append(name: string, value: Blob, filename?: string): void;
                                                         ^^^^^^ string. See lib: <BUILTINS>/bom.js:305
+  Member 3:
+  306:     append(name: string, value: File, filename?: string): void;
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function type. See lib: <BUILTINS>/bom.js:306
+  Error:
+   45: a.append('bar', new File([], 'q'), 2) // incorrect
+                                          ^ number. This type is incompatible with the expected param type of
+  306:     append(name: string, value: File, filename?: string): void;
+                                                        ^^^^^^ string. See lib: <BUILTINS>/bom.js:306
 
 FormData.js:48
  48: a.append('bar', new Blob, 2) // incorrect
@@ -318,35 +318,35 @@ FormData.js:48
  48: a.append('bar', new Blob, 2) // incorrect
      ^^^^^^^^ intersection
   Member 1:
-  303:     append(name: string, value: string): void;
-           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function type. See lib: <BUILTINS>/bom.js:303
+  304:     append(name: string, value: string): void;
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function type. See lib: <BUILTINS>/bom.js:304
   Error:
    48: a.append('bar', new Blob, 2) // incorrect
                        ^^^^^^^^ Blob. This type is incompatible with the expected param type of
-  303:     append(name: string, value: string): void;
-                                       ^^^^^^ string. See lib: <BUILTINS>/bom.js:303
+  304:     append(name: string, value: string): void;
+                                       ^^^^^^ string. See lib: <BUILTINS>/bom.js:304
   Member 2:
-  304:     append(name: string, value: Blob, filename?: string): void;
-           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function type. See lib: <BUILTINS>/bom.js:304
-  Error:
-   48: a.append('bar', new Blob, 2) // incorrect
-                                 ^ number. This type is incompatible with the expected param type of
-  304:     append(name: string, value: Blob, filename?: string): void;
-                                                        ^^^^^^ string. See lib: <BUILTINS>/bom.js:304
-  Member 3:
-  305:     append(name: string, value: File, filename?: string): void;
+  305:     append(name: string, value: Blob, filename?: string): void;
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function type. See lib: <BUILTINS>/bom.js:305
   Error:
    48: a.append('bar', new Blob, 2) // incorrect
+                                 ^ number. This type is incompatible with the expected param type of
+  305:     append(name: string, value: Blob, filename?: string): void;
+                                                        ^^^^^^ string. See lib: <BUILTINS>/bom.js:305
+  Member 3:
+  306:     append(name: string, value: File, filename?: string): void;
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function type. See lib: <BUILTINS>/bom.js:306
+  Error:
+   48: a.append('bar', new Blob, 2) // incorrect
                        ^^^^^^^^ Blob. This type is incompatible with
-  305:     append(name: string, value: File, filename?: string): void;
-                                       ^^^^ File. See lib: <BUILTINS>/bom.js:305
+  306:     append(name: string, value: File, filename?: string): void;
+                                       ^^^^ File. See lib: <BUILTINS>/bom.js:306
 
 FormData.js:52
  52: a.delete(3); // incorrect
               ^ number. This type is incompatible with the expected param type of
-307:     delete(name: string): void;
-                      ^^^^^^ string. See lib: <BUILTINS>/bom.js:307
+308:     delete(name: string): void;
+                      ^^^^^^ string. See lib: <BUILTINS>/bom.js:308
 
 FormData.js:56
  56: for (let x: number of a.keys()) {} // incorrect
@@ -357,336 +357,336 @@ FormData.js:56
 FormData.js:64
  64: for (let [x, y]: [string, string | File | Blob] of a.entries()) {} // incorrect
                                                ^^^^ Blob. This type is incompatible with
-311:     entries(): Iterator<[string, FormDataEntryValue]>;
-                                      ^^^^^^^^^^^^^^^^^^ union: string | File. See lib: <BUILTINS>/bom.js:311
+312:     entries(): Iterator<[string, FormDataEntryValue]>;
+                                      ^^^^^^^^^^^^^^^^^^ union: string | File. See lib: <BUILTINS>/bom.js:312
   Member 1:
-  290: type FormDataEntryValue = string | File
-                                 ^^^^^^ string. See lib: <BUILTINS>/bom.js:290
+  291: type FormDataEntryValue = string | File
+                                 ^^^^^^ string. See lib: <BUILTINS>/bom.js:291
   Error:
    64: for (let [x, y]: [string, string | File | Blob] of a.entries()) {} // incorrect
                                                  ^^^^ Blob. This type is incompatible with
-  290: type FormDataEntryValue = string | File
-                                 ^^^^^^ string. See lib: <BUILTINS>/bom.js:290
+  291: type FormDataEntryValue = string | File
+                                 ^^^^^^ string. See lib: <BUILTINS>/bom.js:291
   Member 2:
-  290: type FormDataEntryValue = string | File
-                                          ^^^^ File. See lib: <BUILTINS>/bom.js:290
+  291: type FormDataEntryValue = string | File
+                                          ^^^^ File. See lib: <BUILTINS>/bom.js:291
   Error:
    64: for (let [x, y]: [string, string | File | Blob] of a.entries()) {} // incorrect
                                                  ^^^^ Blob. This type is incompatible with
-  290: type FormDataEntryValue = string | File
-                                          ^^^^ File. See lib: <BUILTINS>/bom.js:290
+  291: type FormDataEntryValue = string | File
+                                          ^^^^ File. See lib: <BUILTINS>/bom.js:291
 
 FormData.js:65
  65: for (let [x, y]: [number, string] of a.entries()) {} // incorrect
                ^ number. This type is incompatible with
-311:     entries(): Iterator<[string, FormDataEntryValue]>;
-                              ^^^^^^ string. See lib: <BUILTINS>/bom.js:311
+312:     entries(): Iterator<[string, FormDataEntryValue]>;
+                              ^^^^^^ string. See lib: <BUILTINS>/bom.js:312
 
 FormData.js:65
  65: for (let [x, y]: [number, string] of a.entries()) {} // incorrect
                   ^ string. This type is incompatible with
-311:     entries(): Iterator<[string, FormDataEntryValue]>;
-                                      ^^^^^^^^^^^^^^^^^^ File. See lib: <BUILTINS>/bom.js:311
+312:     entries(): Iterator<[string, FormDataEntryValue]>;
+                                      ^^^^^^^^^^^^^^^^^^ File. See lib: <BUILTINS>/bom.js:312
 
 FormData.js:65
  65: for (let [x, y]: [number, string] of a.entries()) {} // incorrect
                        ^^^^^^ number. This type is incompatible with
-311:     entries(): Iterator<[string, FormDataEntryValue]>;
-                              ^^^^^^ string. See lib: <BUILTINS>/bom.js:311
+312:     entries(): Iterator<[string, FormDataEntryValue]>;
+                              ^^^^^^ string. See lib: <BUILTINS>/bom.js:312
 
 FormData.js:65
  65: for (let [x, y]: [number, string] of a.entries()) {} // incorrect
                                ^^^^^^ string. This type is incompatible with
-311:     entries(): Iterator<[string, FormDataEntryValue]>;
-                                      ^^^^^^^^^^^^^^^^^^ File. See lib: <BUILTINS>/bom.js:311
+312:     entries(): Iterator<[string, FormDataEntryValue]>;
+                                      ^^^^^^^^^^^^^^^^^^ File. See lib: <BUILTINS>/bom.js:312
 
 FormData.js:66
  66: for (let [x, y]: [string, number] of a.entries()) {} // incorrect
                   ^ number. This type is incompatible with
-311:     entries(): Iterator<[string, FormDataEntryValue]>;
-                                      ^^^^^^^^^^^^^^^^^^ File. See lib: <BUILTINS>/bom.js:311
+312:     entries(): Iterator<[string, FormDataEntryValue]>;
+                                      ^^^^^^^^^^^^^^^^^^ File. See lib: <BUILTINS>/bom.js:312
 
 FormData.js:66
  66: for (let [x, y]: [string, number] of a.entries()) {} // incorrect
                   ^ number. This type is incompatible with
-311:     entries(): Iterator<[string, FormDataEntryValue]>;
-                                      ^^^^^^^^^^^^^^^^^^ string. See lib: <BUILTINS>/bom.js:311
+312:     entries(): Iterator<[string, FormDataEntryValue]>;
+                                      ^^^^^^^^^^^^^^^^^^ string. See lib: <BUILTINS>/bom.js:312
 
 FormData.js:66
  66: for (let [x, y]: [string, number] of a.entries()) {} // incorrect
                                ^^^^^^ number. This type is incompatible with
-311:     entries(): Iterator<[string, FormDataEntryValue]>;
-                                      ^^^^^^^^^^^^^^^^^^ File. See lib: <BUILTINS>/bom.js:311
+312:     entries(): Iterator<[string, FormDataEntryValue]>;
+                                      ^^^^^^^^^^^^^^^^^^ File. See lib: <BUILTINS>/bom.js:312
 
 FormData.js:66
  66: for (let [x, y]: [string, number] of a.entries()) {} // incorrect
                                ^^^^^^ number. This type is incompatible with
-311:     entries(): Iterator<[string, FormDataEntryValue]>;
-                                      ^^^^^^^^^^^^^^^^^^ string. See lib: <BUILTINS>/bom.js:311
+312:     entries(): Iterator<[string, FormDataEntryValue]>;
+                                      ^^^^^^^^^^^^^^^^^^ string. See lib: <BUILTINS>/bom.js:312
 
 FormData.js:66
  66: for (let [x, y]: [string, number] of a.entries()) {} // incorrect
                                ^^^^^^ number. This type is incompatible with
-311:     entries(): Iterator<[string, FormDataEntryValue]>;
-                                      ^^^^^^^^^^^^^^^^^^ union: string | File. See lib: <BUILTINS>/bom.js:311
+312:     entries(): Iterator<[string, FormDataEntryValue]>;
+                                      ^^^^^^^^^^^^^^^^^^ union: string | File. See lib: <BUILTINS>/bom.js:312
   Member 1:
-  290: type FormDataEntryValue = string | File
-                                 ^^^^^^ string. See lib: <BUILTINS>/bom.js:290
+  291: type FormDataEntryValue = string | File
+                                 ^^^^^^ string. See lib: <BUILTINS>/bom.js:291
   Error:
    66: for (let [x, y]: [string, number] of a.entries()) {} // incorrect
                                  ^^^^^^ number. This type is incompatible with
-  290: type FormDataEntryValue = string | File
-                                 ^^^^^^ string. See lib: <BUILTINS>/bom.js:290
+  291: type FormDataEntryValue = string | File
+                                 ^^^^^^ string. See lib: <BUILTINS>/bom.js:291
   Member 2:
-  290: type FormDataEntryValue = string | File
-                                          ^^^^ File. See lib: <BUILTINS>/bom.js:290
+  291: type FormDataEntryValue = string | File
+                                          ^^^^ File. See lib: <BUILTINS>/bom.js:291
   Error:
    66: for (let [x, y]: [string, number] of a.entries()) {} // incorrect
                                  ^^^^^^ number. This type is incompatible with
-  290: type FormDataEntryValue = string | File
-                                          ^^^^ File. See lib: <BUILTINS>/bom.js:290
+  291: type FormDataEntryValue = string | File
+                                          ^^^^ File. See lib: <BUILTINS>/bom.js:291
 
 FormData.js:67
  67: for (let [x, y]: [number, number] of a.entries()) {} // incorrect
                ^ number. This type is incompatible with
-311:     entries(): Iterator<[string, FormDataEntryValue]>;
-                              ^^^^^^ string. See lib: <BUILTINS>/bom.js:311
+312:     entries(): Iterator<[string, FormDataEntryValue]>;
+                              ^^^^^^ string. See lib: <BUILTINS>/bom.js:312
 
 FormData.js:67
  67: for (let [x, y]: [number, number] of a.entries()) {} // incorrect
                   ^ number. This type is incompatible with
-311:     entries(): Iterator<[string, FormDataEntryValue]>;
-                                      ^^^^^^^^^^^^^^^^^^ File. See lib: <BUILTINS>/bom.js:311
+312:     entries(): Iterator<[string, FormDataEntryValue]>;
+                                      ^^^^^^^^^^^^^^^^^^ File. See lib: <BUILTINS>/bom.js:312
 
 FormData.js:67
  67: for (let [x, y]: [number, number] of a.entries()) {} // incorrect
                   ^ number. This type is incompatible with
-311:     entries(): Iterator<[string, FormDataEntryValue]>;
-                                      ^^^^^^^^^^^^^^^^^^ string. See lib: <BUILTINS>/bom.js:311
+312:     entries(): Iterator<[string, FormDataEntryValue]>;
+                                      ^^^^^^^^^^^^^^^^^^ string. See lib: <BUILTINS>/bom.js:312
 
 FormData.js:67
  67: for (let [x, y]: [number, number] of a.entries()) {} // incorrect
                        ^^^^^^ number. This type is incompatible with
-311:     entries(): Iterator<[string, FormDataEntryValue]>;
-                              ^^^^^^ string. See lib: <BUILTINS>/bom.js:311
+312:     entries(): Iterator<[string, FormDataEntryValue]>;
+                              ^^^^^^ string. See lib: <BUILTINS>/bom.js:312
 
 FormData.js:67
  67: for (let [x, y]: [number, number] of a.entries()) {} // incorrect
                                ^^^^^^ number. This type is incompatible with
-311:     entries(): Iterator<[string, FormDataEntryValue]>;
-                                      ^^^^^^^^^^^^^^^^^^ File. See lib: <BUILTINS>/bom.js:311
+312:     entries(): Iterator<[string, FormDataEntryValue]>;
+                                      ^^^^^^^^^^^^^^^^^^ File. See lib: <BUILTINS>/bom.js:312
 
 FormData.js:67
  67: for (let [x, y]: [number, number] of a.entries()) {} // incorrect
                                ^^^^^^ number. This type is incompatible with
-311:     entries(): Iterator<[string, FormDataEntryValue]>;
-                                      ^^^^^^^^^^^^^^^^^^ string. See lib: <BUILTINS>/bom.js:311
+312:     entries(): Iterator<[string, FormDataEntryValue]>;
+                                      ^^^^^^^^^^^^^^^^^^ string. See lib: <BUILTINS>/bom.js:312
 
 FormData.js:67
  67: for (let [x, y]: [number, number] of a.entries()) {} // incorrect
                                ^^^^^^ number. This type is incompatible with
-311:     entries(): Iterator<[string, FormDataEntryValue]>;
-                                      ^^^^^^^^^^^^^^^^^^ union: string | File. See lib: <BUILTINS>/bom.js:311
+312:     entries(): Iterator<[string, FormDataEntryValue]>;
+                                      ^^^^^^^^^^^^^^^^^^ union: string | File. See lib: <BUILTINS>/bom.js:312
   Member 1:
-  290: type FormDataEntryValue = string | File
-                                 ^^^^^^ string. See lib: <BUILTINS>/bom.js:290
+  291: type FormDataEntryValue = string | File
+                                 ^^^^^^ string. See lib: <BUILTINS>/bom.js:291
   Error:
    67: for (let [x, y]: [number, number] of a.entries()) {} // incorrect
                                  ^^^^^^ number. This type is incompatible with
-  290: type FormDataEntryValue = string | File
-                                 ^^^^^^ string. See lib: <BUILTINS>/bom.js:290
+  291: type FormDataEntryValue = string | File
+                                 ^^^^^^ string. See lib: <BUILTINS>/bom.js:291
   Member 2:
-  290: type FormDataEntryValue = string | File
-                                          ^^^^ File. See lib: <BUILTINS>/bom.js:290
+  291: type FormDataEntryValue = string | File
+                                          ^^^^ File. See lib: <BUILTINS>/bom.js:291
   Error:
    67: for (let [x, y]: [number, number] of a.entries()) {} // incorrect
                                  ^^^^^^ number. This type is incompatible with
-  290: type FormDataEntryValue = string | File
-                                          ^^^^ File. See lib: <BUILTINS>/bom.js:290
+  291: type FormDataEntryValue = string | File
+                                          ^^^^ File. See lib: <BUILTINS>/bom.js:291
 
 MutationObserver.js:10
  10: new MutationObserver(); // incorrect
      ^^^^^^^^^^^^^^^^^^^^^^ constructor call
  10: new MutationObserver(); // incorrect
      ^^^^^^^^^^^^^^^^^^^^^^ undefined (too few arguments, expected default/rest parameters). This type is incompatible with
-339:     constructor(callback: (arr: Array<MutationRecord>, observer: MutationObserver) => any): void;
-                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function type. See lib: <BUILTINS>/bom.js:339
+340:     constructor(callback: (arr: Array<MutationRecord>, observer: MutationObserver) => any): void;
+                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function type. See lib: <BUILTINS>/bom.js:340
 
 MutationObserver.js:11
  11: new MutationObserver(42); // incorrect
                           ^^ number. This type is incompatible with the expected param type of
-339:     constructor(callback: (arr: Array<MutationRecord>, observer: MutationObserver) => any): void;
-                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function type. See lib: <BUILTINS>/bom.js:339
+340:     constructor(callback: (arr: Array<MutationRecord>, observer: MutationObserver) => any): void;
+                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function type. See lib: <BUILTINS>/bom.js:340
 
 MutationObserver.js:12
  12: new MutationObserver((n: number) => {}); // incorrect
                               ^^^^^^ number. This type is incompatible with an argument type of
-339:     constructor(callback: (arr: Array<MutationRecord>, observer: MutationObserver) => any): void;
-                                     ^^^^^^^^^^^^^^^^^^^^^ array type. See lib: <BUILTINS>/bom.js:339
+340:     constructor(callback: (arr: Array<MutationRecord>, observer: MutationObserver) => any): void;
+                                     ^^^^^^^^^^^^^^^^^^^^^ array type. See lib: <BUILTINS>/bom.js:340
 
 MutationObserver.js:18
  18: o.observe(); // incorrect
      ^^^^^^^^^^^ call of method `observe`
  18: o.observe(); // incorrect
      ^^^^^^^^^^^ undefined (too few arguments, expected default/rest parameters). This type is incompatible with
-331: declare type MutationObserverInit = MutationObserverInitRequired & {
-                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ union: object type(s). See lib: <BUILTINS>/bom.js:331
+332: declare type MutationObserverInit = MutationObserverInitRequired & {
+                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ union: object type(s). See lib: <BUILTINS>/bom.js:332
   Member 1:
-  327:     | { childList: true }
-             ^^^^^^^^^^^^^^^^^^^ object type. See lib: <BUILTINS>/bom.js:327
+  328:     | { childList: true }
+             ^^^^^^^^^^^^^^^^^^^ object type. See lib: <BUILTINS>/bom.js:328
   Error:
    18: o.observe(); // incorrect
        ^^^^^^^^^^^ undefined (too few arguments, expected default/rest parameters). This type is incompatible with
-  327:     | { childList: true }
-             ^^^^^^^^^^^^^^^^^^^ object type. See lib: <BUILTINS>/bom.js:327
+  328:     | { childList: true }
+             ^^^^^^^^^^^^^^^^^^^ object type. See lib: <BUILTINS>/bom.js:328
   Member 2:
-  328:     | { attributes: true }
-             ^^^^^^^^^^^^^^^^^^^^ object type. See lib: <BUILTINS>/bom.js:328
+  329:     | { attributes: true }
+             ^^^^^^^^^^^^^^^^^^^^ object type. See lib: <BUILTINS>/bom.js:329
   Error:
    18: o.observe(); // incorrect
        ^^^^^^^^^^^ undefined (too few arguments, expected default/rest parameters). This type is incompatible with
-  328:     | { attributes: true }
-             ^^^^^^^^^^^^^^^^^^^^ object type. See lib: <BUILTINS>/bom.js:328
+  329:     | { attributes: true }
+             ^^^^^^^^^^^^^^^^^^^^ object type. See lib: <BUILTINS>/bom.js:329
   Member 3:
-  329:     | { characterData: true }
-             ^^^^^^^^^^^^^^^^^^^^^^^ object type. See lib: <BUILTINS>/bom.js:329
+  330:     | { characterData: true }
+             ^^^^^^^^^^^^^^^^^^^^^^^ object type. See lib: <BUILTINS>/bom.js:330
   Error:
    18: o.observe(); // incorrect
        ^^^^^^^^^^^ undefined (too few arguments, expected default/rest parameters). This type is incompatible with
-  329:     | { characterData: true }
-             ^^^^^^^^^^^^^^^^^^^^^^^ object type. See lib: <BUILTINS>/bom.js:329
+  330:     | { characterData: true }
+             ^^^^^^^^^^^^^^^^^^^^^^^ object type. See lib: <BUILTINS>/bom.js:330
 
 MutationObserver.js:18
  18: o.observe(); // incorrect
      ^^^^^^^^^^^ call of method `observe`
  18: o.observe(); // incorrect
      ^^^^^^^^^^^ undefined (too few arguments, expected default/rest parameters). This type is incompatible with
-331: declare type MutationObserverInit = MutationObserverInitRequired & {
-                                                                        ^ object type. See lib: <BUILTINS>/bom.js:331
+332: declare type MutationObserverInit = MutationObserverInitRequired & {
+                                                                        ^ object type. See lib: <BUILTINS>/bom.js:332
 
 MutationObserver.js:18
  18: o.observe(); // incorrect
      ^^^^^^^^^^^ call of method `observe`
  18: o.observe(); // incorrect
      ^^^^^^^^^^^ undefined (too few arguments, expected default/rest parameters). This type is incompatible with
-340:     observe(target: Node, options: MutationObserverInit): void;
-                         ^^^^ Node. See lib: <BUILTINS>/bom.js:340
+341:     observe(target: Node, options: MutationObserverInit): void;
+                         ^^^^ Node. See lib: <BUILTINS>/bom.js:341
 
 MutationObserver.js:19
  19: o.observe('invalid'); // incorrect
      ^^^^^^^^^^^^^^^^^^^^ call of method `observe`
  19: o.observe('invalid'); // incorrect
      ^^^^^^^^^^^^^^^^^^^^ undefined (too few arguments, expected default/rest parameters). This type is incompatible with
-331: declare type MutationObserverInit = MutationObserverInitRequired & {
-                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ union: object type(s). See lib: <BUILTINS>/bom.js:331
+332: declare type MutationObserverInit = MutationObserverInitRequired & {
+                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ union: object type(s). See lib: <BUILTINS>/bom.js:332
   Member 1:
-  327:     | { childList: true }
-             ^^^^^^^^^^^^^^^^^^^ object type. See lib: <BUILTINS>/bom.js:327
+  328:     | { childList: true }
+             ^^^^^^^^^^^^^^^^^^^ object type. See lib: <BUILTINS>/bom.js:328
   Error:
    19: o.observe('invalid'); // incorrect
        ^^^^^^^^^^^^^^^^^^^^ undefined (too few arguments, expected default/rest parameters). This type is incompatible with
-  327:     | { childList: true }
-             ^^^^^^^^^^^^^^^^^^^ object type. See lib: <BUILTINS>/bom.js:327
+  328:     | { childList: true }
+             ^^^^^^^^^^^^^^^^^^^ object type. See lib: <BUILTINS>/bom.js:328
   Member 2:
-  328:     | { attributes: true }
-             ^^^^^^^^^^^^^^^^^^^^ object type. See lib: <BUILTINS>/bom.js:328
+  329:     | { attributes: true }
+             ^^^^^^^^^^^^^^^^^^^^ object type. See lib: <BUILTINS>/bom.js:329
   Error:
    19: o.observe('invalid'); // incorrect
        ^^^^^^^^^^^^^^^^^^^^ undefined (too few arguments, expected default/rest parameters). This type is incompatible with
-  328:     | { attributes: true }
-             ^^^^^^^^^^^^^^^^^^^^ object type. See lib: <BUILTINS>/bom.js:328
+  329:     | { attributes: true }
+             ^^^^^^^^^^^^^^^^^^^^ object type. See lib: <BUILTINS>/bom.js:329
   Member 3:
-  329:     | { characterData: true }
-             ^^^^^^^^^^^^^^^^^^^^^^^ object type. See lib: <BUILTINS>/bom.js:329
+  330:     | { characterData: true }
+             ^^^^^^^^^^^^^^^^^^^^^^^ object type. See lib: <BUILTINS>/bom.js:330
   Error:
    19: o.observe('invalid'); // incorrect
        ^^^^^^^^^^^^^^^^^^^^ undefined (too few arguments, expected default/rest parameters). This type is incompatible with
-  329:     | { characterData: true }
-             ^^^^^^^^^^^^^^^^^^^^^^^ object type. See lib: <BUILTINS>/bom.js:329
+  330:     | { characterData: true }
+             ^^^^^^^^^^^^^^^^^^^^^^^ object type. See lib: <BUILTINS>/bom.js:330
 
 MutationObserver.js:19
  19: o.observe('invalid'); // incorrect
      ^^^^^^^^^^^^^^^^^^^^ call of method `observe`
  19: o.observe('invalid'); // incorrect
      ^^^^^^^^^^^^^^^^^^^^ undefined (too few arguments, expected default/rest parameters). This type is incompatible with
-331: declare type MutationObserverInit = MutationObserverInitRequired & {
-                                                                        ^ object type. See lib: <BUILTINS>/bom.js:331
+332: declare type MutationObserverInit = MutationObserverInitRequired & {
+                                                                        ^ object type. See lib: <BUILTINS>/bom.js:332
 
 MutationObserver.js:19
  19: o.observe('invalid'); // incorrect
                ^^^^^^^^^ string. This type is incompatible with the expected param type of
-340:     observe(target: Node, options: MutationObserverInit): void;
-                         ^^^^ Node. See lib: <BUILTINS>/bom.js:340
+341:     observe(target: Node, options: MutationObserverInit): void;
+                         ^^^^ Node. See lib: <BUILTINS>/bom.js:341
 
 MutationObserver.js:20
  20: o.observe(div); // incorrect
      ^^^^^^^^^^^^^^ call of method `observe`
  20: o.observe(div); // incorrect
      ^^^^^^^^^^^^^^ undefined (too few arguments, expected default/rest parameters). This type is incompatible with
-331: declare type MutationObserverInit = MutationObserverInitRequired & {
-                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ union: object type(s). See lib: <BUILTINS>/bom.js:331
+332: declare type MutationObserverInit = MutationObserverInitRequired & {
+                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ union: object type(s). See lib: <BUILTINS>/bom.js:332
   Member 1:
-  327:     | { childList: true }
-             ^^^^^^^^^^^^^^^^^^^ object type. See lib: <BUILTINS>/bom.js:327
+  328:     | { childList: true }
+             ^^^^^^^^^^^^^^^^^^^ object type. See lib: <BUILTINS>/bom.js:328
   Error:
    20: o.observe(div); // incorrect
        ^^^^^^^^^^^^^^ undefined (too few arguments, expected default/rest parameters). This type is incompatible with
-  327:     | { childList: true }
-             ^^^^^^^^^^^^^^^^^^^ object type. See lib: <BUILTINS>/bom.js:327
+  328:     | { childList: true }
+             ^^^^^^^^^^^^^^^^^^^ object type. See lib: <BUILTINS>/bom.js:328
   Member 2:
-  328:     | { attributes: true }
-             ^^^^^^^^^^^^^^^^^^^^ object type. See lib: <BUILTINS>/bom.js:328
+  329:     | { attributes: true }
+             ^^^^^^^^^^^^^^^^^^^^ object type. See lib: <BUILTINS>/bom.js:329
   Error:
    20: o.observe(div); // incorrect
        ^^^^^^^^^^^^^^ undefined (too few arguments, expected default/rest parameters). This type is incompatible with
-  328:     | { attributes: true }
-             ^^^^^^^^^^^^^^^^^^^^ object type. See lib: <BUILTINS>/bom.js:328
+  329:     | { attributes: true }
+             ^^^^^^^^^^^^^^^^^^^^ object type. See lib: <BUILTINS>/bom.js:329
   Member 3:
-  329:     | { characterData: true }
-             ^^^^^^^^^^^^^^^^^^^^^^^ object type. See lib: <BUILTINS>/bom.js:329
+  330:     | { characterData: true }
+             ^^^^^^^^^^^^^^^^^^^^^^^ object type. See lib: <BUILTINS>/bom.js:330
   Error:
    20: o.observe(div); // incorrect
        ^^^^^^^^^^^^^^ undefined (too few arguments, expected default/rest parameters). This type is incompatible with
-  329:     | { characterData: true }
-             ^^^^^^^^^^^^^^^^^^^^^^^ object type. See lib: <BUILTINS>/bom.js:329
+  330:     | { characterData: true }
+             ^^^^^^^^^^^^^^^^^^^^^^^ object type. See lib: <BUILTINS>/bom.js:330
 
 MutationObserver.js:20
  20: o.observe(div); // incorrect
      ^^^^^^^^^^^^^^ call of method `observe`
  20: o.observe(div); // incorrect
      ^^^^^^^^^^^^^^ undefined (too few arguments, expected default/rest parameters). This type is incompatible with
-331: declare type MutationObserverInit = MutationObserverInitRequired & {
-                                                                        ^ object type. See lib: <BUILTINS>/bom.js:331
+332: declare type MutationObserverInit = MutationObserverInitRequired & {
+                                                                        ^ object type. See lib: <BUILTINS>/bom.js:332
 
 MutationObserver.js:21
  21: o.observe(div, {}); // incorrect
      ^^^^^^^^^^^^^^^^^^ call of method `observe`
  21: o.observe(div, {}); // incorrect
                     ^^ object literal. This type is incompatible with
-331: declare type MutationObserverInit = MutationObserverInitRequired & {
-                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ union: object type(s). See lib: <BUILTINS>/bom.js:331
+332: declare type MutationObserverInit = MutationObserverInitRequired & {
+                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ union: object type(s). See lib: <BUILTINS>/bom.js:332
   Member 1:
-  327:     | { childList: true }
-             ^^^^^^^^^^^^^^^^^^^ object type. See lib: <BUILTINS>/bom.js:327
+  328:     | { childList: true }
+             ^^^^^^^^^^^^^^^^^^^ object type. See lib: <BUILTINS>/bom.js:328
   Error:
-  327:     | { childList: true }
-             ^^^^^^^^^^^^^^^^^^^ property `childList`. Property not found in. See lib: <BUILTINS>/bom.js:327
+  328:     | { childList: true }
+             ^^^^^^^^^^^^^^^^^^^ property `childList`. Property not found in. See lib: <BUILTINS>/bom.js:328
    21: o.observe(div, {}); // incorrect
                       ^^ object literal
   Member 2:
-  328:     | { attributes: true }
-             ^^^^^^^^^^^^^^^^^^^^ object type. See lib: <BUILTINS>/bom.js:328
+  329:     | { attributes: true }
+             ^^^^^^^^^^^^^^^^^^^^ object type. See lib: <BUILTINS>/bom.js:329
   Error:
-  328:     | { attributes: true }
-             ^^^^^^^^^^^^^^^^^^^^ property `attributes`. Property not found in. See lib: <BUILTINS>/bom.js:328
+  329:     | { attributes: true }
+             ^^^^^^^^^^^^^^^^^^^^ property `attributes`. Property not found in. See lib: <BUILTINS>/bom.js:329
    21: o.observe(div, {}); // incorrect
                       ^^ object literal
   Member 3:
-  329:     | { characterData: true }
-             ^^^^^^^^^^^^^^^^^^^^^^^ object type. See lib: <BUILTINS>/bom.js:329
+  330:     | { characterData: true }
+             ^^^^^^^^^^^^^^^^^^^^^^^ object type. See lib: <BUILTINS>/bom.js:330
   Error:
-  329:     | { characterData: true }
-             ^^^^^^^^^^^^^^^^^^^^^^^ property `characterData`. Property not found in. See lib: <BUILTINS>/bom.js:329
+  330:     | { characterData: true }
+             ^^^^^^^^^^^^^^^^^^^^^^^ property `characterData`. Property not found in. See lib: <BUILTINS>/bom.js:330
    21: o.observe(div, {}); // incorrect
                       ^^ object literal
 
@@ -695,43 +695,43 @@ MutationObserver.js:22
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call of method `observe`
  22: o.observe(div, { subtree: true }); // incorrect
                     ^^^^^^^^^^^^^^^^^ object literal. This type is incompatible with
-331: declare type MutationObserverInit = MutationObserverInitRequired & {
-                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ union: object type(s). See lib: <BUILTINS>/bom.js:331
+332: declare type MutationObserverInit = MutationObserverInitRequired & {
+                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ union: object type(s). See lib: <BUILTINS>/bom.js:332
   Member 1:
-  327:     | { childList: true }
-             ^^^^^^^^^^^^^^^^^^^ object type. See lib: <BUILTINS>/bom.js:327
+  328:     | { childList: true }
+             ^^^^^^^^^^^^^^^^^^^ object type. See lib: <BUILTINS>/bom.js:328
   Error:
-  327:     | { childList: true }
-             ^^^^^^^^^^^^^^^^^^^ property `childList`. Property not found in. See lib: <BUILTINS>/bom.js:327
+  328:     | { childList: true }
+             ^^^^^^^^^^^^^^^^^^^ property `childList`. Property not found in. See lib: <BUILTINS>/bom.js:328
    22: o.observe(div, { subtree: true }); // incorrect
                       ^^^^^^^^^^^^^^^^^ object literal
   Member 2:
-  328:     | { attributes: true }
-             ^^^^^^^^^^^^^^^^^^^^ object type. See lib: <BUILTINS>/bom.js:328
+  329:     | { attributes: true }
+             ^^^^^^^^^^^^^^^^^^^^ object type. See lib: <BUILTINS>/bom.js:329
   Error:
-  328:     | { attributes: true }
-             ^^^^^^^^^^^^^^^^^^^^ property `attributes`. Property not found in. See lib: <BUILTINS>/bom.js:328
+  329:     | { attributes: true }
+             ^^^^^^^^^^^^^^^^^^^^ property `attributes`. Property not found in. See lib: <BUILTINS>/bom.js:329
    22: o.observe(div, { subtree: true }); // incorrect
                       ^^^^^^^^^^^^^^^^^ object literal
   Member 3:
-  329:     | { characterData: true }
-             ^^^^^^^^^^^^^^^^^^^^^^^ object type. See lib: <BUILTINS>/bom.js:329
+  330:     | { characterData: true }
+             ^^^^^^^^^^^^^^^^^^^^^^^ object type. See lib: <BUILTINS>/bom.js:330
   Error:
-  329:     | { characterData: true }
-             ^^^^^^^^^^^^^^^^^^^^^^^ property `characterData`. Property not found in. See lib: <BUILTINS>/bom.js:329
+  330:     | { characterData: true }
+             ^^^^^^^^^^^^^^^^^^^^^^^ property `characterData`. Property not found in. See lib: <BUILTINS>/bom.js:330
    22: o.observe(div, { subtree: true }); // incorrect
                       ^^^^^^^^^^^^^^^^^ object literal
 
 MutationObserver.js:23
  23: o.observe(div, { attributes: true, attributeFilter: true }); // incorrect
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ object literal. This type is incompatible with the expected param type of
-331: declare type MutationObserverInit = MutationObserverInitRequired & {
-                                                                        ^ object type. See lib: <BUILTINS>/bom.js:331
+332: declare type MutationObserverInit = MutationObserverInitRequired & {
+                                                                        ^ object type. See lib: <BUILTINS>/bom.js:332
   Property `attributeFilter` is incompatible:
      23: o.observe(div, { attributes: true, attributeFilter: true }); // incorrect
                                                              ^^^^ boolean. This type is incompatible with
-    335:     attributeFilter?: Array<string>;
-                               ^^^^^^^^^^^^^ array type. See lib: <BUILTINS>/bom.js:335
+    336:     attributeFilter?: Array<string>;
+                               ^^^^^^^^^^^^^ array type. See lib: <BUILTINS>/bom.js:336
 
 
 Found 53 errors

--- a/tests/fetch/fetch.exp
+++ b/tests/fetch/fetch.exp
@@ -1,106 +1,106 @@
 fetch.js:12
  12: const b: Promise<string> = fetch(myRequest); // incorrect
                       ^^^^^^ string. This type is incompatible with
-888: declare function fetch(input: string | Request, init?: RequestOptions): Promise<Response>;
-                                                                                     ^^^^^^^^ Response. See lib: <BUILTINS>/bom.js:888
+889: declare function fetch(input: string | Request, init?: RequestOptions): Promise<Response>;
+                                                                                     ^^^^^^^^ Response. See lib: <BUILTINS>/bom.js:889
 
 fetch.js:25
  25: const d: Promise<Blob> = fetch('image.png'); // incorrect
                       ^^^^ Blob. This type is incompatible with
-888: declare function fetch(input: string | Request, init?: RequestOptions): Promise<Response>;
-                                                                                     ^^^^^^^^ Response. See lib: <BUILTINS>/bom.js:888
+889: declare function fetch(input: string | Request, init?: RequestOptions): Promise<Response>;
+                                                                                     ^^^^^^^^ Response. See lib: <BUILTINS>/bom.js:889
 
 headers.js:3
   3: const a = new Headers("'Content-Type': 'image/jpeg'"); // not correct
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructor call
   3: const a = new Headers("'Content-Type': 'image/jpeg'"); // not correct
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string. This type is incompatible with
-781:     constructor(init?: HeadersInit): void;
-                            ^^^^^^^^^^^ union: Headers | object type. See lib: <BUILTINS>/bom.js:781
+782:     constructor(init?: HeadersInit): void;
+                            ^^^^^^^^^^^ union: Headers | object type. See lib: <BUILTINS>/bom.js:782
   Member 1:
-  774: type HeadersInit = Headers | {[key: string]: string};
-                          ^^^^^^^ Headers. See lib: <BUILTINS>/bom.js:774
+  775: type HeadersInit = Headers | {[key: string]: string};
+                          ^^^^^^^ Headers. See lib: <BUILTINS>/bom.js:775
   Error:
     3: const a = new Headers("'Content-Type': 'image/jpeg'"); // not correct
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string. This type is incompatible with
-  774: type HeadersInit = Headers | {[key: string]: string};
-                          ^^^^^^^ Headers. See lib: <BUILTINS>/bom.js:774
+  775: type HeadersInit = Headers | {[key: string]: string};
+                          ^^^^^^^ Headers. See lib: <BUILTINS>/bom.js:775
   Member 2:
-  774: type HeadersInit = Headers | {[key: string]: string};
-                                    ^^^^^^^^^^^^^^^^^^^^^^^ object type. See lib: <BUILTINS>/bom.js:774
+  775: type HeadersInit = Headers | {[key: string]: string};
+                                    ^^^^^^^^^^^^^^^^^^^^^^^ object type. See lib: <BUILTINS>/bom.js:775
   Error:
     3: const a = new Headers("'Content-Type': 'image/jpeg'"); // not correct
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string. This type is incompatible with
-  774: type HeadersInit = Headers | {[key: string]: string};
-                                    ^^^^^^^^^^^^^^^^^^^^^^^ object type. See lib: <BUILTINS>/bom.js:774
+  775: type HeadersInit = Headers | {[key: string]: string};
+                                    ^^^^^^^^^^^^^^^^^^^^^^^ object type. See lib: <BUILTINS>/bom.js:775
 
 headers.js:4
   4: const b = new Headers(['Content-Type', 'image/jpeg']); // not correct
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructor call
   4: const b = new Headers(['Content-Type', 'image/jpeg']); // not correct
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ array literal. This type is incompatible with
-781:     constructor(init?: HeadersInit): void;
-                            ^^^^^^^^^^^ union: Headers | object type. See lib: <BUILTINS>/bom.js:781
+782:     constructor(init?: HeadersInit): void;
+                            ^^^^^^^^^^^ union: Headers | object type. See lib: <BUILTINS>/bom.js:782
   Member 1:
-  774: type HeadersInit = Headers | {[key: string]: string};
-                          ^^^^^^^ Headers. See lib: <BUILTINS>/bom.js:774
+  775: type HeadersInit = Headers | {[key: string]: string};
+                          ^^^^^^^ Headers. See lib: <BUILTINS>/bom.js:775
   Error:
     4: const b = new Headers(['Content-Type', 'image/jpeg']); // not correct
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ array literal. This type is incompatible with
-  774: type HeadersInit = Headers | {[key: string]: string};
-                          ^^^^^^^ Headers. See lib: <BUILTINS>/bom.js:774
+  775: type HeadersInit = Headers | {[key: string]: string};
+                          ^^^^^^^ Headers. See lib: <BUILTINS>/bom.js:775
   Member 2:
-  774: type HeadersInit = Headers | {[key: string]: string};
-                                    ^^^^^^^^^^^^^^^^^^^^^^^ object type. See lib: <BUILTINS>/bom.js:774
+  775: type HeadersInit = Headers | {[key: string]: string};
+                                    ^^^^^^^^^^^^^^^^^^^^^^^ object type. See lib: <BUILTINS>/bom.js:775
   Error:
     4: const b = new Headers(['Content-Type', 'image/jpeg']); // not correct
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ array literal. This type is incompatible with
-  774: type HeadersInit = Headers | {[key: string]: string};
-                                    ^^^^^^^^^^^^^^^^^^^^^^^ object type. See lib: <BUILTINS>/bom.js:774
+  775: type HeadersInit = Headers | {[key: string]: string};
+                                    ^^^^^^^^^^^^^^^^^^^^^^^ object type. See lib: <BUILTINS>/bom.js:775
 
 headers.js:9
   9: e.append('Content-Type'); // not correct
      ^^^^^^^^^^^^^^^^^^^^^^^^ call of method `append`
   9: e.append('Content-Type'); // not correct
      ^^^^^^^^^^^^^^^^^^^^^^^^ undefined (too few arguments, expected default/rest parameters). This type is incompatible with
-782:     append(name: string, value: string): void;
-                                     ^^^^^^ string. See lib: <BUILTINS>/bom.js:782
+783:     append(name: string, value: string): void;
+                                     ^^^^^^ string. See lib: <BUILTINS>/bom.js:783
 
 headers.js:10
  10: e.append({'Content-Type', 'image/jpeg'}); // not correct
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call of method `append`
  10: e.append({'Content-Type', 'image/jpeg'}); // not correct
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ undefined (too few arguments, expected default/rest parameters). This type is incompatible with
-782:     append(name: string, value: string): void;
-                                     ^^^^^^ string. See lib: <BUILTINS>/bom.js:782
+783:     append(name: string, value: string): void;
+                                     ^^^^^^ string. See lib: <BUILTINS>/bom.js:783
 
 headers.js:10
  10: e.append({'Content-Type', 'image/jpeg'}); // not correct
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ object literal. This type is incompatible with the expected param type of
-782:     append(name: string, value: string): void;
-                      ^^^^^^ string. See lib: <BUILTINS>/bom.js:782
+783:     append(name: string, value: string): void;
+                      ^^^^^^ string. See lib: <BUILTINS>/bom.js:783
 
 headers.js:12
  12: e.set('Content-Type'); // not correct
      ^^^^^^^^^^^^^^^^^^^^^ call of method `set`
  12: e.set('Content-Type'); // not correct
      ^^^^^^^^^^^^^^^^^^^^^ undefined (too few arguments, expected default/rest parameters). This type is incompatible with
-789:     set(name: string, value: string): void;
-                                  ^^^^^^ string. See lib: <BUILTINS>/bom.js:789
+790:     set(name: string, value: string): void;
+                                  ^^^^^^ string. See lib: <BUILTINS>/bom.js:790
 
 headers.js:13
  13: e.set({'Content-Type', 'image/jpeg'}); // not correct
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call of method `set`
  13: e.set({'Content-Type', 'image/jpeg'}); // not correct
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ undefined (too few arguments, expected default/rest parameters). This type is incompatible with
-789:     set(name: string, value: string): void;
-                                  ^^^^^^ string. See lib: <BUILTINS>/bom.js:789
+790:     set(name: string, value: string): void;
+                                  ^^^^^^ string. See lib: <BUILTINS>/bom.js:790
 
 headers.js:13
  13: e.set({'Content-Type', 'image/jpeg'}); // not correct
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ object literal. This type is incompatible with the expected param type of
-789:     set(name: string, value: string): void;
-                   ^^^^^^ string. See lib: <BUILTINS>/bom.js:789
+790:     set(name: string, value: string): void;
+                   ^^^^^^ string. See lib: <BUILTINS>/bom.js:790
 
 headers.js:15
  15: const f: Headers = e.append('Content-Type', 'image/jpeg'); // not correct
@@ -119,449 +119,449 @@ request.js:2
                         ^^^^^^^^^^^^^ constructor call
   2: const a: Request = new Request(); // incorrect
                         ^^^^^^^^^^^^^ undefined (too few arguments, expected default/rest parameters). This type is incompatible with
-863:     constructor(input: string | Request, init?: RequestOptions): void;
-                            ^^^^^^^^^^^^^^^^ union: string | Request. See lib: <BUILTINS>/bom.js:863
+864:     constructor(input: string | Request, init?: RequestOptions): void;
+                            ^^^^^^^^^^^^^^^^ union: string | Request. See lib: <BUILTINS>/bom.js:864
   Member 1:
-  863:     constructor(input: string | Request, init?: RequestOptions): void;
-                              ^^^^^^ string. See lib: <BUILTINS>/bom.js:863
+  864:     constructor(input: string | Request, init?: RequestOptions): void;
+                              ^^^^^^ string. See lib: <BUILTINS>/bom.js:864
   Error:
     2: const a: Request = new Request(); // incorrect
                           ^^^^^^^^^^^^^ undefined (too few arguments, expected default/rest parameters). This type is incompatible with
-  863:     constructor(input: string | Request, init?: RequestOptions): void;
-                              ^^^^^^ string. See lib: <BUILTINS>/bom.js:863
+  864:     constructor(input: string | Request, init?: RequestOptions): void;
+                              ^^^^^^ string. See lib: <BUILTINS>/bom.js:864
   Member 2:
-  863:     constructor(input: string | Request, init?: RequestOptions): void;
-                                       ^^^^^^^ Request. See lib: <BUILTINS>/bom.js:863
+  864:     constructor(input: string | Request, init?: RequestOptions): void;
+                                       ^^^^^^^ Request. See lib: <BUILTINS>/bom.js:864
   Error:
     2: const a: Request = new Request(); // incorrect
                           ^^^^^^^^^^^^^ undefined (too few arguments, expected default/rest parameters). This type is incompatible with
-  863:     constructor(input: string | Request, init?: RequestOptions): void;
-                                       ^^^^^^^ Request. See lib: <BUILTINS>/bom.js:863
+  864:     constructor(input: string | Request, init?: RequestOptions): void;
+                                       ^^^^^^^ Request. See lib: <BUILTINS>/bom.js:864
 
 request.js:6
   6: const e: Request = new Request(b, c); // incorrect
                         ^^^^^^^^^^^^^^^^^ constructor call
 inconsistent use of library definitions
-868:     cache: CacheType;
-                ^^^^^^^^^ string enum. This type is incompatible with an argument type of. See lib: <BUILTINS>/bom.js:868
-820:     cache?: ?CacheType;
-                  ^^^^^^^^^ null. See lib: <BUILTINS>/bom.js:820
+869:     cache: CacheType;
+                ^^^^^^^^^ string enum. This type is incompatible with an argument type of. See lib: <BUILTINS>/bom.js:869
+821:     cache?: ?CacheType;
+                  ^^^^^^^^^ null. See lib: <BUILTINS>/bom.js:821
 
 request.js:6
   6: const e: Request = new Request(b, c); // incorrect
                         ^^^^^^^^^^^^^^^^^ constructor call
 inconsistent use of library definitions
-868:     cache: CacheType;
-                ^^^^^^^^^ string enum. This type is incompatible with an argument type of. See lib: <BUILTINS>/bom.js:868
-820:     cache?: ?CacheType;
-                  ^^^^^^^^^ undefined. See lib: <BUILTINS>/bom.js:820
+869:     cache: CacheType;
+                ^^^^^^^^^ string enum. This type is incompatible with an argument type of. See lib: <BUILTINS>/bom.js:869
+821:     cache?: ?CacheType;
+                  ^^^^^^^^^ undefined. See lib: <BUILTINS>/bom.js:821
 
 request.js:6
   6: const e: Request = new Request(b, c); // incorrect
                         ^^^^^^^^^^^^^^^^^ constructor call
 inconsistent use of library definitions
-869:     credentials: CredentialsType;
-                      ^^^^^^^^^^^^^^^ string enum. This type is incompatible with an argument type of. See lib: <BUILTINS>/bom.js:869
-821:     credentials?: ?CredentialsType;
-                        ^^^^^^^^^^^^^^^ null. See lib: <BUILTINS>/bom.js:821
+870:     credentials: CredentialsType;
+                      ^^^^^^^^^^^^^^^ string enum. This type is incompatible with an argument type of. See lib: <BUILTINS>/bom.js:870
+822:     credentials?: ?CredentialsType;
+                        ^^^^^^^^^^^^^^^ null. See lib: <BUILTINS>/bom.js:822
 
 request.js:6
   6: const e: Request = new Request(b, c); // incorrect
                         ^^^^^^^^^^^^^^^^^ constructor call
 inconsistent use of library definitions
-869:     credentials: CredentialsType;
-                      ^^^^^^^^^^^^^^^ string enum. This type is incompatible with an argument type of. See lib: <BUILTINS>/bom.js:869
-821:     credentials?: ?CredentialsType;
-                        ^^^^^^^^^^^^^^^ undefined. See lib: <BUILTINS>/bom.js:821
+870:     credentials: CredentialsType;
+                      ^^^^^^^^^^^^^^^ string enum. This type is incompatible with an argument type of. See lib: <BUILTINS>/bom.js:870
+822:     credentials?: ?CredentialsType;
+                        ^^^^^^^^^^^^^^^ undefined. See lib: <BUILTINS>/bom.js:822
 
 request.js:6
   6: const e: Request = new Request(b, c); // incorrect
                         ^^^^^^^^^^^^^^^^^ constructor call
 inconsistent use of library definitions
-870:     headers: Headers;
-                  ^^^^^^^ Headers. This type is incompatible with an argument type of. See lib: <BUILTINS>/bom.js:870
-822:     headers?: ?HeadersInit;
-                    ^^^^^^^^^^^ null. See lib: <BUILTINS>/bom.js:822
+871:     headers: Headers;
+                  ^^^^^^^ Headers. This type is incompatible with an argument type of. See lib: <BUILTINS>/bom.js:871
+823:     headers?: ?HeadersInit;
+                    ^^^^^^^^^^^ null. See lib: <BUILTINS>/bom.js:823
 
 request.js:6
   6: const e: Request = new Request(b, c); // incorrect
                         ^^^^^^^^^^^^^^^^^ constructor call
 inconsistent use of library definitions
-870:     headers: Headers;
-                  ^^^^^^^ Headers. This type is incompatible with an argument type of. See lib: <BUILTINS>/bom.js:870
-822:     headers?: ?HeadersInit;
-                    ^^^^^^^^^^^ object type. See lib: <BUILTINS>/bom.js:822
+871:     headers: Headers;
+                  ^^^^^^^ Headers. This type is incompatible with an argument type of. See lib: <BUILTINS>/bom.js:871
+823:     headers?: ?HeadersInit;
+                    ^^^^^^^^^^^ object type. See lib: <BUILTINS>/bom.js:823
 
 request.js:6
   6: const e: Request = new Request(b, c); // incorrect
                         ^^^^^^^^^^^^^^^^^ constructor call
 inconsistent use of library definitions
-870:     headers: Headers;
-                  ^^^^^^^ Headers. This type is incompatible with an argument type of. See lib: <BUILTINS>/bom.js:870
-822:     headers?: ?HeadersInit;
-                    ^^^^^^^^^^^ undefined. See lib: <BUILTINS>/bom.js:822
+871:     headers: Headers;
+                  ^^^^^^^ Headers. This type is incompatible with an argument type of. See lib: <BUILTINS>/bom.js:871
+823:     headers?: ?HeadersInit;
+                    ^^^^^^^^^^^ undefined. See lib: <BUILTINS>/bom.js:823
 
 request.js:6
   6: const e: Request = new Request(b, c); // incorrect
                         ^^^^^^^^^^^^^^^^^ constructor call
 inconsistent use of library definitions
-871:     integrity: string;
-                    ^^^^^^ string. This type is incompatible with an argument type of. See lib: <BUILTINS>/bom.js:871
-823:     integrity?: ?string;
-                      ^^^^^^ null. See lib: <BUILTINS>/bom.js:823
+872:     integrity: string;
+                    ^^^^^^ string. This type is incompatible with an argument type of. See lib: <BUILTINS>/bom.js:872
+824:     integrity?: ?string;
+                      ^^^^^^ null. See lib: <BUILTINS>/bom.js:824
 
 request.js:6
   6: const e: Request = new Request(b, c); // incorrect
                         ^^^^^^^^^^^^^^^^^ constructor call
 inconsistent use of library definitions
-871:     integrity: string;
-                    ^^^^^^ string. This type is incompatible with an argument type of. See lib: <BUILTINS>/bom.js:871
-823:     integrity?: ?string;
-                      ^^^^^^ undefined. See lib: <BUILTINS>/bom.js:823
+872:     integrity: string;
+                    ^^^^^^ string. This type is incompatible with an argument type of. See lib: <BUILTINS>/bom.js:872
+824:     integrity?: ?string;
+                      ^^^^^^ undefined. See lib: <BUILTINS>/bom.js:824
 
 request.js:6
   6: const e: Request = new Request(b, c); // incorrect
                         ^^^^^^^^^^^^^^^^^ constructor call
 inconsistent use of library definitions
-872:     method: MethodType;
-                 ^^^^^^^^^^ string enum. This type is incompatible with an argument type of. See lib: <BUILTINS>/bom.js:872
-824:     method?: ?MethodType;
-                   ^^^^^^^^^^ null. See lib: <BUILTINS>/bom.js:824
+873:     method: MethodType;
+                 ^^^^^^^^^^ string enum. This type is incompatible with an argument type of. See lib: <BUILTINS>/bom.js:873
+825:     method?: ?MethodType;
+                   ^^^^^^^^^^ null. See lib: <BUILTINS>/bom.js:825
 
 request.js:6
   6: const e: Request = new Request(b, c); // incorrect
                         ^^^^^^^^^^^^^^^^^ constructor call
 inconsistent use of library definitions
-872:     method: MethodType;
-                 ^^^^^^^^^^ string enum. This type is incompatible with an argument type of. See lib: <BUILTINS>/bom.js:872
-824:     method?: ?MethodType;
-                   ^^^^^^^^^^ undefined. See lib: <BUILTINS>/bom.js:824
+873:     method: MethodType;
+                 ^^^^^^^^^^ string enum. This type is incompatible with an argument type of. See lib: <BUILTINS>/bom.js:873
+825:     method?: ?MethodType;
+                   ^^^^^^^^^^ undefined. See lib: <BUILTINS>/bom.js:825
 
 request.js:6
   6: const e: Request = new Request(b, c); // incorrect
                         ^^^^^^^^^^^^^^^^^ constructor call
 inconsistent use of library definitions
-873:     mode: ModeType;
-               ^^^^^^^^ string enum. This type is incompatible with an argument type of. See lib: <BUILTINS>/bom.js:873
-825:     mode?: ?ModeType;
-                 ^^^^^^^^ null. See lib: <BUILTINS>/bom.js:825
+874:     mode: ModeType;
+               ^^^^^^^^ string enum. This type is incompatible with an argument type of. See lib: <BUILTINS>/bom.js:874
+826:     mode?: ?ModeType;
+                 ^^^^^^^^ null. See lib: <BUILTINS>/bom.js:826
 
 request.js:6
   6: const e: Request = new Request(b, c); // incorrect
                         ^^^^^^^^^^^^^^^^^ constructor call
 inconsistent use of library definitions
-873:     mode: ModeType;
-               ^^^^^^^^ string enum. This type is incompatible with an argument type of. See lib: <BUILTINS>/bom.js:873
-825:     mode?: ?ModeType;
-                 ^^^^^^^^ undefined. See lib: <BUILTINS>/bom.js:825
+874:     mode: ModeType;
+               ^^^^^^^^ string enum. This type is incompatible with an argument type of. See lib: <BUILTINS>/bom.js:874
+826:     mode?: ?ModeType;
+                 ^^^^^^^^ undefined. See lib: <BUILTINS>/bom.js:826
 
 request.js:6
   6: const e: Request = new Request(b, c); // incorrect
                         ^^^^^^^^^^^^^^^^^ constructor call
 inconsistent use of library definitions
-874:     redirect: RedirectType;
-                   ^^^^^^^^^^^^ string enum. This type is incompatible with an argument type of. See lib: <BUILTINS>/bom.js:874
-826:     redirect?: ?RedirectType;
-                     ^^^^^^^^^^^^ null. See lib: <BUILTINS>/bom.js:826
+875:     redirect: RedirectType;
+                   ^^^^^^^^^^^^ string enum. This type is incompatible with an argument type of. See lib: <BUILTINS>/bom.js:875
+827:     redirect?: ?RedirectType;
+                     ^^^^^^^^^^^^ null. See lib: <BUILTINS>/bom.js:827
 
 request.js:6
   6: const e: Request = new Request(b, c); // incorrect
                         ^^^^^^^^^^^^^^^^^ constructor call
 inconsistent use of library definitions
-874:     redirect: RedirectType;
-                   ^^^^^^^^^^^^ string enum. This type is incompatible with an argument type of. See lib: <BUILTINS>/bom.js:874
-826:     redirect?: ?RedirectType;
-                     ^^^^^^^^^^^^ undefined. See lib: <BUILTINS>/bom.js:826
+875:     redirect: RedirectType;
+                   ^^^^^^^^^^^^ string enum. This type is incompatible with an argument type of. See lib: <BUILTINS>/bom.js:875
+827:     redirect?: ?RedirectType;
+                     ^^^^^^^^^^^^ undefined. See lib: <BUILTINS>/bom.js:827
 
 request.js:6
   6: const e: Request = new Request(b, c); // incorrect
                         ^^^^^^^^^^^^^^^^^ constructor call
 inconsistent use of library definitions
-875:     referrer: string;
-                   ^^^^^^ string. This type is incompatible with an argument type of. See lib: <BUILTINS>/bom.js:875
-827:     referrer?: ?string;
-                     ^^^^^^ null. See lib: <BUILTINS>/bom.js:827
+876:     referrer: string;
+                   ^^^^^^ string. This type is incompatible with an argument type of. See lib: <BUILTINS>/bom.js:876
+828:     referrer?: ?string;
+                     ^^^^^^ null. See lib: <BUILTINS>/bom.js:828
 
 request.js:6
   6: const e: Request = new Request(b, c); // incorrect
                         ^^^^^^^^^^^^^^^^^ constructor call
 inconsistent use of library definitions
-875:     referrer: string;
-                   ^^^^^^ string. This type is incompatible with an argument type of. See lib: <BUILTINS>/bom.js:875
-827:     referrer?: ?string;
-                     ^^^^^^ undefined. See lib: <BUILTINS>/bom.js:827
+876:     referrer: string;
+                   ^^^^^^ string. This type is incompatible with an argument type of. See lib: <BUILTINS>/bom.js:876
+828:     referrer?: ?string;
+                     ^^^^^^ undefined. See lib: <BUILTINS>/bom.js:828
 
 request.js:6
   6: const e: Request = new Request(b, c); // incorrect
                         ^^^^^^^^^^^^^^^^^ constructor call
 inconsistent use of library definitions
-876:     referrerPolicy: ReferrerPolicyType;
-                         ^^^^^^^^^^^^^^^^^^ string enum. This type is incompatible with an argument type of. See lib: <BUILTINS>/bom.js:876
-828:     referrerPolicy?: ?ReferrerPolicyType;
-                           ^^^^^^^^^^^^^^^^^^ null. See lib: <BUILTINS>/bom.js:828
+877:     referrerPolicy: ReferrerPolicyType;
+                         ^^^^^^^^^^^^^^^^^^ string enum. This type is incompatible with an argument type of. See lib: <BUILTINS>/bom.js:877
+829:     referrerPolicy?: ?ReferrerPolicyType;
+                           ^^^^^^^^^^^^^^^^^^ null. See lib: <BUILTINS>/bom.js:829
 
 request.js:6
   6: const e: Request = new Request(b, c); // incorrect
                         ^^^^^^^^^^^^^^^^^ constructor call
 inconsistent use of library definitions
-876:     referrerPolicy: ReferrerPolicyType;
-                         ^^^^^^^^^^^^^^^^^^ string enum. This type is incompatible with an argument type of. See lib: <BUILTINS>/bom.js:876
-828:     referrerPolicy?: ?ReferrerPolicyType;
-                           ^^^^^^^^^^^^^^^^^^ undefined. See lib: <BUILTINS>/bom.js:828
+877:     referrerPolicy: ReferrerPolicyType;
+                         ^^^^^^^^^^^^^^^^^^ string enum. This type is incompatible with an argument type of. See lib: <BUILTINS>/bom.js:877
+829:     referrerPolicy?: ?ReferrerPolicyType;
+                           ^^^^^^^^^^^^^^^^^^ undefined. See lib: <BUILTINS>/bom.js:829
 
 request.js:8
   8: const f: Request = new Request({}) // incorrect
                         ^^^^^^^^^^^^^^^ constructor call
   8: const f: Request = new Request({}) // incorrect
                                     ^^ object literal. This type is incompatible with
-863:     constructor(input: string | Request, init?: RequestOptions): void;
-                            ^^^^^^^^^^^^^^^^ union: string | Request. See lib: <BUILTINS>/bom.js:863
+864:     constructor(input: string | Request, init?: RequestOptions): void;
+                            ^^^^^^^^^^^^^^^^ union: string | Request. See lib: <BUILTINS>/bom.js:864
   Member 1:
-  863:     constructor(input: string | Request, init?: RequestOptions): void;
-                              ^^^^^^ string. See lib: <BUILTINS>/bom.js:863
+  864:     constructor(input: string | Request, init?: RequestOptions): void;
+                              ^^^^^^ string. See lib: <BUILTINS>/bom.js:864
   Error:
     8: const f: Request = new Request({}) // incorrect
                                       ^^ object literal. This type is incompatible with
-  863:     constructor(input: string | Request, init?: RequestOptions): void;
-                              ^^^^^^ string. See lib: <BUILTINS>/bom.js:863
+  864:     constructor(input: string | Request, init?: RequestOptions): void;
+                              ^^^^^^ string. See lib: <BUILTINS>/bom.js:864
   Member 2:
-  863:     constructor(input: string | Request, init?: RequestOptions): void;
-                                       ^^^^^^^ Request. See lib: <BUILTINS>/bom.js:863
+  864:     constructor(input: string | Request, init?: RequestOptions): void;
+                                       ^^^^^^^ Request. See lib: <BUILTINS>/bom.js:864
   Error:
     8: const f: Request = new Request({}) // incorrect
                                       ^^ object literal. This type is incompatible with
-  863:     constructor(input: string | Request, init?: RequestOptions): void;
-                                       ^^^^^^^ Request. See lib: <BUILTINS>/bom.js:863
+  864:     constructor(input: string | Request, init?: RequestOptions): void;
+                                       ^^^^^^^ Request. See lib: <BUILTINS>/bom.js:864
 
 request.js:30
  30: const j: Request = new Request('http://example.org', {
                         ^ constructor call
  32:   headers: 'Content-Type: image/jpeg',
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^ string. This type is incompatible with
-822:     headers?: ?HeadersInit;
-                    ^^^^^^^^^^^ union: Headers | object type. See lib: <BUILTINS>/bom.js:822
+823:     headers?: ?HeadersInit;
+                    ^^^^^^^^^^^ union: Headers | object type. See lib: <BUILTINS>/bom.js:823
   Member 1:
-  774: type HeadersInit = Headers | {[key: string]: string};
-                          ^^^^^^^ Headers. See lib: <BUILTINS>/bom.js:774
+  775: type HeadersInit = Headers | {[key: string]: string};
+                          ^^^^^^^ Headers. See lib: <BUILTINS>/bom.js:775
   Error:
    32:   headers: 'Content-Type: image/jpeg',
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^ string. This type is incompatible with
-  774: type HeadersInit = Headers | {[key: string]: string};
-                          ^^^^^^^ Headers. See lib: <BUILTINS>/bom.js:774
+  775: type HeadersInit = Headers | {[key: string]: string};
+                          ^^^^^^^ Headers. See lib: <BUILTINS>/bom.js:775
   Member 2:
-  774: type HeadersInit = Headers | {[key: string]: string};
-                                    ^^^^^^^^^^^^^^^^^^^^^^^ object type. See lib: <BUILTINS>/bom.js:774
+  775: type HeadersInit = Headers | {[key: string]: string};
+                                    ^^^^^^^^^^^^^^^^^^^^^^^ object type. See lib: <BUILTINS>/bom.js:775
   Error:
    32:   headers: 'Content-Type: image/jpeg',
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^ string. This type is incompatible with
-  774: type HeadersInit = Headers | {[key: string]: string};
-                                    ^^^^^^^^^^^^^^^^^^^^^^^ object type. See lib: <BUILTINS>/bom.js:774
+  775: type HeadersInit = Headers | {[key: string]: string};
+                                    ^^^^^^^^^^^^^^^^^^^^^^^ object type. See lib: <BUILTINS>/bom.js:775
 
 request.js:37
  37: const k: Request = new Request('http://example.org', {
                                                           ^ object literal. This type is incompatible with the expected param type of
-863:     constructor(input: string | Request, init?: RequestOptions): void;
-                                                     ^^^^^^^^^^^^^^ object type. See lib: <BUILTINS>/bom.js:863
+864:     constructor(input: string | Request, init?: RequestOptions): void;
+                                                     ^^^^^^^^^^^^^^ object type. See lib: <BUILTINS>/bom.js:864
   Property `method` is incompatible:
      38:   method: 'CONNECT',
                    ^^^^^^^^^ string. This type is incompatible with
-    824:     method?: ?MethodType;
-                       ^^^^^^^^^^ string enum. See lib: <BUILTINS>/bom.js:824
+    825:     method?: ?MethodType;
+                       ^^^^^^^^^^ string enum. See lib: <BUILTINS>/bom.js:825
 
 request.js:49
  49: h.text().then((t: Buffer) => t); // incorrect
                        ^^^^^^ Buffer. This type is incompatible with an argument type of
-885:     text(): Promise<string>;
-                         ^^^^^^ string. See lib: <BUILTINS>/bom.js:885
+886:     text(): Promise<string>;
+                         ^^^^^^ string. See lib: <BUILTINS>/bom.js:886
 
 request.js:51
  51: h.arrayBuffer().then((ab: Buffer) => ab); // incorrect
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call of method `then`
  51: h.arrayBuffer().then((ab: Buffer) => ab); // incorrect
                                ^^^^^^ Buffer. This type is incompatible with
-881:     arrayBuffer(): Promise<ArrayBuffer>;
-                                ^^^^^^^^^^^ ArrayBuffer. See lib: <BUILTINS>/bom.js:881
+882:     arrayBuffer(): Promise<ArrayBuffer>;
+                                ^^^^^^^^^^^ ArrayBuffer. See lib: <BUILTINS>/bom.js:882
 
 response.js:10
  10: const e: Response = new Response("responsebody", {
                                                       ^ object literal. This type is incompatible with the expected param type of
-838:     constructor(input?: string | URLSearchParams | FormData | Blob, init?: ResponseOptions): void;
-                                                                                ^^^^^^^^^^^^^^^ object type. See lib: <BUILTINS>/bom.js:838
+839:     constructor(input?: string | URLSearchParams | FormData | Blob, init?: ResponseOptions): void;
+                                                                                ^^^^^^^^^^^^^^^ object type. See lib: <BUILTINS>/bom.js:839
   Property `status` is incompatible:
      11:     status: "404"
                      ^^^^^ string. This type is incompatible with
-    832:     status?: ?number;
-                       ^^^^^^ number. See lib: <BUILTINS>/bom.js:832
+    833:     status?: ?number;
+                       ^^^^^^ number. See lib: <BUILTINS>/bom.js:833
 
 response.js:14
  14: const f: Response = new Response("responsebody", {
                          ^ constructor call
  16:     headers: "'Content-Type': 'image/jpeg'"
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string. This type is incompatible with
-834:     headers?: ?HeadersInit
-                    ^^^^^^^^^^^ union: Headers | object type. See lib: <BUILTINS>/bom.js:834
+835:     headers?: ?HeadersInit
+                    ^^^^^^^^^^^ union: Headers | object type. See lib: <BUILTINS>/bom.js:835
   Member 1:
-  774: type HeadersInit = Headers | {[key: string]: string};
-                          ^^^^^^^ Headers. See lib: <BUILTINS>/bom.js:774
+  775: type HeadersInit = Headers | {[key: string]: string};
+                          ^^^^^^^ Headers. See lib: <BUILTINS>/bom.js:775
   Error:
    16:     headers: "'Content-Type': 'image/jpeg'"
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string. This type is incompatible with
-  774: type HeadersInit = Headers | {[key: string]: string};
-                          ^^^^^^^ Headers. See lib: <BUILTINS>/bom.js:774
+  775: type HeadersInit = Headers | {[key: string]: string};
+                          ^^^^^^^ Headers. See lib: <BUILTINS>/bom.js:775
   Member 2:
-  774: type HeadersInit = Headers | {[key: string]: string};
-                                    ^^^^^^^^^^^^^^^^^^^^^^^ object type. See lib: <BUILTINS>/bom.js:774
+  775: type HeadersInit = Headers | {[key: string]: string};
+                                    ^^^^^^^^^^^^^^^^^^^^^^^ object type. See lib: <BUILTINS>/bom.js:775
   Error:
    16:     headers: "'Content-Type': 'image/jpeg'"
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string. This type is incompatible with
-  774: type HeadersInit = Headers | {[key: string]: string};
-                                    ^^^^^^^^^^^^^^^^^^^^^^^ object type. See lib: <BUILTINS>/bom.js:774
+  775: type HeadersInit = Headers | {[key: string]: string};
+                                    ^^^^^^^^^^^^^^^^^^^^^^^ object type. See lib: <BUILTINS>/bom.js:775
 
 response.js:33
  33: const i: Response = new Response({
                          ^ constructor call
  33: const i: Response = new Response({
                                       ^ object literal. This type is incompatible with
-838:     constructor(input?: string | URLSearchParams | FormData | Blob, init?: ResponseOptions): void;
-                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ union: string | URLSearchParams | FormData | Blob. See lib: <BUILTINS>/bom.js:838
+839:     constructor(input?: string | URLSearchParams | FormData | Blob, init?: ResponseOptions): void;
+                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ union: string | URLSearchParams | FormData | Blob. See lib: <BUILTINS>/bom.js:839
   Member 1:
-  838:     constructor(input?: string | URLSearchParams | FormData | Blob, init?: ResponseOptions): void;
-                               ^^^^^^ string. See lib: <BUILTINS>/bom.js:838
+  839:     constructor(input?: string | URLSearchParams | FormData | Blob, init?: ResponseOptions): void;
+                               ^^^^^^ string. See lib: <BUILTINS>/bom.js:839
   Error:
    33: const i: Response = new Response({
                                         ^ object literal. This type is incompatible with
-  838:     constructor(input?: string | URLSearchParams | FormData | Blob, init?: ResponseOptions): void;
-                               ^^^^^^ string. See lib: <BUILTINS>/bom.js:838
+  839:     constructor(input?: string | URLSearchParams | FormData | Blob, init?: ResponseOptions): void;
+                               ^^^^^^ string. See lib: <BUILTINS>/bom.js:839
   Member 2:
-  838:     constructor(input?: string | URLSearchParams | FormData | Blob, init?: ResponseOptions): void;
-                                        ^^^^^^^^^^^^^^^ URLSearchParams. See lib: <BUILTINS>/bom.js:838
+  839:     constructor(input?: string | URLSearchParams | FormData | Blob, init?: ResponseOptions): void;
+                                        ^^^^^^^^^^^^^^^ URLSearchParams. See lib: <BUILTINS>/bom.js:839
   Error:
    33: const i: Response = new Response({
                                         ^ object literal. This type is incompatible with
-  838:     constructor(input?: string | URLSearchParams | FormData | Blob, init?: ResponseOptions): void;
-                                        ^^^^^^^^^^^^^^^ URLSearchParams. See lib: <BUILTINS>/bom.js:838
+  839:     constructor(input?: string | URLSearchParams | FormData | Blob, init?: ResponseOptions): void;
+                                        ^^^^^^^^^^^^^^^ URLSearchParams. See lib: <BUILTINS>/bom.js:839
   Member 3:
-  838:     constructor(input?: string | URLSearchParams | FormData | Blob, init?: ResponseOptions): void;
-                                                          ^^^^^^^^ FormData. See lib: <BUILTINS>/bom.js:838
+  839:     constructor(input?: string | URLSearchParams | FormData | Blob, init?: ResponseOptions): void;
+                                                          ^^^^^^^^ FormData. See lib: <BUILTINS>/bom.js:839
   Error:
    33: const i: Response = new Response({
                                         ^ object literal. This type is incompatible with
-  838:     constructor(input?: string | URLSearchParams | FormData | Blob, init?: ResponseOptions): void;
-                                                          ^^^^^^^^ FormData. See lib: <BUILTINS>/bom.js:838
+  839:     constructor(input?: string | URLSearchParams | FormData | Blob, init?: ResponseOptions): void;
+                                                          ^^^^^^^^ FormData. See lib: <BUILTINS>/bom.js:839
   Member 4:
-  838:     constructor(input?: string | URLSearchParams | FormData | Blob, init?: ResponseOptions): void;
-                                                                     ^^^^ Blob. See lib: <BUILTINS>/bom.js:838
+  839:     constructor(input?: string | URLSearchParams | FormData | Blob, init?: ResponseOptions): void;
+                                                                     ^^^^ Blob. See lib: <BUILTINS>/bom.js:839
   Error:
    33: const i: Response = new Response({
                                         ^ object literal. This type is incompatible with
-  838:     constructor(input?: string | URLSearchParams | FormData | Blob, init?: ResponseOptions): void;
-                                                                     ^^^^ Blob. See lib: <BUILTINS>/bom.js:838
+  839:     constructor(input?: string | URLSearchParams | FormData | Blob, init?: ResponseOptions): void;
+                                                                     ^^^^ Blob. See lib: <BUILTINS>/bom.js:839
 
 response.js:44
  44: h.text().then((t: Buffer) => t); // incorrect
                        ^^^^^^ Buffer. This type is incompatible with an argument type of
-859:     text(): Promise<string>;
-                         ^^^^^^ string. See lib: <BUILTINS>/bom.js:859
+860:     text(): Promise<string>;
+                         ^^^^^^ string. See lib: <BUILTINS>/bom.js:860
 
 response.js:46
  46: h.arrayBuffer().then((ab: Buffer) => ab); // incorrect
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call of method `then`
  46: h.arrayBuffer().then((ab: Buffer) => ab); // incorrect
                                ^^^^^^ Buffer. This type is incompatible with
-855:     arrayBuffer(): Promise<ArrayBuffer>;
-                                ^^^^^^^^^^^ ArrayBuffer. See lib: <BUILTINS>/bom.js:855
+856:     arrayBuffer(): Promise<ArrayBuffer>;
+                                ^^^^^^^^^^^ ArrayBuffer. See lib: <BUILTINS>/bom.js:856
 
 urlsearchparams.js:4
   4: const b = new URLSearchParams(['key1', 'value1']); // not correct
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructor call
   4: const b = new URLSearchParams(['key1', 'value1']); // not correct
                                    ^^^^^^^^^^^^^^^^^^ array literal. This type is incompatible with
-795:     constructor(query?: string | URLSearchParams): void;
-                             ^^^^^^^^^^^^^^^^^^^^^^^^ union: string | URLSearchParams. See lib: <BUILTINS>/bom.js:795
+796:     constructor(query?: string | URLSearchParams): void;
+                             ^^^^^^^^^^^^^^^^^^^^^^^^ union: string | URLSearchParams. See lib: <BUILTINS>/bom.js:796
   Member 1:
-  795:     constructor(query?: string | URLSearchParams): void;
-                               ^^^^^^ string. See lib: <BUILTINS>/bom.js:795
+  796:     constructor(query?: string | URLSearchParams): void;
+                               ^^^^^^ string. See lib: <BUILTINS>/bom.js:796
   Error:
     4: const b = new URLSearchParams(['key1', 'value1']); // not correct
                                      ^^^^^^^^^^^^^^^^^^ array literal. This type is incompatible with
-  795:     constructor(query?: string | URLSearchParams): void;
-                               ^^^^^^ string. See lib: <BUILTINS>/bom.js:795
+  796:     constructor(query?: string | URLSearchParams): void;
+                               ^^^^^^ string. See lib: <BUILTINS>/bom.js:796
   Member 2:
-  795:     constructor(query?: string | URLSearchParams): void;
-                                        ^^^^^^^^^^^^^^^ URLSearchParams. See lib: <BUILTINS>/bom.js:795
+  796:     constructor(query?: string | URLSearchParams): void;
+                                        ^^^^^^^^^^^^^^^ URLSearchParams. See lib: <BUILTINS>/bom.js:796
   Error:
     4: const b = new URLSearchParams(['key1', 'value1']); // not correct
                                      ^^^^^^^^^^^^^^^^^^ array literal. This type is incompatible with
-  795:     constructor(query?: string | URLSearchParams): void;
-                                        ^^^^^^^^^^^^^^^ URLSearchParams. See lib: <BUILTINS>/bom.js:795
+  796:     constructor(query?: string | URLSearchParams): void;
+                                        ^^^^^^^^^^^^^^^ URLSearchParams. See lib: <BUILTINS>/bom.js:796
 
 urlsearchparams.js:5
   5: const c = new URLSearchParams({'key1', 'value1'}); // not correct
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructor call
   5: const c = new URLSearchParams({'key1', 'value1'}); // not correct
                                    ^^^^^^^^^^^^^^^^^^ object literal. This type is incompatible with
-795:     constructor(query?: string | URLSearchParams): void;
-                             ^^^^^^^^^^^^^^^^^^^^^^^^ union: string | URLSearchParams. See lib: <BUILTINS>/bom.js:795
+796:     constructor(query?: string | URLSearchParams): void;
+                             ^^^^^^^^^^^^^^^^^^^^^^^^ union: string | URLSearchParams. See lib: <BUILTINS>/bom.js:796
   Member 1:
-  795:     constructor(query?: string | URLSearchParams): void;
-                               ^^^^^^ string. See lib: <BUILTINS>/bom.js:795
+  796:     constructor(query?: string | URLSearchParams): void;
+                               ^^^^^^ string. See lib: <BUILTINS>/bom.js:796
   Error:
     5: const c = new URLSearchParams({'key1', 'value1'}); // not correct
                                      ^^^^^^^^^^^^^^^^^^ object literal. This type is incompatible with
-  795:     constructor(query?: string | URLSearchParams): void;
-                               ^^^^^^ string. See lib: <BUILTINS>/bom.js:795
+  796:     constructor(query?: string | URLSearchParams): void;
+                               ^^^^^^ string. See lib: <BUILTINS>/bom.js:796
   Member 2:
-  795:     constructor(query?: string | URLSearchParams): void;
-                                        ^^^^^^^^^^^^^^^ URLSearchParams. See lib: <BUILTINS>/bom.js:795
+  796:     constructor(query?: string | URLSearchParams): void;
+                                        ^^^^^^^^^^^^^^^ URLSearchParams. See lib: <BUILTINS>/bom.js:796
   Error:
     5: const c = new URLSearchParams({'key1', 'value1'}); // not correct
                                      ^^^^^^^^^^^^^^^^^^ object literal. This type is incompatible with
-  795:     constructor(query?: string | URLSearchParams): void;
-                                        ^^^^^^^^^^^^^^^ URLSearchParams. See lib: <BUILTINS>/bom.js:795
+  796:     constructor(query?: string | URLSearchParams): void;
+                                        ^^^^^^^^^^^^^^^ URLSearchParams. See lib: <BUILTINS>/bom.js:796
 
 urlsearchparams.js:9
   9: e.append('key1'); // not correct
      ^^^^^^^^^^^^^^^^ call of method `append`
   9: e.append('key1'); // not correct
      ^^^^^^^^^^^^^^^^ undefined (too few arguments, expected default/rest parameters). This type is incompatible with
-796:     append(name: string, value: string): void;
-                                     ^^^^^^ string. See lib: <BUILTINS>/bom.js:796
+797:     append(name: string, value: string): void;
+                                     ^^^^^^ string. See lib: <BUILTINS>/bom.js:797
 
 urlsearchparams.js:10
  10: e.append({'key1', 'value1'}); // not correct
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call of method `append`
  10: e.append({'key1', 'value1'}); // not correct
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ undefined (too few arguments, expected default/rest parameters). This type is incompatible with
-796:     append(name: string, value: string): void;
-                                     ^^^^^^ string. See lib: <BUILTINS>/bom.js:796
+797:     append(name: string, value: string): void;
+                                     ^^^^^^ string. See lib: <BUILTINS>/bom.js:797
 
 urlsearchparams.js:10
  10: e.append({'key1', 'value1'}); // not correct
               ^^^^^^^^^^^^^^^^^^ object literal. This type is incompatible with the expected param type of
-796:     append(name: string, value: string): void;
-                      ^^^^^^ string. See lib: <BUILTINS>/bom.js:796
+797:     append(name: string, value: string): void;
+                      ^^^^^^ string. See lib: <BUILTINS>/bom.js:797
 
 urlsearchparams.js:12
  12: e.set('key1'); // not correct
      ^^^^^^^^^^^^^ call of method `set`
  12: e.set('key1'); // not correct
      ^^^^^^^^^^^^^ undefined (too few arguments, expected default/rest parameters). This type is incompatible with
-803:     set(name: string, value: string): void;
-                                  ^^^^^^ string. See lib: <BUILTINS>/bom.js:803
+804:     set(name: string, value: string): void;
+                                  ^^^^^^ string. See lib: <BUILTINS>/bom.js:804
 
 urlsearchparams.js:13
  13: e.set({'key1', 'value1'}); // not correct
      ^^^^^^^^^^^^^^^^^^^^^^^^^ call of method `set`
  13: e.set({'key1', 'value1'}); // not correct
      ^^^^^^^^^^^^^^^^^^^^^^^^^ undefined (too few arguments, expected default/rest parameters). This type is incompatible with
-803:     set(name: string, value: string): void;
-                                  ^^^^^^ string. See lib: <BUILTINS>/bom.js:803
+804:     set(name: string, value: string): void;
+                                  ^^^^^^ string. See lib: <BUILTINS>/bom.js:804
 
 urlsearchparams.js:13
  13: e.set({'key1', 'value1'}); // not correct
            ^^^^^^^^^^^^^^^^^^ object literal. This type is incompatible with the expected param type of
-803:     set(name: string, value: string): void;
-                   ^^^^^^ string. See lib: <BUILTINS>/bom.js:803
+804:     set(name: string, value: string): void;
+                   ^^^^^^ string. See lib: <BUILTINS>/bom.js:804
 
 urlsearchparams.js:15
  15: const f: URLSearchParams = e.append('key1', 'value1'); // not correct


### PR DESCRIPTION
I have added WebUSB API definitions, based on the [draft](https://wicg.github.io/webusb/).

I am not sure if I even *want* this merged right now - the draft is still a draft, and it's supported only on Chrome/ium and only either via "trial mode" or via special flag in Chrome/ium settings.

But I am still making this PR - either for merging, or for tracking progress; as you wish. 

The definition is rewritten directly from the draft - partly by hand, partly by [webidl tools](https://www.npmjs.com/package/webidl-tools).