### PR TITLE
Buffer.from(): avoid clash between Iterable<number> and string case for first arg

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -108,10 +108,10 @@ declare class Buffer extends Uint8Array {
   static compare(buf1: Buffer, buf2: Buffer): number;
   static concat(list: Array<Buffer>, totalLength?: number): Buffer;
 
-  static from(value: Iterable<number>): this;
   static from(value: Buffer): Buffer;
   static from(value: string, encoding?: buffer$Encoding): Buffer;
   static from(value: ArrayBuffer, byteOffset?: number, length?: number): Buffer;
+  static from(value: Iterable<number>): this;
   static isBuffer(obj: any): boolean;
   static isEncoding(encoding: string): boolean;
 }


### PR DESCRIPTION
In some cases, Flow seems to eagerly choose the Iterable<number> case for the first argument to Buffer.from(), reporting the following error when Buffer.from(aString, encoding) is used:

```
inconsistent use of library definitions
274:     @@iterator(): Iterator<string>;
                                ^^^^^^ string. This type is incompatible with. See lib: /private/tmp/flow/flowlib_253af11f/core.js:274
111:   static from(value: Iterable<number>): this;
                                   ^^^^^^ number. See lib: /private/tmp/flow/flowlib_253af11f/node.js:111
```

Reordering the lib def for Buffer.from() fixes that problem for now, though the over-eagerness in choosing the Iterable<number> case should obviously be investigated too.