### PR TITLE
Fix documentation typo in Types/Objects

### DIFF
--- a/website/en/docs/types/objects.md
+++ b/website/en/docs/types/objects.md
@@ -59,7 +59,7 @@ In addition to their set value type, these optional properties can either be
 
 ```js
 // @flow
-function acceptsObject(value: { optionalProp?: string }) {
+function acceptsObject(value: { foo?: string }) {
   // ...
 }
 


### PR DESCRIPTION
Object type optional property should be "foo".