### PR TITLE
Add FreeBSD support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@
 
 EXTRA_INCLUDE_PATHS=
 EXTRA_LIB_PATHS=
+EXTRA_LIBS=
 INTERNAL_MODULES=hack/stubs src/stubs
 INTERNAL_NATIVE_C_FILES=
 
@@ -23,11 +24,22 @@ endif
 ################################################################################
 
 ifeq ($(UNAME_S), Linux)
+  EXTRA_LIBS += rt
   INOTIFY=hack/third-party/inotify
   INOTIFY_STUBS=$(INOTIFY)/inotify_stubs.c
   FSNOTIFY=hack/fsnotify_linux
   FSNOTIFY_STUBS=
-  RT=rt
+  FRAMEWORKS=
+  EXE=
+endif
+ifeq ($(UNAME_S), FreeBSD)
+  EXTRA_INCLUDE_PATHS += /usr/local/include
+  EXTRA_LIB_PATHS += /usr/local/lib
+  EXTRA_LIBS += inotify
+  INOTIFY=hack/third-party/inotify
+  INOTIFY_STUBS=$(INOTIFY)/inotify_stubs.c
+  FSNOTIFY=hack/fsnotify_linux
+  FSNOTIFY_STUBS=
   FRAMEWORKS=
   EXE=
 endif
@@ -36,7 +48,6 @@ ifeq ($(UNAME_S), Darwin)
   INOTIFY_STUBS=$(INOTIFY)/fsevents_stubs.c
   FSNOTIFY=hack/fsnotify_darwin
   FSNOTIFY_STUBS=
-  RT=
   FRAMEWORKS=CoreServices CoreFoundation
   EXE=
 endif
@@ -45,7 +56,6 @@ ifeq ($(UNAME_S), Windows)
   INOTIFY_STUBS=
   FSNOTIFY=hack/fsnotify_win
   FSNOTIFY_STUBS=$(FSNOTIFY)/fsnotify_stubs.c
-  RT=
   FRAMEWORKS=
   EXE=.exe
 endif
@@ -117,7 +127,7 @@ OCAML_LIBRARIES=\
 
 NATIVE_LIBRARIES=\
   pthread\
-  $(RT)
+  $(EXTRA_LIBS)
 
 OCP_BUILD_FILES=\
   ocp_build_flow.ocp\
@@ -134,7 +144,7 @@ JS_STUBS=\
 JSOO_VERSION=$(shell which js_of_ocaml 2> /dev/null > /dev/null && js_of_ocaml --version)
 JSOO_MAJOR=$(shell echo $(JSOO_VERSION) | cut -d. -f 1)
 JSOO_MINOR=$(shell echo $(JSOO_VERSION) | cut -d. -f 2)
-ifeq (1, $(shell [[ -z "$(JSOO_VERSION)" ]] || [ $(JSOO_MAJOR) -gt 2 ] || [ $(JSOO_MAJOR) -eq 2 -a $(JSOO_MINOR) -gt 7 ]; echo $$?))
+ifeq (1, $(shell [ -z "$(JSOO_VERSION)" ] || [ $(JSOO_MAJOR) -gt 2 ] || [ $(JSOO_MAJOR) -eq 2 -a $(JSOO_MINOR) -gt 7 ]; echo $$?))
 	JS_STUBS += js/optional/caml_hexstring_of_float.js
 endif
 

--- a/hack/heap/hh_shared.c
+++ b/hack/heap/hh_shared.c
@@ -162,7 +162,6 @@
     #endif
   #endif
 
