### PR TITLE
Remove vscode-flow from docs

### DIFF
--- a/website/en/docs/editors/vscode.md
+++ b/website/en/docs/editors/vscode.md
@@ -17,5 +17,4 @@ after you save a file.
 
 Other extensions that you may try are:
 
-- [vscode-flow](https://marketplace.visualstudio.com/items?itemName=rtorr.vscode-flow)
 - [vscode-flow-ide](https://marketplace.visualstudio.com/items?itemName=gcazaciuc.vscode-flow-ide)


### PR DESCRIPTION
I recently (a few months ago) deprecated `vscode-flow` in favor of people using the official project vscode extension. 

closes: #3584