### PR TITLE
Fixes issue where flow-upgrade would not check .jsx files

### DIFF
--- a/packages/flow-upgrade/src/findFlowFiles.js
+++ b/packages/flow-upgrade/src/findFlowFiles.js
@@ -87,9 +87,11 @@ module.exports = function findFlowFiles(
             processDirectory(filePath);
           }
         } else if (stats.isFile()) {
-          // Otherwise if this is a JavaScript file and it is not an ignored
+          // Otherwise if this is a JavaScript/JSX file and it is not an ignored
           // JavaScript file...
-          if (fileName.endsWith('.js') && !fileName.endsWith('-flowtest.js')) {
+          const fileIsJsOrJsx = /\.jsx?$/.test(fileName);
+          const fileIsIgnored = fileName.endsWith('-flowtest.js');
+          if (fileIsJsOrJsx && !fileIsIgnored) {
             // Then process the file path as JavaScript.
             processJavaScriptFilePath(filePath, stats.size);
           }


### PR DESCRIPTION
Fixes #4637 (see also #4724).

flow-upgrade was skipping over `.jsx` files. This PR allows the `.jsx` file extension to be a valid extension.