-  #define MEMFD_CREATE 1
   #include <asm/unistd.h>
 
   /* Originally this function would call uname(), parse the linux
@@ -547,12 +546,6 @@ void memfd_init(char *shm_dir, size_t shared_mem_size, uint64_t minimum_avail) {
 
 static int memfd = -1;
 
-static void raise_failed_anonymous_memfd_init() {
-  static value *exn = NULL;
-  if (!exn) exn = caml_named_value("failed_anonymous_memfd_init");
-  caml_raise_constant(*exn);
-}
-
 static void raise_less_than_minimum_available(uint64_t avail) {
   value arg;
   static value *exn = NULL;
@@ -593,40 +586,44 @@ void assert_avail_exceeds_minimum(char *shm_dir, uint64_t minimum_avail) {
 void memfd_init(char *shm_dir, size_t shared_mem_size, uint64_t minimum_avail) {
   if (shm_dir == NULL) {
     // This means that we should try to use the anonymous-y system calls
-#if defined(MEMFD_CREATE)
+#ifdef __linux__
     memfd = memfd_create("fb_heap", 0);
-#endif
-#if defined(__APPLE__)
     if (memfd < 0) {
-      char memname[255];
-      snprintf(memname, sizeof(memname), "/fb_heap.%d", getpid());
-      // the ftruncate below will fail with errno EINVAL if you try to
-      // ftruncate the same sharedmem fd more than once. We're seeing this in
-      // some tests, which might imply that two flow processes with the same
-      // pid are starting up. This shm_unlink should prevent that from
-      // happening. Here's a stackoverflow about it
-      // http://stackoverflow.com/questions/25502229/ftruncate-not-working-on-posix-shared-memory-in-mac-os-x
-      shm_unlink(memname);
-      memfd = shm_open(memname, O_CREAT | O_RDWR, 0666);
-      if (memfd < 0) {
-          uerror("shm_open", Nothing);
-      }
-
-      // shm_open sets FD_CLOEXEC automatically. This is undesirable, because
-      // we want this fd to be open for other processes, so that they can
-      // reconnect to the shared memory.
-      int fcntl_flags = fcntl(memfd, F_GETFD);
-      if (fcntl_flags == -1) {
-        printf("Error with fcntl(memfd): %s\n", strerror(errno));
-        uerror("fcntl", Nothing);
-      }
-      // Unset close-on-exec
-      fcntl(memfd, F_SETFD, fcntl_flags & ~FD_CLOEXEC);
+      uerror("memfd_create", Nothing);
     }
-#endif
+#else
+#ifdef __FreeBSD__
+    // FreeBSD shm_open path is a real FS path, so use the specific anonymous
+    // behaviour instead.
+    memfd = shm_open(SHM_ANON, O_CREAT | O_EXCL | O_RDWR, 0666);
     if (memfd < 0) {
-      raise_failed_anonymous_memfd_init();
+      uerror("shm_open", Nothing);
     }
+#else
+    char memname[255];
+    snprintf(memname, sizeof(memname), "/fb_heap.%d", getpid());
+    // Use O_EXCL to ensure we get a fresh file.  This is required for
+    // ftruncate to success on OS X, but is good practice anyway.
+    // http://stackoverflow.com/questions/25502229/ftruncate-not-working-on-posix-shared-memory-in-mac-os-x
+    memfd = shm_open(memname, O_CREAT | O_EXCL | O_RDWR, 0666);
+    if (memfd < 0) {
+      uerror("shm_open", Nothing);
+    }
+    // Unlink before leaving to anonymize memfd.
+    shm_unlink(memname);
+#endif
+    
+    // shm_open sets FD_CLOEXEC automatically. This is undesirable, because
+    // we want this fd to be open for other processes, so that they can
+    // reconnect to the shared memory.
+    int fcntl_flags = fcntl(memfd, F_GETFD);
+    if (fcntl_flags == -1) {
+      printf("Error with fcntl(memfd): %s\n", strerror(errno));
+      uerror("fcntl", Nothing);
+    }
+    // Unset close-on-exec
+    fcntl(memfd, F_SETFD, fcntl_flags & ~FD_CLOEXEC);
+#endif
   } else {
     assert_avail_exceeds_minimum(shm_dir, minimum_avail);
     if (memfd < 0) {

--- a/hack/heap/hh_shared.c
+++ b/hack/heap/hh_shared.c
@@ -148,7 +148,7 @@
  * with the MAP_ANONYMOUS flag. The memfd_create() system call first
  * appeared in Linux 3.17.
  ****************************************************************************/
-#if !defined __APPLE__ && !defined _WIN32
+#ifdef __linux__
   // Linux version for the architecture must support syscall memfd_create
   #ifndef SYS_memfd_create
     #if defined(__x86_64__)
@@ -174,6 +174,10 @@
   static int memfd_create(const char *name, unsigned int flags) {
     return syscall(SYS_memfd_create, name, flags);
   }
+#endif
+
+#ifndef MAP_NORESERVE
+  #define MAP_NORESERVE 0
 #endif
 
 // The following 'typedef' won't be required anymore

--- a/hack/third-party/inotify/inotify_stubs.c
+++ b/hack/third-party/inotify/inotify_stubs.c
@@ -28,7 +28,9 @@
 #include <caml/callback.h>
 #include <caml/unixsupport.h>
 
+#ifdef __linux__
 #include <features.h>
+#endif
 #include <sys/inotify.h>
 
 static int inotify_flag_table[] = {

--- a/hack/utils/sysinfo.c
+++ b/hack/utils/sysinfo.c
@@ -13,10 +13,8 @@
 #include <caml/mlvalues.h>
 
 #include <assert.h>
-#ifndef _WIN32
-#ifndef __APPLE__
+#ifdef __linux__
 #include <sys/sysinfo.h>
-#endif
 #endif
 
 #ifdef _WIN32


### PR DESCRIPTION
This set of changes makes it possible to compile `flow` on FreeBSD.

It does require `libinotify` to be install separately, but otherwise seems fine.  I'm not sure how to make the local `libinotify` a dependency through the `opam` build system.

Additionally, the current install instructions in `README.md` specify that `opam init --comp 4.03.0` is sufficient to change versions but on FreeBSD it is necessary to use `opam switch 4.03.0` since the `init` subcommand will not replace the system version (currently 4.02.3 on FreeBSD) which is automatically installed as a dependency of `opam`.