### PR TITLE
[Docs] Explain function subtyping and variance

### DIFF
--- a/website/en/docs/lang/subtypes.md
+++ b/website/en/docs/lang/subtypes.md
@@ -113,22 +113,32 @@ recursively until we can decide if we have a subtype or not.
 
 #### Subtypes of functions <a class="toc" id="toc-subtypes-of-functions" href="#toc-subtypes-of-functions"></a>
 
-Flow compares two functions by comparing its inputs and outputs. If all the
-inputs and outputs are a subset of the other function, then it is a subtype.
+The subtyping of functions is a bit trickier. So far we've used the rule that one
+type is a subtype of another if it contains all the possible values of the parent.
+It's not clear how to apply this rule to function types.
+
+For functions, we'll adopt a different way of looking at that rule: for a function
+type to be a subtype of another, it should be safe to use in all the places where
+its parent can be used.
+
+Let's say we have a function type:
 
 ```js
-type Func1 = (1 | 2)     => "A" | "B";
-type Func2 = (1 | 2 | 3) => "A" | "B" | "C";
+type Func1 = (1 | 2) => "A" | "B";
 ```
 
-This also applies to the number of parameters in the functions. If one function
-contains a subset of the parameters of the other, then the other is a subtype.
+For another function type to be a subtype of this, it must be usable in any code that
+relies on the `Func1` type. That code expects to be allowed to send `1` or `2` as
+an argument and receive back `"A"` or `"B"` as the result. For another function type
+to be a subtype, it must:
 
-```js
-// @flow
-type Func1 = (number) => void;
-type Func2 = (number, string) => void;
+- Accept _at least_ `1` and `2` as inputs, though it may also accept other values (or additional parameters)
+- Return _at most_ `"A" | "B"`, though it may only return one or the other.
 
-let func1: Func1 = (a: number) => {};
-let func2: Func2 = func1;
-```
+In general, for one function type to be a subtype of another, its inputs must be a supertype
+of the parent's, but its output must be a subtype of the parent's. (The distinction between
+input and output becomes even trickier if some of the function's arguments are themselves functions
+or are written to.)
+
+This subtyping rules for inputs and outputs are called "variance" and are the subject of the next
+section.

--- a/website/en/docs/lang/subtypes.md
+++ b/website/en/docs/lang/subtypes.md
@@ -139,7 +139,7 @@ values that `FuncType` does, so its type is a subtype of `FuncType`.
 
 In general, the function subtyping rule is this: A function type `B` is a subtype
 of a function type `A` only if `B`'s inputs are a superset of `A`'s, and `B`'s outputs
-are a subset of `B`'s. The subtype must accept _at least_ the same inputs as its parent,
+are a subset of `A`'s. The subtype must accept _at least_ the same inputs as its parent,
 and must return _at most_ the same outputs.
 
 The decision of which direction to apply the subtyping rule on inputs and outputs is

--- a/website/en/docs/lang/subtypes.md
+++ b/website/en/docs/lang/subtypes.md
@@ -113,32 +113,34 @@ recursively until we can decide if we have a subtype or not.
 
 #### Subtypes of functions <a class="toc" id="toc-subtypes-of-functions" href="#toc-subtypes-of-functions"></a>
 
-The subtyping of functions is a bit trickier. So far we've used the rule that one
-type is a subtype of another if it contains all the possible values of the parent.
-It's not clear how to apply this rule to function types.
+Subtyping rules for functions are more complicated. So far, we've seen that `A`
+is a subtype of `B` if `B` contains all possible values for `A`. For functions,
+it's not clear how this relationship would apply. To simplify things, you can think
+of a function type `A` being a subtype of a function type `B` if functions of type
+`A` can be used wherever a function of type `B` is expected.
 
