### PR TITLE
mktemp's interface changed in OSX 10.11

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -177,7 +177,7 @@ all: $(FLOWLIB) build-flow copy-flow-files
 all-ocp: build-flow-with-ocp copy-flow-files-ocp
 
 all-homebrew: 
-	export OPAMROOT="$(shell mktemp -d)"; \
+	export OPAMROOT="$(shell mktemp -d 2> /dev/null || mktemp -d -t opam)"; \
 	export OPAMYES="1"; \
 	opam init --no-setup && \
 	opam pin add flowtype . && \


### PR DESCRIPTION
This is a way to support OSX <10.11