### PR TITLE
Removing Impossible Intersection Types

### DIFF
--- a/website/en/docs/types/intersections.md
+++ b/website/en/docs/types/intersections.md
@@ -47,10 +47,10 @@ Each of the members of a intersection type can be any type, even another
 intersection type.
 
 ```js
-type Numbers = 1 & 2;
-type Colors = 'red' & 'blue'
+type Foo = Type1 & Type2;
+type Bar = Type3 & Type4;
 
-type Fish = Numbers & Colors;
+type Baz = Foo & Bar;
 ```
 
 Intersection types require all in, but one out


### PR DESCRIPTION
Unless I misunderstand, these types do not exist & should not be used as examples.

````js
// @flow

// Type Annotations
var bar1: 'red' & 'green' = 'red' + 'green' // Error
var bar2: 'red' & 'green' = 'redgreen' // Error
var bar3: 'red' & 'green' = 'red'.concat('green') // Error

// Functions
declare var bar4: (void => 'red') | (void => 'green')
var bar5: 'red' & 'green' = bar4()  // Error
````
````js
4: var bar1: 'red' & 'green' = 'red' + 'green'                               ^ string. Expected string literal `green`
4: var bar1: 'red' & 'green' = 'red' + 'green'
                     ^ string literal `green`
4: var bar1: 'red' & 'green' = 'red' + 'green'                               ^ string. Expected string literal `red`
4: var bar1: 'red' & 'green' = 'red' + 'green'
             ^ string literal `red`
5: var bar2: 'red' & 'green' = 'redgreen'                               ^ string. Expected string literal `green`, got `redgreen` instead
5: var bar2: 'red' & 'green' = 'redgreen'
                     ^ string literal `green`
5: var bar2: 'red' & 'green' = 'redgreen'                               ^ string. Expected string literal `red`, got `redgreen` instead
5: var bar2: 'red' & 'green' = 'redgreen'
             ^ string literal `red`
6: var bar3: 'red' & 'green' = 'red'.concat('green')                               ^ string. Expected string literal `green`
6: var bar3: 'red' & 'green' = 'red'.concat('green')
                     ^ string literal `green`
6: var bar3: 'red' & 'green' = 'red'.concat('green')                               ^ string. Expected string literal `red`
6: var bar3: 'red' & 'green' = 'red'.concat('green')
             ^ string literal `red`
10: var bar5: 'red' & 'green' = bar4()                                ^ string literal `green`. Expected string literal `red`, got `green` instead
10: var bar5: 'red' & 'green' = bar4()
              ^ string literal `red`
10: var bar5: 'red' & 'green' = bar4()                                ^ string literal `red`. Expected string literal `green`, got `red` instead
10: var bar5: 'red' & 'green' = bar4()
                      ^ string literal `green`
````

https://flow.org/try/#0PTAEAEDMBsHsHcBQiSgCoE8AOBTUBBAO0NgBcBDUgS1kIGdEA3cgJ1ACNWBGALlAHIWOACb9QAMgEBzITkJiAvAKGjQAammz5TVh1YAmPoJFjJ-GTjmLlIi1Z1tOLAMxGVpzZfmglx0QDoAY1pAygAKcy1+AEpkVAAxAFdCQOpaBmEcQOhWPGZHVgAWPjDGWCphHwA+G1Fo0AAfUFLyyoUayK8Yhz0WAFY3EwlPKx9ewrDooA