### PR TITLE
Add documentation for $ObjMap

### DIFF
--- a/website/en/docs/types/utilities.md
+++ b/website/en/docs/types/utilities.md
@@ -253,6 +253,11 @@ const user2 = {name: 'John Wilkes Booth'};
 ## `$ObjMap<T, F>` <a class="toc" id="toc-objmap" href="#toc-objmap"></a>
 `ObjMap<T, F>` is the type obtained by taking the type of the values of an object and mapping them with a type function.
 
+> ### Warning
+> `$ObjMap` is currently in an unstable state, due to a bug that allows invalid writes.
+>
+> For more information, please refer to [#2674](https://github.com/facebook/flow/issues/2674).
+
 Let's see an example. Suppose you have a function called `run` that takes an object of thunks (functions in the form `() => A`) in input:
 
 ```js


### PR DESCRIPTION
This is long due.

I volunteered [some time ago](https://github.com/facebook/flow/issues/2464#issuecomment-274808633) to document advanced features, and @thejameskyle was so nice to even reach out and ask for help for the new website that saw the light yesterday.

Unfortunately "life happened" and I couldn't find the time to contribute as I thought.

Now that the new gorgeous docs are out, I feel really sorry for not having helped like I promised and I think the minimum I can do is to fill some of the remaining the gaps.

Here's the documentation for `$ObjMap`, a powerful advanced feature that many asked to explain.

Hope this helps!