### PR TITLE
Loosen the type definition of setState() in React

### DIFF
--- a/lib/react.js
+++ b/lib/react.js
@@ -23,7 +23,7 @@ declare class React$Component<DefaultProps, Props, State> {
   // action methods
 
   // TODO: partialState could be a function as well
-  setState(partialState: $Shape<State>, callback?: () => void): void;
+  setState(partialState: $Shape<State>, callback?: () => mixed): void;
 
   forceUpdate(callback?: () => void): void;
 


### PR DESCRIPTION
It's pretty common to have an async function as the callback argument of `setState()` in React. Making it `() => mixed` allows the callback to be `() => Promise<any>`.

cc @samwgoldman -- thanks!