### PR TITLE
Remove deprecated WeakMap.prototype.clear() from core defs

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -592,7 +592,6 @@ declare class Map<K, V> {
 }
 
 declare class WeakMap<K, V> {
-    clear(): void;
     delete(key: K): boolean;
     get(key: K): V | void;
     has(key: K): boolean;


### PR DESCRIPTION
`WeakMap` doesn't support `.clear()` on most platforms and it has been deprecated on others - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakMap/clear