### PR TITLE
Add `make all-homebrew`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -180,7 +180,8 @@ all-homebrew:
 	export OPAMROOT="$(shell mktemp -d)"; \
 	export OPAMYES="1"; \
 	opam init --no-setup && \
-	opam install ocamlfind sedlex && \
+	opam pin add flowtype . && \
+	opam install flowtype --deps-only && \
 	opam config exec -- make
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -176,6 +176,13 @@ LINKER_FLAGS=$(BYTECODE_LINKER_FLAGS) $(SECTCREATE)
 all: $(FLOWLIB) build-flow copy-flow-files
 all-ocp: build-flow-with-ocp copy-flow-files-ocp
 
+all-homebrew: 
+	export OPAMROOT="$(shell mktemp -d)"; \
+	export OPAMYES="1"; \
+	opam init --no-setup && \
+	opam install ocamlfind sedlex && \
+	opam config exec -- make
+
 clean:
 	ocamlbuild -clean
 	rm -rf bin

--- a/opam
+++ b/opam
@@ -21,7 +21,7 @@ depends: [
   "ocamlbuild" {build}
   "ocp-build" {build}
 ]
-available: [ocaml-version >= "4.03.0" & ocaml-version < "4.04.0"]
+available: [ocaml-version >= "4.03.0"]
 build: [ [ make ] ]
 depexts: [
  [ ["debian"] ["libelf-dev"] ]


### PR DESCRIPTION
This upstreams the homebrew build that @ilovezfs suggested in
https://github.com/Homebrew/homebrew-core/pull/12970. It's basically just
`make all` which assumes you have `opam` installed but no opam packages.

When I deploy v0.46.0 to homebrew, I'll update the install step to just be
`make all-homebrew`