### PR TITLE
Add missing parameters to localeCompare definition

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -285,7 +285,7 @@ declare class String {
     indexOf(searchString: string, position?: number): number;
     lastIndexOf(searchString: string, position?: number): number;
     link(href: string): string;
-    localeCompare(that: string): number;
+    localeCompare(that: string, locales?: string | Array<string>, options?: Object): number;
     match(regexp: string | RegExp): ?Array<string>;
     normalize(format?: string): string;
     padEnd(targetLength: number, padString?: string): string;


### PR DESCRIPTION
Declare the `locales` and `options` optional parameter of the `localeCompare` string method.

References:

* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/localeCompare
* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl#Locale_identification_and_negotiation
* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl#options_argument