### PR TITLE
fix(bom): make readyStates static props of XMLHttpRequest

### DIFF
--- a/lib/bom.js
+++ b/lib/bom.js
@@ -493,14 +493,14 @@ declare class XMLHttpRequest extends EventTarget {
     getResponseHeader(header: string): string;
     msCachingEnabled(): boolean;
     overrideMimeType(mime: string): void;
-    LOADING: number;
-    DONE: number;
-    UNSENT: number;
-    OPENED: number;
-    HEADERS_RECEIVED: number;
 
     statics: {
         create(): XMLHttpRequest;
+        LOADING: number;
+        DONE: number;
+        UNSENT: number;
+        OPENED: number;
+        HEADERS_RECEIVED: number;
     }
 }
 


### PR DESCRIPTION
Hi

I detected this issue with this false positive in my code:

```
  9:     if (this.readyState !== XMLHttpRequest.DONE) return
                                                ^^^^ property `DONE`. Property not found in
  9:     if (this.readyState !== XMLHttpRequest.DONE) return
                                 ^^^^^^^^^^^^^^ statics of XMLHttpRequest

```