### PR TITLE
Better definition for `process.nextTick`

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -1729,8 +1729,7 @@ declare class Process extends events$EventEmitter {
     heapTotal : number;
     heapUsed : number;
   };
-  nextTick<A, B, C, D, E, F>(cb: (A, B, C, D, E, F) => mixed, A, B, C, D, E, F) : void;
-  nextTick(cb : Function, ...Array<any>) : void;
+  nextTick<T>(cb: (...T) => mixed, ...T) : void;
   pid : number;
   platform : string;
   release : {


### PR DESCRIPTION
Newer versions of Buck sometimes have trouble deciding the correct definition of `process.nextTick`. On the other hand, we can now use a single generic type and spread it as function parameters.