### PR TITLE
Add Flow definition to `React refs` Example

### DIFF
--- a/website/en/docs/frameworks/react.md
+++ b/website/en/docs/frameworks/react.md
@@ -162,7 +162,7 @@ class MyComponent extends React.Component {
   button: HTMLButtonElement;
 
   render() {
-    return <button ref={el => this.button = el}>Toggle</button>;
+    return <button ref={(el: HTMLButtonElement) => this.button = el}>Toggle</button>;
   }
 }
 ```


### PR DESCRIPTION
Previous example causes a flow warning without `HTMLButtonElement`