### PR TITLE
Fix incorrect commands in documentation for `flow-remove-types`

### DIFF
--- a/website/en/docs/_install/compiler-flow-remove-types.md
+++ b/website/en/docs/_install/compiler-flow-remove-types.md
@@ -13,7 +13,7 @@ If you then put all your source files in a `src` directory you can compile them
 to another directory by running:
 
 ```sh
-{{include.run_command}}flow-remove-types src/ -D lib/
+{{include.run_command}}
 ```
 
 You can add this to your `package.json` scripts easily.
@@ -23,7 +23,7 @@ You can add this to your `package.json` scripts easily.
   "name": "my-project",
   "main": "lib/index.js",
   "scripts": {
-    "build": "flow-remove-types src/ -D lib/",
+    "build": "flow-remove-types src/ -d lib/",
     "prepublish": "{{include.package_manager}} run build"
   }
 }

--- a/website/en/docs/_install/include.html
+++ b/website/en/docs/_install/include.html
@@ -1,9 +1,9 @@
 {% if include.package_manager == "yarn" %}
   {% assign install_command = "yarn add --dev" %}
-  {% assign run_command = "yarn run " %}
+  {% assign run_command = "yarn run flow-remove-types src/ -- -d lib/" %}
 {% elsif include.package_manager == "npm" %}
   {% assign install_command = "npm install --save-dev" %}
-  {% assign run_command = "./node_modules/.bin/" %}
+  {% assign run_command = "./node_modules/.bin/flow-remove-types src/ -d lib/" %}
 {% endif %}
 
 {% capture compiler_intro %}{% include_relative _install/compiler-intro.md %}{% endcapture %}


### PR DESCRIPTION
The commands in the install documentation are incorrect and will give the ambigious error message `Source "src/" is not a file.` or ` Multiple files require providing --out-dir`.