### PR TITLE
Remove 4.04 ocaml version upper bound

### DIFF
--- a/opam
+++ b/opam
@@ -22,7 +22,7 @@ depends: [
   "ocamlbuild" {build}
   "sedlex"
 ]
-available: [ocaml-version >= "4.03.0" & ocaml-version < "4.04.0"]
+available: [ocaml-version >= "4.03.0"]
 build: [ [ make ] ]
 depexts: [
  [ ["debian"] ["libelf-dev"] ]


### PR DESCRIPTION
Tried installing ocaml 4.04.0 and running `make`. It worked fine.