### PR TITLE
Define defaultProps directly in docs

### DIFF
--- a/website/docs/ref/react.doc.js
+++ b/website/docs/ref/react.doc.js
@@ -144,7 +144,7 @@ class Button extends React.Component {
     display: 'static' | 'hover' | 'active',
   };
 
-  static defaultProps: { visited: boolean };
+  static defaultProps = { visited: false };
 
   onMouseEnter: () => void;
   onMouseLeave: () => void;
@@ -180,7 +180,6 @@ class Button extends React.Component {
     );
   }
 }
-Button.defaultProps = { visited: false };
 
 function renderButton(container: HTMLElement, visited?: boolean) {
   const element = (


### PR DESCRIPTION
Previously the doc recommended giving `defaultProps` a type and then doing the definition outside of the class definition. This is cleaner and more understandable. The type of `defaultProps` doesn't really matter since it should be static and should already be constrained by the type of `Props`.