### PR TITLE
Fixes array destructuring with defaults pattern parsing. Fixes #1985

### DIFF
--- a/src/parser/pattern_parser.ml
+++ b/src/parser/pattern_parser.ml
@@ -196,7 +196,7 @@ module Pattern
         let pattern = match Peek.token env with
           | T_ASSIGN ->
             Expect.token env T_ASSIGN;
-            let default = Parse.expression env in
+            let default = Parse.assignment env in
             let loc = Loc.btwn (fst pattern) (fst default) in
             loc, Pattern.(Assignment Assignment.({
               left = pattern;

--- a/src/parser/test/hardcoded_tests.js
+++ b/src/parser/test/hardcoded_tests.js
@@ -4502,6 +4502,40 @@ module.exports = {
             'name': 'y',
           }
         }]
+      },
+      'let [x=1, y=2, z=3] = []': {
+        'errors.length': 0,
+        'body.0.declarations.0.id.elements': [{
+          'type': 'AssignmentPattern',
+          'left': {
+            'type': 'Identifier',
+            'name': 'x',
+          },
+          'right': {
+            'type': 'Literal',
+            'value': 1
+          }
+        }, {
+          'type': 'AssignmentPattern',
+          'left': {
+            'type': 'Identifier',
+            'name': 'y',
+          },
+          'right': {
+            'type': 'Literal',
+            'value': 2
+          }
+        }, {
+          'type': 'AssignmentPattern',
+          'left': {
+            'type': 'Identifier',
+            'name': 'z',
+          },
+          'right': {
+            'type': 'Literal',
+            'value': 3
+          }
+        }]
       }
     },
     'Type Parameter Defaults': {


### PR DESCRIPTION
There's an error in the AST parsing for default values in array pattern parsing, where as the second destructured pattern whould be sequence expression in stead of array of assignment expressions.

It seems to me that it should be parsed as an assignment instead of expression, as `1, y = 1` is a valid expression.

This PR fixes this issue and would hopefully fix the issue in prettier (https://github.com/prettier/prettier/issues/1457) as well.

I don't know if there is anything more to test then the hardcoded tests? Let me know if there's anything else you need from me.