### PR TITLE
fix: add missing InputEvent(Listener|Handler|Types|)

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -128,6 +128,8 @@ type FocusEventHandler = (event: FocusEvent) => mixed
 type FocusEventListener = {handleEvent: FocusEventHandler} | FocusEventHandler
 type KeyboardEventHandler = (event: KeyboardEvent) => mixed
 type KeyboardEventListener = {handleEvent: KeyboardEventHandler} | KeyboardEventHandler
+type InputEventHandler = (event: InputEvent) => mixed
+type InputEventListener = {handleEvent: InputEventHandler} | InputEventHandler
 type TouchEventHandler = (event: TouchEvent) => mixed
 type TouchEventListener = {handleEvent: TouchEventHandler} | TouchEventHandler
 type WheelEventHandler = (event: WheelEvent) => mixed
@@ -142,6 +144,7 @@ type AnimationEventListener = {handleEvent: AnimationEventHandler} | AnimationEv
 type MouseEventTypes = 'contextmenu' | 'mousedown' | 'mouseenter' | 'mouseleave' | 'mousemove' | 'mouseout' | 'mouseover' | 'mouseup' | 'click' | 'dblclick';
 type FocusEventTypes = 'blur' | 'focus' | 'focusin' | 'focusout';
 type KeyboardEventTypes = 'keydown' | 'keyup' | 'keypress';
+type InputEventTypes = 'input' | 'beforeinput'
 type TouchEventTypes = 'touchstart' | 'touchmove' | 'touchend' | 'touchcancel';
 type WheelEventTypes = 'wheel';
 type ProgressEventTypes = 'abort' | 'error' | 'load' | 'loadend' | 'loadstart' | 'progress' | 'timeout';
@@ -158,6 +161,7 @@ declare class EventTarget {
   addEventListener(type: MouseEventTypes, listener: MouseEventListener, optionsOrUseCapture?: EventListenerOptionsOrUseCapture): void;
   addEventListener(type: FocusEventTypes, listener: FocusEventListener, optionsOrUseCapture?: EventListenerOptionsOrUseCapture): void;
   addEventListener(type: KeyboardEventTypes, listener: KeyboardEventListener, optionsOrUseCapture?: EventListenerOptionsOrUseCapture): void;
+  addEventListener(type: InputEventTypes, listener: InputEventHandler, optionsOrUseCapture?: EventListenerOptionsOrUseCapture): void;
   addEventListener(type: TouchEventTypes, listener: TouchEventListener, optionsOrUseCapture?: EventListenerOptionsOrUseCapture): void;
   addEventListener(type: WheelEventTypes, listener: WheelEventListener, optionsOrUseCapture?: EventListenerOptionsOrUseCapture): void;
   addEventListener(type: ProgressEventTypes, listener: ProgressEventListener, optionsOrUseCapture?: EventListenerOptionsOrUseCapture): void;
@@ -178,6 +182,7 @@ declare class EventTarget {
   attachEvent?: (type: MouseEventTypes, listener: MouseEventListener) => void;
   attachEvent?: (type: FocusEventTypes, listener: FocusEventListener) => void;
   attachEvent?: (type: KeyboardEventTypes, listener: KeyboardEventListener) => void;
+  attachEvent?: (type: InputEventTypes, listener: InputEventHandler) => void;
   attachEvent?: (type: TouchEventTypes, listener: TouchEventListener) => void;
   attachEvent?: (type: WheelEventTypes, listener: WheelEventListener) => void;
   attachEvent?: (type: ProgressEventTypes, listener: ProgressEventListener) => void;
@@ -188,6 +193,7 @@ declare class EventTarget {
   detachEvent?: (type: MouseEventTypes, listener: MouseEventListener) => void;
   detachEvent?: (type: FocusEventTypes, listener: FocusEventListener) => void;
   detachEvent?: (type: KeyboardEventTypes, listener: KeyboardEventListener) => void;
+  detachEvent?: (type: InputEventTypes, listener: InputEventListener) => void;
   detachEvent?: (type: TouchEventTypes, listener: TouchEventListener) => void;
   detachEvent?: (type: WheelEventTypes, listener: WheelEventListener) => void;
   detachEvent?: (type: ProgressEventTypes, listener: ProgressEventListener) => void;
@@ -367,6 +373,11 @@ declare class KeyboardEvent extends UIEvent {
   charCode: number;
   keyCode: number;
   which: number;
+}
+
+declare class InputEvent extends UIEvent {
+  data: string | null;
+  isComposing: boolean;
 }
 
 declare class AnimationEvent extends UIEvent {


### PR DESCRIPTION
This adds the missing `InputEvent` type, and associated types - to allow for `InputEvents` to be used with `addEventListener`.

These events are part of the DOM Level 3 spec, documentation here: https://w3c.github.io/uievents/#events-inputevents