### PR TITLE
Fix typo in type cast

### DIFF
--- a/website/en/docs/types/casting.md
+++ b/website/en/docs/types/casting.md
@@ -15,7 +15,7 @@ with the `Type` and wrap the expression with parentheses `(` `)`.
 (value: Type)
 ```
 
-> **Note:** The parenthesis are necessary to avoid ambiguity with other syntax.
+> **Note:** The parentheses are necessary to avoid ambiguity with other syntax.
 
 Type cast expressions can appear anywhere an expression can appear.
 

--- a/website/en/docs/types/casting.md
+++ b/website/en/docs/types/casting.md
@@ -8,7 +8,7 @@ syntax which can be used in a number of different ways.
 
 ## Type Cast Expression Syntax <a class="toc" id="toc-type-cast-expression-syntax" href="#toc-type-cast-expression-syntax"></a>
 
-In order to create a type cast expression around a `value`, add a semicolon `:`
+In order to create a type cast expression around a `value`, add a colon `:`
 with the `Type` and wrap the expression with parenthesis `(` `)`.
 
 ```js

--- a/website/en/docs/types/casting.md
+++ b/website/en/docs/types/casting.md
@@ -9,7 +9,7 @@ syntax which can be used in a number of different ways.
 ## Type Cast Expression Syntax <a class="toc" id="toc-type-cast-expression-syntax" href="#toc-type-cast-expression-syntax"></a>
 
 In order to create a type cast expression around a `value`, add a colon `:`
-with the `Type` and wrap the expression with parenthesis `(` `)`.
+with the `Type` and wrap the expression with parentheses `(` `)`.
 
 ```js
 (value: Type)


### PR DESCRIPTION
`:` is a colon, a semicolon would be `;`