### PR TITLE
Add Buffer/EventEmitter export vars

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -118,6 +118,7 @@ declare class Buffer extends Uint8Array {
 
 declare module "buffer" {
   declare var kMaxLength: number;
+  declare export var Buffer: typeof Buffer;
   declare var INSPECT_MAX_BYTES: number;
   declare function transcode(source: Buffer, fromEnc: buffer$Encoding, toEnc: buffer$Encoding): Buffer;
 }
@@ -675,6 +676,7 @@ declare module "events" {
     static EventEmitter: typeof EventEmitter;
   }
 
+  declare export var EventEmitter: typeof EventEmitter;
   declare var exports: typeof EventEmitter;
 }
 


### PR DESCRIPTION
Fixes #3723: the node "buffer" module exports a `Buffer` property, and "events" exports an `EventEmitter` property.