### PR TITLE
Another try to get Appveyor to publish binary

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -39,7 +39,7 @@ deploy:
   # flow-bot
   auth_token:
     secure: f1YgYz9csZ8QokY6+aXF10toZtXlFxicbm7uTcylqq+ILoRE6y5GUaf1TfoUalx5
-  artifact: /bin\\.*\.zip/
+  artifact: /.*\.zip/
   force_update: true
   on:
     appveyor_repo_tag: true


### PR DESCRIPTION
Honestly, I don't know why Appveyor refuses to publish this bloody binary. It's definitely uploading the binary. But it sort of looks like the regex isn't matching. So let's make it way simpler and publish any `.zip` artifact.

```
[00:16:50] Collecting artifacts...
[00:16:50] Found artifact 'bin\flow-win64-v0.47.0.zip' matching 'bin\*.zip' path
[00:16:50] Uploading artifacts...
[00:16:51] 
[00:16:51] [1/1] bin\flow-win64-v0.47.0.zip (2,328,083 bytes)...3%
[00:16:51] [1/1] bin\flow-win64-v0.47.0.zip (2,328,083 bytes)...20%
[00:16:51] [1/1] bin\flow-win64-v0.47.0.zip (2,328,083 bytes)...40%
[00:16:51] [1/1] bin\flow-win64-v0.47.0.zip (2,328,083 bytes)...60%
[00:16:51] [1/1] bin\flow-win64-v0.47.0.zip (2,328,083 bytes)...100%
[00:16:52] Deploying using GitHub provider
[00:16:52] Creating "v0.47.0" release for repository "facebook/flow" tag "v0.47.0" commit "8a2a296d70754d4dc448e55999374a6705d2fc2e"...Skipped - release with tag "v0.47.0" already exists
[00:16:53] No artifacts were published. Make sure you have specified correct artifacts filter.
[00:16:53] Updating "v0.47.0" release for repository "facebook/flow" tag "v0.47.0" commit "8a2a296d70754d4dc448e55999374a6705d2fc2e"...OK
```