### PR TITLE
Fixed number primitive link in docs

### DIFF
--- a/website/docs/ref/quickref.doc.js
+++ b/website/docs/ref/quickref.doc.js
@@ -14,7 +14,7 @@ next: syntax.html
   Flow has types for all of the JavaScript **primitive types**.
 
   * [boolean](builtins.html#boolean)
-  * [number](builtins.html#mixed)
+  * [number](builtins.html#number)
   * [string](builtins.html#string)
   * [null](builtins.html#null-and-void)
   * [void](builtins.html#null-and-void)


### PR DESCRIPTION
The number anchor was pointing to the wrong section (to `mixed` instead of `number`)