### PR TITLE
Fix an `export default const` mistake in the docs

### DIFF
--- a/website/en/docs/types/modules.md
+++ b/website/en/docs/types/modules.md
@@ -27,7 +27,8 @@ Flow also supports importing the type of values exported by other modules using
 **`exports.js`**
 
 ```js
-export default const myNumber = 42;
+const myNumber = 42;
+export default myNumber;
 export class MyClass {
   // ...
 }


### PR DESCRIPTION
See https://github.com/facebook/flow/issues/4203.