### PR TITLE
Add `force_update: true` to appveyor's deploy

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,5 +40,6 @@ deploy:
   auth_token:
     secure: f1YgYz9csZ8QokY6+aXF10toZtXlFxicbm7uTcylqq+ILoRE6y5GUaf1TfoUalx5
   artifact: /bin\\.*\.zip/
+  force_update: true
   on:
     appveyor_repo_tag: true


### PR DESCRIPTION
Looking at the logs, I see

```
[00:14:09] Collecting artifacts...
[00:14:09] Found artifact 'bin\flow-win64-v0.46.0.zip' matching 'bin\*.zip' path
[00:14:09] Uploading artifacts...
[00:14:09] 
[00:14:09] [1/1] bin\flow-win64-v0.46.0.zip (2,341,000 bytes)...3%
[00:14:09] [1/1] bin\flow-win64-v0.46.0.zip (2,341,000 bytes)...20%
[00:14:10] [1/1] bin\flow-win64-v0.46.0.zip (2,341,000 bytes)...40%
[00:14:10] [1/1] bin\flow-win64-v0.46.0.zip (2,341,000 bytes)...70%
[00:14:10] [1/1] bin\flow-win64-v0.46.0.zip (2,341,000 bytes)...90%
[00:14:10] [1/1] bin\flow-win64-v0.46.0.zip (2,341,000 bytes)...100%
[00:14:10] Deploying using GitHub provider
[00:14:11] Creating "v0.46.0" release for repository "facebook/flow" tag "v0.46.0" commit "9f9b4d529baac4d1904f98b496873eaf4210ec55"...Skipped - release with tag "v0.46.0" already exists
[00:14:11] No artifacts were published. Make sure you have specified correct artifacts filter.
```

From [the docs](https://www.appveyor.com/docs/deployment/github/):

> Force update (force_update) - true to overwrite files in an existing release; default is false which will fail deployment if the release already exists on GitHub.

So hopefully this will finally make Appveyor update the Github release