### PR TITLE
Fix for class method default parameters that use `this`

### DIFF
--- a/src/typing/func_sig.ml
+++ b/src/typing/func_sig.ml
@@ -233,6 +233,11 @@ let toplevels id cx this super ~decls ~stmts ~expr
   (* push the scope early so default exprs can reference earlier params *)
   Env.push_var_scope cx function_scope;
 
+  (* add `this` before looking at parameter bindings as when using `this`
+     in default parameter values it refers to the function scope
+  *)
+  Scope.add_entry (internal_name "this") this function_scope;
+
   (* bind type params *)
   SMap.iter (fun name t ->
     let r = reason_of_t t in
@@ -290,7 +295,6 @@ let toplevels id cx this super ~decls ~stmts ~expr
     new_entry yield_t, new_entry next_t, new_entry return_t
   ) in
 
-  Scope.add_entry (internal_name "this") this function_scope;
   Scope.add_entry (internal_name "super") super function_scope;
   Scope.add_entry (internal_name "yield") yield function_scope;
   Scope.add_entry (internal_name "next") next function_scope;

--- a/tests/class_method_default_parameters/.flowconfig
+++ b/tests/class_method_default_parameters/.flowconfig
@@ -1,0 +1,2 @@
+[options]
+no_flowlib=false

--- a/tests/class_method_default_parameters/class_method_default_parameters.exp
+++ b/tests/class_method_default_parameters/class_method_default_parameters.exp
@@ -1,0 +1,8 @@
+class_method_default_parameters.js:17
+ 17:     h(i: number = this.b) { // error
+                       ^^^^^^ string. This type is incompatible with
+ 17:     h(i: number = this.b) { // error
+              ^^^^^^ number
+
+
+Found 1 error

--- a/tests/class_method_default_parameters/class_method_default_parameters.js
+++ b/tests/class_method_default_parameters/class_method_default_parameters.js
@@ -1,0 +1,21 @@
+class A {
+
+    b: string;
+
+    c(d = this.b) { // ok - can use `this` in function default parameter values
+
+    }
+
+    e() {
+        return this.b;
+    }
+
+    f(g = this.e()) { // ok - can use `this` in function default parameter values
+
+    }
+
+    h(i: number = this.b) { // error
+
+    }
+
+}


### PR DESCRIPTION
Example of bug - https://flowtype.org/try/#0PQKgBAAgZgNg9gdzCYAoVBjGBDAzrsAQTAG9UwxyxsAuMXAFwCcBLAOwHMqqAjACgxgAvGAYALFrgB02AJSkqFKgF9uyoA