### PR TITLE
Assigning 'yarn run babel src/ --- -d lib/' to run_command if user ha…

### DIFF
--- a/website/en/docs/_install/include.html
+++ b/website/en/docs/_install/include.html
@@ -1,6 +1,11 @@
 {% if include.package_manager == "yarn" %}
   {% assign install_command = "yarn add --dev" %}
-  {% assign run_command = "yarn run flow-remove-types src/ -- -d lib/" %}
+  {% if include.compiler == "babel" %}
+    {% assign run_command = "yarn run babel src/ -- -d lib/" %}
+  {% elsif include.compiler == "flow-remove-types" %}
+    {% assign run_command = "yarn run flow-remove-types src/ -- -d lib/" %}
+  {% endif %}
+
 {% elsif include.package_manager == "npm" %}
   {% assign install_command = "npm install --save-dev" %}
   {% assign run_command = "./node_modules/.bin/flow-remove-types src/ -d lib/" %}

--- a/website/en/docs/_install/include.html
+++ b/website/en/docs/_install/include.html
@@ -8,7 +8,10 @@
 
 {% elsif include.package_manager == "npm" %}
   {% assign install_command = "npm install --save-dev" %}
-  {% assign run_command = "./node_modules/.bin/flow-remove-types src/ -d lib/" %}
+  {% if include.compiler == "babel" %}
+    {% assign run_command = "./node_modules/.bin/babel src/ -d lib/" %}
+  {% elsif include.compiler == "flow-remove-types" %}
+    {% assign run_command = "./node_modules/.bin/flow-remove-types src/ -d lib/" %}
 {% endif %}
 
 {% capture compiler_intro %}{% include_relative _install/compiler-intro.md %}{% endcapture %}


### PR DESCRIPTION
Currently, the Setup Compiler step in Installation docs shows the flow-remove-types command even if the reader has selected babel as the compiler. This should change the command depending on if babel or flow-remove-types is selected.