### PR TITLE
Downgrade ocp-build for now

### DIFF
--- a/opam
+++ b/opam
@@ -19,7 +19,7 @@ depends: [
   "base-bytes"
   "sedlex"
   "ocamlbuild" {build}
-  "ocp-build" {build}
+  "ocp-build" {build & <"1.99.19-beta"}
 ]
 available: [ocaml-version >= "4.03.0"]
 build: [ [ make ] ]

--- a/resources/appveyor/build.sh
+++ b/resources/appveyor/build.sh
@@ -18,6 +18,6 @@ cd "${APPVEYOR_BUILD_FOLDER}"
 opam pin add flowtype-ci . -n
 opam depext -u flowtype-ci
 opam install flowtype-ci --deps-only
-opam install camlp4 ocp-build
+opam install camlp4
 make all-ocp
 make build-parser-test-with-ocp


### PR DESCRIPTION
Until https://github.com/OCamlPro/ocp-build/issues/92 is closed, let's stick with older versions of ocp-build.