### PR TITLE
Upgrade to ocaml-4.03 in appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,22 +4,29 @@ os: Visual Studio 2015
 platform: x64
 environment:
   matrix:
-    - ocaml_version: 4.02.1
-      ocpwin_version: 4.02.1+ocp1-full-mingw64-20160113
-      ocpwin_zip: C:\ocpwin64-20160113-4.02.1+ocp1-full-mingw64.zip
-      ocpwin_uri: https://s3.amazonaws.com/ci-cache.flowtype.org/master/ocpwin/ocpwin64-20160113-4.02.1%2Bocp1-full-mingw64.zip
+    - OPAM_SWITCH: 4.03.0+mingw64c
+      FORK_USER: ocaml
+      FORK_BRANCH: master
+      CYG_ROOT: C:\cygwin64
+      TESTS: false
+      INSTALL: false
+      DEPOPTS: false
+      REVDEPS: false
 
 install:
 - ps: C:\projects\flow\resources\appveyor\install.ps1
+- ps: iex ((new-object net.webclient).DownloadString("https://raw.githubusercontent.com/$env:FORK_USER/ocaml-ci-scripts/$env:FORK_BRANCH/appveyor-install.ps1"))
 
 build_script:
-- ps: C:\projects\flow\resources\appveyor\build.ps1
-
-test_script:
-- ps: C:\projects\flow\resources\appveyor\test.ps1
+- call %CYG_ROOT%\bin\bash.exe -l %APPVEYOR_BUILD_FOLDER%\appveyor-opam.sh
+- call %CYG_ROOT%\bin\bash.exe -l %APPVEYOR_BUILD_FOLDER%\resources\appveyor\build.sh
+#- ps: C:\projects\flow\resources\appveyor\build.ps1
 
 after_build:
 - ps: C:\projects\flow\resources\appveyor\after_build.ps1
+
+test_script:
+- ps: C:\projects\flow\resources\appveyor\test.ps1
 
 artifacts:
   - path: bin\*.zip

