### PR TITLE
Fix library definitions for some node `fs` functions

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -777,11 +777,32 @@ declare module "fs" {
   declare function mkdirSync(path: string, mode?: number): void;
   declare function mkdtemp(prefix: string, callback: (err: ?ErrnoError, folderPath: string) => void): void;
   declare function mkdtempSync(prefix: string): string;
-  declare function readdir(path: string, callback?: (err: ?ErrnoError, files: Array<string>) => void): void;
-  declare function readdirSync(path: string): Array<string>;
-  declare function close(fd: number, callback?: (err: ?ErrnoError) => void): void;
+  declare function readdir(
+    path: string,
+    options: string | { encoding: string },
+    callback: (err: ?ErrnoError, files: Array<string>) => void
+  ): void;
+  declare function readdir(
+    path: string,
+    callback: (err: ?ErrnoError, files: Array<string>) => void
+  ): void;
+  declare function readdirSync(
+    path: string,
+    options?: string | { encoding: string }
+  ): Array<string>;
+  declare function close(fd: number, callback: (err: ?ErrnoError) => void): void;
   declare function closeSync(fd: number): void;
-  declare function open(path: string | Buffer, flags: string | number, mode?: number, callback?: (err: ?ErrnoError, fd: number) => void): void;
+  declare function open(
+    path: string | Buffer | URL,
+    flags: string | number,
+    mode: number,
+    callback: (err: ?ErrnoError, fd: number) => void
+  ): void;
+  declare function open(
+    path: string | Buffer | URL,
+    flags: string | number,
+    callback: (err: ?ErrnoError, fd: number) => void
+  ): void;
   declare function openSync(path: string | Buffer, flags: string | number, mode?: number): number;
   declare function utimes(path: string, atime: number, mtime: number, callback?: (err: ?ErrnoError) => void): void;
   declare function utimesSync(path: string, atime: number, mtime: number): void;
@@ -789,17 +810,86 @@ declare module "fs" {
   declare function futimesSync(fd: number, atime: number, mtime: number): void;
   declare function fsync(fd: number, callback?: (err: ?ErrnoError) => void): void;
   declare function fsyncSync(fd: number): void;
-  declare var write: (fd: number, buffer: Buffer, offset: number, length: number, position?: mixed, callback?: (err: ?ErrnoError, write: number, str: string) => void) => void
-                   | (fd: number, data: mixed, position?: mixed, encoding?: string, callback?: (err: ?ErrnoError, write: number, str: string) => void) => void;
-  declare var writeSync: (fd: number, buffer: Buffer, offset: number, length: number, position?: number) => number
-                       | (fd: number, data: mixed, position?: mixed, encoding?: string) => number;
+  declare function write(
+    fd: number,
+    buffer: Buffer,
+    offset: number,
+    length: number,
+    position: number,
+    callback: (err: ?ErrnoError, write: number, buf: Buffer) => void
+  ): void;
+  declare function write(
+    fd: number,
+    buffer: Buffer,
+    offset: number,
+    length: number,
+    callback: (err: ?ErrnoError, write: number, buf: Buffer) => void
+  ): void;
+  declare function write(
+    fd: number,
+    buffer: Buffer,
+    offset: number,
+    callback: (err: ?ErrnoError, write: number, buf: Buffer) => void
+  ): void;
+  declare function write(
+    fd: number,
+    buffer: Buffer,
+    callback: (err: ?ErrnoError, write: number, buf: Buffer) => void
+  ): void;
+  declare function write(
+    fd: number,
+    data: string,
+    position: number,
+    encoding: string,
+    callback: (err: ?ErrnoError, write: number, str: string) => void
+  ): void;
+  declare function write(
+    fd: number,
+    data: string,
+    position: number,
+    callback: (err: ?ErrnoError, write: number, str: string) => void
+  ): void;
+  declare function write(
+    fd: number,
+    data: string,
+    callback: (err: ?ErrnoError, write: number, str: string) => void
+  ): void;
+  declare function writeSync(
+    fd: number,
+    buffer: Buffer,
+    offset: number,
+    length: number,
+    position: number,
+  ): number;
+  declare function writeSync(
+    fd: number,
+    buffer: Buffer,
+    offset: number,
+    length: number,
+  ): number;
+  declare function writeSync(
+    fd: number,
+    buffer: Buffer,
+    offset?: number,
+  ): number;
+  declare function writeSync(
+    fd: number,
+    str: string,
+    position: number,
+    encoding: string,
+  ): number;
+  declare function writeSync(
+    fd: number,
+    str: string,
+    position?: number,
+  ): number;
   declare function read(
     fd: number,
     buffer: Buffer,
     offset: number,
     length: number,
     position: ?number,
-    callback?: (err: ?ErrnoError, bytesRead: number, buffer: Buffer) => void
+    callback: (err: ?ErrnoError, bytesRead: number, buffer: Buffer) => void
   ): void;
   declare function readSync(
     fd: number,
@@ -809,41 +899,81 @@ declare module "fs" {
     position: number
   ): number;
   declare function readFile(
-    filename: string,
+    path: string | Buffer | URL | number,
     callback: (err: ?ErrnoError, data: Buffer) => void
   ): void;
   declare function readFile(
-    filename: string,
+    path: string | Buffer | URL | number,
     encoding: string,
     callback: (err: ?ErrnoError, data: string) => void
   ): void;
   declare function readFile(
-    filename: string,
+    path: string | Buffer | URL | number,
     options: { encoding: string; flag?: string },
     callback: (err: ?ErrnoError, data: string) => void
   ): void;
   declare function readFile(
-    filename: string,
+    path: string | Buffer | URL | number,
     options: { flag?: string },
     callback: (err: ?ErrnoError, data: Buffer) => void
   ): void;
-  declare function readFileSync(filename: string, _: void): Buffer;
-  declare function readFileSync(filename: string, encoding: string): string;
-  declare function readFileSync(filename: string, options: { encoding: string, flag?: string }): string;
-  declare function readFileSync(filename: string, options: { encoding?: void, flag?: string }): Buffer;
+  declare function readFileSync(
+    path: string | Buffer | URL | number
+  ): Buffer;
+  declare function readFileSync(
+    path: string | Buffer | URL | number,
+    encoding: string
+  ): string;
+  declare function readFileSync(path: string | Buffer | URL | number, options: { encoding: string, flag?: string }): string;
+  declare function readFileSync(path: string | Buffer | URL | number, options: { encoding?: void, flag?: string }): Buffer;
   declare function writeFile(
-    filename: string,
+    filename: string | Buffer | number,
     data: Buffer | string,
-    options?: Object | string,
+    options: string | {
+      encoding?: ?string,
+      mode?: number,
+      flag?: string
+    },
+    callback: (err: ?ErrnoError) => void
+  ): void;
+  declare function writeFile(
+    filename: string | Buffer | number,
+    data: Buffer | string,
     callback?: (err: ?ErrnoError) => void
   ): void;
   declare function writeFileSync(
     filename: string,
     data: Buffer | string,
-    options?: Object | string
+    options?: string | {
+      encoding?: ?string,
+      mode?: number,
+      flag?: string
+    }
   ): void;
-  declare function appendFile(filename: string, data: string | Buffer, options?: Object, callback?: (err: ?ErrnoError) => void): void;
-  declare function appendFileSync(filename: string, data: string | Buffer, options?: Object): void;
+  declare function appendFile(
+    filename: string | Buffer | number,
+    data: string | Buffer,
+    options: {
+      encoding?: ?string,
+        mode?: number,
+        flag?: string
+    },
+    callback: (err: ?ErrnoError) => void
+  ): void;
+  declare function appendFile(
+    filename: string | Buffer | number,
+    data: string | Buffer,
+    callback: (err: ?ErrnoError) => void
+  ): void;
+  declare function appendFileSync(
+    filename: string | Buffer | number,
+    data: string | Buffer,
+    options?: {
+      encoding?: ?string,
+        mode?: number,
+        flag?: string
+    }
+  ): void;
   declare function watchFile(filename: string, options?: Object, listener?: (curr: Stats, prev: Stats) => void): void;
   declare function unwatchFile(filename: string, listener?: (curr: Stats, prev: Stats) => void): void;
   declare function watch(filename: string, options?: Object, listener?: (event: string, filename: string) => void): FSWatcher;

--- a/tests/node_tests/fs/fs.js
+++ b/tests/node_tests/fs/fs.js
@@ -18,6 +18,10 @@ fs.readFile("file.exp", {}, (_, data) => {
   (data : Buffer);
 });
 
+fs.readFile(0, {}, (_, data) => {
+  (data : Buffer);
+});
+
 /* readFileSync */
 
 (fs.readFileSync("file.exp") : Buffer);
@@ -31,3 +35,53 @@ fs.readFile("file.exp", {}, (_, data) => {
 
 (fs.readFileSync("file.exp", {}) : Buffer);
 (fs.readFileSync("file.exp", {}) : string); // error
+
+/* write */
+
+(fs.write(0, Buffer.alloc(0), 0, 0, 0, (err, bytesWritten, buffer) => {
+  (err: ?ErrnoError);
+  (bytesWritten: number);
+  (buffer: Buffer);
+}));
+
+(fs.write(0, Buffer.alloc(0), 0, 0, (err, bytesWritten, buffer) => {
+  (err: ?ErrnoError);
+  (bytesWritten: number);
+  (buffer: Buffer);
+}));
+
+(fs.write(0, Buffer.alloc(0), (err, bytesWritten, buffer) => {
+  (err: ?ErrnoError);
+  (bytesWritten: number);
+  (buffer: Buffer);
+}));
+
+(fs.write(0, "test", 0, "utf8", (err, written, str) => {
+  (err: ?ErrnoError);
+  (written: number);
+  (str: string);
+}));
+
+(fs.write(0, "test", 0, (err, written, str) => {
+  (err: ?ErrnoError);
+  (written: number);
+  (str: string);
+}));
+
+(fs.write(0, "test", (err, written, str) => {
+  (err: ?ErrnoError);
+  (written: number);
+  (str: string);
+}));
+
+/* open */
+
+(fs.open("file.exp", "r", (err, fd) => {
+  (err: ?ErrnoError);
+  (fd: number);
+}));
+
+(fs.open("file.exp", "r", 0o666, (err, fd) => {
+  (err: ?ErrnoError);
+  (fd: number);
+}));

--- a/tests/node_tests/node_tests.exp
+++ b/tests/node_tests/node_tests.exp
@@ -100,24 +100,24 @@ Error: crypto/crypto.js:16
          ^^^^^^^^^^^^^^^ call of method `write`
  16:     hmac.write(123); // 2 errors: not a string or a Buffer
                     ^^^ number. This type is incompatible with
-1340:     chunk: Buffer | string,
-                 ^^^^^^^^^^^^^^^ union: Buffer | string. See lib: <BUILTINS>/node.js:1340
+1470:     chunk: Buffer | string,
+                 ^^^^^^^^^^^^^^^ union: Buffer | string. See lib: <BUILTINS>/node.js:1470
   Member 1:
-  1340:     chunk: Buffer | string,
-                   ^^^^^^ Buffer. See lib: <BUILTINS>/node.js:1340
+  1470:     chunk: Buffer | string,
+                   ^^^^^^ Buffer. See lib: <BUILTINS>/node.js:1470
   Error:
    16:     hmac.write(123); // 2 errors: not a string or a Buffer
                       ^^^ number. This type is incompatible with
-  1340:     chunk: Buffer | string,
-                   ^^^^^^ Buffer. See lib: <BUILTINS>/node.js:1340
+  1470:     chunk: Buffer | string,
+                   ^^^^^^ Buffer. See lib: <BUILTINS>/node.js:1470
   Member 2:
-  1340:     chunk: Buffer | string,
-                            ^^^^^^ string. See lib: <BUILTINS>/node.js:1340
+  1470:     chunk: Buffer | string,
+                            ^^^^^^ string. See lib: <BUILTINS>/node.js:1470
   Error:
    16:     hmac.write(123); // 2 errors: not a string or a Buffer
                       ^^^ number. This type is incompatible with
-  1340:     chunk: Buffer | string,
-                            ^^^^^^ string. See lib: <BUILTINS>/node.js:1340
+  1470:     chunk: Buffer | string,
+                            ^^^^^^ string. See lib: <BUILTINS>/node.js:1470
 
 Error: crypto/crypto.js:26
  26:     hmac.update('foo', 'bogus'); // 1 error
@@ -154,55 +154,55 @@ Error: fs/fs.js:13
  15: });
      -^ call of method `readFile`. Could not decide which case to select
                                 v
-811:   declare function readFile(
-812:     filename: string,
-813:     callback: (err: ?ErrnoError, data: Buffer) => void
-814:   ): void;
-       ------^ intersection type. See lib: <BUILTINS>/node.js:811
+901:   declare function readFile(
+902:     path: string | Buffer | URL | number,
+903:     callback: (err: ?ErrnoError, data: Buffer) => void
+904:   ): void;
+       ------^ intersection type. See lib: <BUILTINS>/node.js:901
   Case 3 may work:
                                   v
-  820:   declare function readFile(
-  821:     filename: string,
-  822:     options: { encoding: string; flag?: string },
-  823:     callback: (err: ?ErrnoError, data: string) => void
-  824:   ): void;
-         ------^ function type. See lib: <BUILTINS>/node.js:820
+  910:   declare function readFile(
+  911:     path: string | Buffer | URL | number,
+  912:     options: { encoding: string; flag?: string },
+  913:     callback: (err: ?ErrnoError, data: string) => void
+  914:   ): void;
+         ------^ function type. See lib: <BUILTINS>/node.js:910
   But if it doesn't, case 4 looks promising too:
                                   v
-  825:   declare function readFile(
-  826:     filename: string,
-  827:     options: { flag?: string },
-  828:     callback: (err: ?ErrnoError, data: Buffer) => void
-  829:   ): void;
-         ------^ function type. See lib: <BUILTINS>/node.js:825
+  915:   declare function readFile(
+  916:     path: string | Buffer | URL | number,
+  917:     options: { flag?: string },
+  918:     callback: (err: ?ErrnoError, data: Buffer) => void
+  919:   ): void;
+         ------^ function type. See lib: <BUILTINS>/node.js:915
   Please provide additional annotation(s) to determine whether case 3 works (or consider merging it with case 4):
    13: fs.readFile("file.exp", { encoding: "blah" }, (_, data) => {
                                                       ^ parameter `_`
    13: fs.readFile("file.exp", { encoding: "blah" }, (_, data) => {
                                                          ^^^^ parameter `data`
 
-Error: fs/fs.js:24
- 24: (fs.readFileSync("file.exp") : string); // error
+Error: fs/fs.js:28
+ 28: (fs.readFileSync("file.exp") : string); // error
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Buffer. This type is incompatible with
- 24: (fs.readFileSync("file.exp") : string); // error
+ 28: (fs.readFileSync("file.exp") : string); // error
                                     ^^^^^^ string
 
-Error: fs/fs.js:27
- 27: (fs.readFileSync("file.exp", "blah") : Buffer); // error
+Error: fs/fs.js:31
+ 31: (fs.readFileSync("file.exp", "blah") : Buffer); // error
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string. This type is incompatible with
- 27: (fs.readFileSync("file.exp", "blah") : Buffer); // error
+ 31: (fs.readFileSync("file.exp", "blah") : Buffer); // error
                                             ^^^^^^ Buffer
 
-Error: fs/fs.js:30
- 30: (fs.readFileSync("file.exp", { encoding: "blah" }) : Buffer); // error
+Error: fs/fs.js:34
+ 34: (fs.readFileSync("file.exp", { encoding: "blah" }) : Buffer); // error
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string. This type is incompatible with
- 30: (fs.readFileSync("file.exp", { encoding: "blah" }) : Buffer); // error
+ 34: (fs.readFileSync("file.exp", { encoding: "blah" }) : Buffer); // error
                                                           ^^^^^^ Buffer
 
-Error: fs/fs.js:33
- 33: (fs.readFileSync("file.exp", {}) : string); // error
+Error: fs/fs.js:37
+ 37: (fs.readFileSync("file.exp", {}) : string); // error
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Buffer. This type is incompatible with
- 33: (fs.readFileSync("file.exp", {}) : string); // error
+ 37: (fs.readFileSync("file.exp", {}) : string); // error
                                         ^^^^^^ string
 
 Error: invalid_package_file/package.json:1
@@ -335,8 +335,8 @@ Error: process/nextTick.js:26
      ^ call of method `nextTick`
  27:   (a: string, b: number, c: boolean) => {} // Error: too few arguments
            ^^^^^^ string. This type is incompatible with
-1805:   nextTick: <T>(cb: (...T) => mixed, ...T) => void;
-                          ^^^^^^^^^^^^^^^ undefined (too few arguments, expected default/rest parameters). See lib: <BUILTINS>/node.js:1805
+1935:   nextTick: <T>(cb: (...T) => mixed, ...T) => void;
+                          ^^^^^^^^^^^^^^^ undefined (too few arguments, expected default/rest parameters). See lib: <BUILTINS>/node.js:1935
 
 Error: process/nextTick.js:26
      v----------------
@@ -346,8 +346,8 @@ Error: process/nextTick.js:26
      ^ call of method `nextTick`
  27:   (a: string, b: number, c: boolean) => {} // Error: too few arguments
                       ^^^^^^ number. This type is incompatible with
-1805:   nextTick: <T>(cb: (...T) => mixed, ...T) => void;
-                          ^^^^^^^^^^^^^^^ undefined (too few arguments, expected default/rest parameters). See lib: <BUILTINS>/node.js:1805
+1935:   nextTick: <T>(cb: (...T) => mixed, ...T) => void;
+                          ^^^^^^^^^^^^^^^ undefined (too few arguments, expected default/rest parameters). See lib: <BUILTINS>/node.js:1935
 
 Error: process/nextTick.js:26
      v----------------
@@ -357,8 +357,8 @@ Error: process/nextTick.js:26
      ^ call of method `nextTick`
  27:   (a: string, b: number, c: boolean) => {} // Error: too few arguments
                                  ^^^^^^^ boolean. This type is incompatible with
-1805:   nextTick: <T>(cb: (...T) => mixed, ...T) => void;
-                          ^^^^^^^^^^^^^^^ undefined (too few arguments, expected default/rest parameters). See lib: <BUILTINS>/node.js:1805
+1935:   nextTick: <T>(cb: (...T) => mixed, ...T) => void;
+                          ^^^^^^^^^^^^^^^ undefined (too few arguments, expected default/rest parameters). See lib: <BUILTINS>/node.js:1935
 
 
 Found 40 errors


### PR DESCRIPTION
Fix definitions for:
- write(Sync)
- readFile(Sync)
- readdir(Sync)
- readFile(Sync)
- appendFile(Sync)
- open
- close

I believe this closes #3992, #3714, #3081, and #2902.

**Note:** Some of these changes are breaking, as they change some `callback` arguments from optional to required (as indicated in the node documentation).e