### PR TITLE
Fix minor goof on ArrayBuffer

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -673,7 +673,7 @@ declare class ArrayBuffer {
     constructor(byteLength: number): void;
     byteLength: number;
     slice(begin: number, end?: number): this;
-    static [key: $SymbolSpecies]: Function; // This would be the constructor, can't think of a way to correctly type this
+    static [key: $SymbolSpecies]: Class<this>;
 }
 
 // This is a helper type to simplify the specification, it isn't an interface

--- a/lib/core.js
+++ b/lib/core.js
@@ -673,7 +673,7 @@ declare class ArrayBuffer {
     constructor(byteLength: number): void;
     byteLength: number;
     slice(begin: number, end?: number): this;
-    [key: $SymbolSpecies]: Function; // This would be the constructor, can't think of a way to correctly type this
+    static [key: $SymbolSpecies]: Function; // This would be the constructor, can't think of a way to correctly type this
 }
 
 // This is a helper type to simplify the specification, it isn't an interface


### PR DESCRIPTION
It's `ArrayBuffer[Symbol.species]`, not `someBuffer[Symbol.species]`.