### PR TITLE
Fixes types for node.js function `dns.lookup`

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -596,7 +596,7 @@ declare module "dns" {
 
   declare function lookup(
     domain: string,
-    family?: ?number,
+    options?: ?number | ?Object,
     callback?: (err: ?Error, address: string, family: number) => void
   ): void;
 


### PR DESCRIPTION
The 2nd parameter in `lookup` is either a number (currently what flow expects) or an object (what this PR adds).

Docs: https://nodejs.org/api/dns.html#dns_dns_lookup_hostname_options_callback