### PR TITLE
Appveyor should run opam update

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,8 +5,8 @@ platform: x64
 environment:
   matrix:
     - OPAM_SWITCH: 4.03.0+mingw64c
-      FORK_USER: ocaml
-      FORK_BRANCH: master
+      FORK_USER: gabelevi
+      FORK_BRANCH: opam-update
       CYG_ROOT: C:\cygwin64
       TESTS: false
       INSTALL: false


### PR DESCRIPTION
Looks like ocaml-build [changed their checksum after a hotfix](https://github.com/ocaml/opam-repository/commit/99024cada5cf60c9f479126ccfd582e320cd6d3b). This led to appveyor erroring like

```
[ERROR] Bad checksum for
        C:/cygwin64/home/appveyor/.opam/packages.dev/ocp-build.1.99.19-beta/1.99.19-beta.tar.gz:
          - 83a32517f9e49119b200952f34e533d9 [expected result]
          - ac7000cfff5a0d94970050fa86f93667 [actual result]
        Metadata might be out of date, in this case run `opam update`.
```

Hopefully this fixes that issue.