### PR TITLE
Change JSON.parse return type from to `mixed`

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -533,7 +533,7 @@ declare class URIError extends Error {
 }
 
 declare class JSON {
-    static parse(text: string, reviver?: (key: any, value: any) => any): any;
+    static parse(text: string, reviver?: (key: any, value: any) => any): mixed;
     static stringify(
       value: any,
       replacer?: ?((key: string, value: any) => any) | Array<any>,


### PR DESCRIPTION
The return type of JSON.parse should be mixed, because it can return just about anything and still be valid (especially if a `reviver` function is provided).