### PR TITLE
Add type for React.checkPropTypes

### DIFF
--- a/lib/react.js
+++ b/lib/react.js
@@ -161,6 +161,13 @@ declare module react {
 
   declare function initializeTouchEvents(shouldUseTouch: boolean): void;
 
+  declare function checkPropTypes<V>(
+    propTypes: $Subtype<{[_: $Keys<V>]: ReactPropsCheckType}>,
+    values: V,
+    location: string,
+    componentName: string,
+    getStack: ?(() => ?string)
+  ) : void;
 
   declare var createClass: React$CreateClass;
 

--- a/tests/more_react/checkPropTypes.js
+++ b/tests/more_react/checkPropTypes.js
@@ -1,0 +1,14 @@
+/* @flow */
+
+import { PropTypes, checkPropTypes } from "react";
+
+checkPropTypes({ foo: PropTypes.string }, { foo: 'foo' }, 'value', 'TestComponent'); // OK
+
+checkPropTypes({ foo: PropTypes.string }, { foo: 'foo' }); // error: missing arguments
+checkPropTypes({ foo: PropTypes.string }, { foo: 'foo' }, 'value'); // error: missing argument
+
+checkPropTypes({ bar: PropTypes.string }, { foo: 'foo' }, 'value', 'TestComponent'); // error: property not found
+
+checkPropTypes({ foo: PropTypes.string }, { foo: 'foo' }, 'value', 'TestComponent', () => 123); // error: number ~> string
+checkPropTypes({ foo: PropTypes.string }, { foo: 'foo' }, 'value', 'TestComponent', () => null); // OK
+checkPropTypes({ foo: PropTypes.string }, { foo: 'foo' }, 'value', 'TestComponent', () => undefined); // OK

--- a/tests/more_react/more_react.exp
+++ b/tests/more_react/more_react.exp
@@ -24,6 +24,44 @@ JSX.js:8
  14:   getDefaultProps: function(): { y: string } {
                                          ^^^^^^ string. See: App.react.js:14
 
+checkPropTypes.js:7
+  7: checkPropTypes({ foo: PropTypes.string }, { foo: 'foo' }); // error: missing arguments
+     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function call
+  7: checkPropTypes({ foo: PropTypes.string }, { foo: 'foo' }); // error: missing arguments
+     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ undefined (too few arguments, expected default/rest parameters). This type is incompatible with
+167:     location: string,
+                   ^^^^^^ string. See lib: <BUILTINS>/react.js:167
+
+checkPropTypes.js:7
+  7: checkPropTypes({ foo: PropTypes.string }, { foo: 'foo' }); // error: missing arguments
+     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function call
+  7: checkPropTypes({ foo: PropTypes.string }, { foo: 'foo' }); // error: missing arguments
+     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ undefined (too few arguments, expected default/rest parameters). This type is incompatible with
+168:     componentName: string,
+                        ^^^^^^ string. See lib: <BUILTINS>/react.js:168
+
+checkPropTypes.js:8
+  8: checkPropTypes({ foo: PropTypes.string }, { foo: 'foo' }, 'value'); // error: missing argument
+     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function call
+  8: checkPropTypes({ foo: PropTypes.string }, { foo: 'foo' }, 'value'); // error: missing argument
+     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ undefined (too few arguments, expected default/rest parameters). This type is incompatible with
+168:     componentName: string,
+                        ^^^^^^ string. See lib: <BUILTINS>/react.js:168
+
+checkPropTypes.js:10
+ 10: checkPropTypes({ bar: PropTypes.string }, { foo: 'foo' }, 'value', 'TestComponent'); // error: property not found
+     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function call
+ 10: checkPropTypes({ bar: PropTypes.string }, { foo: 'foo' }, 'value', 'TestComponent'); // error: property not found
+                    ^^^^^^^^^^^^^^^^^^^^^^^^^ property `bar`. Property not found in
+165:     propTypes: $Subtype<{[_: $Keys<V>]: ReactPropsCheckType}>,
+                                  ^^^^^^^^ object literal. See lib: <BUILTINS>/react.js:165
+
+checkPropTypes.js:12
+ 12: checkPropTypes({ foo: PropTypes.string }, { foo: 'foo' }, 'value', 'TestComponent', () => 123); // error: number ~> string
+                                                                                               ^^^ number. This type is incompatible with the expected param type of
+169:     getStack: ?(() => ?string)
+                            ^^^^^^ string. See lib: <BUILTINS>/react.js:169
+
 propTypes.js:15
  15: <D />; // errors: properties `name` and `title` not found
      ^^^^^ React element `D`
@@ -41,4 +79,4 @@ propTypes.js:15
      ^^^^^ props of React element `D`
 
 
-Found 6 errors
+Found 11 errors


### PR DESCRIPTION
checkPropTypes is a new API that will be released in React 16. Its purpose is to check external (non-React) objects against React prop type checkers and print a warning if they do not match.

It's possible there's a better way to type this. The React module this corresponds to can be found here: https://github.com/facebook/react/blob/master/src/isomorphic/classic/types/checkPropTypes.js