### PR TITLE
Fix typo in Markdown in Union Types docs

### DIFF
--- a/website/en/docs/types/unions.md
+++ b/website/en/docs/types/unions.md
@@ -206,7 +206,7 @@ handleResponse({
 Unless the objects somehow conflict with one another there is no way to
 distinguish them.
 
-However, to get around this you could use** exact object types**.
+However, to get around this you could use **exact object types**.
 
 ```js
 // @flow


### PR DESCRIPTION
in the Markdown text for [Union Types](https://flowtype.org/en/docs/types/unions/): `use** exact object types**` -> `use **exact object types**`