### PR TITLE
HTMLMediaElement#play() return Promise

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -2679,7 +2679,7 @@ declare class HTMLMediaElement extends HTMLElement {
   ended: boolean;
   autoplay: boolean;
   loop: boolean;
-  play(): void;
+  play(): Promise<void>;
   pause(): void;
   fastSeek(): void;
 


### PR DESCRIPTION
# Problem

`HTMLMediaElement#play()` return Promise object on browser.

ref. https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/play

but the following code will result in an type error

```js
function playMedia(media: HTMLMediaElement): Promise<any> {
  return media.play();
}
```
```
Error: eample.js:5
  5:   return media.play();
              ^^^^^^^^^^^^ undefined. This type is incompatible with the expected return type of
  4: function playMedia(media: HTMLMediaElement): Promise<any> {
                                                  ^^^^^^^^^^^^ Promise
```