### PR TITLE
Adds missing property to node.js Process global

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -1622,6 +1622,7 @@ declare class Process extends events$EventEmitter {
   connected : boolean;
   cwd() : string;
   disconnect? : () => void;
+  domain? : domain$Domain;
   env : { [key: string] : ?string };
   execArgv : Array<string>;
   execPath : string;


### PR DESCRIPTION
When using node.js domains, `process.domain` is automatically pointed to the domain currently executing. ([See docs](https://nodejs.org/api/domain.html#domain_domain_enter)) This property is not included on the current `Process` type which makes trying to include flow in legacy code which still make use of domains challenging.

This PR updates `Process` to include `domain` as an optional field.