### PR TITLE
Hash.update accepts encoding for buffers

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -357,17 +357,17 @@ declare class crypto$Cipher extends stream$Duplex {
   setAutoPadding(auto_padding?: boolean): crypto$Cipher;
   update(
     data: string,
-    input_encoding: 'utf8'| 'ascii' | 'latin1' | 'binary',
-    output_encoding: 'latin1' | 'binary'| 'base64' | 'hex'
+    input_encoding: 'utf8' | 'ascii' | 'latin1' | 'binary',
+    output_encoding: 'latin1' | 'binary' | 'base64' | 'hex'
   ): string;
   update(
     data: string,
-    input_encoding: 'utf8'| 'ascii' | 'latin1' | 'binary',
+    input_encoding: 'utf8' | 'ascii' | 'latin1' | 'binary',
     output_encoding: void
   ): Buffer;
   update(
     data: Buffer,
-    input_encoding: void,
+    input_encoding: void | 'utf8' | 'ascii' | 'latin1' | 'binary',
     output_encoding: 'latin1' | 'binary' | 'base64' | 'hex'
   ): string;
   update(
@@ -428,16 +428,14 @@ declare class crypto$Decipher extends stream$Duplex {
 declare class crypto$Hash extends stream$Duplex {
   digest(encoding: 'hex' | 'latin1' | 'binary' | 'base64'): string;
   digest(encoding: void): Buffer;
-  update(data: Buffer, input_encoding?: void): crypto$Hash;
-  update(data: string, input_encoding?: 'utf8' | 'ascii' | 'latin1' |
+  update(data: string | Buffer, input_encoding?: 'utf8' | 'ascii' | 'latin1' |
   'binary'): crypto$Hash;
 }
 
 declare class crypto$Hmac extends stream$Duplex {
   digest(encoding: 'hex' | 'latin1' | 'binary' | 'base64'): string;
   digest(encoding: void): Buffer;
-  update(data: Buffer, input_encoding?: void): crypto$Hmac;
-  update(data: string, input_encoding?: 'utf8' | 'ascii' | 'latin1' |
+  update(data: string | Buffer, input_encoding?: 'utf8' | 'ascii' | 'latin1' |
   'binary'): crypto$Hmac;
 }
 
@@ -456,16 +454,14 @@ declare class crypto$Sign extends stream$Writable {
     private_key: crypto$Sign$private_key,
     output_format: void
   ): Buffer;
-  update(data: Buffer, input_encoding?: void): crypto$Sign;
-  update(data: string, input_encoding?: 'utf8' | 'ascii' | 'latin1'|
-  'binary' ): crypto$Sign;
+  update(data: string | Buffer, input_encoding?: 'utf8' | 'ascii' | 'latin1' |
+  'binary'): crypto$Sign;
 }
 
 declare class crypto$Verify extends stream$Writable {
   static(algorithm: string, options?: writableStreamOptions): crypto$Verify,
   constructor(algorithm: string, options?: writableStreamOptions): void;
-  update(data: Buffer, input_encoding?: void): crypto$Verify;
-  update(data: string, input_encoding?: 'utf8' | 'ascii' | 'latin1' |
+  update(data: string | Buffer, input_encoding?: 'utf8' | 'ascii' | 'latin1' |
   'binary' ): crypto$Verify;
   verify(
     object: string,


### PR DESCRIPTION
Allows to call `crypto.Hash.update` with `Buffer, 'utf8' | 'ascii' | 'latin1' | 'binary')`

While this might seem incorrect, node.js just [ignores this parameter for buffers](https://github.com/nodejs/node/blob/master/src/node_crypto.cc#L3905-L3914).

The same is true for `Cipher`, `Hmac`, `Sign`, and `Verify`

This change allows calling code to work with `string | Buffer` unions without having to refine types.