### PR TITLE
Add $ReadOnly<T> utility type

### DIFF
--- a/src/common/reason.ml
+++ b/src/common/reason.ml
@@ -153,6 +153,7 @@ type reason_desc =
   | RStatics of reason_desc
   | RSuperOf of reason_desc
   | RFrozen of reason_desc
+  | RReadOnly of reason_desc
   | RBound of reason_desc
   | RVarianceCheck of reason_desc
   | RPredicateOf of reason_desc
@@ -454,6 +455,7 @@ let rec string_of_desc = function
   | RStatics d -> spf "statics of %s" (string_of_desc d)
   | RSuperOf d -> spf "super of %s" (string_of_desc d)
   | RFrozen d -> spf "frozen %s" (string_of_desc d)
+  | RReadOnly d -> spf "read-only %s" (string_of_desc d)
   | RBound d -> spf "bound %s" (string_of_desc d)
   | RVarianceCheck d -> spf "variance check: %s" (string_of_desc d)
   | RPredicateOf d -> spf "predicate of %s" (string_of_desc d)

--- a/src/common/reason.mli
+++ b/src/common/reason.mli
@@ -105,6 +105,7 @@ type reason_desc =
   | RStatics of reason_desc
   | RSuperOf of reason_desc
   | RFrozen of reason_desc
+  | RReadOnly of reason_desc
   | RBound of reason_desc
   | RVarianceCheck of reason_desc
   | RPredicateOf of reason_desc

