### PR TITLE
[travis] build with Trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: false
-dist: precise
+dist: trusty
 
 env:
   global:

--- a/resources/travis/install_deps.sh
+++ b/resources/travis/install_deps.sh
@@ -65,6 +65,8 @@ eval "$(opam config env)"
 echo "Installed packages:"
 ocamlfind list
 
+unset PREFIX
+
 printf "travis_fold:end:opam_installer\n"
 
 printf "travis_fold:start:yarn_install\nInstalling yarn dependencies\n"


### PR DESCRIPTION
jobs are starting to run on their own with `dist: trusty`. we should pin to either `dist: precise` (old) or `dist: trusty` (new).

trusty seems to fail because (I assume) it has a newer `nvm`, which is not happy with the `PREFIX` that we export while setting up ocaml. I don't think `PREFIX` needs to be set anymore after it's installed, so let's try unsetting it.