### PR TITLE
Remove forEach method from NodeList

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -479,7 +479,6 @@ declare class NodeList<T> {
   item(index: number): T;
   [index: number]: T;
 
-  forEach(callbackfn: (value: T, index: number, list: NodeList<T>) => any, thisArg?: any): void;
   entries(): Iterator<[number, T]>;
   keys(): Iterator<number>;
   values(): Iterator<T>;


### PR DESCRIPTION
According to MDN [`forEach()` isn't in any Spec](https://developer.mozilla.org/en-US/docs/Web/API/NodeList/forEach). It's only implemented by some Vendors, to be nice to us developers. Even though there is a wide adoption, this shouldn't be in Flow.

At the guardian we are trying to [align the flow behavoir with polyfill.io](https://github.com/Financial-Times/polyfill-service/issues/1233) so that all developers can rely on the type definitions being eventually polyfilled.

Opinions?