--- a/src/typing/codegen.ml
+++ b/src/typing/codegen.ml
@@ -209,6 +209,7 @@ let rec gen_type t env = Type.(
       |> add_str ">"
   | ExactT (_, t) -> add_str "$Exact<" env |> gen_type t |> add_str ">"
   | ObjProtoT _ -> add_str "typeof Object.prototype" env
+  | ReadOnlyT (_, t) -> add_str "$ReadOnly<" env |> gen_type t |> add_str ">"
   | FunProtoT _ -> add_str "typeof Function.prototype" env
   | FunProtoApplyT _ -> add_str "typeof Function.prototype.apply" env
   | FunProtoBindT _ -> add_str "typeof Function.prototype.bind" env

--- a/src/typing/debug_js.ml
+++ b/src/typing/debug_js.ml
@@ -238,6 +238,10 @@ and _json_of_t_impl json_cx t = Hh_json.(
       "type", _json_of_t json_cx t
     ]
 
+  | ReadOnlyT (_, t) -> [
+      "type", _json_of_t json_cx t
+    ]
+
   | SingletonStrT (_, s) -> [
       "literal", JSON_String s
     ]
@@ -1461,6 +1465,7 @@ and dump_t_ (depth, tvars) cx t =
   | ShapeT arg -> p ~reason:false ~extra:(kid arg) t
   | DiffT (x, y) -> p ~reason:false ~extra:(spf "%s, %s" (kid x) (kid y)) t
   | KeysT (_, arg) -> p ~extra:(kid arg) t
+  | ReadOnlyT (_, arg) -> p ~extra:(kid arg) t
   | SingletonStrT (_, s) -> p ~extra:(spf "%S" s) t
   | SingletonNumT (_, (_, s)) -> p ~extra:s t
   | SingletonBoolT (_, b) -> p ~extra:(spf "%B" b) t

--- a/src/typing/gc_js.ml
+++ b/src/typing/gc_js.ml
@@ -94,6 +94,7 @@ let rec gc cx state = function
       ts |> List.iter (gc cx state);
       gc cx state t1;
       gc cx state t2
+  | ReadOnlyT (_, t) -> gc cx state t
   | FunProtoApplyT _ -> ()
   | FunProtoBindT _ -> ()
   | FunProtoCallT _ -> ()

--- a/src/typing/graph.ml
+++ b/src/typing/graph.ml
@@ -184,6 +184,7 @@ and parts_of_t cx = function
 | ExactT (_, t) -> ["t", Def t]
 | ExistsT _ -> []
 | ExtendsT (nexts, l, u) -> ("l", Def l) :: ("u", Def u) :: list_parts nexts
+| ReadOnlyT (_, t) -> ["t", Def t]
 | FunProtoApplyT _ -> []
 | FunProtoBindT _ -> []
 | FunProtoCallT _ -> []

--- a/src/typing/sigHash.ml
+++ b/src/typing/sigHash.ml
@@ -71,6 +71,7 @@ type hash =
   | ShapeH
   | DiffH
   | KeysH
+  | ReadOnlyH
   | SingletonStrH of string
   | SingletonNumH of Type.number_literal
   | SingletonBoolH of bool
@@ -109,6 +110,7 @@ let hash_of_ctor = Type.(function
   | ExactT _ -> ExactH
   | ExistsT _ -> ExistsH
   | ExtendsT _ -> ExtendsH
+  | ReadOnlyT _ -> ReadOnlyH
   | FunProtoApplyT _ -> FunProtoApplyH
   | FunProtoBindT _ -> FunProtoBindH
   | FunProtoCallT _ -> FunProtoCallH

--- a/src/typing/type.ml
+++ b/src/typing/type.ml
@@ -153,6 +153,10 @@ module rec TypeTerm : sig
 
     (* collects the keys of an object *)
     | KeysT of reason * t
+
+    (* describes a type as being frozen *)
+    | ReadOnlyT of reason * t
+
     (* singleton string, matches exactly a given string literal *)
     | SingletonStrT of reason * string
     (* matches exactly a given number literal, for some definition of "exactly"
@@ -1613,6 +1617,7 @@ let rec reason_of_t = function
   | ExistsT reason -> reason
   | ExtendsT (_,_,t) ->
       replace_reason (fun desc -> RExtends desc) (reason_of_t t)
+  | ReadOnlyT (reason, _) -> reason
   | FunProtoApplyT reason -> reason
   | FunProtoBindT reason -> reason
   | FunProtoCallT reason -> reason
@@ -1768,6 +1773,7 @@ let rec mod_reason_of_t f = function
   | ExactT (reason, t) -> ExactT (f reason, t)
   | ExistsT reason -> ExistsT (f reason)
   | ExtendsT (ts, t, tc) -> ExtendsT (ts, t, mod_reason_of_t f tc)
+  | ReadOnlyT (reason, t) -> ReadOnlyT (f reason, t)
   | FunProtoApplyT (reason) -> FunProtoApplyT (f reason)
   | FunProtoBindT (reason) -> FunProtoBindT (f reason)
   | FunProtoCallT (reason) -> FunProtoCallT (f reason)
@@ -1962,6 +1968,7 @@ let string_of_ctor = function
   | ExactT _ -> "ExactT"
   | ExistsT _ -> "ExistsT"
   | ExtendsT _ -> "ExtendsT"
+  | ReadOnlyT _ -> "ReadOnlyT"
   | FunProtoApplyT _ -> "FunProtoApplyT"
   | FunProtoBindT _ -> "FunProtoBindT"
   | FunProtoCallT _ -> "FunProtoCallT"

--- a/src/typing/type_annotation.ml
+++ b/src/typing/type_annotation.ml
@@ -271,6 +271,12 @@ let rec convert cx tparams_map = Ast.Type.(function
       KeysT (mk_reason RKeySet loc, t)
     )
 
+  | "$ReadOnly" ->
+    check_type_param_arity cx loc typeParameters 1 (fun () ->
+      let t = convert_type_params () |> List.hd in
+      ReadOnlyT (mk_reason (RReadOnly (desc_of_t t)) loc, t)
+    )
+
   | "$Exact" ->
     check_type_param_arity cx loc typeParameters 1 (fun () ->
       let t = List.hd (convert_type_params ()) in

--- a/src/typing/type_normalizer.ml
+++ b/src/typing/type_normalizer.ml
@@ -403,6 +403,9 @@ let rec normalize_type_impl cx ids t = match t with
   | KeysT (_, t) ->
       KeysT (locationless_reason RKeySet, normalize_type_impl cx ids t)
 
+  | ReadOnlyT (_, t) ->
+      ReadOnlyT (locationless_reason RKeySet, normalize_type_impl cx ids t)
+
   | AbstractT t ->
       AbstractT (normalize_type_impl cx ids t)
 

--- a/src/typing/type_printer.ml
+++ b/src/typing/type_printer.ml
@@ -247,6 +247,7 @@ let rec type_printer_impl ~size override enclosure cx t =
     (* The following types are not syntax-supported in all cases *)
     | AnnotT t -> pp EnclosureNone cx t
     | KeysT (_, t) -> spf "$Keys<%s>" (pp EnclosureNone cx t)
+    | ReadOnlyT (_, t) -> spf "$ReadOnly<%s>" (pp EnclosureNone cx t)
     | ShapeT t -> spf "$Shape<%s>" (pp EnclosureNone cx t)
     | TaintT (_) -> spf "$Tainted<any>"
 

--- a/src/typing/type_visitor.ml
+++ b/src/typing/type_visitor.ml
@@ -126,6 +126,7 @@ class ['a] t = object(self)
     acc
 
   | KeysT (_, t) -> self#type_ cx acc t
+  | ReadOnlyT (_, t) -> self#type_ cx acc t
 
   | SingletonStrT _
   | SingletonNumT _

--- a/tests/readonly/.flowconfig
+++ b/tests/readonly/.flowconfig
@@ -1,0 +1,8 @@
+[ignore]
+
+[include]
+
+[libs]
+
+[options]
+no_flowlib=false

--- a/tests/readonly/readonly.exp
+++ b/tests/readonly/readonly.exp
@@ -1,0 +1,38 @@
+readonly.js:14
+ 14:   obj.name = 'bar'; // error
+           ^^^^ property `name`. Property cannot be assigned on
+ 14:   obj.name = 'bar'; // error
+       ^^^ read-only object type
+
+readonly.js:16
+ 16:   Object.assign(obj, {
+       ^ property `name` of object literal. Property cannot be assigned on
+ 16:   Object.assign(obj, {
+                     ^^^ read-only object type
+
+readonly.js:22
+ 22:   obj.name = 'foo'; // error
+           ^^^^ property `name`. Property cannot be assigned on
+ 22:   obj.name = 'foo'; // error
+       ^^^ read-only NormalObject
+
+readonly.js:26
+ 26:   arr.push(''); // error
+       ^^^^^^^^^^^^ call of method `push`. Method cannot be called on
+ 26:   arr.push(''); // error
+       ^^^ read-only array type
+
+readonly.js:27
+ 27:   arr.pop(); // error
+       ^^^^^^^^^ call of method `pop`. Method cannot be called on
+ 27:   arr.pop(); // error
+       ^^^ read-only array type
+
+readonly.js:28
+ 28:   arr[0] = ''; // error
+       ^^^^^^ assignment of computed property/element. Computed property/element cannot be assigned on
+ 28:   arr[0] = ''; // error
+       ^^^ read-only array type
+
+
+Found 6 errors

--- a/tests/readonly/readonly.js
+++ b/tests/readonly/readonly.js
@@ -1,0 +1,40 @@
+/* @flow */
+
+type NormalObject = {
+  name: string
+}
+
+type ReadOnlyObject = $ReadOnly<{
+  name: string
+}>
+
+type ReadOnlyList = $ReadOnly<Array<string>>
+
+function acceptsReadOnlyObject(obj: ReadOnlyObject) {
+  obj.name = 'bar'; // error
+
+  Object.assign(obj, {
+    name: 'baz'
+  });
+}
+
+function acceptsObjectButDelcaresItFrozen(obj: $ReadOnly<NormalObject>) {
+  obj.name = 'foo'; // error
+}
+
+function acceptsReadOnlyArray(arr: ReadOnlyList) {
+  arr.push(''); // error
+  arr.pop(); // error
+  arr[0] = ''; // error
+}
+
+function makesFrozen(): ReadOnlyObject {
+  return Object.freeze({name: 'bar'}); // ok
+}
+
+function makesNotFrozen(): ReadOnlyObject {
+  return {name: 'bar'}; // ok
+}
+
+acceptsReadOnlyObject(Object.freeze({name: 'bar'})); // ok
+acceptsReadOnlyObject({name: 'bar'}); // ok


### PR DESCRIPTION
This is in reference to https://github.com/facebook/flow/issues/739 and https://github.com/facebook/flow/issues/18 and adds the utility type `$ReadOnly` which can be used to indicate that a type is (or should be considered) read only.

For example if you define a type like so:

```js
type Person = $ReadOnly<{
    name: string
}>
```

All objects of type `Person` will now be considered read only.

```js
const person: Person  = {name: 'Sally'};
person.name = 'Helen'; // error
```

Full Disclosure: I am no OCaml expert and won't pretend I fully understand the implications of this change so am looking for feedback / reviews.