### PR TITLE
Fixed setup guide for yarn

### DIFF
--- a/website/en/docs/_install/setup-yarn.md
+++ b/website/en/docs/_install/setup-yarn.md
@@ -16,4 +16,4 @@ $ flow
 No errors!
 ✨  Done in 0.17s.
 ```
-**Note:** you may need to run `flow init` before executing `yarn run flow`.
+**Note:** you may need to run `yarn run flow init` before executing `yarn run flow`.


### PR DESCRIPTION
`flow init` results in `command not found: flow`

It needs to be `yarn run flow init` instead of `flow init`