### PR TITLE
Disable all warnings for homebrew & opam release builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,12 +162,15 @@ FRAMEWORK_OPTS=$(foreach framework, $(FRAMEWORKS),-cclib -framework -cclib $(fra
 BYTECODE_LINKER_FLAGS=$(NATIVE_OBJECT_FILES) $(NATIVE_LIB_OPTS) $(EXTRA_LIB_OPTS) $(FRAMEWORK_OPTS)
 LINKER_FLAGS=$(BYTECODE_LINKER_FLAGS)
 
+RELEASE_TAGS=$(if $(FLOW_RELEASE),-tag warn_a,)
+
 all: build-flow copy-flow-files
 all-ocp: build-flow-with-ocp copy-flow-files-ocp
 
 all-homebrew:
 	export OPAMROOT="$(shell mktemp -d 2> /dev/null || mktemp -d -t opam)"; \
 	export OPAMYES="1"; \
+	export FLOW_RELEASE="1"; \
 	opam init --no-setup && \
 	opam pin add flowtype . && \
 	opam install flowtype --deps-only && \
@@ -188,6 +191,7 @@ build-flow: _build/scripts/ppx_gen_flowlibs.native $(BUILT_OBJECT_FILES) $(COPIE
 		-use-ocamlfind -pkgs sedlex \
 		-no-links  $(INCLUDE_OPTS) $(LIB_OPTS) \
 		-lflags "$(LINKER_FLAGS)" \
+		$(RELEASE_TAGS) \
 		src/flow.native
 
 %.ocp: %.ocp.fb scripts/utils.ml scripts/ocp_build_glob.ml

--- a/opam
+++ b/opam
@@ -23,6 +23,6 @@ depends: [
   "sedlex"
 ]
 available: [ocaml-version >= "4.03.0"]
-build: [ [ make ] ]
+build: [ [ "env" "FLOW_RELEASE=1" make ] ]
 depexts: [
 ]


### PR DESCRIPTION
This should avoid issues like https://github.com/Homebrew/homebrew-core/pull/14545 where our CI is happy with the build (since we use 4.03.0) but it hits a warning in 4.04.0 when built with homebrew.

Test Plan: 
```
opam switch 4.04.0
eval `opam config env`
make clean
make # Errored
make clean
FLOW_RELEASE=1 make # Worked
make all-homebrew # Worked
opam pin add flowtype .
```

Previously `make all-homebrew` would error with 4.04.0

I could never get `opam install flowtype` to error, but I can at least confirm that this doesn't make it worse.