### PR TITLE
Fix typo on HTMLElement.dir

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -1194,7 +1194,7 @@ declare class HTMLElement extends Element {
   contentEditable: string;
   contextMenu: ?HTMLMenuElement;
   dataset: {[key:string]: string};
-  dir: 'ltr' | 'trl' | 'auto';
+  dir: 'ltr' | 'rtl' | 'auto';
   draggable: bool;
   dropzone: any;
   hidden: boolean;


### PR DESCRIPTION
Original implementation had `trl` instead of `rtl` as one of the possible values of the `dir` attribute.

Please see [MDN’s definition of `dir`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/dir) and its possible values, which are indeed `ltr`, **`rtl`** and `auto`.

Fixes #2864