### PR TITLE
set up opam in flow-parser npm deploy

### DIFF
--- a/resources/travis/build.sh
+++ b/resources/travis/build.sh
@@ -1,11 +1,7 @@
 #!/bin/bash -e
 
-PLATFORM=$(uname -s || echo unknown)
-ARCH=$(uname -m || echo unknown)
-INSTALL_DIR="$HOME/.flow_cache/ocaml-${OCAML_VERSION}_opam-${OPAM_VERSION}_${PLATFORM}-${ARCH}"
-export PATH="$INSTALL_DIR/usr/bin:$PATH"
-export OPAMROOT="$INSTALL_DIR/.opam"
-eval "$(opam config env)"
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source $DIR/setup_opam.sh
 
 printf "Using ocaml %s from %s\n  and opam %s from %s\n" \
   "$(ocaml -vnum)" "$(which ocaml)" \

--- a/resources/travis/deploy_npm.sh
+++ b/resources/travis/deploy_npm.sh
@@ -6,6 +6,9 @@ set +x
 # only run on tags
 if [[ "$TRAVIS_TAG" = "" ]]; then exit 0; fi
 
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source $DIR/setup_opam.sh
+
 NPM_V=$(sed -n 's/.*"version":.*\([0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}\).*/\1/p' src/parser/package.json)
 TAG_V=$(echo "${TRAVIS_TAG}" | sed -n 's/v\{0,\}\([0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}\)/\1/p')
 if [[ "$TAG_V" == "$NPM_V" ]]; then

--- a/resources/travis/setup_opam.sh
+++ b/resources/travis/setup_opam.sh
@@ -1,0 +1,6 @@
+PLATFORM=$(uname -s || echo unknown)
+ARCH=$(uname -m || echo unknown)
+INSTALL_DIR="$HOME/.flow_cache/ocaml-${OCAML_VERSION}_opam-${OPAM_VERSION}_${PLATFORM}-${ARCH}"
+export PATH="$INSTALL_DIR/usr/bin:$PATH"
+export OPAMROOT="$INSTALL_DIR/.opam"
+eval "$(opam config env)"


### PR DESCRIPTION
travis is supposed to deploy flow-parser to npm. it looks like it fails because `npm publish` calls `make js` which calls ocaml, and opam's environment is not set up in the shell used by the deploy scripts.

calling `eval "$(opam config env)"` should fix this.