### PR TITLE
Add missing classes and functions to url module

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -1434,7 +1434,7 @@ declare module "url" {
     entries(): Iterator<[string, string]>;
     forEach(fn: (value: string, name: string, searchParams: URLSearchParams) => void, thisArg?: any): void;
     get(name: string): string | null;
-    getAll(name: string): [string];
+    getAll(name: string): string[];
     has(name: string): boolean;
     keys(): Iterator<string>;
     set(name: string, value: string): void;

--- a/lib/node.js
+++ b/lib/node.js
@@ -1425,6 +1425,39 @@ declare module "url" {
     +hash?: string;
   }): string;
   declare function resolve(from: string, to: string): string;
+  declare class URLSearchParams {
+    constructor(init?: string): void;
+    append(name: string, value: string): void;
+    delete(name: string): void;
+    entries(): Iterator<[string, string]>;
+    forEach(fn: (value: string, name: string, searchParams: URLSearchParams) => void, thisArg?: any): void;
+    get(name: string): string | null;
+    getAll(name: string): [string];
+    has(name: string): boolean;
+    keys(): Iterator<string>;
+    set(name: string, value: string): void;
+    sort(): void;
+    toString(): string;
+    values(): Iterator<string>;
+    @@Iterator(): Iterator<[string, string]>;
+  }
+  declare class URL {
+    constructor(input: string, base?: string | URL): void;
+    hash: string;
+    host: string;
+    hostname: string;
+    href: string;
+    origin: string;
+    password: string;
+    pathname: string;
+    port: string;
+    protocol: string;
+    search: string;
+    searchParams: URLSearchParams;
+    username: string;
+    toString(): string;
+    toJSON(): string;
+  }
 }
 
 declare module "util" {

--- a/lib/node.js
+++ b/lib/node.js
@@ -1425,6 +1425,8 @@ declare module "url" {
     +hash?: string;
   }): string;
   declare function resolve(from: string, to: string): string;
+  declare function domainToASCII(domain: string): string;
+  declare function domainToUnicode(domain: string): string;
   declare class URLSearchParams {
     constructor(init?: string): void;
     append(name: string, value: string): void;


### PR DESCRIPTION
This adds the two classes `URL` and `URLSearchParams` and the two functions `domainToASCII` and `domainToUnicode` that where missing from the `url` module.

Node docs for url module: https://nodejs.org/api/url.html

I have tested that this works in a local project that used these features