### PR TITLE
Fixes .featurette sections overlapping below 'md' breakpoint

### DIFF
--- a/website/_assets/css/_feature.scss
+++ b/website/_assets/css/_feature.scss
@@ -344,7 +344,7 @@ $feature-hero-text-shadow: '';
 
 @include media-breakpoint-up('md') {
   .featurette {
-    height: 8rem;
+    height: 11rem;
     margin-top: 0;
     margin-bottom: 3rem;
   }

--- a/website/_assets/css/_feature.scss
+++ b/website/_assets/css/_feature.scss
@@ -344,8 +344,14 @@ $feature-hero-text-shadow: '';
 
 @include media-breakpoint-up('md') {
   .featurette {
-    height: 11rem;
+    height: 8rem;
     margin-top: 0;
     margin-bottom: 3rem;
+  }
+}
+
+@include media-breakpoint-only('md') {
+  .featurette {
+    height: 11rem;
   }
 }


### PR DESCRIPTION
Increases `.featurette` section height to `11rem` when targeting the `'md'` segment (`768px-991px`) ([see docs](https://v4-alpha.getbootstrap.com/layout/overview/#responsive-breakpoints)).

Fixes #4308 

![screen shot 2017-07-04 at 10 06 38 am](https://user-images.githubusercontent.com/860099/27823803-4eb9de78-60a2-11e7-94b7-a1416c37ee53.png)
