### PR TITLE
Mark "tests/malformed_code/text.js" as binary

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,3 +9,4 @@ src/parser/test/esprima/expression/primary/literal/string/migrated_0017.js binar
 src/parser/test/esprima/invalid-syntax/migrated_0153.js binary
 src/parser/test/esprima/invalid-syntax/migrated_0155.js binary
 src/parser/test/esprima/invalid-syntax/migrated_0159.js binary
+tests/malformed_code/text.js binary


### PR DESCRIPTION
40d05e414f60d67321e965bb41b0efd86485908d introduced this file and it's showing up as a modified file when I pull:

```
warning: CRLF will be replaced by LF in tests/malformed_code/text.js.
The file will have its original line endings in your working directory.
warning: CRLF will be replaced by LF in tests/malformed_code/text.js.
The file will have its original line endings in your working directory.
```