### PR TITLE
Fix getContext return type

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -2447,7 +2447,7 @@ type RenderingContext = CanvasRenderingContext2D | WebGLRenderingContext;
 declare class HTMLCanvasElement extends HTMLElement {
   width: number;
   height: number;
-  getContext(contextId: "2d", ...args: any): ?CanvasRenderingContext2D;
+  getContext(contextId: "2d", ...args: any): CanvasRenderingContext2D;
   getContext(contextId: "webgl", contextAttributes?: $Shape<WebGLContextAttributes>): ?WebGLRenderingContext;
   // IE currently only supports "experimental-webgl"
   getContext(contextId: "experimental-webgl", contextAttributes?: $Shape<WebGLContextAttributes>): ?WebGLRenderingContext;


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/getContext

`canvas.getContext('2d')` is supported in all browsers, so we shouldn't have to null-check it.