### PR TITLE
Add TRACE method type

### DIFF
--- a/lib/bom.js
+++ b/lib/bom.js
@@ -818,7 +818,7 @@ type CacheType =  'default' | 'no-store' | 'reload' | 'no-cache' | 'force-cache'
 type CredentialsType = 'omit' | 'same-origin' | 'include';
 type ModeType = 'cors' | 'no-cors' | 'same-origin';
 type RedirectType = 'follow' | 'error' | 'manual';
-type MethodType = 'GET' | 'POST' | 'DELETE' | 'HEAD' | 'OPTIONS' | 'PUT' | 'PATCH' ;
+type MethodType = 'GET' | 'POST' | 'DELETE' | 'HEAD' | 'OPTIONS' | 'PUT' | 'PATCH' | 'TRACE';
 type ReferrerPolicyType =
     '' | 'no-referrer' | 'no-referrer-when-downgrade' | 'origin-only' |
     'origin-when-cross-origin' | 'unsafe-url';


### PR DESCRIPTION
TRACE is a valid HTTP method and should be in the type declaration.

Technically, the [method specification](https://fetch.spec.whatwg.org/#methods) claims "There are no restrictions on methods", so technically any string should be allowed as method.