### PR TITLE
update to sedlex 1.99.4

### DIFF
--- a/ocp_build_flow.ocp.fb
+++ b/ocp_build_flow.ocp.fb
@@ -219,7 +219,7 @@ begin library "flow-parser"
   files += [
     "src/parser/lexer.ml" (comp += [
       "-w" "-31-39"
-      "-ppx" "%{sedlex_FULL_SRC_DIR}%/ppx_sedlex"
+      "-ppx" "%{sedlex_FULL_SRC_DIR}%/ppx_sedlex --as-ppx"
     ])
   ]
   requires = [

--- a/opam
+++ b/opam
@@ -20,7 +20,7 @@ depends: [
   "base-unix"
   "base-bytes"
   "ocamlbuild" {build}
-  "sedlex"
+  "sedlex" { >= "1.99.4" }
 ]
 available: [ocaml-version >= "4.03.0"]
 build: [ [ "env" "FLOW_RELEASE=1" make ] ]

--- a/resources/travis/install_deps.sh
+++ b/resources/travis/install_deps.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-OPAM_DEPENDS="ocamlfind ocp-build js_of_ocaml.2.8.1 sedlex.1.99.3"
+OPAM_DEPENDS="ocamlfind ocp-build js_of_ocaml.2.8.1 sedlex.1.99.4"
 
 TMP=${TMPDIR:-/tmp}
 


### PR DESCRIPTION
sedlex 1.99.4 when used with the `-ppx` flag requires the `--as-ppx` flag. ocamfind takes care of it automatically, but we have to pick either <= 1.99.3 or >= 1.99.4 because of ocp-build.