### PR TITLE
Fix recursive type definitions

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -2917,9 +2917,9 @@ declare class HTMLEmbedElement extends HTMLElement {}
 
 declare class HTMLHeadingElement extends HTMLElement {}
 
-declare class HTMLHRElement extends HTMLHRElement {}
+declare class HTMLHRElement extends HTMLElement {}
 
-declare class HTMLBRElement extends HTMLHRElement {}
+declare class HTMLBRElement extends HTMLElement {}
 
 declare class HTMLDListElement extends HTMLElement {}
 


### PR DESCRIPTION
HTMLBRElement was incorrectly a subclass of HTMLHRElement and HTMLHRElement was incorrectly subclassing itself.