### PR TITLE
fix docs typo: it's -> its

### DIFF
--- a/website/en/docs/types/objects.md
+++ b/website/en/docs/types/objects.md
@@ -233,7 +233,7 @@ var foo: {| foo: string |} = { foo: "Hello", bar: "World!" }; // Error!
 
 Newer versions of the JavaScript standard include a `Map` class, but it is
 still very common to use objects as maps as well. In this use case, an object
-will likely have properties added to it and retrieved throughout it's life.
+will likely have properties added to it and retrieved throughout its life.
 Furthermore, the property keys may not even be known statically, so writing out
 a type annotation would not be possible.
 


### PR DESCRIPTION
When used as a possessive, "its" doesn't have an apostrophe.  More at http://grammarist.com/spelling/its-its/. 