### PR TITLE
Fix ocp-build parser test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,7 +176,7 @@ LINKER_FLAGS=$(BYTECODE_LINKER_FLAGS) $(SECTCREATE)
 all: $(FLOWLIB) build-flow copy-flow-files
 all-ocp: build-flow-with-ocp copy-flow-files-ocp
 
-all-homebrew: 
+all-homebrew:
 	export OPAMROOT="$(shell mktemp -d 2> /dev/null || mktemp -d -t opam)"; \
 	export OPAMYES="1"; \
 	opam init --no-setup && \
@@ -211,9 +211,14 @@ build-flow-with-ocp: $(OCP_BUILD_FILES) $(FLOWLIB) hack/utils/get_build_id.gen.c
 	cp _obuild/flow/flow.asm$(EXE) bin/flow$(EXE)
 	rm -f $(OCP_BUILD_FILES)
 
-build-parser-test-with-ocp: $(OCP_BUILD_FILES)
+build-parser-test-with-ocp: $(OCP_BUILD_FILES) hack/utils/get_build_id.gen.c
 	[ -d _obuild ] || ocp-build init
 	ocp-build build flow-parser-hardcoded-test
+	rm -f $(OCP_BUILD_FILES)
+
+test-parser-ocp: $(OCP_BUILD_FILES) hack/utils/get_build_id.gen.c
+	[ -d _obuild ] || ocp-build init
+	ocp-build tests flow-parser-hardcoded-test
 	rm -f $(OCP_BUILD_FILES)
 
 build-flow-debug: $(BUILT_OBJECT_FILES) $(FLOWLIB)

--- a/ocp_build_flow.ocp.fb
+++ b/ocp_build_flow.ocp.fb
@@ -435,13 +435,12 @@ begin program "flow-parser-hardcoded-test"
   sort = true
   dirname = "src/parser/test"
   files = [
-    "hardcoded_test_runner.ml"
-    "run_hardcoded_tests.ml"
+    "run_esprima_tests.ml"
   ]
   requires = [
     "flow-parser"
     "flow-common-utils"
   ]
   tests = [ "hardcoded_tests" ]
-  test_args = [ "%{sources}%\hardcoded_tests.js" ]
+  test_args = [ "%{sources}%/flow/" ]
 end

--- a/resources/appveyor/test.ps1
+++ b/resources/appveyor/test.ps1
@@ -1,4 +1,4 @@
-﻿pushd "C:\projects\flow"
+pushd "C:\projects\flow"
 try {
   echo "Running tool tests"
   echo "Using node version $(node --version)"
@@ -7,7 +7,7 @@ try {
     Throw "node tool test exited with error code: $LASTEXITCODE"
   }
 
-  .\_obuild\flow-parser-hardcoded-test\flow-parser-hardcoded-test.asm.exe .\src\parser\test\hardcoded_tests.js
+  .\_obuild\flow-parser-hardcoded-test\flow-parser-hardcoded-test.asm.exe .\src\parser\test\flow\
   if ($LASTEXITCODE -gt 0) {
     Throw "flow parser hardcoded ocaml tests exited with error code: $LASTEXITCODE"
   }

--- a/resources/travis/build.sh
+++ b/resources/travis/build.sh
@@ -37,4 +37,5 @@ printf "travis_fold:end:run_tool_test\n"
 
 printf "travis_fold:start:run_parser_tests\nRunning parser tests\n"
 (cd src/parser && make test)
+make test-parser-ocp
 printf "travis_fold:end:run_parser_tests\n"


### PR DESCRIPTION
I broke the parser test runner in ocp-build.

This fixes the .ocp file, makes Appveyor actually run the test instead of just building it, and makes Travis build and run the test.