### PR TITLE
Getting Started page - Remove $DocIssue from line 36

### DIFF
--- a/website/docs/getting-started.doc.js
+++ b/website/docs/getting-started.doc.js
@@ -33,7 +33,6 @@ next: five-simple-examples.html
 
 // @flow
 
-// $DocIssue
 var str = 'hello world!';
 console.log(str);
 


### PR DESCRIPTION
In the first code example, we haven't added any flow annotations, but there is an error being indicated. It seems like `$DocIssue` is responsible.

Note: I have not gone through the build steps with OCaml in order to test this..

---

![flow_error](https://cloud.githubusercontent.com/assets/6667096/21966735/a7acf4aa-db3e-11e6-86ad-f1a032736eea.gif)