### PR TITLE
Declare that node's assert module exports AssertionError.

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -1587,6 +1587,7 @@ declare module "zlib" {
 }
 
 declare module "assert" {
+  declare class AssertionError extends Error {}
   declare var exports: {
     (value: any, message?: string): void;
     ok(value: any, message?: string): void;
@@ -1608,7 +1609,6 @@ declare module "assert" {
     ifError(value: any): void;
     AssertionError: typeof AssertionError;
   }
-  declare class AssertionError extends Error {}
 }
 
 /* globals: https://nodejs.org/api/globals.html */

--- a/lib/node.js
+++ b/lib/node.js
@@ -1606,7 +1606,9 @@ declare module "assert" {
     ): void;
     doesNotThrow(block: Function, message?: string): void;
     ifError(value: any): void;
+    AssertionError: typeof AssertionError;
   }
+  declare class AssertionError extends Error {}
 }
 
 /* globals: https://nodejs.org/api/globals.html */


### PR DESCRIPTION
Looks like the current version of `lib/node.js` forgot to declare that node's assert library exports `AssertionError`.