### PR TITLE
Accept generic return type for AsyncIterator

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -522,7 +522,7 @@ interface $AsyncIterator<+Yield,+Return,-Next> {
     @@asyncIterator(): $AsyncIterator<Yield,Return,Next>;
     next(value?: Next): Promise<IteratorResult<Yield,Return>>;
 }
-type AsyncIterator<+T> = $AsyncIterator<T,void,void>;
+type AsyncIterator<+T,+R = void> = $AsyncIterator<T,R,void>;
 
 interface $AsyncIterable<+Yield,+Return,-Next> {
     @@asyncIterator(): $AsyncIterator<Yield,Return,Next>;


### PR DESCRIPTION
I'm not 100% sure if this makes sense. However I find myself implementing AsyncIterator object **by hand** without generator sugar syntax and I need to notify the consumer about `{done: true}` **immediately** with the last result of the iteration and now its not possible because by declaring `AsyncIteratorByHand<T>` I can only return `{value: T, done: false} | {value?: undefined, done: true}`.

Example code which wont work can be check [here](https://flow.org/try/#0PTAEAEDMBsHsHcBQBjWA7AzgF1AcwKZYASAltrAE4CeoAvKABQCUAXKAIIZVrICSW+CgEMslADxoArgFsARoIB8dJQG9EoUNEKgSdUAAZ1oIxUKSKaUGo0a0+AB5ZmVozdABqdyVc3TWc5Z28KAAChSw0mT4DKYYsNAAbvjKLm5uqJg4ACboyfS6SgDMPm4lNiSQjDl2TKlpbrHxSQwqoAlC0JL4bCQANKDV3aBYFF2gAL5MZQ1mFtMT8-WlS6CNidGt7Z1DfQO5bJAdGMmTZadu470+ANoA5ODgQlw8-IIilLcAus7WaX4BwwAFmQfOMjGDxkA)
After the change could be used like [this](https://flow.org/try/#0PTAEAEDMBsHsHcBQAXAngBwKagLKoJLKYBOAhsrMQEqYDOArtMgDwCaAlptACYA0NyesQB2APlABeRKFAAfUAG9Q3WMMwAuUMmL1MvUADdS0XQH5NAocNABfaXMXLVG0JGO09h47s0cu3WwBuRER2YSJiNwBjbAASPABBWlRhKMISckpmAGo-Hl5syxFeAFoAOUwAD2RxBXsZcHBSZNT0sgpiAAoASk141CSUtIjM4jZOfKLhXgrq0WCZGTVqzqMTTHNQWeRe0AAFYlgAW3YPZjw20ZoGJnH-fkxBEVF5xDs0LFwBluGMjpyACoFKiSQywdjccQSUD9QatEb-IFUXgGcGQ4KIKKqWjIUAAc0eAAlTh1UKCeppEj9Lv9hPQjgAjEj6OmMkhQ2r2aCPUDsUEABi5PJUans9mIjysinqoGWyB60sWi2y2XYMpkEqe1jU8H2hxOHk6EtosGgBmwEk5SqVWOEOKcalBfPEAGZ1Yt2JBQJ0RRaJNDtLpuorrUrjabzZ0lGsfLz9L7NIHsDZuu6w5KRGnbFnw2bMFGvOtNOx485NG5oB5bKnQymZTZeDKANoAckazSGNMoLYAugq6qHNVLkAALU71+x2GxAA), although Ive also noticed that it suffers from poor refinement:
1. in the if block I need to be explicit about `done: true`, although refinement should already know that its `true` and should allow me to `resolve({ value: i, done })`
2. i cannot just resolve with shorthand `resolve({ value: i, done: i > 3 })` - imho this should be possible, because Ive specified Yield and Return generics to be the same

IMHO this makes sense also for Next and regular Iterator - can add those to the PR. It would look like this:
```js
type Iterator<+T, +R = void, -N = void> = $Iterator<T,R,N>;
type AsyncIterator<+T,+R = void, -N = void> = $AsyncIterator<T,R,N>;
```