### PR TITLE
Fix parser locations for unary operators

### DIFF
--- a/src/parser/expression_parser.ml
+++ b/src/parser/expression_parser.ml
@@ -380,7 +380,7 @@ module Expression
         | None -> postfix env
         | Some operator ->
             Eat.token env;
-            let argument = unary env in
+            let end_loc, argument = with_loc unary env in
             if not (is_lhs argument)
             then error_at env (fst argument, Error.InvalidLHSInAssignment);
             (match argument with
@@ -388,7 +388,7 @@ module Expression
               when is_restricted name ->
                 strict_error env Error.StrictLHSPrefix
             | _ -> ());
-            Loc.btwn begin_loc (fst argument), Expression.(Update Update.({
+            Loc.btwn begin_loc end_loc, Expression.(Update Update.({
               operator;
               prefix = true;
               argument;
@@ -396,8 +396,8 @@ module Expression
       end
     | Some operator ->
       Eat.token env;
-      let argument = unary env in
-      let loc = Loc.btwn begin_loc (fst argument) in
+      let end_loc, argument = with_loc unary env in
+      let loc = Loc.btwn begin_loc end_loc in
       Expression.(match operator, argument with
       | Unary.Delete, (_, Identifier _) ->
           strict_error_at env (loc, Error.StrictDelete)

--- a/src/parser/test/esprima_tests.js
+++ b/src/parser/test/esprima_tests.js
@@ -925,6 +925,8 @@ module.exports = {
         'void x',
         'delete x',
         'typeof x',
+        '!(x)',
+        '++(x)',
     ],
 
     'Multiplicative Operators': [

--- a/tests/refinements/refinements.exp
+++ b/tests/refinements/refinements.exp
@@ -1078,11 +1078,11 @@ void.js:75
 
 void.js:82
  82:   if (100 * void(0)) {
-                 ^^^^^^ undefined. The operand of an arithmetic operation must be a number.
+                 ^^^^^^^ undefined. The operand of an arithmetic operation must be a number.
 
 void.js:85
  85:   if (void(0) * 100) {
-           ^^^^^^ undefined. The operand of an arithmetic operation must be a number.
+           ^^^^^^^ undefined. The operand of an arithmetic operation must be a number.
 
 
 Found 186 errors


### PR DESCRIPTION
Fixes #3744

Previously, when determining the end location of a unary operator, the parser
would just be the the end location of its operand, but this is wrong if the operand
is surrounded in parens. To fix, we can use `with_loc` to get the full location
including parens, like is done for binary operators.