### PR TITLE
Adds typecheck for optional 3rd callback ReactDOM.render arg

### DIFF
--- a/lib/react.js
+++ b/lib/react.js
@@ -247,7 +247,8 @@ declare module 'react-dom' {
 
   declare function render<Config>(
     element: React$Element<Config>,
-    container: any
+    container: any,
+    callback?: () => void
   ): React$Component<$DefaultPropsOf<Config>, $PropsOf<Config>, any>;
 
   declare function unmountComponentAtNode(container: any): boolean;

--- a/tests/react/react.exp
+++ b/tests/react/react.exp
@@ -1,3 +1,10 @@
+Library type error:
+<BUILTINS>/react.js:251
+251:     callback?: () => void
+                    ^^^^^^^^^^ function type. Callable signature not found in
+ 23: ReactDOM.render(<Example/>, document.querySelector('#site'), {});
+                                                                  ^^ object literal. See: render_callback.js:23
+
 createElementRequiredProp_string.js:5
               v
   5:   props: {
@@ -1037,5 +1044,23 @@ proptypes_sealed.js:22
  22:     this.props.baz = 0;
          ^^^^^^^^^^ propTypes of React component
 
+render_callback.js:22
+ 22: ReactDOM.render(<Example/>, document.querySelector('#site'), 1);
+                                                                  ^ number. This type is incompatible with the expected param type of
+251:     callback?: () => void
+                    ^^^^^^^^^^ function type. See lib: <BUILTINS>/react.js:251
 
-Found 117 errors
+render_callback.js:24
+ 24: ReactDOM.render(<Example/>, document.querySelector('#site'), '');
+                                                                  ^^ string. This type is incompatible with the expected param type of
+251:     callback?: () => void
+                    ^^^^^^^^^^ function type. See lib: <BUILTINS>/react.js:251
+
+render_callback.js:25
+ 25: ReactDOM.render(<Example/>, document.querySelector('#site'), null);
+                                                                  ^^^^ null. This type is incompatible with the expected param type of
+251:     callback?: () => void
+                    ^^^^^^^^^^ function type. See lib: <BUILTINS>/react.js:251
+
+
+Found 121 errors

--- a/tests/react/render_callback.js
+++ b/tests/react/render_callback.js
@@ -1,0 +1,25 @@
+/* @flow */
+
+const React = require('react');
+const ReactDOM = require('react-dom');
+const Example = React.createClass({
+  propTypes: {
+  },
+  render() {
+  	return <div>Hello</div>;
+  }
+});
+
+ReactDOM.render(<Example/>, document.querySelector('#site'), () => {
+	console.log('Rendered - arrow callback');
+});
+
+ReactDOM.render(<Example/>, document.querySelector('#site'), function() {
+	console.log('Rendered - function callback');
+});
+
+// These should raise a warning
+ReactDOM.render(<Example/>, document.querySelector('#site'), 1);
+ReactDOM.render(<Example/>, document.querySelector('#site'), {});
+ReactDOM.render(<Example/>, document.querySelector('#site'), '');
+ReactDOM.render(<Example/>, document.querySelector('#site'), null);


### PR DESCRIPTION
Adds typecheck for optional 3rd callback ReactDOM.render arg as per [docs](https://facebook.github.io/react/docs/react-dom.html#render).

Fixes #4060 