### PR TITLE
Fix source location for class instances.

### DIFF
--- a/src/parser/object_parser.ml
+++ b/src/parser/object_parser.ml
@@ -342,10 +342,17 @@ module Object
               Some (Parse.expression env)
             end else None
           ) else None in
-        let end_loc = Peek.loc env in
-        if Expect.maybe env T_SEMICOLON then () else begin
-          if Peek.token env == T_LBRACKET || Peek.token env == T_LPAREN then error_unexpected env
-        end;
+        let end_of_value_loc = match value with
+          | Some expr -> fst expr
+          | None -> start_loc in
+        let end_loc =
+          begin
+            if Peek.token env == T_LBRACKET || Peek.token env == T_LPAREN then
+              error_unexpected env;
+            match Peek.semicolon_loc env with
+            | Some loc -> Eat.semicolon env; loc
+            | None -> end_of_value_loc
+          end in
         let loc = Loc.btwn start_loc end_loc in
         Ast.Class.(Body.Property (loc, Property.({
           key;

--- a/src/parser/object_parser.ml
+++ b/src/parser/object_parser.ml
@@ -342,16 +342,14 @@ module Object
               Some (Parse.expression env)
             end else None
           ) else None in
-        let end_of_value_loc = match value with
-          | Some expr -> fst expr
-          | None -> start_loc in
-        let end_loc =
-          begin
+        let end_loc = begin
             if Peek.token env == T_LBRACKET || Peek.token env == T_LPAREN then
               error_unexpected env;
             match Peek.semicolon_loc env with
             | Some loc -> Eat.semicolon env; loc
-            | None -> end_of_value_loc
+            | None -> match value with
+                      | Some expr -> fst expr
+                      | None -> start_loc
           end in
         let loc = Loc.btwn start_loc end_loc in
         Ast.Class.(Body.Property (loc, Property.({

--- a/src/parser/test/hardcoded_tests.js
+++ b/src/parser/test/hardcoded_tests.js
@@ -3843,6 +3843,15 @@ module.exports = {
           'message': 'Unexpected token ?',
         }]
       },
+      'class X {f = 4 \n x; }': {
+        '%parse_options%': {
+          'esproposal_class_instance_fields': true,
+        },
+        'body.0.body.body.0': {
+          'type': 'ClassProperty',
+          'range': [9, 14],
+        }
+      },
     },
     'Comments': {
       // Regression test: "/*" should be allowed inside block comments

--- a/src/parser/test/hardcoded_tests.js
+++ b/src/parser/test/hardcoded_tests.js
@@ -3843,14 +3843,20 @@ module.exports = {
           'message': 'Unexpected token ?',
         }]
       },
-      'class X {f = 4 \n x; }': {
+      'class X {f = 4 \n x = 5; y = 6}': {
         '%parse_options%': {
           'esproposal_class_instance_fields': true,
         },
-        'body.0.body.body.0': {
+        'body.0.body.body': [{
           'type': 'ClassProperty',
           'range': [9, 14],
-        }
+        }, {
+          'type': 'ClassProperty',
+          'range': [17, 23],
+        }, {
+          'type': 'ClassProperty',
+          'range': [24, 29],
+        }]
       },
     },
     'Comments': {


### PR DESCRIPTION
Class instances without an explicit trailing semicolon absorb the next token into their location. For example, given
```
class C {
 |x = null
  y|= 4
}
```
the node for `x` extends between the `|`.

I've added a test demonstrating this behavior, as well as a fix for it. The problem was that `end_loc` was determined based on the next token, regardless of whether or not that token was a semicolon.

Any feedback very welcome :)