### PR TITLE
React$Element type param default to React$ElementType

### DIFF
--- a/lib/react.js
+++ b/lib/react.js
@@ -156,7 +156,7 @@ declare type React$ElementType =
  * Type of a React element. React elements are commonly created using JSX
  * literals, which desugar to React.createElement calls (see below).
  */
-declare type React$Element<+ElementType: React$ElementType> = {|
+declare type React$Element<+ElementType: React$ElementType = React$ElementType> = {|
   +type: ElementType,
   +props: React$ElementProps<ElementType>,
   +key: React$Key | null,


### PR DESCRIPTION
This will allow you to do:

```js
type Props = {
  foo: React.Element
};
```

in order to accept any valid element type if you don't care to be more specific

[Example](https://flow.org/try/#0PQKgBAAgZgNg9gdzCYAoVBLAtgBzgJwBdkwBDAZzACUBTUgY2KnzizAHJ87H2BudQgE8cNMAAUWOSgF4wAb1RgwUOHABc1boQB0AURg0sNAHaEAPLQY79hk4QAqwmgD4ANKgC+-VDQAeeIjAAExooUgBXGGJ6GApKAFlBAGFWPGM7MD9CEyDKS0ZtFNw4dNMzCTgpZ3lFMGBgMG0mz3QDaIBGMFkzRKK0jJU4aTkzIIwAN2BnDyn+NrB6ACYusB7k1JKB1WGzchxSYymZ514gA)