### PR TITLE
Socket.send has two optional arguments in the middle

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -545,10 +545,10 @@ type dgram$Socket = {
   ref(): void;
   send(
     buf: Buffer,
-    offset: number,
-    length: number,
-    port: number,
-    address: string,
+    offsetOrPprt: number,
+    lengthOrAddress: number | string,
+    portOrCallback?: number | (err: ?Error, bytes: any) => void,
+    address?: string,
     callback?: (err: ?Error, bytes: any) => void
   ): void;
   setBroadcast(flag: boolean): void;

--- a/lib/node.js
+++ b/lib/node.js
@@ -545,7 +545,7 @@ type dgram$Socket = {
   ref(): void;
   send(
     buf: Buffer,
-    offsetOrPprt: number,
+    offsetOrPort: number,
     lengthOrAddress: number | string,
     portOrCallback?: number | (err: ?Error, bytes: any) => void,
     address?: string,

--- a/lib/node.js
+++ b/lib/node.js
@@ -544,12 +544,18 @@ type dgram$Socket = {
   dropMembership(multicastAddress: string, multicastInterface?: string): void;
   ref(): void;
   send(
-    buf: Buffer,
-    offsetOrPort: number,
-    lengthOrAddress: number | string,
-    portOrCallback?: number | (err: ?Error, bytes: any) => void,
-    address?: string,
-    callback?: (err: ?Error, bytes: any) => void
+    msg: Buffer,
+    port: number,
+    address: string,
+    callback?: (err: ?Error, bytes: any) => mixed,
+  ): void;
+  send(
+    msg: Buffer,
+    offset: number,
+    length: number,
+    port: number,
+    address: string,
+    callback?: (err: ?Error, bytes: any) => mixed,
   ): void;
   setBroadcast(flag: boolean): void;
   setMulticastLoopback(flag: boolean): void;

--- a/tests/node_tests/node_tests.exp
+++ b/tests/node_tests/node_tests.exp
@@ -54,24 +54,24 @@ crypto/crypto.js:16
          ^^^^^^^^^^^^^^^ call of method `write`
  16:     hmac.write(123); // 2 errors: not a string or a Buffer
                     ^^^ number. This type is incompatible with
-1287:     chunk: Buffer | string,
-                 ^^^^^^^^^^^^^^^ union: Buffer | string. See lib: <BUILTINS>/node.js:1287
+1293:     chunk: Buffer | string,
+                 ^^^^^^^^^^^^^^^ union: Buffer | string. See lib: <BUILTINS>/node.js:1293
   Member 1:
-  1287:     chunk: Buffer | string,
-                   ^^^^^^ Buffer. See lib: <BUILTINS>/node.js:1287
+  1293:     chunk: Buffer | string,
+                   ^^^^^^ Buffer. See lib: <BUILTINS>/node.js:1293
   Error:
    16:     hmac.write(123); // 2 errors: not a string or a Buffer
                       ^^^ number. This type is incompatible with
-  1287:     chunk: Buffer | string,
-                   ^^^^^^ Buffer. See lib: <BUILTINS>/node.js:1287
+  1293:     chunk: Buffer | string,
+                   ^^^^^^ Buffer. See lib: <BUILTINS>/node.js:1293
   Member 2:
-  1287:     chunk: Buffer | string,
-                            ^^^^^^ string. See lib: <BUILTINS>/node.js:1287
+  1293:     chunk: Buffer | string,
+                            ^^^^^^ string. See lib: <BUILTINS>/node.js:1293
   Error:
    16:     hmac.write(123); // 2 errors: not a string or a Buffer
                       ^^^ number. This type is incompatible with
-  1287:     chunk: Buffer | string,
-                            ^^^^^^ string. See lib: <BUILTINS>/node.js:1287
+  1293:     chunk: Buffer | string,
+                            ^^^^^^ string. See lib: <BUILTINS>/node.js:1293
 
 crypto/crypto.js:26
  26:     hmac.update('foo', 'bogus'); // 1 error
@@ -132,14 +132,14 @@ crypto/crypto.js:36
 fs/fs.js:13
  13: fs.readFile("file.exp", { encoding: "blah" }, (_, data) => {
      ^ call of method `readFile`. Could not decide which case to select
-798:   declare function readFile(
-                                ^ intersection type. See lib: <BUILTINS>/node.js:798
+804:   declare function readFile(
+                                ^ intersection type. See lib: <BUILTINS>/node.js:804
   Case 3 may work:
-  807:   declare function readFile(
-                                  ^ function type. See lib: <BUILTINS>/node.js:807
+  813:   declare function readFile(
+                                  ^ function type. See lib: <BUILTINS>/node.js:813
   But if it doesn't, case 4 looks promising too:
-  812:   declare function readFile(
-                                  ^ function type. See lib: <BUILTINS>/node.js:812
+  818:   declare function readFile(
+                                  ^ function type. See lib: <BUILTINS>/node.js:818
   Please provide additional annotation(s) to determine whether case 3 works (or consider merging it with case 4):
    13: fs.readFile("file.exp", { encoding: "blah" }, (_, data) => {
                                                       ^ parameter `_`


### PR DESCRIPTION
This is likely the least-bad way to support this.

https://nodejs.org/api/dgram.html#dgram_socket_send_msg_offset_length_port_address_callback