### PR TITLE
Add missing property "valid" to ValidityState

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -2640,6 +2640,7 @@ declare class ValidityState {
   tooLong: boolean;
   typeMismatch: boolean;
   valueMissing: boolean;
+  valid: boolean;
 }
 
 // http://www.w3.org/TR/html5/forms.html#dom-textarea/input-setselectionrange


### PR DESCRIPTION
W3C, MDN or MSDN saids ValidityState has "valid" property, and  almost browsers have implemented this.