### PR TITLE
Make `port` argument to `socket.bind` optional.

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -539,7 +539,7 @@ type net$Socket$address = {address: string; family: string; port: number};
 declare class dgram$Socket extends events$EventEmitter {
   addMembership(multicastAddress: string, multicastInterface?: string): void;
   address(): net$Socket$address;
-  bind(port: number, address?: string, callback?: () => void): void;
+  bind(port?: number, address?: string, callback?: () => void): void;
   close(): void;
   dropMembership(multicastAddress: string, multicastInterface?: string): void;
   ref(): void;


### PR DESCRIPTION
According to https://nodejs.org/api/dgram.html#dgram_socket_bind_port_address_callback, the `port` argument to `socket.bind` of UPD Sockets is optional.