### PR TITLE
Fixed incorrect object destructuring

### DIFF
--- a/website/docs/01-destructuring.md
+++ b/website/docs/01-destructuring.md
@@ -57,7 +57,7 @@ Found 1 error
 
 ```js +line_numbers
 /* @flow */
-var {x, y, ...o} = {x: '', y: 3, o: {z: false} }
+var {x, y, o} = {x: '', y: 3, o: {z: false} }
 // x: string, y: number, o: {z: boolean}
 var z: number = o;
 ```


### PR DESCRIPTION
The code as it is implemented now (considering the stage-3 `Rest/Spread Properties` proposal) would type `o` as `{o: {z: boolean} }`

I think it's just a typo and it should be just `var {x, y, o}` in the destructuring declaration. Otherwise the typing + the following explanation should be fixed.