### PR TITLE
Fix `process.hrtime` parameter type

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -1720,7 +1720,7 @@ declare class Process extends events$EventEmitter {
   getgid? : () => number;
   getgroups? : () => Array<number>;
   getuid? : () => number;
-  hrtime() : [ number, number ];
+  hrtime(time?: [ number, number ]) : [ number, number ];
   initgroups? : (user : number | string, extra_group : number | string) => void;
   kill(pid : number, signal? : string | number) : void;
   mainModule : Object;


### PR DESCRIPTION
> `time` is an optional parameter that must be the result of a previous `process.hrtime()` call (and therefore, a real time in a `[seconds, nanoseconds]` tuple Array containing a previous time) to diff with the current time. 

https://nodejs.org/api/process.html#process_process_hrtime_time
