### PR TITLE
Changes dynamic import syntax to work without assignments

### DIFF
--- a/src/parser/parser_flow.ml
+++ b/src/parser/parser_flow.ml
@@ -180,8 +180,6 @@ module rec Parse : PARSER = struct
     (* If we see an else then it's definitely an error, but we can probably
      * assume that this is a malformed if statement that is missing the if *)
     | T_ELSE -> _if env
-    (* Handle dynamic imports *)
-    | T_IMPORT when Peek.token ~i:1 env = T_LPAREN -> expression env
     (* There are a bunch of tokens that aren't the start of any valid
      * statement. We list them here in order to skip over them, rather than
      * getting stuck *)
@@ -201,7 +199,6 @@ module rec Parse : PARSER = struct
     | T_EXTENDS
     | T_STATIC
     | T_EXPORT (* TODO *)
-    | T_IMPORT (* Not dynamic import *)
     | T_ELLIPSIS ->
         error_unexpected env;
         Eat.token env;

--- a/src/parser/parser_flow.ml
+++ b/src/parser/parser_flow.ml
@@ -153,6 +153,7 @@ module rec Parse : PARSER = struct
     | _ when Peek.is_class env -> class_declaration env decorators
     | T_INTERFACE -> interface env
     | T_DECLARE -> declare env
+    | T_IMPORT when Peek.token ~i:1 env = T_LPAREN -> expression env
     | T_TYPE -> type_alias env
     | _ -> statement env)
 

--- a/src/parser/parser_flow.ml
+++ b/src/parser/parser_flow.ml
@@ -153,7 +153,6 @@ module rec Parse : PARSER = struct
     | _ when Peek.is_class env -> class_declaration env decorators
     | T_INTERFACE -> interface env
     | T_DECLARE -> declare env
-    | T_IMPORT when Peek.token ~i:1 env = T_LPAREN -> expression env
     | T_TYPE -> type_alias env
     | _ -> statement env)
 
@@ -181,6 +180,8 @@ module rec Parse : PARSER = struct
     (* If we see an else then it's definitely an error, but we can probably
      * assume that this is a malformed if statement that is missing the if *)
     | T_ELSE -> _if env
+    (* Handle dynamic imports *)
+    | T_IMPORT when Peek.token ~i:1 env = T_LPAREN -> expression env
     (* There are a bunch of tokens that aren't the start of any valid
      * statement. We list them here in order to skip over them, rather than
      * getting stuck *)
@@ -199,8 +200,8 @@ module rec Parse : PARSER = struct
     | T_DEFAULT
     | T_EXTENDS
     | T_STATIC
-    | T_IMPORT (* TODO *)
     | T_EXPORT (* TODO *)
+    | T_IMPORT (* Not dynamic import *)
     | T_ELLIPSIS ->
         error_unexpected env;
         Eat.token env;

--- a/src/parser/parser_flow.ml
+++ b/src/parser/parser_flow.ml
@@ -99,7 +99,10 @@ module rec Parse : PARSER = struct
     | T_EXPORT -> Statement.export_declaration env decorators
     | T_IMPORT ->
         error_on_decorators env decorators;
-        Statement.import_declaration env
+        let statement = match Peek.token ~i:1 env with
+          | T_LPAREN -> Statement.expression env
+          | _ -> Statement.import_declaration env in
+        statement
     | T_DECLARE when Peek.token ~i:1 env = T_EXPORT ->
         error_on_decorators env decorators;
         Statement.declare_export_declaration env

--- a/src/parser/test/hardcoded_tests.js
+++ b/src/parser/test/hardcoded_tests.js
@@ -3041,11 +3041,6 @@ module.exports = {
       },
 
       // Invalid syntax tests
-      'import("asdf");': {
-        'errors': {
-          '0.message': 'Unexpected token (',
-        }
-      },
       'const a = import("asdf", nope);': {
         'errors': {
           '0.message': 'Unexpected token ,',

--- a/src/parser/test/hardcoded_tests.js
+++ b/src/parser/test/hardcoded_tests.js
@@ -3039,11 +3039,38 @@ module.exports = {
           'arguments': []
         }
       },
-
+      '{ import("dsa").then(); }': {
+        'body.0.body.0.expression': {
+          'type': 'CallExpression',
+          'callee': {
+            'type': 'MemberExpression',
+            'object': {
+              'type': 'CallExpression',
+              'callee': {'type': 'Import'},
+              'arguments': [{
+                'type': 'Literal',
+                'value': 'dsa'
+              }]
+            },
+            'property': {
+              'type': 'Identifier',
+              'name': 'then'
+            }
+          },
+          'arguments': []
+        },
+        'errors': [],
+      },
       // Invalid syntax tests
       'const a = import("asdf", nope);': {
         'errors': {
           '0.message': 'Unexpected token ,',
+        }
+      },
+      // Should not be detected as dynamic import.
+      '{ import "asdf"; }': {
+        'errors': {
+          '0.message': 'Unexpected token import',
         }
       }
     },

--- a/src/parser/test/hardcoded_tests.js
+++ b/src/parser/test/hardcoded_tests.js
@@ -3070,7 +3070,7 @@ module.exports = {
       // Should not be detected as dynamic import.
       '{ import "asdf"; }': {
         'errors': {
-          '0.message': 'Unexpected token import',
+          '0.message': 'Unexpected string',
         }
       }
     },

--- a/src/parser/test/hardcoded_tests.js
+++ b/src/parser/test/hardcoded_tests.js
@@ -3018,6 +3018,27 @@ module.exports = {
           'arguments': [{'type': 'BinaryExpression'}]
         }
       },
+      'import("dsa").then();': {
+        'body.0.expression': {
+          'type': 'CallExpression',
+          'callee': {
+            'type': 'MemberExpression',
+            'object': {
+              'type': 'CallExpression',
+              'callee': {'type': 'Import'},
+              'arguments': [{
+                'type': 'Literal',
+                'value': 'dsa'
+              }]
+            },
+            'property': {
+              'type': 'Identifier',
+              'name': 'then'
+            }
+          },
+          'arguments': []
+        }
+      },
 
       // Invalid syntax tests
       'import("asdf");': {


### PR DESCRIPTION
Looks to me that the parsing only looks at the `import` only supports static imports and not dynamic imports, as it's matching the token and parsing it as a import statement, even if the next token is a parenthesis. But when it is dynamic it should be treated as an expression.

This matches up with how babylon6 ast parser does it: http://astexplorer.net/#/gist/4dcc5f44e952f664c4e9f4c9098b864c/3db751c05b8b6ce7dd0f813f913c0c79efd7b120

This breaks with calling `import()` without `.then()`, but as promises are eager does really observing the result make a difference? I couldn't find any information on whether or not this is not supported. I know `import` isn't strictly a function, but a keyword with parenthesis, so maybe this changes the semantics. If this is the case we need to see if there is an identifier property as a port of the expression.

Looks like @deecewan added the initial testcase. Maybe you have some inside into if `import('dsa')` is valid or not?