### PR TITLE
Print out usage guidelines when non-numeric line & column are given to type-at-pos

### DIFF
--- a/src/commands/typeAtPosCommand.ml
+++ b/src/commands/typeAtPosCommand.ml
@@ -41,18 +41,27 @@ let spec = {
   )
 }
 
+let exit () =
+    CommandSpec.usage spec;
+    FlowExitStatus.(exit Commandline_usage_error)
+
+let parse_line_and_column line column =
+    try (int_of_string line), (int_of_string column)
+    with Failure(_) -> exit ()
+
 let parse_args path args =
   let (file, line, column) = match args with
   | [file; line; column] ->
       let file = expand_path file in
-      ServerProt.FileName file, (int_of_string line), (int_of_string column)
+      let line, column = parse_line_and_column line column in
+      ServerProt.FileName file, line, column
   | [line; column] ->
+      let line, column = parse_line_and_column line column in
       get_file_from_filename_or_stdin path None,
-      (int_of_string line),
-      (int_of_string column)
+      line,
+      column
   | _ ->
-      CommandSpec.usage spec;
-      FlowExitStatus.(exit Commandline_usage_error)
+      exit ()
   in
   let (line, column) = convert_input_pos (line, column) in
   file, line, column


### PR DESCRIPTION
Hello!
I noticed that the error feedback when using `type-at-pos` incorrectly could be a little more consistent.

In the current build, passing a filename and line but no column results in the following output:
```bash
$ ./bin/flow type-at-pos some/file 2
Unhandled exception: Failure("int_of_string")
```
This is because with two arguments `type-at-pos` expects to receive line and column, and for the filename to be given via stdin. Most filenames can't be parsed as ints, hence the `Failure`.

The same error occurs if three args are passed, but the second two are non-numeric, e.g.
```bash
$ ./bin/flow type-at-pos some/file 2 a
Unhandled exception: Failure("int_of_string")
```

This change just makes `type-at-pos` bail out if the line & column are unparseable with the same behavior used for the zero arguments case.

Please let me know if there's anything I can do to make this better!