### PR TITLE
Fix IntersectionObserver constructor definition

### DIFF
--- a/lib/bom.js
+++ b/lib/bom.js
@@ -407,7 +407,7 @@ declare type IntersectionObserverOptions = {
 declare class IntersectionObserver {
     constructor(
       callback: IntersectionObserverCallback,
-      options: IntersectionObserverOptions
+      options?: IntersectionObserverOptions
     ): void,
     observe(target: HTMLElement): void,
     unobserve(): void,


### PR DESCRIPTION
The options argument in IntersectionObserver's constructor should be optional:
https://wicg.github.io/IntersectionObserver/#intersection-observer-interface