-For functions, we'll adopt a different way of looking at that rule: for a function
-type to be a subtype of another, it should be safe to use in all the places where
-its parent can be used.
-
-Let's say we have a function type:
+Let's say we have a function type and a few functions. Which of the functions can
+be used safely in code that expects the given function type?
 
 ```js
-type Func1 = (1 | 2) => "A" | "B";
+type FuncType = (1 | 2) => "A" | "B";
+
+let f1: (1 | 2) => "A" | "B" | "C" = (x) => /* ... */
+let f2: (1 | null) => "A" | "B" = (x) => /* ... */
+let f3: (1 | 2 | 3) => "A" = (x) => /* ... */
 ```
 
-For another function type to be a subtype of this, it must be usable in any code that
-relies on the `Func1` type. That code expects to be allowed to send `1` or `2` as
-an argument and receive back `"A"` or `"B"` as the result. For another function type
-to be a subtype, it must:
+- `f1` can return a value that `FuncType` never does, so code that relies on `FuncType`
+might not be safe if `f1` is used. Its type is not a subtype of `FuncType`.
+- `f2` can't handle all the argument values that `FuncType` does, so code that relies on
+`FuncType` can't safely use `f2`. Its type is also not a subtype of `FuncType`.
+- `f3` can accept all the argument values that `FuncType` does, and only returns
+values that `FuncType` does, so its type is a subtype of `FuncType`.
 
-- Accept _at least_ `1` and `2` as inputs, though it may also accept other values (or additional parameters)
-- Return _at most_ `"A" | "B"`, though it may only return one or the other.
+In general, the function subtyping rule is this: A function type `B` is a subtype
+of a function type `A` only if `B`'s inputs are a superset of `A`'s, and `B`'s outputs
+are a subset of `B`'s. The subtype must accept _at least_ the same inputs as its parent,
+and must return _at most_ the same outputs.
 
-In general, for one function type to be a subtype of another, its inputs must be a supertype
-of the parent's, but its output must be a subtype of the parent's. (The distinction between
-input and output becomes even trickier if some of the function's arguments are themselves functions
-or are written to.)
-
-This subtyping rules for inputs and outputs are called "variance" and are the subject of the next
-section.
+The decision of which direction to apply the subtyping rule on inputs and outputs is
+governed by variance, which is the topic of the next section.

--- a/website/en/docs/lang/subtypes.md
+++ b/website/en/docs/lang/subtypes.md
@@ -116,7 +116,7 @@ recursively until we can decide if we have a subtype or not.
 Subtyping rules for functions are more complicated. So far, we've seen that `A`
 is a subtype of `B` if `B` contains all possible values for `A`. For functions,
 it's not clear how this relationship would apply. To simplify things, you can think
-of a function type `A` being a subtype of a function type `B` if functions of type
+of a function type `A` as being a subtype of a function type `B` if functions of type
 `A` can be used wherever a function of type `B` is expected.
 
 Let's say we have a function type and a few functions. Which of the functions can
@@ -138,7 +138,7 @@ might not be safe if `f1` is used. Its type is not a subtype of `FuncType`.
 values that `FuncType` does, so its type is a subtype of `FuncType`.
 
 In general, the function subtyping rule is this: A function type `B` is a subtype
-of a function type `A` only if `B`'s inputs are a superset of `A`'s, and `B`'s outputs
+of a function type `A` if and only if `B`'s inputs are a superset of `A`'s, and `B`'s outputs
 are a subset of `A`'s. The subtype must accept _at least_ the same inputs as its parent,
 and must return _at most_ the same outputs.
 


### PR DESCRIPTION
I'm not an expert at type theory, but trying out the previous function subtyping example seemed to convince me that it was not correct because it explained that inputs and outputs should both be subtypes, whereas inputs should actually be a super type.

I'm also not an expert at technical writing, so please let me know (or just edit) if my tone and style don't fit with the rest of the docs.

I tried to add a light explanation of function subtyping that might help for simple cases, while still pointing to the Variance page for a more detailed discussion. 

(Note that, in reading the Variance page, I notice that it mostly focuses on variance as applied to OO class hierarchies. I think there might be room for a simpler explanation of function input/output types. There is also probably a need for some examples of just functions with complex cases: arguments that are callbacks, whose arguments are in output position and therefore covariant, arguments that are written to, and therefore invariant, etc.)

