### PR TITLE
Fix pre-publish command in install guide (fixes #3594)

### DIFF
--- a/website/en/docs/_install/compiler-flow-remove-types.md
+++ b/website/en/docs/_install/compiler-flow-remove-types.md
@@ -24,7 +24,7 @@ You can add this to your `package.json` scripts easily.
   "main": "lib/index.js",
   "scripts": {
     "build": "flow-remove-types src/ -D lib/",
-    "prepublish": "yarn run build"
+    "prepublish": "{{include.package_manager}} run build"
   }
 }
 ```

--- a/website/en/docs/_install/include.html
+++ b/website/en/docs/_install/include.html
@@ -9,7 +9,7 @@
 {% capture compiler_intro %}{% include_relative _install/compiler-intro.md %}{% endcapture %}
 {% capture setup_intro %}{% include_relative _install/setup-intro.md %}{% endcapture %}
 
-{% capture babel %}{% include_relative _install/compiler-babel.md install_command=install_command run_command=run_command %}{% endcapture %}
+{% capture babel %}{% include_relative _install/compiler-babel.md install_command=install_command run_command=run_command package_manager=include.package_manager %}{% endcapture %}
 {% capture flowRemoveTypes %}{% include_relative _install/compiler-flow-remove-types.md install_command=install_command run_command=run_command %}{% endcapture %}
 
 {% capture yarn %}{% include_relative _install/setup-yarn.md %}{% endcapture %}

--- a/website/en/docs/_install/include.html
+++ b/website/en/docs/_install/include.html
@@ -10,7 +10,7 @@
 {% capture setup_intro %}{% include_relative _install/setup-intro.md %}{% endcapture %}
 
 {% capture babel %}{% include_relative _install/compiler-babel.md install_command=install_command run_command=run_command package_manager=include.package_manager %}{% endcapture %}
-{% capture flowRemoveTypes %}{% include_relative _install/compiler-flow-remove-types.md install_command=install_command run_command=run_command %}{% endcapture %}
+{% capture flowRemoveTypes %}{% include_relative _install/compiler-flow-remove-types.md install_command=install_command run_command=run_command package_manager=include.package_manager %}{% endcapture %}
 
 {% capture yarn %}{% include_relative _install/setup-yarn.md %}{% endcapture %}
 {% capture npm %}{% include_relative _install/setup-npm.md %}{% endcapture %}


### PR DESCRIPTION
I've broken the pre-publish command install guide in #3594 (now the package manager is completely missing).

This fixes it (this time I tested the website locally to ensure it works!)

Bonus: I've also added the same fix to the flow-remove-type section, so that now it respects the `yarn`/`npm` selection too.

![](http://g.recordit.co/A5zugGrBgu.gif)