### PR TITLE
Fix prop name in "Optional object properties" example

### DIFF
--- a/website/en/docs/types/primitives.md
+++ b/website/en/docs/types/primitives.md
@@ -233,7 +233,7 @@ In addition to their set value type, these optional properties can either be
 
 ```js
 // @flow
-function acceptsObject(value: { optionalProp?: string }) {
+function acceptsObject(value: { foo?: string }) {
   // ...
 }
 


### PR DESCRIPTION
The third example given in the "Optional object properties" section on the "Primitive Types" page is supposed to produce an error, but doesn't. I verified this using the "Try Flow" page, as well as a new repo with a minimal Flow setup installed.

It looks like the prop name used in the function signature is unintentionally different from the one used in the function calls. Changing `optionalProp` to `foo` causes the third example to produce an error, as expected.