### PR TITLE
Fix Number.parseInt missing parameter type

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -125,7 +125,7 @@ declare class Number {
     static isNaN(value: any): boolean;
     static isSafeInteger(value: any): boolean;
     static parseFloat(value: string): number;
-    static parseInt(value: string): number;
+    static parseInt(value: string, radix?: number): number;
     constructor(value?: mixed): void;
     toExponential(fractionDigits?: number): string;
     toFixed(fractionDigits?: number): string;


### PR DESCRIPTION
`Number.parseInt` is just like `parseInt`.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/parseInt