### PR TITLE
Add NonMaybeType description in docs

### DIFF
--- a/website/en/docs/types/utilities.md
+++ b/website/en/docs/types/utilities.md
@@ -250,6 +250,21 @@ const user2 = {name: 'John Wilkes Booth'};
 (user2: ExactUserShorthand);
 ```
 
+## `$NonMaybeType<T>` <a class="toc" id="toc-nonmaybe" href="#toc-nonmaybe"></a>
+
+`$NonMaybeType<T>` converts a maybe type `T` to a non-maybe type.
+
+```js
+// @flow
+type MaybeName = ?string;
+type Name = $NonMaybeType<MaybeName>;
+
+('Gabriel': MaybeName); // Ok
+(null: MaybeName) // Ok
+('Gabriel': Name); // Ok
+(null: Name); // Error! null can't be annotated as Name because Name is not a maybe type
+```
+
 ## `$ObjMap<T, F>` <a class="toc" id="toc-objmap" href="#toc-objmap"></a>
 `ObjMap<T, F>` is the type obtained by taking the type of the values of an object and mapping them with a type function.
 


### PR DESCRIPTION
There exist tests for a `$NonMaybeType` in the [code](https://github.com/facebook/flow/blob/ad328691b3f6ab7689db030e15ef6ccce38d7206/tests/type-destructors/non_maybe_type.js).

I tried it out [here](https://flow.org/try/#0C4TwDgpgBAsghiARhAcnAttAvFA-AZ2ACcBLAOwHMBuAKFEijUyhwBIUB7M+JCAFXAQAPD2RMIAPlo0AFAHIA4nESkIAGzkAuWAjEYIASloyyAVzVrto1PqOzFy1Ru3i7J85ca2qQA).

I couldn't find it in the documentation so I thought about adding it to the `utilities.md`.