### PR TITLE
Update FileReader.result

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -37,7 +37,7 @@ declare class FileReader extends EventTarget {
   readAsDataURL(blob: Blob): void;
   readAsText(blob: Blob, encoding?: string): void;
   readyState: 0 | 1 | 2;
-  result: any;
+  result: string | ArrayBuffer;
 }
 
 declare type FilePropertyBag = {


### PR DESCRIPTION
According to https://developer.mozilla.org/en-US/docs/Web/API/FileReader/result the FileReader.result prop is either a string or a ArrayBuffer.