### PR TITLE
Update EventTarget definition to extend HTMLElement

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -154,7 +154,7 @@ type EventListenerOptionsOrUseCapture = boolean | {
   passive?: boolean
 };
 
-declare class EventTarget {
+declare class EventTarget extends HTMLElement {
   addEventListener(type: MouseEventTypes, listener: MouseEventListener, optionsOrUseCapture?: EventListenerOptionsOrUseCapture): void;
   addEventListener(type: FocusEventTypes, listener: FocusEventListener, optionsOrUseCapture?: EventListenerOptionsOrUseCapture): void;
   addEventListener(type: KeyboardEventTypes, listener: KeyboardEventListener, optionsOrUseCapture?: EventListenerOptionsOrUseCapture): void;


### PR DESCRIPTION
```js
document.body.addEventListener('click', event => {
  console.log(event.target instanceof HTMLElement); // true
});
```

> Note: Hi this is @thejameskyle