### PR TITLE
Make String.replace callback args less unassuming

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -306,7 +306,7 @@ declare class String {
     padEnd(targetLength: number, padString?: string): string;
     padStart(targetLength: number, padString?: string): string;
     repeat(count: number): string;
-    replace(searchValue: string | RegExp, replaceValue: string | (substring: string, ...args: Array<any>) => string): string;
+    replace(searchValue: string | RegExp, replaceValue: string | (substring: string, ...args: Array<string | number>) => string): string;
     search(regexp: string | RegExp): number;
     slice(start?: number, end?: number): string;
     split(separator?: string | RegExp, limit?: number): Array<string>;


### PR DESCRIPTION
The callback in `String.prototype.replace(regex, callback)` will always receive the following arguments:

* 0: full match as string,
* 1-n: single matches from parantheses inside the regex (no match will return empty string)
* n+1: start position of full match as number
* n+2: full string

So `(substring: string, ...args: Array<any>)` is too unassuming.

In the future, some logic that was able to detect parantheses in RegExp and computed the callback arguments accordingly would be desirable.