### PR TITLE
Update ReactDOM.findDOMNode signature to match React

### DIFF
--- a/lib/react.js
+++ b/lib/react.js
@@ -201,8 +201,8 @@ declare module react {
   ): React$Component<$DefaultPropsOf<Config>, $PropsOf<Config>, any>;
 
   declare function findDOMNode(
-    object: React$Component<any, any, any> | HTMLElement
-  ): any;
+    componentOrElement : Element | ?React$Component<any, any, any>,
+  ): null | Element | Text;
 
   declare function render<Config>(
     element: React$Element<Config>,
@@ -236,8 +236,8 @@ declare module React {
 // 0.15 comes out and removes them.
 declare module 'react-dom' {
   declare function findDOMNode(
-    object: React$Component<any, any, any> | HTMLElement
-  ): any;
+    componentOrElement : Element | ?React$Component<any, any, any>,
+  ): null | Element | Text;
 
   declare function render<Config>(
     element: React$Element<Config>,


### PR DESCRIPTION
Update the `ReactDOM.findDOMNode` signature to match the type definitions React itself has for the function: https://github.com/facebook/react/blob/3438d503db2aba2b0e036912fa708cd3322310df/src/renderers/dom/shared/findDOMNode.js

Primarily allows `findDOMNode` to accept null, which is very common when working with refs. Also updates the return type of `findDOMNode` to be much more strict than `any`. This has the most potential to cause new (legitimate) errors.