### PR TITLE
serve_website.sh script to serve the website

### DIFF
--- a/scripts/serve_website.sh
+++ b/scripts/serve_website.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -e
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+WEBSITE=$(realpath "$DIR/../website")
+export BUNDLE_GEMFILE="$WEBSITE/Gemfile"
+source "$HOME/.rvm/scripts/rvm"
+
+# We need flow.js to exist, so let's build it
+(cd "$DIR/../" && make js)
+
+FLOW_OUT_DIR=$(realpath "$DIR/../bin")
+
+rm -rf "_site/"
+rm -rf "$WEBSITE/.asset-cache"
+
+# Symlink flow.js and the flowlibs into place directly in the _site folder since
+# they are not managed by jekyll-assets.
+mkdir -p "_site/static/master"
+ln -sf "$FLOW_OUT_DIR/flow.js" "_site/static/master/flow.js"
+ln -sf "$DIR/../lib" "_site/static/master/flowlib"
+
+# PATH="$FLOW_OUT_DIR/flow:$PATH" bundle exec jekyll build --source "$WEBSITE" "$@"
+PATH="$FLOW_OUT_DIR/flow:$PATH" bundle exec jekyll serve --source "$WEBSITE" --host :: --port 8080 "$@"


### PR DESCRIPTION
This is a rough copy of an internal script which we have to serve our website. I've updated it to work in our GitHub repo.

Some setup was necessary. I mainly followed the steps from https://help.github.com/articles/setting-up-your-github-pages-site-locally-with-jekyll/

```
$ \curl -sSL https://get.rvm.io | bash # installed rvm
$ rvm install 2.3.4
$ gem install bundler
$ cd website
$ yarn
$ bundle install
$ cd ..
$ ./scripts/serve_website.sh
```