### PR TITLE
Fix Date locale parameter types

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -457,9 +457,9 @@ declare class Date {
     toDateString(): string;
     toISOString(): string;
     toJSON(key?: any): string;
-    toLocaleDateString(locales?: string, options?: Date$LocaleOptions): string;
-    toLocaleString(locales?: string, options?: Date$LocaleOptions): string;
-    toLocaleTimeString(locales?: string, options?: Date$LocaleOptions): string;
+    toLocaleDateString(locales?: string | Array<string>, options?: Date$LocaleOptions): string;
+    toLocaleString(locales?: string | Array<string>, options?: Date$LocaleOptions): string;
+    toLocaleTimeString(locales?: string | Array<string>, options?: Date$LocaleOptions): string;
     toTimeString(): string;
     toUTCString(): string;
     valueOf(): number;


### PR DESCRIPTION
#3843 added an incomplete definition for Date locale functions. `locales` (the first param) can be a string, or an array of strings:

> locales
>> Optional. A string with a BCP 47 language tag, or an array of such strings. 

- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleDateString#Parameters
- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleString#Parameters
- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleTimeString#Parameters