### PR TITLE
Work around error with Result when compiling JS build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -237,11 +237,16 @@ test-ocp: build-flow-with-ocp copy-flow-files-ocp
 
 js: $(BUILT_OBJECT_FILES)
 	mkdir -p bin
+	# NOTE: temporarily disabling warning 31 because
+	# hack/third-party/core/result.ml and the opam `result` module both define
+	# result.cma, and this is the most expedient (though fragile) way to unblock
+	# ourselves.
 	ocamlbuild -use-ocamlfind \
 		-pkgs js_of_ocaml \
 		-build-dir _build \
 		-lflags -custom -no-links \
-		$(INCLUDE_OPTS) $(LIB_OPTS) -lflags "$(BYTECODE_LINKER_FLAGS)" \
+		$(INCLUDE_OPTS) $(LIB_OPTS) \
+		-lflags "$(BYTECODE_LINKER_FLAGS) -warn-error -31" \
 		src/flow_dot_js.byte
 	# js_of_ocaml has no ability to upgrade warnings to errors, but we want to
 	# error if, for example, there are any unimplemented C primitives.


### PR DESCRIPTION
`hack/third-party/core/result.ml` and the opam `result` module, which is a dependency of `lwt` and `base64`, which are dependencies of `js_of_ocaml`, both provide `result.cma`, leading to a Warning 31 about two modules with the same name. Warning 31 is an error in ocaml-4.03. Since this was a problem in 4.02 and things were ok, we'll just suppress the error until we can find a real solution.