### PR TITLE
add captureStream() to HTMLCanvasElement and HTMLMediaElement

### DIFF
--- a/lib/bom.js
+++ b/lib/bom.js
@@ -737,6 +737,11 @@ declare class AudioBufferSourceNode extends AudioNode {
   stop(when?: number): void;
 }
 
+declare class CanvasCaptureMediaStream extends MediaStream {
+  canvas: HTMLCanvasElement;
+  requestFrame(): void;
+}
+
 declare class MediaStream extends EventTarget {
   active: bool;
   ended: bool;

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -2681,6 +2681,7 @@ declare class HTMLMediaElement extends HTMLElement {
   play(): Promise<void>;
   pause(): void;
   fastSeek(): void;
+  captureStream(): MediaStream;
 
   // media controller
   mediaGroup: string;

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -2454,6 +2454,7 @@ declare class HTMLCanvasElement extends HTMLElement {
   getContext(contextId: string, ...args: any): ?RenderingContext; // fallback
   toDataURL(type?: string, ...args: any): string;
   toBlob(callback: (v: File) => void, type?: string, ...args: any): void;
+  captureStream(frameRate?: number): CanvasCaptureMediaStream;
 }
 
 // https://html.spec.whatwg.org/multipage/forms.html#the-details-element


### PR DESCRIPTION
Add `captureStream()` method to [`HTMLCanvasElement`] and [`HTMLMediaElement`].

[`HTMLCanvasElement`]: https://developer.mozilla.org/docs/Web/API/HTMLCanvasElement/captureStream

[`HTMLMediaElement`]: https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/captureStream