### PR TITLE
Fix inconsistency prop vs. p

### DIFF
--- a/website/en/docs/lang/depth-subtyping.md
+++ b/website/en/docs/lang/depth-subtyping.md
@@ -28,9 +28,9 @@ where an object containing a `Person` instance is expected.
 class Person { name: string }
 class Employee extends Person { department: string }
 
-var employee: { prop: Employee } = { prop: new Employee };
+var employee: { who: Employee } = { who: new Employee };
 // $ExpectError
-var person: { prop: Person } = employee; // Error
+var person: { who: Person } = employee; // Error
 ```
 
 This is an error because objects are mutable. The value referenced by the
@@ -38,11 +38,11 @@ This is an error because objects are mutable. The value referenced by the
 variable.
 
 ```js
-person.p = new Person;
+person.who = new Person;
 ```
 
-If we write into the `p` property of the `person` object, we've also changed
-the value of `employee.p`, which is explicitly annotated to be an `Employee`
+If we write into the `who` property of the `person` object, we've also changed
+the value of `employee.who`, which is explicitly annotated to be an `Employee`
 instance.
 
 If we prevented any code from ever writing a new value to the object through
@@ -54,15 +54,15 @@ provides a syntax for this:
 class Person { name: string }
 class Employee extends Person { department: string }
 
-var employee: { prop: Employee } = { prop: new Employee };
-var person: { +prop: Person } = employee; // OK
+var employee: { who: Employee } = { prop: new Employee };
+var person: { +who: Person } = employee; // OK
 // $ExpectError
-person.prop = new Person; // Error!
+person.who = new Person; // Error!
 ```
 
-The plus sign indicates that the `p` property is "covariant." Using a covariant
+The plus sign indicates that the `who` property is "covariant." Using a covariant
 property allows us to use objects which have subtype-compatible values for that
 property. By default, object properties are invariant, which allow both reads
 and writes, but are more restrictive in the values they accept.
 
-Read more about property variance.
+Read more about property variance (TODO: where?).


### PR DESCRIPTION
Text referred to property 'p' but code had 'prop'.  This change fixes that inconsistency.

Besides making them consistent, I propose 'who' instead of either 'prop' or 'p'.
Also, I find it confusing to have variables named 'employee' and 'person' that are not of type 'Employee' and 'Person', but rather contain a property 'p', or 'prop' that is of those types. I think calling the property 'who' alleviates the problem somewhat.