### PR TITLE
Fix the travis deploy

### DIFF
--- a/_tags
+++ b/_tags
@@ -9,3 +9,4 @@
 <src/typing/flow_error.ml>: warn(-3)
 <src/typing/statement.ml>: warn(-3)
 <**/node_modules/**>: -traverse
+<_obuild>: -traverse

--- a/resources/appveyor/build.sh
+++ b/resources/appveyor/build.sh
@@ -19,5 +19,5 @@ opam pin add flowtype-ci . -n
 opam depext -u flowtype-ci
 opam install flowtype-ci --deps-only
 opam install camlp4 ocp-build
-make build-flow-with-ocp
+make all-ocp
 make build-parser-test-with-ocp

--- a/resources/travis/build.sh
+++ b/resources/travis/build.sh
@@ -19,6 +19,10 @@ printf "travis_fold:start:make_js\nBuilding flow.js\n"
 make js
 printf "travis_fold:end:make_js\n"
 
+printf "travis_fold:start:make_ocp-build\nBuilding flow with ocp-build\n"
+make all-ocp
+printf "travis_fold:end:make_ocp-build\n"
+
 printf "travis_fold:start:flow_check\nRunning flow check\n"
 bin/flow check
 printf "travis_fold:end:flow_check\n"
@@ -34,7 +38,3 @@ printf "travis_fold:end:run_tool_test\n"
 printf "travis_fold:start:run_parser_tests\nRunning parser tests\n"
 (cd src/parser && make test)
 printf "travis_fold:end:run_parser_tests\n"
-
-printf "travis_fold:start:make_ocp-build\nBuilding flow with ocp-build\n"
-make build-flow-with-ocp
-printf "travis_fold:end:make_ocp-build\n"


### PR DESCRIPTION
`make build-flow-with-ocp` would build Flow with ocp-build, but wouldn't do the `objcopy` step which would copy the flowlibs into the binary. Since it was performed last, it was overriding the `bin/flow` binary that we had previously tested. Then, on tagged commits, we would publish the bad binary.

This makes two main changes:

1. Use `make all-ocp`, which does the full ocp-build build.
2. Move the ocp-build build before we test, so that whatever is in `bin/flow` is properly tested.