### PR TITLE
add covered_locs output to coverage

### DIFF
--- a/src/commands/coverageCommand.ml
+++ b/src/commands/coverageCommand.ml
@@ -194,10 +194,15 @@ let handle_response ~json ~pretty ~color ~debug (types : (Loc.t * bool) list) co
       |> List.filter (fun (_, is_covered) -> not is_covered)
       |> List.map (fun (loc, _) -> loc)
     in
+    let covered_locs = types
+      |> List.filter (fun (_, is_covered) -> is_covered)
+      |> List.map (fun (loc, _) -> loc)
+    in
     let open Hh_json in
     JSON_Object [
       "expressions", JSON_Object [
         "covered_count", int_ covered;
+        "covered_locs", JSON_Array (covered_locs |> List.map Reason.json_of_loc);
         "uncovered_count", int_ (total - covered);
         "uncovered_locs", JSON_Array (uncovered_locs |> List.map Reason.json_of_loc);
       ];


### PR DESCRIPTION
Hello 👋 

I've been working with the @codecov team on the flow coverage report so I can upload my flow coverage report to http://codecov.io/ and use the service to analyze coverage over time.

One thing I was told was missing from the flow coverage report (in json format) was a `covered_locs` output.  There is `uncovered_locs` but no inverse for `covered_locs`, only the sum `covered_count` which makes it difficult for them to create the line-by-line report. Because the flow report only shows lines not covered Codecov never knows when lines are covered so it always results in 0% coverage. 🐼 

This change simply adds `covered_locs` as an additional field to the json output.  I can't foresee that this could be a breaking change for anyone ingesting the json output. It does create slightly larger output files as all covered lines now need to be described as well.

I've only just given the latest coverage output to Codecov, when I hear back I'll update this if there are any additional issues but I wanted to get this conversation started in the mean time.