### PR TITLE
Use [-- <args>] syntax with `yarn run` command

### DIFF
--- a/website/en/docs/_install/compiler-babel.md
+++ b/website/en/docs/_install/compiler-babel.md
@@ -22,7 +22,7 @@ If you then put all your source files in a `src` directory you can compile them
 to another directory by running:
 
 ```sh
-{{include.run_command}}babel src/ -d lib/
+{{include.run_command}}babel -- src/ -d lib/
 ```
 
 You can add this to your `package.json` scripts easily.


### PR DESCRIPTION
Running through the installation I stumbled over an issue with the example command discarding arguments. It turns out to pass multiple arguments to `yarn run` commands you need to use the `[-- <args>]` syntax as explained here: https://github.com/yarnpkg/yarn/issues/1582#issuecomment-257535540