### PR TITLE
Expose pre-ES6 inheritance through `inherits` on `declare class...`

### DIFF
--- a/src/parser/ast.ml
+++ b/src/parser/ast.ml
@@ -369,6 +369,7 @@ and Statement : sig
   module Interface : sig
     type t = {
       id: Identifier.t;
+      es6: bool;
       typeParameters: Type.ParameterDeclaration.t option;
       body: Loc.t * Type.Object.t;
       extends: (Loc.t * Type.Generic.t) list;

--- a/src/parser/lexer.ml
+++ b/src/parser/lexer.ml
@@ -367,6 +367,7 @@ let _ = List.iter (fun (key, token) -> Hashtbl.add keywords key token)
     "for", T_FOR;
     "class", T_CLASS;
     "extends", T_EXTENDS;
+    "inherits", T_INHERITS;
     "static", T_STATIC;
     "else", T_ELSE;
     "new", T_NEW;

--- a/src/parser/parser_flow.ml
+++ b/src/parser/parser_flow.ml
@@ -198,6 +198,7 @@ module rec Parse : PARSER = struct
     | T_CASE
     | T_DEFAULT
     | T_EXTENDS
+    | T_INHERITS
     | T_STATIC
     | T_EXPORT (* TODO *)
     | T_ELLIPSIS ->
@@ -241,6 +242,7 @@ module rec Parse : PARSER = struct
       strict_error env Error.StrictReservedWord;
       Eat.token env
     | T_DECLARE
+    | T_INHERITS
     | T_OF
     | T_ASYNC
     | T_AWAIT

--- a/src/parser/token.ml
+++ b/src/parser/token.ml
@@ -57,6 +57,7 @@ type t =
   | T_FOR
   | T_CLASS
   | T_EXTENDS
+  | T_INHERITS
   | T_STATIC
   | T_ELSE
   | T_NEW
@@ -188,6 +189,7 @@ let token_to_string = function
   | T_FOR -> "T_FOR"
   | T_CLASS -> "T_CLASS"
   | T_EXTENDS -> "T_EXTENDS"
+  | T_INHERITS -> "T_INHERITS"
   | T_STATIC -> "T_STATIC"
   | T_ELSE -> "T_ELSE"
   | T_NEW -> "T_NEW"

--- a/src/typing/class_sig.mli
+++ b/src/typing/class_sig.mli
@@ -11,6 +11,7 @@ val empty:
   ?structural:bool ->
   int -> (* id *)
   Reason.t ->
+  bool -> (* es6 *)
   Type.typeparam list ->
   Type.t SMap.t -> (* tparams_map *)
   Type.t -> (* super *)

--- a/tests/inherits/inherits.exp
+++ b/tests/inherits/inherits.exp
@@ -1,0 +1,14 @@
+test.js:5
+  5:   static Error: Class<E1>;
+                     ^^^^^^^^^ E1. This type is incompatible with
+  9:   static Error: Class<E2>; //ng
+                           ^^ E2
+
+test.js:9
+  9:   static Error: Class<E2>; //ng
+                     ^^^^^^^^^ E2. This type is incompatible with
+  5:   static Error: Class<E1>;
+                           ^^ E1
+
+
+Found 2 errors

--- a/tests/inherits/test.js
+++ b/tests/inherits/test.js
@@ -1,0 +1,14 @@
+class E1 {}
+class E2 {}
+
+declare class A {
+  static Error: Class<E1>;
+}
+
+declare class B1 extends A {
+  static Error: Class<E2>; //ng
+}
+
+declare class B2 inherits A {
+  static Error: Class<E2>; //ok
+}


### PR DESCRIPTION
See https://github.com/facebook/flow/issues/4204#issuecomment-309883477 for the problem. See https://github.com/facebook/flow/issues/4204#issuecomment-310235076 for the hackish workaround that relies on a bug (in my opinion).