### PR TITLE
Add declaration for node.js’ process.emitWarning

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -1621,6 +1621,7 @@ declare class Process extends events$EventEmitter {
   cwd() : string;
   disconnect? : () => void;
   env : { [key: string] : ?string };
+  emitWarning(warning : string | Error, name? : string, ctor? : Function) : void;
   execArgv : Array<string>;
   execPath : string;
   exit(code? : number) : void;

--- a/tests/node_tests/node_tests.exp
+++ b/tests/node_tests/node_tests.exp
@@ -274,5 +274,71 @@ os/userInfo.js:14
  14: (u3.username: string); // error
                    ^^^^^^ string
 
+process/process.js:10
+ 10: process.emitWarning(); // error
+     ^^^^^^^^^^^^^^^^^^^^^ call of method `emitWarning`
+ 10: process.emitWarning(); // error
+     ^^^^^^^^^^^^^^^^^^^^^ undefined (too few arguments, expected default/rest parameters). This type is incompatible with
+1624:   emitWarning(warning : string | Error, name? : string, ctor? : Function) : void;
+                              ^^^^^^^^^^^^^^ union: string | Error. See lib: <BUILTINS>/node.js:1624
+  Member 1:
+  1624:   emitWarning(warning : string | Error, name? : string, ctor? : Function) : void;
+                                ^^^^^^ string. See lib: <BUILTINS>/node.js:1624
+  Error:
+   10: process.emitWarning(); // error
+       ^^^^^^^^^^^^^^^^^^^^^ undefined (too few arguments, expected default/rest parameters). This type is incompatible with
+  1624:   emitWarning(warning : string | Error, name? : string, ctor? : Function) : void;
+                                ^^^^^^ string. See lib: <BUILTINS>/node.js:1624
+  Member 2:
+  1624:   emitWarning(warning : string | Error, name? : string, ctor? : Function) : void;
+                                         ^^^^^ Error. See lib: <BUILTINS>/node.js:1624
+  Error:
+   10: process.emitWarning(); // error
+       ^^^^^^^^^^^^^^^^^^^^^ undefined (too few arguments, expected default/rest parameters). This type is incompatible with
+  1624:   emitWarning(warning : string | Error, name? : string, ctor? : Function) : void;
+                                         ^^^^^ Error. See lib: <BUILTINS>/node.js:1624
 
-Found 33 errors
+process/process.js:11
+ 11: process.emitWarning(42); // error
+     ^^^^^^^^^^^^^^^^^^^^^^^ call of method `emitWarning`
+ 11: process.emitWarning(42); // error
+                         ^^ number. This type is incompatible with
+1624:   emitWarning(warning : string | Error, name? : string, ctor? : Function) : void;
+                              ^^^^^^^^^^^^^^ union: string | Error. See lib: <BUILTINS>/node.js:1624
+  Member 1:
+  1624:   emitWarning(warning : string | Error, name? : string, ctor? : Function) : void;
+                                ^^^^^^ string. See lib: <BUILTINS>/node.js:1624
+  Error:
+   11: process.emitWarning(42); // error
+                           ^^ number. This type is incompatible with
+  1624:   emitWarning(warning : string | Error, name? : string, ctor? : Function) : void;
+                                ^^^^^^ string. See lib: <BUILTINS>/node.js:1624
+  Member 2:
+  1624:   emitWarning(warning : string | Error, name? : string, ctor? : Function) : void;
+                                         ^^^^^ Error. See lib: <BUILTINS>/node.js:1624
+  Error:
+   11: process.emitWarning(42); // error
+                           ^^ number. This type is incompatible with
+  1624:   emitWarning(warning : string | Error, name? : string, ctor? : Function) : void;
+                                         ^^^^^ Error. See lib: <BUILTINS>/node.js:1624
+
+process/process.js:12
+ 12: process.emitWarning("blah", 42); // error
+                                 ^^ number. This type is incompatible with the expected param type of
+1624:   emitWarning(warning : string | Error, name? : string, ctor? : Function) : void;
+                                                      ^^^^^^ string. See lib: <BUILTINS>/node.js:1624
+
+process/process.js:13
+ 13: process.emitWarning("blah", "blah", 42); // error
+                                         ^^ number. This type is incompatible with the expected param type of
+1624:   emitWarning(warning : string | Error, name? : string, ctor? : Function) : void;
+                                                                      ^^^^^^^^ function type. See lib: <BUILTINS>/node.js:1624
+
+process/process.js:14
+ 14: (process.emitWarning("blah"): string); // error
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^ undefined. This type is incompatible with
+ 14: (process.emitWarning("blah"): string); // error
+                                   ^^^^^^ string
+
+
+Found 38 errors

--- a/tests/node_tests/process/process.js
+++ b/tests/node_tests/process/process.js
@@ -1,0 +1,14 @@
+/* @flow */
+
+/* emitWarning */
+
+process.emitWarning("blah");
+process.emitWarning(new Error("blah"));
+process.emitWarning("blah", "blah");
+process.emitWarning("blah", "blah", () => {});
+
+process.emitWarning(); // error
+process.emitWarning(42); // error
+process.emitWarning("blah", 42); // error
+process.emitWarning("blah", "blah", 42); // error
+(process.emitWarning("blah"): string); // error


### PR DESCRIPTION
Add declaration and tests for [process.emitWarning](https://nodejs.org/api/process.html#process_process_emitwarning_warning_name_ctor) (introduced in v6.0.0 nodejs/node#4782)