### PR TITLE
change return types for some Geolocation callback functions;

### DIFF
--- a/lib/bom.js
+++ b/lib/bom.js
@@ -520,13 +520,13 @@ declare class XMLSerializer {
 
 declare class Geolocation {
     getCurrentPosition: (
-        success: (position: Position) => any,
-        error?: (error: PositionError) => any,
+        success: (position: Position) => void,
+        error?: (error: PositionError) => void,
         options?: PositionOptions
     ) => any;
     watchPosition: (
-        success: (position: Position) => any,
-        error?: (error: PositionError) => any,
+        success: (position: Position) => void,
+        error?: (error: PositionError) => void,
         options?: PositionOptions
     ) => any;
     clearWatch: any;


### PR DESCRIPTION
success & error are callback functions, so it seems like it would be an error for the user to try and return a value from them. That is why I voided them.

Thoughts?