### PR TITLE
fixes an example of optional properties usage

### DIFF
--- a/website/en/docs/types/objects.md
+++ b/website/en/docs/types/objects.md
@@ -59,7 +59,7 @@ In addition to their set value type, these optional properties can either be
 
 ```js
 // @flow
-function acceptsObject(value: { optionalProp?: string }) {
+function acceptsObject(value: { foo?: string }) {
   // ...
 }
 

--- a/website/en/docs/types/primitives.md
+++ b/website/en/docs/types/primitives.md
@@ -233,7 +233,7 @@ In addition to their set value type, these optional properties can either be
 
 ```js
 // @flow
-function acceptsObject(value: { optionalProp?: string }) {
+function acceptsObject(value: { foo?: string }) {
   // ...
 }
 


### PR DESCRIPTION
fixes the case of `acceptsObject({ foo: null }); // Error!`