### PR TITLE
Add `FocusEvent` type

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -115,6 +115,8 @@ type EventHandler = (event: Event) => mixed
 type EventListener = {handleEvent: EventHandler} | EventHandler
 type MouseEventHandler = (event: MouseEvent) => mixed
 type MouseEventListener = {handleEvent: MouseEventHandler} | MouseEventHandler
+type FocusEventHandler = (event: FocusEvent) => mixed
+type FocusEventListener = {handleEvent: FocusEventHandler} | FocusEventHandler
 type KeyboardEventHandler = (event: KeyboardEvent) => mixed
 type KeyboardEventListener = {handleEvent: KeyboardEventHandler} | KeyboardEventHandler
 type TouchEventHandler = (event: TouchEvent) => mixed
@@ -129,6 +131,7 @@ type AnimationEventHandler = (event: AnimationEvent) => mixed
 type AnimationEventListener = {handleEvent: AnimationEventHandler} | AnimationEventHandler
 
 type MouseEventTypes = 'contextmenu' | 'mousedown' | 'mouseenter' | 'mouseleave' | 'mousemove' | 'mouseout' | 'mouseover' | 'mouseup' | 'click' | 'dblclick';
+type FocusEventTypes = 'blur' | 'focus' | 'focusin' | 'focusout';
 type KeyboardEventTypes = 'keydown' | 'keyup' | 'keypress';
 type TouchEventTypes = 'touchstart' | 'touchmove' | 'touchend' | 'touchcancel';
 type WheelEventTypes = 'wheel';
@@ -144,6 +147,7 @@ type EventListenerOptionsOrUseCapture = boolean | {
 
 declare class EventTarget {
   addEventListener(type: MouseEventTypes, listener: MouseEventListener, optionsOrUseCapture?: EventListenerOptionsOrUseCapture): void;
+  addEventListener(type: FocusEventTypes, listener: FocusEventListener, optionsOrUseCapture?: EventListenerOptionsOrUseCapture): void;
   addEventListener(type: KeyboardEventTypes, listener: KeyboardEventListener, optionsOrUseCapture?: EventListenerOptionsOrUseCapture): void;
   addEventListener(type: TouchEventTypes, listener: TouchEventListener, optionsOrUseCapture?: EventListenerOptionsOrUseCapture): void;
   addEventListener(type: WheelEventTypes, listener: WheelEventListener, optionsOrUseCapture?: EventListenerOptionsOrUseCapture): void;
@@ -153,6 +157,7 @@ declare class EventTarget {
   addEventListener(type: string, listener: EventListener, optionsOrUseCapture?: EventListenerOptionsOrUseCapture): void;
 
   removeEventListener(type: MouseEventTypes, listener: MouseEventListener, optionsOrUseCapture?: EventListenerOptionsOrUseCapture): void;
+  removeEventListener(type: FocusEventTypes, listener: FocusEventListener, optionsOrUseCapture?: EventListenerOptionsOrUseCapture): void;
   removeEventListener(type: KeyboardEventTypes, listener: KeyboardEventListener, optionsOrUseCapture?: EventListenerOptionsOrUseCapture): void;
   removeEventListener(type: TouchEventTypes, listener: TouchEventListener, optionsOrUseCapture?: EventListenerOptionsOrUseCapture): void;
   removeEventListener(type: WheelEventTypes, listener: WheelEventListener, optionsOrUseCapture?: EventListenerOptionsOrUseCapture): void;
@@ -162,6 +167,7 @@ declare class EventTarget {
   removeEventListener(type: string, listener: EventListener, optionsOrUseCapture?: EventListenerOptionsOrUseCapture): void;
 
   attachEvent?: (type: MouseEventTypes, listener: MouseEventListener) => void;
+  attachEvent?: (type: FocusEventTypes, listener: FocusEventListener) => void;
   attachEvent?: (type: KeyboardEventTypes, listener: KeyboardEventListener) => void;
   attachEvent?: (type: TouchEventTypes, listener: TouchEventListener) => void;
   attachEvent?: (type: WheelEventTypes, listener: WheelEventListener) => void;
@@ -171,6 +177,7 @@ declare class EventTarget {
   attachEvent?: (type: string, listener: EventListener) => void;
 
   detachEvent?: (type: MouseEventTypes, listener: MouseEventListener) => void;
+  detachEvent?: (type: FocusEventTypes, listener: FocusEventListener) => void;
   detachEvent?: (type: KeyboardEventTypes, listener: KeyboardEventListener) => void;
   detachEvent?: (type: TouchEventTypes, listener: TouchEventListener) => void;
   detachEvent?: (type: WheelEventTypes, listener: WheelEventListener) => void;
@@ -265,6 +272,10 @@ declare class MouseEvent extends UIEvent {
   shiftKey: boolean;
   relatedTarget: ?EventTarget;
   getModifierState(keyArg: string): boolean;
+}
+
+declare class FocusEvent extends UIEvent {
+  relatedTarget: ?EventTarget;
 }
 
 declare class WheelEvent extends MouseEvent {


### PR DESCRIPTION
I noticed that the `FocusEvent` (used for `focus`, `blur`, `focusin`, and `focusout`) was missing. I've added it here.

Let me know if I've done something wrong here, this is my first PR for Flow. Thanks.