### PR TITLE
Include birthtime on Stats object

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -710,6 +710,7 @@ declare module "fs" {
     atime: Date;
     mtime: Date;
     ctime: Date;
+    birthtime: Date;
 
     isFile(): boolean;
     isDirectory(): boolean;


### PR DESCRIPTION
The `Stats` object was missing `birthtime`.