### PR TITLE
Add declarations for Node's http.Agent

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -895,6 +895,17 @@ declare module "fs" {
   };
 }
 
+declare class http$Agent {
+  createConnection(options: net$connectOptions, callback: ?Function): net$Socket;
+  destroy(): void;
+  freeSockets: {[name: string]: Array<net$Socket>};
+  getName(options: {host: string, port: number, localAddress: string}): string;
+  maxFreeSockets: number;
+  maxSockets: number;
+  requests: {[name: string]: Array<http$ClientRequest>};
+  sockets: {[name: string]: Array<net$Socket>};
+}
+
 declare class http$IncomingMessage extends stream$Readable {
   headers: Object;
   httpVersion: string;
@@ -943,6 +954,7 @@ declare module "http" {
     timeout: number;
   }
 
+  declare class Agent extends http$Agent {}
   declare class ClientRequest extends http$ClientRequest {}
   declare class IncomingMessage extends http$IncomingMessage {}
   declare class ServerResponse extends http$ServerResponse {}

--- a/tests/node_tests/node_tests.exp
+++ b/tests/node_tests/node_tests.exp
@@ -54,24 +54,24 @@ crypto/crypto.js:16
          ^^^^^^^^^^^^^^^ call of method `write`
  16:     hmac.write(123); // 2 errors: not a string or a Buffer
                     ^^^ number. This type is incompatible with
-1293:     chunk: Buffer | string,
-                 ^^^^^^^^^^^^^^^ union: Buffer | string. See lib: <BUILTINS>/node.js:1293
+1305:     chunk: Buffer | string,
+                 ^^^^^^^^^^^^^^^ union: Buffer | string. See lib: <BUILTINS>/node.js:1305
   Member 1:
-  1293:     chunk: Buffer | string,
-                   ^^^^^^ Buffer. See lib: <BUILTINS>/node.js:1293
+  1305:     chunk: Buffer | string,
+                   ^^^^^^ Buffer. See lib: <BUILTINS>/node.js:1305
   Error:
    16:     hmac.write(123); // 2 errors: not a string or a Buffer
                       ^^^ number. This type is incompatible with
-  1293:     chunk: Buffer | string,
-                   ^^^^^^ Buffer. See lib: <BUILTINS>/node.js:1293
+  1305:     chunk: Buffer | string,
+                   ^^^^^^ Buffer. See lib: <BUILTINS>/node.js:1305
   Member 2:
-  1293:     chunk: Buffer | string,
-                            ^^^^^^ string. See lib: <BUILTINS>/node.js:1293
+  1305:     chunk: Buffer | string,
+                            ^^^^^^ string. See lib: <BUILTINS>/node.js:1305
   Error:
    16:     hmac.write(123); // 2 errors: not a string or a Buffer
                       ^^^ number. This type is incompatible with
-  1293:     chunk: Buffer | string,
-                            ^^^^^^ string. See lib: <BUILTINS>/node.js:1293
+  1305:     chunk: Buffer | string,
+                            ^^^^^^ string. See lib: <BUILTINS>/node.js:1305
 
 crypto/crypto.js:26
  26:     hmac.update('foo', 'bogus'); // 1 error


### PR DESCRIPTION
Summary:
Add the Agent class to the http module.

    https://nodejs.org/api/http.html#http_class_http_agent

Closes #3124
Closes #1815