### PR TITLE
Updating broken babel option for output directory (-d instead of -D)

### DIFF
--- a/website/en/docs/_install/compiler-babel.md
+++ b/website/en/docs/_install/compiler-babel.md
@@ -22,7 +22,7 @@ If you then put all your source files in a `src` directory you can compile them
 to another directory by running:
 
 ```sh
-{{include.run_command}}babel src/ -D lib/
+{{include.run_command}}babel src/ -d lib/
 ```
 
 You can add this to your `package.json` scripts easily.
@@ -32,7 +32,7 @@ You can add this to your `package.json` scripts easily.
   "name": "my-project",
   "main": "lib/index.js",
   "scripts": {
-    "build": "babel src/ -D lib/",
+    "build": "babel src/ -d lib/",
     "prepublish": "{{include.package_manager}} run build"
   }
 }


### PR DESCRIPTION
-D didn't work in babel for me just now on a fresh install. Look at their docs and found --out-dir or -d are defined,  but uppercase -D, isn't. Works with the change. Relevant docs: http://babeljs.io/docs/usage/cli/#babel-compile-directories