### PR TITLE
Update README with instructions on how to build flow.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,20 @@ make
 
 This produces a `bin` folder containing the `flow` binary.
 
+In order to make the flow.js file, you first need to install js_of_ocaml:
+
+```
+opam install -y js_of_ocaml
+```
+
+After that, making flow.js is easy:
+
+```
+make js
+```
+
+The new `flow.js` file will also live in the `bin` folder.
+
 *Note: at this time, the OCaml dependency prevents us from adding Flow to [npm](http://npmjs.org). Try [flow-bin](https://www.npmjs.org/package/flow-bin) if you need a npm binary wrapper.*
 
 Flow can also compile its parser to JavaScript. [Read how here](src/parser/README.md).


### PR DESCRIPTION
Add instructions on how to build `flow.js`.

While trying to build the flow website (which I'm still trying) I notice that it expects the `flow.js` file inside the `bin` folder. 

This PR adds instructions on how to achieve that.