### PR TITLE
fix return type for AudioContext.createMediaStreamDestination()

### DIFF
--- a/lib/bom.js
+++ b/lib/bom.js
@@ -652,7 +652,7 @@ declare class AudioContext {
   createBufferSource(myMediaElement?: HTMLMediaElement): AudioBufferSourceNode;
   createMediaElementSource(myMediaElement: HTMLMediaElement): MediaElementAudioSourceNode;
   createMediaStreamSource(): MediaStreamAudioSourceNode;
-  createMediaStreamDestination(): MediaStream;
+  createMediaStreamDestination(): MediaStreamAudioDestinationNode;
   createScriptProcessor(bufferSize: number, numberOfInputChannels: number, numberOfOutputChannels: number): ScriptProcessorNode;
   createAnalyser(): AnalyserNode;
   createBiquadFilter(): BiquadFilterNode;
@@ -779,6 +779,10 @@ declare class MediaStreamTrack {
 
 declare class MediaElementAudioSourceNode extends AudioNode {}
 declare class MediaStreamAudioSourceNode extends AudioNode {}
+
+declare class MediaStreamAudioDestinationNode extends AudioNode {
+  stream: MediaStream;
+}
 
 declare class ScriptProcessorNode extends AudioNode {
   bufferSize: number;


### PR DESCRIPTION
Fix return type for [`AudioContext.createMediaStreamDestination()`].

master: [`MediaStream`]
patch: [`MediaStreamAudioDestinationNode`]

[`AudioContext.createMediaStreamDestination()`]: https://developer.mozilla.org/docs/Web/API/AudioContext/createMediaStreamDestination

[`MediaStream`]: https://developer.mozilla.org/docs/Web/API/MediaStream

[`MediaStreamAudioDestinationNode`]: https://developer.mozilla.org/docs/Web/API/MediaStreamAudioDestinationNode