### PR TITLE
Add how to extend the constructor and prototype

### DIFF
--- a/website/en/docs/types/classes.md
+++ b/website/en/docs/types/classes.md
@@ -62,6 +62,24 @@ class MyClass {
 }
 ```
 
+Fields added ouside of the class definition need to be annotated within the body
+of the class.
+
+```js
+// @flow
+function func_we_use_everywhere (x: number): number {
+  return x + 1;
+}
+class MyClass {
+  static constant: number;
+  static helper: (number) => number;
+  method: number => number;
+}
+MyClass.helper = func_we_use_everywhere
+MyClass.constant = 42
+MyClass.prototype.method = func_we_use_everywhere
+```
+
 Flow also supports using the [class properties syntax](https://tc39.github.io/proposal-class-public-fields/).
 
 ```js


### PR DESCRIPTION
Addressing issue #4717.
These changes make it clear how to extend the prototype and constructor of a class. Methods added in the class declaration do not need to be annotated. At this time, methods and properties defined on the constructor (static) and on the prototype need to be annotated in the class definition. This is probably a best practice since, if the class is modified in a location not local to the definition we will want the type checker to notify us.