### PR TITLE
Fix grammatical mistake in website

### DIFF
--- a/website/en/docs/types/generics.md
+++ b/website/en/docs/types/generics.md
@@ -69,7 +69,7 @@ type (parameter or return types).
 <T>(param: T) => T
 ```
 
-Which then gets used as it's own type.
+Which then gets used as its own type.
 
 ```js
 function method(func: <T>(param: T) => T) {


### PR DESCRIPTION
Fix grammatical mistake "it's" -> "its" in generics type docs