### PR TITLE
Render typeinfo as text rather than HTML

### DIFF
--- a/website/_assets/js/tryFlow.js.es6.liquid
+++ b/website/_assets/js/tryFlow.js.es6.liquid
@@ -348,11 +348,11 @@ function createEditor(
       ))
       .then(typeAtPos => {
         typeAtPosNode.title = typeAtPos ? typeAtPos[1].c : '';
-        typeAtPosNode.innerHTML = typeAtPos ? typeAtPos[1].c : '';
+        typeAtPosNode.textContent = typeAtPos ? typeAtPos[1].c : '';
       })
       .catch(() => {
         typeAtPosNode.title = '';
-        typeAtPosNode.innerHTML = '';
+        typeAtPosNode.textContent = '';
       });
     });
 


### PR DESCRIPTION
https://flow.org/try/ prints type information of item under the cursor but information was rendered by updating `innerHTML` which leads to incorrect rendering as `Array<string>` would render Array string and `string` element. Using `.textContent`  instead will render text `Array<string>` instead.