### PR TITLE
Better definition for `process.nextTick`

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -1729,8 +1729,7 @@ declare class Process extends events$EventEmitter {
     heapTotal : number;
     heapUsed : number;
   };
-  nextTick<A, B, C, D, E, F>(cb: (A, B, C, D, E, F) => mixed, A, B, C, D, E, F) : void;
-  nextTick(cb : Function, ...Array<any>) : void;
+  nextTick: <T>(cb: (...T) => mixed, ...T) => void;
   pid : number;
   platform : string;
   release : {

--- a/tests/node_tests/node_tests.exp
+++ b/tests/node_tests/node_tests.exp
@@ -274,5 +274,47 @@ os/userInfo.js:14
  14: (u3.username: string); // error
                    ^^^^^^ string
 
+process/nextTick.js:14
+ 14:   0, // Error: number ~> string
+       ^ number. This type is incompatible with the expected param type of
+ 13:   (a: string, b: number, c: boolean) => {},
+           ^^^^^^ string
 
-Found 33 errors
+process/nextTick.js:16
+ 16:   null // Error: null ~> boolean
+       ^^^^ null. This type is incompatible with the expected param type of
+ 13:   (a: string, b: number, c: boolean) => {},
+                                 ^^^^^^^ boolean
+
+process/nextTick.js:22
+ 22:   'y', // Error: string ~> number
+       ^^^ string. This type is incompatible with the expected param type of
+ 20:   (a: string, b: number, c: boolean) => {},
+                      ^^^^^^ number
+
+process/nextTick.js:26
+ 26: process.nextTick(
+     ^ call of method `nextTick`
+ 27:   (a: string, b: number, c: boolean) => {} // Error: too few arguments
+           ^^^^^^ string. This type is incompatible with
+1732:   nextTick: <T>(cb: (...T) => mixed, ...T) => void;
+                          ^^^^^^^^^^^^^^^ undefined (too few arguments, expected default/rest parameters). See lib: <BUILTINS>/node.js:1732
+
+process/nextTick.js:26
+ 26: process.nextTick(
+     ^ call of method `nextTick`
+ 27:   (a: string, b: number, c: boolean) => {} // Error: too few arguments
+                      ^^^^^^ number. This type is incompatible with
+1732:   nextTick: <T>(cb: (...T) => mixed, ...T) => void;
+                          ^^^^^^^^^^^^^^^ undefined (too few arguments, expected default/rest parameters). See lib: <BUILTINS>/node.js:1732
+
+process/nextTick.js:26
+ 26: process.nextTick(
+     ^ call of method `nextTick`
+ 27:   (a: string, b: number, c: boolean) => {} // Error: too few arguments
+                                 ^^^^^^^ boolean. This type is incompatible with
+1732:   nextTick: <T>(cb: (...T) => mixed, ...T) => void;
+                          ^^^^^^^^^^^^^^^ undefined (too few arguments, expected default/rest parameters). See lib: <BUILTINS>/node.js:1732
+
+
+Found 39 errors

--- a/tests/node_tests/process/nextTick.js
+++ b/tests/node_tests/process/nextTick.js
@@ -1,0 +1,28 @@
+/* @flow */
+
+process.nextTick(() => {});
+
+process.nextTick(
+  (a: string, b: number, c: boolean) => {},
+  'z',
+  1,
+  true
+);
+
+process.nextTick(
+  (a: string, b: number, c: boolean) => {},
+  0, // Error: number ~> string
+  1,
+  null // Error: null ~> boolean
+);
+
+process.nextTick(
+  (a: string, b: number, c: boolean) => {},
+  'z',
+  'y', // Error: string ~> number
+  true
+);
+
+process.nextTick(
+  (a: string, b: number, c: boolean) => {} // Error: too few arguments
+);


### PR DESCRIPTION
Newer versions of Buck sometimes have trouble deciding the correct definition of `process.nextTick`. On the other hand, we can now use a single generic type and spread it as function parameters.

Thanks @zertosh for the help.