### PR TITLE
Tweaks to built-in http module.

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -950,17 +950,29 @@ declare class http$ServerResponse extends stream$Writable {
   writeHead(status: number, headers?: {[key: string] : string}): void;
 }
 
-declare module "http" {
-  declare class Server extends net$Server {
-    listen(port: number, hostname?: string, backlog?: number, callback?: Function): Server;
-    listen(path: string, callback?: Function): Server;
-    listen(handle: Object, callback?: Function): Server;
-    close(callback?: (error: ?Error) => mixed): Server;
-    maxHeadersCount: number;
-    setTimeout(msecs: number, callback: Function): Server;
-    timeout: number;
-  }
+declare class http$Server extends net$Server {
+  listen(port: number, hostname?: string, backlog?: number, callback?: Function): Server;
+  listen(port: number, hostname?: string, callback?: Function): Server;
+  listen(path: string, callback?: Function): Server;
+  listen(handle: Object, callback?: Function): Server;
+  close(callback?: (error: ?Error) => mixed): Server;
+  maxHeadersCount: number;
+  setTimeout(msecs: number, callback: Function): Server;
+  timeout: number;
+}
 
+declare class https$Server extends tls$Server {
+  listen(port: number, hostname?: string, backlog?: number, callback?: Function): Server;
+  listen(port: number, hostname?: string, callback?: Function): Server;
+  listen(path: string, callback?: Function): Server;
+  listen(handle: Object, callback?: Function): Server;
+  close(callback?: (error: ?Error) => mixed): Server;
+  setTimeout(msecs: number, callback: Function): Server;
+  timeout: number;
+}
+
+declare module "http" {
+  declare class Server extends http$Server {}
   declare class Agent extends http$Agent {}
   declare class ClientRequest extends http$ClientRequest {}
   declare class IncomingMessage extends http$IncomingMessage {}
@@ -983,14 +995,7 @@ declare module "http" {
 }
 
 declare module "https" {
-  declare class Server extends tls$Server {
-    listen(port: number, hostname?: string, backlog?: number, callback?: Function): Server;
-    listen(path: string, callback?: Function): Server;
-    listen(handle: Object, callback?: Function): Server;
-    close(callback?: (error: ?Error) => mixed): Server;
-    setTimeout(msecs: number, callback: Function): Server;
-    timeout: number;
-  }
+  declare class Server extends https$Server {}
 
   declare class ClientRequest extends http$ClientRequest {}
   declare class IncomingMessage extends http$IncomingMessage {}


### PR DESCRIPTION
In particular, it was not possible for libdefs to import `http$Server` (making it difficult to type e.g. Express), because imports in libdefs appear to coerce the module into a broken type.

This makes `http$Server` and `https$Server` globals so they can be easily used in libdefs without importing `'http'`. 

Additionally, added a third `listen()` form without the `backlog` arg.