### PR TITLE
Add destroy method to http.IncomingMessage

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -917,6 +917,7 @@ declare class http$Agent {
 }
 
 declare class http$IncomingMessage extends stream$Readable {
+  destroy(error?: Error): void;
   headers: Object;
   httpVersion: string;
   method: string;

--- a/tests/node_tests/node_tests.exp
+++ b/tests/node_tests/node_tests.exp
@@ -54,24 +54,24 @@ crypto/crypto.js:16
          ^^^^^^^^^^^^^^^ call of method `write`
  16:     hmac.write(123); // 2 errors: not a string or a Buffer
                     ^^^ number. This type is incompatible with
-1315:     chunk: Buffer | string,
-                 ^^^^^^^^^^^^^^^ union: Buffer | string. See lib: <BUILTINS>/node.js:1315
+1316:     chunk: Buffer | string,
+                 ^^^^^^^^^^^^^^^ union: Buffer | string. See lib: <BUILTINS>/node.js:1316
   Member 1:
-  1315:     chunk: Buffer | string,
-                   ^^^^^^ Buffer. See lib: <BUILTINS>/node.js:1315
+  1316:     chunk: Buffer | string,
+                   ^^^^^^ Buffer. See lib: <BUILTINS>/node.js:1316
   Error:
    16:     hmac.write(123); // 2 errors: not a string or a Buffer
                       ^^^ number. This type is incompatible with
-  1315:     chunk: Buffer | string,
-                   ^^^^^^ Buffer. See lib: <BUILTINS>/node.js:1315
+  1316:     chunk: Buffer | string,
+                   ^^^^^^ Buffer. See lib: <BUILTINS>/node.js:1316
   Member 2:
-  1315:     chunk: Buffer | string,
-                            ^^^^^^ string. See lib: <BUILTINS>/node.js:1315
+  1316:     chunk: Buffer | string,
+                            ^^^^^^ string. See lib: <BUILTINS>/node.js:1316
   Error:
    16:     hmac.write(123); // 2 errors: not a string or a Buffer
                       ^^^ number. This type is incompatible with
-  1315:     chunk: Buffer | string,
-                            ^^^^^^ string. See lib: <BUILTINS>/node.js:1315
+  1316:     chunk: Buffer | string,
+                            ^^^^^^ string. See lib: <BUILTINS>/node.js:1316
 
 crypto/crypto.js:26
  26:     hmac.update('foo', 'bogus'); // 1 error


### PR DESCRIPTION
The type definition for the node.js `http.IncomingMessage` was missing the `destroy` method, this PR adds it.

Relevant node.js docs: https://nodejs.org/api/http.html#http_message_destroy_error