### PR TITLE
Indicate additional opam dependencies necessary for compile

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,13 @@ brew install libelf opam
 opam init --comp 4.03.0
 ```
 
+Then, restart your shell and install these additional libraries:
+
+```
+opam update
+opam install -y ocamlfind sedlex
+```
+
 Once you have these dependencies, building Flow just requires running
 
 ```


### PR DESCRIPTION
On macOS environment where I've never done OCaml development before, these additional libraries were required in order to build the project using `make`.

I'm not sure whether these instructions are applicable to non-macOS environments. I figured this might help someone getting started with the project.

/cc @mroch https://github.com/facebook/flow/pull/3411