### PR TITLE
ReactDOM takes optional `callback` in 3rd argument

### DIFF
--- a/lib/react.js
+++ b/lib/react.js
@@ -247,7 +247,8 @@ declare module 'react-dom' {
 
   declare function render<Config>(
     element: React$Element<Config>,
-    container: any
+    container: any,
+    callback?: () => void
   ): React$Component<$DefaultPropsOf<Config>, $PropsOf<Config>, any>;
 
   declare function unmountComponentAtNode(container: any): boolean;


### PR DESCRIPTION
FIX: #4060

[`ReactDOM.render`](https://facebook.github.io/react/docs/react-dom.html#render) takes `callback` but this argument is missing in flow.