### PR TITLE
Fix Promise.catch

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -636,8 +636,8 @@ declare class Promise<+R> {
     ): Promise<U>;
 
     catch<U>(
-      onReject?: (error: any) => ?Promise<U> | U
-    ): Promise<U>;
+      onReject?: (error: any) => Promise<U> | U
+    ): Promise<R | U>;
 
     static resolve<T>(object: Promise<T> | T): Promise<T>;
     static reject<T>(error?: any): Promise<T>;

--- a/tests/promises/promise.js
+++ b/tests/promises/promise.js
@@ -217,12 +217,10 @@ Promise.reject(0)
     var b: number = str; // Error: string ~> number
   });
 
-// TODO: resolvedPromise<T> -> catch() -> then():T
+// resolvedPromise<T> -> catch() -> then():?T
 Promise.resolve(0)
   .catch(function(err) {})
   .then(function(num) {
-    var a: number = num;
-
-    // TODO
+    var a: ?number = num;
     var b: string = num; // Error: string ~> number
   });

--- a/tests/promises/promises.exp
+++ b/tests/promises/promises.exp
@@ -225,11 +225,11 @@ promise.js:201
 promise.js:206
 206:   .catch(function(num) { return Promise.resolve('asdf'); })
                                      ^^^^^^^^^^^^^^^^^^^^^^^ Promise. This type is incompatible with
-639:       onReject?: (error: any) => ?Promise<U> | U
-                                      ^^^^^^^^^^^^^^^ union: ?type application of class `Promise` | type parameter `U` of call of method `catch`. See lib: <BUILTINS>/core.js:639
+639:       onReject?: (error: any) => Promise<U> | U
+                                      ^^^^^^^^^^^^^^ union: type application of class `Promise` | type parameter `U` of call of method `catch`. See lib: <BUILTINS>/core.js:639
   Member 1:
-  639:       onReject?: (error: any) => ?Promise<U> | U
-                                        ^^^^^^^^^^^ ?type application of class `Promise`. See lib: <BUILTINS>/core.js:639
+  639:       onReject?: (error: any) => Promise<U> | U
+                                        ^^^^^^^^^^ type application of class `Promise`. See lib: <BUILTINS>/core.js:639
   Error:
   209:     var b: number = str; // Error: string ~> number
                            ^^^ string. This type is incompatible with
@@ -265,6 +265,18 @@ promise.js:214
                            ^^^ Promise. This type is incompatible with
   216:     var a: string = str;
                   ^^^^^^ string
+
+promise.js:225
+225:     var b: string = num; // Error: string ~> number
+                         ^^^ number. This type is incompatible with
+225:     var b: string = num; // Error: string ~> number
+                ^^^^^^ string
+
+promise.js:225
+225:     var b: string = num; // Error: string ~> number
+                         ^^^ undefined. This type is incompatible with
+225:     var b: string = num; // Error: string ~> number
+                ^^^^^^ string
 
 resolve_global.js:35
  35:   return Promise.resolve(0);
@@ -307,4 +319,4 @@ resolve_void.js:5
                                             ^^^^^^ number
 
 
-Found 26 errors
+Found 28 errors


### PR DESCRIPTION
This pull request fixes a problem with the built-in `Promise.catch` declaration. In a snippet like `Promise.resolve(1).catch(() => 2)`, then resulting expression should not typecheck as a `Promise<2>`, since the promise actually resolves into `1`.

The example below shows how the proposed fix will catch the error [(try)](https://flowtype.org/try/#0PQKgBAAgZgNg9gdzCYAoVBjOA7AzgFzBwFMAuMABQCc4BbAS12IB4BGAPjAF5KaGmAdFWK44MAG7EAFKwCUAbkw4CYXAAs4AVxgATAGIBDejHLU6jFgCZOPEgIwH8GNVKmzunSwtTBgYHXAiYNhwhFBGMAA0YAYw+BqaAOZqYPSE6lq6YAB66DrEGDAGwmCFBri4vOZMAPrMANQASpwA3qhgHfHE2MwAquxS7R3DOHraUMYwAPzkUuKxmmRgje5cnGb8xHX9YAA+YL2RQ8NE2I3EAFYF+DNgUsRUNFTkBtgAnqvrfBbbnPu9xzAslM31qfXYikBDicanBgxOHRw5yuGBusweTxe70+YCmGx+4L2B0BwKqmzqjSJ-UhJwIjnoGDAwlEEhYABUBnAAEYo-Ag6pbZgcols0n4sEcxQAX3QWDwhBINX55LYNjJPyEIjEkhk3jlKgCIkMxmVBOs3FOW3sjmcrhxXkUvlKcEe1yU8v8gVwADlQsaTOqwaxdubbNgrdDbW4PGAHT4-FhXaigA):
```js
/* @flow */

const one: Promise<1> = Promise.resolve(1);
const shouldFail: Promise<2> = one.catch(() => 2);
// does not fail, although it should ^

declare class Promise_<+R> {
   then<U>(
      onFulfill?: (value: R) => Promise_<U> | U,
      onReject?: (error: any) => Promise_<U> | U
    ): Promise_<U>;

    catch<U>(
      onReject?: (error: any) => ?Promise_<U> | U
    ): Promise_<R | U>;

    static resolve<T>(object: Promise_<T> | T): Promise_<T>;
}

const one_: Promise_<1> = Promise_.resolve(1);
const doesFail: Promise_<2> = one_.catch(() => 2);
// correct
const doesNotFail: Promise_<1|2> = one_.catch(() => 2);
// correct
```

If any edits are needed to merge this (tests?), I'd be happy to collaborate — please let me know.