### PR TITLE
StringDecoder.end() returns a string type

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -1340,7 +1340,7 @@ declare module "tty" {
 
 declare class string_decoder$StringDecoder {
   constructor(encoding?: 'utf8' | 'ucs2' | 'utf16le' | 'base64'): void;
-  end(): void;
+  end(): string;
   write(buffer: Buffer): string;
 }
 


### PR DESCRIPTION
According to https://nodejs.org/api/string_decoder.html end() returns remaining bytes as string