### PR TITLE
Redirect /docs/ to /en/docs/

### DIFF
--- a/website/s3_website.yml
+++ b/website/s3_website.yml
@@ -13,6 +13,7 @@ cloudfront_wildcard_invalidation: true
 redirects:
   index.html: en/
   about/: en/docs/lang/
+  docs/: en/docs/
   docs/about-flow.html: en/docs/lang/
   docs/getting-started.html: en/docs/getting-started/
   # docs/five-simple-examples.html: ??


### PR DESCRIPTION
Fixes #3602

Not sure this is the way to go, and I can't really test it since it's at the S3 level, but maybe @samwgoldman can tell whether it's correct.