### PR TITLE
Remove error from example function

### DIFF
--- a/website/en/docs/types/mixed.md
+++ b/website/en/docs/types/mixed.md
@@ -16,7 +16,7 @@ function square(n: number) {
 
 **A group of different possible types:**
 
-Here the input value could be either a `string`, a `number`.
+Here the input value could be either a `string` or a `number`.
 
 ```js
 function stringifyBasicValue(value: string | number) {

--- a/website/en/docs/types/mixed.md
+++ b/website/en/docs/types/mixed.md
@@ -16,10 +16,10 @@ function square(n: number) {
 
 **A group of different possible types:**
 
-Here the input value could be either a `string`, a `number`, or a `boolean`.
+Here the input value could be either a `string`, a `number`.
 
 ```js
-function stringifyBasicValue(value: string | number | boolean) {
+function stringifyBasicValue(value: string | number) {
   return '' + value;
 }
 ```


### PR DESCRIPTION
`''+true` returns an error in Flow, `This type cannot be added to string`. I don't know of a simple way to stringily all three types.