### PR TITLE
Support annotations in catch clause

### DIFF
--- a/src/parser/statement_parser.ml
+++ b/src/parser/statement_parser.ml
@@ -359,10 +359,11 @@ module Statement
         let start_loc = Peek.loc env in
         Expect.token env T_CATCH;
         Expect.token env T_LPAREN;
-        let id = Parse.identifier ~restricted_error:Error.StrictCatchVariable env in
-        let param = fst id, Pattern.Identifier {
-          Pattern.Identifier.name=id;
-                             typeAnnotation=None;
+        let loc, { Pattern.Identifier.name; typeAnnotation; _; } =
+          Parse.identifier_with_type env ~no_optional:false Error.StrictCatchVariable  in
+        let param = loc, Pattern.Identifier {
+          Pattern.Identifier.name=name;
+                             typeAnnotation;
                              optional=false;
         } in
         Expect.token env T_RPAREN;

--- a/src/typing/flow_error.ml
+++ b/src/typing/flow_error.ml
@@ -160,7 +160,6 @@ and unsupported_syntax =
   | ReactCreateClassPropertyNonInit
   | RequireDynamicArgument
   | RequireLazyDynamicArgument
-  | CatchParameterAnnotation
   | CatchParameterDeclaration
   | DestructuringObjectPropertyLiteralNonString
   | DestructuringExpressionPattern
@@ -827,8 +826,6 @@ let rec error_of_msg ~trace_reasons ~op ~source_file =
         | RequireLazyDynamicArgument ->
             "The first arg to requireLazy() must be a literal array of \
              string literals!"
-        | CatchParameterAnnotation ->
-            "type annotations for catch params not yet supported"
         | CatchParameterDeclaration ->
             "unsupported catch parameter declaration"
         | DestructuringObjectPropertyLiteralNonString ->

--- a/src/typing/statement.ml
+++ b/src/typing/statement.ml
@@ -476,10 +476,10 @@ and statement cx = Ast.Statement.(
   let catch_clause cx { Try.CatchClause.param; body = (_, b) } =
     Ast.Pattern.(match param with
       | loc, Identifier {
-          Identifier.name = (_, name); typeAnnotation = None; _;
+          Identifier.name = (_, name); typeAnnotation = annot; _;
         } ->
           let r = mk_reason (RCustom "catch") loc in
-          let t = Flow.mk_tvar cx r in
+          let t = Anno.mk_type_annotation cx SMap.empty r annot in
 
           Hashtbl.replace (Context.type_table cx) loc t;
 
@@ -495,10 +495,6 @@ and statement cx = Ast.Statement.(
           | Some exn -> Abnormal.throw_control_flow_exception exn
           | None -> ()
           )
-
-      | loc, Identifier _ ->
-          Flow_js.add_output cx
-            Flow_error.(EUnsupportedSyntax (loc, CatchParameterAnnotation))
 
       | loc, _ ->
           Flow_js.add_output cx


### PR DESCRIPTION
This PR adds support for type annotations in `catch` clause, like this:

```js
try {
} catch (e: Error) {
}
```

By default `any` is used, so this change is fully backwards compatible.

Fixes: https://github.com/facebook/flow/issues/2470