### PR TITLE
Fix exported type of React.StatelessFunctionalComponent

### DIFF
--- a/lib/react.js
+++ b/lib/react.js
@@ -123,8 +123,8 @@ declare class LegacyReactComponent<Props, State>
  */
 declare type React$StatelessFunctionalComponent<Props> = {
   (props: Props, context: any): React$Node,
-
   propTypes?: $Subtype<{[_: $Keys<Props>]: any}>,
+  contextTypes?: any
 };
 
 /**
@@ -201,8 +201,8 @@ declare module react {
 
   declare export var Component: typeof React$Component;
   declare export var PureComponent: typeof React$PureComponent;
-  declare export type StatelessFunctionalComponent<P, C> =
-    React$StatelessFunctionalComponent<P, C>;
+  declare export type StatelessFunctionalComponent<P> =
+    React$StatelessFunctionalComponent<P>;
   declare export type ComponentType<P> = React$ComponentType<P>;
   declare export type ElementType = React$ElementType;
   declare export type Element<C> = React$Element<C>;

--- a/tests/react_functional/test.js
+++ b/tests/react_functional/test.js
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 
 function F(props: { foo: string }) {}
 <F />; // error: missing `foo`
@@ -11,3 +11,7 @@ function G(props: { foo: string|numner }) {}
 
 var Z = 0;
 <Z />; // error, expected React component
+
+// Ensure StatelessFunctionalComponent type is usable
+const H: React.StatelessFunctionalComponent<{foo: string}> = (props) => {};
+<H foo=""/>; // ok


### PR DESCRIPTION
Resolves #4650.

I don't know if the `C` type variable was intended to model something else, but it was not used and seemingly causing a lot of problems. Removing it made things work as (I, at least) expected.

I also noticed that the tests previously did not contain any explicit usages of `StatelessFunctionalComponent`, which is presumably how this wasn't noticed. So I added a new test using that type, which passes only after this commit.

(I've also added the contextTypes as an optional value on a stateless functional component following the pattern currently used for full Components. That could be committed separately, but I thought it was worth adding while I was in there...)