### PR TITLE
Point to the latest WebStorm version

### DIFF
--- a/website/en/docs/editors/webstorm.md
+++ b/website/en/docs/editors/webstorm.md
@@ -2,4 +2,6 @@
 layout: guide
 ---
 
-Webstorm installation instructions can be found [here](https://www.jetbrains.com/help/webstorm/2016.3/using-the-flow-type-checker.html). 
+Webstorm installation instructions can be found here:
+- [WebStorm 2016.3](https://www.jetbrains.com/help/webstorm/2016.3/using-the-flow-type-checker.html)
+- [WebStorm 2017.1](https://www.jetbrains.com/help/webstorm/2017.1/flow-type-checker.html)


### PR DESCRIPTION
The current WebStorm editor documentation page only points to WebStorm 2016.3. I added an additional link for WebStorm 2017.1.