### PR TITLE
[doc] Link to refinement invalidation from maybe

### DIFF
--- a/website/en/docs/types/maybe.md
+++ b/website/en/docs/types/maybe.md
@@ -62,3 +62,5 @@ function acceptsMaybeNumber(value: ?number) {
   }
 }
 ```
+
+However, type refinement can be lost. For instance calling a function after refining the type of an object's property will invalidate this refinement. Consult the [refinement invalidations section](https://flow.org/en/docs/lang/refinements/) for more details, to understand why Flow works this way, and how you can avoid this common pitfall.


### PR DESCRIPTION
Some people are confused by the refinement invalidation (see #3786), directing them to the refinement section from the maybe types section might help.