### PR TITLE
[tiny] coverage --color hint known -> unknown

### DIFF
--- a/src/commands/coverageCommand.ml
+++ b/src/commands/coverageCommand.ml
@@ -32,7 +32,7 @@ let spec = {
     |> root_flag
     |> json_flags
     |> flag "--color" no_arg
-        ~doc:"Print the file with colors showing which parts have known types"
+        ~doc:"Print the file with colors showing which parts have unknown types"
     |> flag "--debug" no_arg
         ~doc:"Print debugging info about each range in the file to stderr"
     |> flag "--strip-root" no_arg


### PR DESCRIPTION
If I am correctly interpreting the output of the `flow coverage <targetfile> --color` command (which I did test by adding additional annotations), it appears that the parts of the files highlighted in red have no type information.  The command line hint says the reverse is true.

Genuinely a tiny update.