### PR TITLE
[docs] Fix symbol declaration typo

### DIFF
--- a/website/en/docs/types/primitives.md
+++ b/website/en/docs/types/primitives.md
@@ -28,7 +28,7 @@ Or as constructed wrapper objects.
 new Boolean(false);
 new String("world");
 new Number(42);
-new Symbol("foo");
+Symbol("foo");
 ```
 
 Types for literal values are lowercase.


### PR DESCRIPTION
According to ECMAScript 2015 Language Specification symbols do not support the syntax "new Symbol()".