### PR TITLE
Add missing types for the buffer module

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -117,7 +117,10 @@ declare class Buffer extends Uint8Array {
 }
 
 declare module "buffer" {
+  declare var Buffer: Class<Buffer>;
+  declare var kMaxLength: number;
   declare var INSPECT_MAX_BYTES: number;
+  declare function transcode(source: Buffer, fromEnc: buffer$Encoding, toEnc: buffer$Encoding): Buffer;
 }
 
 type child_process$execOpts = {


### PR DESCRIPTION
Just like the title says

You can find these types documented in the [official docs](https://nodejs.org/api/buffer.html) or in my screenshot below

<img src="https://cloud.githubusercontent.com/assets/4278113/23771532/1d8b161a-0539-11e7-923d-48713c27b7d3.png">


**Note:** I did not add types for `SlowBuffer` because according to the official docs, it's depreciated and no longer recommended for use.