### PR TITLE
Update Buffer.fill to accept a Buffer value

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -38,7 +38,7 @@ declare class Buffer extends Uint8Array {
   copy(targetBuffer: Buffer, targetStart?: number, sourceStart?: number, sourceEnd?: number): number;
   entries(): Iterator<[number, number]>;
   equals(otherBuffer: Buffer): boolean;
-  fill(value: string | number, offset?: number, end?: number, encoding?: string): this;
+  fill(value: string | Buffer | number, offset?: number, end?: number, encoding?: string): this;
   fill(value: string, encoding?: string): this;
   includes(
     value: string | Buffer | number,


### PR DESCRIPTION
[`Buffer.fill`](https://nodejs.org/api/buffer.html#buffer_buf_fill_value_offset_end_encoding) accepts a `Buffer` for the value argument.

Currently, `Buffer.alloc(1).fill(Buffer.alloc(1));` results in the error

```
1: Buffer.alloc(1).fill(Buffer.alloc(1));
   ^ call of method `fill`. Function cannot be called on any member of intersection type
1: Buffer.alloc(1).fill(Buffer.alloc(1));
   ^ intersection
```

https://flow.org/try/#0EIVwZmCmBOB0CGAbRB7AxgCgIwEpZgEtkNQIYFl1sccBuIA