### PR TITLE
Use SingletonStrT in case of const literal declarations

### DIFF
--- a/newtests/gen_flow_files_command/test.js
+++ b/newtests/gen_flow_files_command/test.js
@@ -146,7 +146,7 @@ export default suite(({addFile, addFiles, flowCmd}) => [
           // @flow
 
           declare export default number;
-          declare export var str: string;
+          declare export var str: "asdf";
 
 
         `,


### PR DESCRIPTION
```
// @flow

const x = 'X';
const y: typeof x = 'Y';
```

Before: no errors.

After:
```
Cannot assign 'Y' to y because string [1] is incompatible with typeof x [2].

        1│ // @flow
        2│
        3│ const x = 'X';
 [2][1] 4│ const y: typeof x = 'Y';
        5│
```

Fixes https://github.com/facebook/flow/issues/2639.

This is my first attempt to dive into Flow codebase, not sure if the implementation is sane. I would like to get some comments on this. Will add tests if everything is ok.