### PR TITLE
Add missing properties to the `readline$Interface` class

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -1233,6 +1233,14 @@ declare class readline$Interface extends events$EventEmitter {
     shift?: boolean,
     meta?: boolean
   }): void;
+  _refreshLine(): void;
+
+  line: string;
+  cursor: number;
+  _prompt: string;
+  history: string[];
+  input: stream$Readable;
+  output: stream$Writable;
 }
 
 declare module "readline" {

--- a/lib/node.js
+++ b/lib/node.js
@@ -1237,6 +1237,7 @@ declare class readline$Interface extends events$EventEmitter {
 
   line: string;
   cursor: number;
+  terminal: boolean;
   _prompt: string;
   history: string[];
   input: stream$Readable;


### PR DESCRIPTION
Library definitions for Node's `readline` module are missing a few properties.