--- a/hack/utils/handle_stubs.c
+++ b/hack/utils/handle_stubs.c
@@ -38,7 +38,7 @@ value caml_hh_worker_create_handle(value x) {
 
 #ifdef _WIN32
 static void win_handle_serialize(value h, uintnat *wsize_32, uintnat *wsize_64) {
-  serialize_int_8((int64)Handle_val(h));
+  serialize_int_8((int64_t)Handle_val(h));
   serialize_int_1(Descr_kind_val(h));
   serialize_int_1(CRT_fd_val(h));
   serialize_int_1(Flags_fd_val(h));
@@ -67,4 +67,3 @@ value win_setup_handle_serialization(value unit) {
 #endif
   return Val_unit;
 }
-

--- a/ocp_build_flow.ocp.fb
+++ b/ocp_build_flow.ocp.fb
@@ -146,8 +146,8 @@ begin library "flow-embedded"
     "hh-find"
   ]
   if (os_type = "Win32") then {
-    flow_source = ".\flowlib.rc"
-    flow_target = "%{flow-embedded_FULL_DST_DIR}%/flow_res.o"
+    flow_source = "./flowlib.rc"
+    flow_target = "%{flow-embedded_DST_DIR}%/flow_res.o"
     cclib = [ flow_target ]
     build_rules = [
       flow_target (

--- a/opam
+++ b/opam
@@ -1,0 +1,29 @@
+opam-version: "1.2"
+maintainer: "gabe@fb.com"
+homepage: "http://flowtype.org"
+dev-repo: "https://github.com/facebook/flow.git"
+bug-reports: "https://github.com/facebook/flow/issues"
+authors: [
+  "Avik Chaudhuri"
+  "Basil Hosmer"
+  "Gabe Levi"
+  "Jeff Morrison"
+  "Marshall Roch"
+  "Sam Goldman"
+  "James Kyle"
+]
+doc: "http://flowtype.org/docs/getting-started.html"
+license: "BSD3"
+depends: [
+  "base-unix"
+  "base-bytes"
+  "ocamlbuild" {build}
+  "ocp-build" {build & os = "win32"}
+]
+available: [ocaml-version >= "4.01.0" & ocaml-version < "4.04.0"]
+build: [ [ make ] ]
+depexts: [
+ [ ["debian"] ["libelf-dev"] ]
+ [ ["ubuntu"] ["libelf-dev"] ]
+ [ ["centos"] ["elfutils-libelf-devel"] ]
+]

--- a/resources/appveyor/build.ps1
+++ b/resources/appveyor/build.ps1
@@ -1,4 +1,7 @@
-﻿pushd $PSScriptRoot\..\..
+pushd $PSScriptRoot\..\..
+
+$env:PATH += ";C:\cygwin64\home\appveyor\.opam\$env:OPAM_SWITCH\bin"
+$env:OCAMLLIB = "C:\cygwin64\home\appveyor\.opam\$env:OPAM_SWITCH\lib"
 
 try {
   ./make.bat 2>&1 | %{ "$_" }

--- a/resources/appveyor/build.sh
+++ b/resources/appveyor/build.sh
@@ -1,0 +1,23 @@
+PATH=/usr/local/bin:/usr/bin:/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/Wbem:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0
+export PATH
+OPAMYES=1
+export OPAMYES
+
+# print cwd
+pwd
+
+# print opam config
+opam config list
+
+eval $(opam config env)
+
+# print ocaml config
+ocamlc -config
+
+cd "${APPVEYOR_BUILD_FOLDER}"
+opam pin add flowtype-ci . -n
+opam depext -u flowtype-ci
+opam install flowtype-ci --deps-only
+opam install camlp4 ocp-build
+make build-flow-with-ocp
+make build-parser-test-with-ocp

--- a/resources/appveyor/install.ps1
+++ b/resources/appveyor/install.ps1
@@ -1,46 +1,6 @@
-﻿echo "Using ocaml version $env:ocaml_version"
-echo "Using ocpwin version $env:win_version"
 echo "System architecture: $env:PLATFORM"
 echo "Repo build branch is: $env:APPVEYOR_REPO_BRANCH"
 echo "Build folder is: $env:APPVEYOR_BUILD_FOLDER"
-
-echo "Downloading $env:ocpwin_uri to $env:ocpwin_zip"
-appveyor DownloadFile $env:ocpwin_uri -FileName $env:ocpwin_zip
-
-mkdir ~/AppData/Roaming/OCamlPro
-mkdir ~/AppData/Roaming/OCamlPro/OCPWin
-
-echo "Installing ocpwin..."
-pushd ~/AppData/Roaming/OCamlPro/OCPWin
-try {
-  7z x $env:ocpwin_zip
-  ls
-  cd $env:ocpwin_version
-
-  ./bin/ocpwin -in 2>&1 | %{ "$_" }
-  if ($LASTEXITCODE -gt 0) {
-    Throw "The ocpwin installation exited with error code: $LASTEXITCODE"
-  }
-
-  # Verify we have actually installed the right version of ocpwin
-  $installed_versions = ./bin/ocpwin -list
-  echo $installed_versions
-  if (-Not ($installed_versions | grep $env:ocpwin_version)) {
-    Throw "ocpwin appeared to suceed but ocpwin -list is missing $env:ocpwin_version"
-  }
-} finally {
-  popd
-}
-
-# ocpwin modifies the path, so we need to reload it for ocaml utils to be available
-echo "Reloading the path..."
-$env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User")
-
-$installed_ocaml_version = ocaml -version
-echo $installed_ocaml_version
-if (-Not ($installed_ocaml_version | grep $env:ocaml_version)) {
-  Throw "ocaml -version is not some form of $env:ocaml_verson"
-}
 
 echo "Installing npm dependencies..."
 pushd $PSScriptRoot\..\..

--- a/scripts/gen_index.ml
+++ b/scripts/gen_index.ml
@@ -8,7 +8,7 @@
  *
  *)
 
-#use "scripts/utils.ml"
+#use "utils.ml"
 
 let get_idx =
   let idx = ref 100 in


### PR DESCRIPTION
OCPWin doesn't have a 4.03 build, and likely never will.

This switches over to using opam to install 4.03. it also will let us start depending on opam modules in appveyor. we currently use it to install ocp-build (which shipped with ocpwin before), but will unblock using opam for other things in the future.

I think it's possible to make opam work outside of cygwin, but I found it easiest to stay inside cygwin. So, this uses `build.sh` instead of `build.ps1` and `Makefile` instead of `make.bat`. I had to add Windows support to `Makefile`. `build-flow-with-ocp` works, `build-flow` mostly works but doesn't embed `flowlib.rc` just because I didn't figure out how to port the commands from the .ocp files.