### PR TITLE
Add React context support to lib definitions

### DIFF
--- a/lib/react.js
+++ b/lib/react.js
@@ -13,7 +13,7 @@
  * Base class of ES6 React classes, modeled as a polymorphic class whose type
  * parameters are DefaultProps, Props, State.
  */
-declare class React$Component<DefaultProps, Props, State, Context, ChildContext> {
+declare class React$Component<DefaultProps, Props, State, Context> {
   // fields
 
   static displayName: string;
@@ -30,29 +30,30 @@ declare class React$Component<DefaultProps, Props, State, Context, ChildContext>
 
   // lifecycle methods
 
+  constructor(props: Props, context: Context): void;
   render(): ?React$Element<any>;
   componentWillMount(): void;
   componentDidMount(component?: any): void;
-  componentWillReceiveProps(nextProps: Props, nextContext?: Context): void;
+  componentWillReceiveProps(nextProps: Props, nextContext: Context): void;
   shouldComponentUpdate(nextProps: Props, nextState: State, nextContext: Context): boolean;
   componentWillUpdate(nextProps: Props, nextState: State, nextContext: Context): void;
   componentDidUpdate(nextProps: Props, nextState: State, nextContext: Context, component: any): void;
   componentWillUnmount(): void;
-  getChildContext(): ChildContext;
+
+  // objects whose keys are in PropTypes
+
+  static contextTypes: $Subtype<{[_: $Keys<Context>]: any}>;
+  static propTypes: $Subtype<{[_: $Keys<Props>]: any}>;
 
   // long tail of other stuff not modeled very well
 
   refs: any;
-
-  // objects whose keys are in PropTypes
-
-  static childContextTypes: $Subtype<{[_: $Keys<ChildContext>]: any}>;
-  static contextTypes: $Subtype<{[_: $Keys<Context>]: any}>;
-  static propTypes: $Subtype<{[_: $Keys<Props>]: any}>;
+  getChildContext(): any;
+  static childContextTypes: any;
 }
 
-declare class React$PureComponent<DefaultProps, Props, State, Context, ChildContext> extends
-  React$Component<DefaultProps, Props, State, Context, ChildContext> {
+declare class React$PureComponent<DefaultProps, Props, State, Context> extends
+  React$Component<DefaultProps, Props, State, Context> {
   // TODO: Due to bugs in Flow's handling of React.createClass, some fields
   // already declared in the base class need to be redeclared below. Ideally
   // they should simply be inherited.
@@ -67,7 +68,7 @@ declare class React$PureComponent<DefaultProps, Props, State, Context, ChildCont
  * Base class of legacy React classes, which extends the base class of ES6 React
  * classes and supports additional methods.
  */
-declare class LegacyReactComponent<DefaultProps, Props, State, Context, ChildContext> extends React$Component<DefaultProps, Props, State, Context, ChildContext> {
+declare class LegacyReactComponent<DefaultProps, Props, State, Context> extends React$Component<DefaultProps, Props, State, Context> {
   // additional methods
 
   getDefaultProps(): DefaultProps;
@@ -89,7 +90,6 @@ declare class LegacyReactComponent<DefaultProps, Props, State, Context, ChildCon
 
   // objects whose keys are in PropTypes
 
-  static childContextTypes: $Subtype<{[_: $Keys<ChildContext>]: any}>;
   static contextTypes: $Subtype<{[_: $Keys<Context>]: any}>;
   static propTypes: $Subtype<{[_: $Keys<Props>]: any}>;
 }
@@ -109,7 +109,7 @@ declare class LegacyReactComponent<DefaultProps, Props, State, Context, ChildCon
  * fill in the type from context.
  */
 type ReactClass<Config> = _ReactClass<*, *, Config, *>;
-type _ReactClass<DefaultProps, Props, Config: $Diff<Props, DefaultProps>, C: React$Component<DefaultProps, Props, any, any, any>> = Class<C>;
+type _ReactClass<DefaultProps, Props, Config: $Diff<Props, DefaultProps>, C: React$Component<DefaultProps, Props, any, any>> = Class<C>;
 
 // TODO: DefaultProps and Props are needed to type some introspection APIs
 // below, but in general, Config does not carry enough information to recover
@@ -198,23 +198,23 @@ declare module react {
     name: ReactClass<Config>,
     config: Config,
     container: any
-  ): React$Component<$DefaultPropsOf<Config>, $PropsOf<Config>, any, any, any>;
+  ): React$Component<$DefaultPropsOf<Config>, $PropsOf<Config>, any, any>;
 
   // TODO: React DOM elements
   declare function constructAndRenderComponentByID<Config>(
     name: ReactClass<Config>,
     config: Config,
     id: string
-  ): React$Component<$DefaultPropsOf<Config>, $PropsOf<Config>, any, any, any>;
+  ): React$Component<$DefaultPropsOf<Config>, $PropsOf<Config>, any, any>;
 
   declare function findDOMNode(
-    object: React$Component<any, any, any, any, any> | HTMLElement
+    object: React$Component<any, any, any, any> | HTMLElement
   ): any;
 
   declare function render<Config>(
     element: React$Element<Config>,
     container: any
-  ): React$Component<$DefaultPropsOf<Config>, $PropsOf<Config>, any, any, any>;
+  ): React$Component<$DefaultPropsOf<Config>, $PropsOf<Config>, any, any>;
 
   declare function renderToString(
     element: React$Element<any>
@@ -243,13 +243,13 @@ declare module React {
 // 0.15 comes out and removes them.
 declare module 'react-dom' {
   declare function findDOMNode(
-    object: React$Component<any, any, any, any, any> | HTMLElement
+    object: React$Component<any, any, any, any> | HTMLElement
   ): any;
 
   declare function render<Config>(
     element: React$Element<Config>,
     container: any
-  ): React$Component<$DefaultPropsOf<Config>, $PropsOf<Config>, any, any, any>;
+  ): React$Component<$DefaultPropsOf<Config>, $PropsOf<Config>, any, any>;
 
   declare function unmountComponentAtNode(container: any): boolean;
   declare var version: string;
@@ -263,11 +263,11 @@ declare module 'react-dom' {
     e: E
   ): void;
   declare function unstable_renderSubtreeIntoContainer<Config>(
-    parentComponent: React$Component<any, any, any, any, any>,
+    parentComponent: React$Component<any, any, any, any>,
     nextElement: React$Element<Config>,
     container: any,
     callback?: () => void
-  ): React$Component<$DefaultPropsOf<Config>, $PropsOf<Config>, any, any, any>;
+  ): React$Component<$DefaultPropsOf<Config>, $PropsOf<Config>, any, any>;
 }
 
 // TODO: Delete the corresponding method defs from the 'react' module once React

--- a/lib/react.js
+++ b/lib/react.js
@@ -13,10 +13,12 @@
  * Base class of ES6 React classes, modeled as a polymorphic class whose type
  * parameters are DefaultProps, Props, State.
  */
-declare class React$Component<DefaultProps, Props, State> {
+declare class React$Component<DefaultProps, Props, State, Context, ChildContext> {
   // fields
 
+  static displayName: string;
   static defaultProps: $Abstract<DefaultProps>;
+  context: Context;
   props: Props;
   state: $Abstract<State>;
 
@@ -24,7 +26,6 @@ declare class React$Component<DefaultProps, Props, State> {
 
   // TODO: partialState could be a function as well
   setState(partialState: $Shape<State>, callback?: () => void): void;
-
   forceUpdate(callback?: () => void): void;
 
   // lifecycle methods
@@ -32,29 +33,32 @@ declare class React$Component<DefaultProps, Props, State> {
   render(): ?React$Element<any>;
   componentWillMount(): void;
   componentDidMount(component?: any): void;
-  componentWillReceiveProps(nextProps: Props, nextContext?: any): void;
-  shouldComponentUpdate(nextProps: Props, nextState: State, nextContext: any): boolean;
-  componentWillUpdate(nextProps: Props, nextState: State, nextContext: any): void;
-  componentDidUpdate(nextProps: Props, nextState: State, nextContext: any, component: any): void;
+  componentWillReceiveProps(nextProps: Props, nextContext?: Context): void;
+  shouldComponentUpdate(nextProps: Props, nextState: State, nextContext: Context): boolean;
+  componentWillUpdate(nextProps: Props, nextState: State, nextContext: Context): void;
+  componentDidUpdate(nextProps: Props, nextState: State, nextContext: Context, component: any): void;
   componentWillUnmount(): void;
+  getChildContext(): ChildContext;
 
   // long tail of other stuff not modeled very well
 
   refs: any;
-  context: any;
-  getChildContext(): any;
-  static displayName: string;
-  static childContextTypes: any;
-  static contextTypes: any;
-  static propTypes: $Subtype<{[_: $Keys<Props>]: any}>; //object whose keys are in PropTypes
+
+  // objects whose keys are in PropTypes
+
+  static childContextTypes: $Subtype<{[_: $Keys<ChildContext>]: any}>;
+  static contextTypes: $Subtype<{[_: $Keys<Context>]: any}>;
+  static propTypes: $Subtype<{[_: $Keys<Props>]: any}>;
 }
 
-declare class React$PureComponent<DefaultProps, Props, State> extends React$Component<DefaultProps, Props, State> {
+declare class React$PureComponent<DefaultProps, Props, State, Context, ChildContext> extends
+  React$Component<DefaultProps, Props, State, Context, ChildContext> {
   // TODO: Due to bugs in Flow's handling of React.createClass, some fields
   // already declared in the base class need to be redeclared below. Ideally
   // they should simply be inherited.
 
   static defaultProps: $Abstract<DefaultProps>;
+  context: Context;
   props: Props;
   state: $Abstract<State>;
 }
@@ -63,7 +67,7 @@ declare class React$PureComponent<DefaultProps, Props, State> extends React$Comp
  * Base class of legacy React classes, which extends the base class of ES6 React
  * classes and supports additional methods.
  */
-declare class LegacyReactComponent<DefaultProps, Props, State> extends React$Component<DefaultProps, Props, State> {
+declare class LegacyReactComponent<DefaultProps, Props, State, Context, ChildContext> extends React$Component<DefaultProps, Props, State, Context, ChildContext> {
   // additional methods
 
   getDefaultProps(): DefaultProps;
@@ -77,14 +81,17 @@ declare class LegacyReactComponent<DefaultProps, Props, State> extends React$Com
   // already declared in the base class need to be redeclared below. Ideally
   // they should simply be inherited.
 
+  static displayName: string;
   static defaultProps: DefaultProps;
+  context: Context;
   props: Props;
   state: State;
 
-  static propTypes: $Subtype<{[_: $Keys<Props>]: any}>; //object whose keys are in PropTypes
-  static contextTypes: any;
-  static childContextTypes: any;
-  static displayName: string;
+  // objects whose keys are in PropTypes
+
+  static childContextTypes: $Subtype<{[_: $Keys<ChildContext>]: any}>;
+  static contextTypes: $Subtype<{[_: $Keys<Context>]: any}>;
+  static propTypes: $Subtype<{[_: $Keys<Props>]: any}>;
 }
 
 /**
@@ -102,7 +109,7 @@ declare class LegacyReactComponent<DefaultProps, Props, State> extends React$Com
  * fill in the type from context.
  */
 type ReactClass<Config> = _ReactClass<*, *, Config, *>;
-type _ReactClass<DefaultProps, Props, Config: $Diff<Props, DefaultProps>, C: React$Component<DefaultProps, Props, any>> = Class<C>;
+type _ReactClass<DefaultProps, Props, Config: $Diff<Props, DefaultProps>, C: React$Component<DefaultProps, Props, any, any, any>> = Class<C>;
 
 // TODO: DefaultProps and Props are needed to type some introspection APIs
 // below, but in general, Config does not carry enough information to recover
@@ -191,23 +198,23 @@ declare module react {
     name: ReactClass<Config>,
     config: Config,
     container: any
-  ): React$Component<$DefaultPropsOf<Config>, $PropsOf<Config>, any>;
+  ): React$Component<$DefaultPropsOf<Config>, $PropsOf<Config>, any, any, any>;
 
   // TODO: React DOM elements
   declare function constructAndRenderComponentByID<Config>(
     name: ReactClass<Config>,
     config: Config,
     id: string
-  ): React$Component<$DefaultPropsOf<Config>, $PropsOf<Config>, any>;
+  ): React$Component<$DefaultPropsOf<Config>, $PropsOf<Config>, any, any, any>;
 
   declare function findDOMNode(
-    object: React$Component<any, any, any> | HTMLElement
+    object: React$Component<any, any, any, any, any> | HTMLElement
   ): any;
 
   declare function render<Config>(
     element: React$Element<Config>,
     container: any
-  ): React$Component<$DefaultPropsOf<Config>, $PropsOf<Config>, any>;
+  ): React$Component<$DefaultPropsOf<Config>, $PropsOf<Config>, any, any, any>;
 
   declare function renderToString(
     element: React$Element<any>
@@ -236,13 +243,13 @@ declare module React {
 // 0.15 comes out and removes them.
 declare module 'react-dom' {
   declare function findDOMNode(
-    object: React$Component<any, any, any> | HTMLElement
+    object: React$Component<any, any, any, any, any> | HTMLElement
   ): any;
 
   declare function render<Config>(
     element: React$Element<Config>,
     container: any
-  ): React$Component<$DefaultPropsOf<Config>, $PropsOf<Config>, any>;
+  ): React$Component<$DefaultPropsOf<Config>, $PropsOf<Config>, any, any, any>;
 
   declare function unmountComponentAtNode(container: any): boolean;
   declare var version: string;
@@ -256,11 +263,11 @@ declare module 'react-dom' {
     e: E
   ): void;
   declare function unstable_renderSubtreeIntoContainer<Config>(
-    parentComponent: React$Component<any, any, any>,
+    parentComponent: React$Component<any, any, any, any, any>,
     nextElement: React$Element<Config>,
     container: any,
     callback?: () => void
-  ): React$Component<$DefaultPropsOf<Config>, $PropsOf<Config>, any>;
+  ): React$Component<$DefaultPropsOf<Config>, $PropsOf<Config>, any, any, any>;
 }
 
 // TODO: Delete the corresponding method defs from the 'react' module once React

--- a/lib/react.js
+++ b/lib/react.js
@@ -16,7 +16,6 @@
 declare class React$Component<DefaultProps, Props, State, Context> {
   // fields
 
-  static displayName: string;
   static defaultProps: $Abstract<DefaultProps>;
   context: Context;
   props: Props;
@@ -49,6 +48,7 @@ declare class React$Component<DefaultProps, Props, State, Context> {
 
   refs: any;
   getChildContext(): any;
+  static displayName: string;
   static childContextTypes: any;
 }
 
@@ -73,16 +73,13 @@ declare class LegacyReactComponent<DefaultProps, Props, State, Context> extends 
 
   getDefaultProps(): DefaultProps;
   getInitialState(): State;
-
   replaceState(state: State, callback?: () => void): void;
-
   isMounted(): bool;
 
   // TODO: Due to bugs in Flow's handling of React.createClass, some fields
   // already declared in the base class need to be redeclared below. Ideally
   // they should simply be inherited.
 
-  static displayName: string;
   static defaultProps: DefaultProps;
   context: Context;
   props: Props;
@@ -90,8 +87,13 @@ declare class LegacyReactComponent<DefaultProps, Props, State, Context> extends 
 
   // objects whose keys are in PropTypes
 
-  static contextTypes: $Subtype<{[_: $Keys<Context>]: any}>;
   static propTypes: $Subtype<{[_: $Keys<Props>]: any}>;
+  static contextTypes: $Subtype<{[_: $Keys<Context>]: any}>;
+
+  // things not modeled well
+
+  static childContextTypes: any;
+  static displayName: string;
 }
 
 /**

--- a/src/common/reason.ml
+++ b/src/common/reason.ml
@@ -169,9 +169,11 @@ type reason_desc =
   | RReactStatics
   | RReactDefaultProps
   | RReactState
+  | RReactContext
   | RReactComponentProps
   | RReactElementProps of string
   | RReactPropTypes
+  | RReactContextTypes
   | RPropTypeArray
   | RPropTypeFunc
   | RPropTypeObject
@@ -474,9 +476,11 @@ let rec string_of_desc = function
   | RReactStatics -> "statics of React class"
   | RReactDefaultProps -> "default props of React component"
   | RReactState -> "state of React component"
+  | RReactContext -> "inherited context of React component"
   | RReactComponentProps -> "props of React component"
   | RReactElementProps x -> spf "props of React element `%s`" x
   | RReactPropTypes -> "propTypes of React component"
+  | RReactContextTypes -> "contextTypes of React component"
   | RPropTypeArray -> "array"
   | RPropTypeFunc -> "func"
   | RPropTypeObject -> "object"

--- a/src/common/reason.mli
+++ b/src/common/reason.mli
@@ -121,9 +121,11 @@ type reason_desc =
   | RReactStatics
   | RReactDefaultProps
   | RReactState
+  | RReactContext
   | RReactComponentProps
   | RReactElementProps of string
   | RReactPropTypes
+  | RReactContextTypes
   | RPropTypeArray
   | RPropTypeFunc
   | RPropTypeObject

--- a/tests/get-def2/lib/jsx.js
+++ b/tests/get-def2/lib/jsx.js
@@ -1,5 +1,5 @@
 declare var $React: $Exports<'react'>; // fake import
-type $JSXIntrinsic<T> = Class<$React.Component<void,T,mixed>>;
+type $JSXIntrinsic<T> = Class<$React.Component<void,T,mixed,mixed>>;
 
 type $JSXIntrinsics = {
   div: $JSXIntrinsic<{id: string}>,

--- a/tests/jsx_intrinsics.custom/lib/jsx.js
+++ b/tests/jsx_intrinsics.custom/lib/jsx.js
@@ -1,5 +1,5 @@
 declare var $React: $Exports<'react'>; // fake import
-type $JSXIntrinsic<T> = Class<$React.Component<void,T,mixed>>;
+type $JSXIntrinsic<T> = Class<$React.Component<void,T,mixed,mixed>>;
 
 type $JSXIntrinsics = {
   div: $JSXIntrinsic<{id: string}>,

--- a/tests/new_react/bad_default_props.js
+++ b/tests/new_react/bad_default_props.js
@@ -4,10 +4,10 @@ type T1 = { }
 type T2 = { x: number }
 type T3 = { x: number, y: number }
 
-class C1 extends React.Component<T1, T2, any> { // error
+class C1 extends React.Component<T1, T2, any, any> { // error
 }
 
-class C2 extends React.Component<void, T2, any> { // OK
+class C2 extends React.Component<void, T2, any, any> { // OK
 }
 
 // no need to add type arguments to React.Component
@@ -21,7 +21,7 @@ class C4 extends React.Component { // OK, recommended
   props: T2;
 }
 
-class C5 extends React.Component<T2, T3, any> { // error
+class C5 extends React.Component<T2, T3, any, any> { // error
 }
 
 class C6 extends React.Component { // OK, recommended

--- a/tests/new_react/fakelib/type_aliases.js
+++ b/tests/new_react/fakelib/type_aliases.js
@@ -2,5 +2,5 @@ declare var $React: $Exports<'react'>; // fake import
 // Strawman: revised definition of $jsx (alternatively, React.Element).
 // Using bounded poly to specify a constraint on a type parameter, and
 // existentials to elide type arguments.
-type _ReactElement<DefaultProps, Props, Config: $Diff<Props, DefaultProps>, C: $React.Component<DefaultProps, Props, any>> = $React.Element<Config>;
+type _ReactElement<DefaultProps, Props, Config: $Diff<Props, DefaultProps>, C: $React.Component<DefaultProps, Props, any, any>> = $React.Element<Config>;
 type $jsx<C> = _ReactElement<*, *, *, C>;

--- a/tests/new_react/new_react.exp
+++ b/tests/new_react/new_react.exp
@@ -1,25 +1,25 @@
 bad_default_props.js:7
-  7: class C1 extends React.Component<T1, T2, any> { // error
+  7: class C1 extends React.Component<T1, T2, any, any> { // error
                                       ^^ object type. This type is incompatible with
-  7: class C1 extends React.Component<T1, T2, any> { // error
+  7: class C1 extends React.Component<T1, T2, any, any> { // error
                                       ^^ undefined. Did you forget to declare T1?
 
 bad_default_props.js:7
-  7: class C1 extends React.Component<T1, T2, any> { // error
+  7: class C1 extends React.Component<T1, T2, any, any> { // error
                                       ^^ undefined. Did you forget to declare T1?. This type is incompatible with
-  7: class C1 extends React.Component<T1, T2, any> { // error
+  7: class C1 extends React.Component<T1, T2, any, any> { // error
                                       ^^ object type
 
 bad_default_props.js:24
- 24: class C5 extends React.Component<T2, T3, any> { // error
+ 24: class C5 extends React.Component<T2, T3, any, any> { // error
                                       ^^ object type. This type is incompatible with
- 24: class C5 extends React.Component<T2, T3, any> { // error
+ 24: class C5 extends React.Component<T2, T3, any, any> { // error
                                       ^^ undefined. Did you forget to declare T2?
 
 bad_default_props.js:24
- 24: class C5 extends React.Component<T2, T3, any> { // error
+ 24: class C5 extends React.Component<T2, T3, any, any> { // error
                                       ^^ undefined. Did you forget to declare T2?. This type is incompatible with
- 24: class C5 extends React.Component<T2, T3, any> { // error
+ 24: class C5 extends React.Component<T2, T3, any, any> { // error
                                       ^^ object type
 
 classes.js:17
@@ -66,8 +66,8 @@ classes.js:41
                              ^^^^^^ React element `Foo`
  41: var foo: $jsx<number> = <Foo/>;
                    ^^^^^^ number. This type is incompatible with
-  5: type _ReactElement<DefaultProps, Props, Config: $Diff<Props, DefaultProps>, C: $React.Component<DefaultProps, Props, any>> = $React.Element<Config>;
-                                                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ React$Component. See lib: fakelib/type_aliases.js:5
+  5: type _ReactElement<DefaultProps, Props, Config: $Diff<Props, DefaultProps>, C: $React.Component<DefaultProps, Props, any, any>> = $React.Element<Config>;
+                                                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ React$Component. See lib: fakelib/type_aliases.js:5
 
 classes.js:59
  59:     var _: string = this.props.x;
@@ -94,8 +94,8 @@ classes.js:81
                                     ^^^^^^^^^^^^ React element `FooLegacy`
  81: var foo_legacy: $jsx<number> = <FooLegacy/>;
                           ^^^^^^ number. This type is incompatible with
-  5: type _ReactElement<DefaultProps, Props, Config: $Diff<Props, DefaultProps>, C: $React.Component<DefaultProps, Props, any>> = $React.Element<Config>;
-                                                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ React$Component. See lib: fakelib/type_aliases.js:5
+  5: type _ReactElement<DefaultProps, Props, Config: $Diff<Props, DefaultProps>, C: $React.Component<DefaultProps, Props, any, any>> = $React.Element<Config>;
+                                                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ React$Component. See lib: fakelib/type_aliases.js:5
 
 import-react.js:18
  18: <HelloMessage name={007} />; // number ~/~> string error

--- a/tests/react/import_react.js
+++ b/tests/react/import_react.js
@@ -3,5 +3,5 @@
 import react from "react";
 import {Component} from "react";
 
-var a: Component<*,*,*> = new react.Component();
+var a: Component<*,*,*,*> = new react.Component();
 var b: number = new react.Component(); // Error: ReactComponent ~> number

--- a/tests/react_modules/es6class-proptypes-callsite.js
+++ b/tests/react_modules/es6class-proptypes-callsite.js
@@ -2,7 +2,7 @@
 import React from 'react';
 import Hello from './es6class-proptypes-module';
 
-class HelloLocal extends React.Component<void, {name: string}, void> {
+class HelloLocal extends React.Component<void, {name: string}, void, void> {
   defaultProps = {};
   propTypes = {
     name: React.PropTypes.string.isRequired,
@@ -12,7 +12,7 @@ class HelloLocal extends React.Component<void, {name: string}, void> {
   }
 }
 
-class Callsite extends React.Component<void, {}, void> {
+class Callsite extends React.Component<void, {}, void, void> {
   render(): React.Element<*> {
     return (
       <div>

--- a/tests/react_modules/es6class-proptypes-module.js
+++ b/tests/react_modules/es6class-proptypes-module.js
@@ -1,7 +1,7 @@
 /* @flow */
 import React from 'react';
 
-class Hello extends React.Component<void, {name: string}, void> {
+class Hello extends React.Component<void, {name: string}, void, void> {
   defaultProps = {};
   propTypes = {
     name: React.PropTypes.string.isRequired,

--- a/tests/react_modules/es6class-types-callsite.js
+++ b/tests/react_modules/es6class-types-callsite.js
@@ -4,7 +4,7 @@ import Hello from './es6class-types-module';
 
 type Props = {name: string};
 
-class HelloLocal extends React.Component<void, Props, void> {
+class HelloLocal extends React.Component<void, Props, void, void> {
   props: Props;
 
   render(): React.Element<*> {
@@ -12,7 +12,7 @@ class HelloLocal extends React.Component<void, Props, void> {
   }
 }
 
-class Callsite extends React.Component<void, Props, void> {
+class Callsite extends React.Component<void, Props, void, void> {
   render(): React.Element<*> {
     return (
       <div>

--- a/tests/react_modules/es6class-types-module.js
+++ b/tests/react_modules/es6class-types-module.js
@@ -3,7 +3,7 @@ import React from 'react';
 
 type Props = {name: string};
 
-class Hello extends React.Component<{}, Props, void>{
+class Hello extends React.Component<{}, Props, void, void> {
   props: Props;
   static defaultProps: {};
 

--- a/tests/react_modules/react_modules.exp
+++ b/tests/react_modules/react_modules.exp
@@ -15,7 +15,7 @@ createclass-callsite.js:20
              ^^^^^^^^^^^^^^ props of React element `HelloLocal`
 
 es6class-proptypes-callsite.js:5
-  5: class HelloLocal extends React.Component<void, {name: string}, void> {
+  5: class HelloLocal extends React.Component<void, {name: string}, void, void> {
                                                     ^^^^^^^^^^^^^^ property `name`. Property not found in
  20:         <HelloLocal />
              ^^^^^^^^^^^^^^ props of React element `HelloLocal`
@@ -23,13 +23,13 @@ es6class-proptypes-callsite.js:5
 es6class-proptypes-callsite.js:19
  19:         <Hello />
              ^^^^^^^^^ React element `Hello`
-  4: class Hello extends React.Component<void, {name: string}, void> {
+  4: class Hello extends React.Component<void, {name: string}, void, void> {
                                                ^^^^^^^^^^^^^^ property `name`. Property not found in. See: es6class-proptypes-module.js:4
  19:         <Hello />
              ^^^^^^^^^ props of React element `Hello`
 
 es6class-types-callsite.js:7
-  7: class HelloLocal extends React.Component<void, Props, void> {
+  7: class HelloLocal extends React.Component<void, Props, void, void> {
                                                     ^^^^^ property `name`. Property not found in
  20:         <HelloLocal />
              ^^^^^^^^^^^^^^ props of React element `HelloLocal`
@@ -37,7 +37,7 @@ es6class-types-callsite.js:7
 es6class-types-callsite.js:19
  19:         <Hello />
              ^^^^^^^^^ React element `Hello`
-  6: class Hello extends React.Component<{}, Props, void>{
+  6: class Hello extends React.Component<{}, Props, void, void> {
                                              ^^^^^ property `name`. Property not found in. See: es6class-types-module.js:6
  19:         <Hello />
              ^^^^^^^^^ props of React element `Hello`


### PR DESCRIPTION
I got annoyed with React context always being defined as `any`, so this is a quick PR in which context takes advantage of generics (the 4th argument). The PR takes the following assumptions into account:

* The typing of context is only necessary for the component itself, mainly the life-cycle events.
* Child context doesn't need to be typed as it only has 1 call site, `getChildContext()`. Perhaps this could use method generics?
* The `Config` in `ReactClass` doesn't require context for uniqueness.

Furthermore, I don't know OCaml, so I kind of guessed on how things work. I also avoided writing tests (besides fixing existing ones) in case this is a feature that is purposefully not supported.