### PR TITLE
Carry on even if there is no TERM environment variable set.

### DIFF
--- a/src/common/utils_js.ml
+++ b/src/common/utils_js.ml
@@ -18,7 +18,7 @@ let prerr_endlinef fmt = Printf.ksprintf prerr_endline fmt
 let can_emoji =
   Sys.os_type <> "Win32" &&
   Unix.isatty Unix.stdout &&
-  Sys.getenv "TERM" <> "dumb"
+  (try Sys.getenv "TERM" with Not_found -> "dumb") <> "dumb"
 
 (* JSON numbers must not end in a `.`, but string_of_float returns things like
    `1.` instead of `1.0`, so we want to truncate the `.` *)


### PR DESCRIPTION
There are a few continuous integration systems which act as STDOUT is a
TTY, but don't set `TERM`. On those occasions, we get the following
error message:

    Fatal error: exception Not_found

This, obviously, makes it pretty hard to figure out what the actual
problem is. An alternative implementation could throw a better error,
but it felt like defaulting to `"dumb"` was a reasonable solution here.

I couldn't see a reasonable place to put tests, so I omitted them. If there
is, please let me know.