### PR TITLE
Change definition for node cluster module workers

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -340,7 +340,9 @@ declare module "cluster" {
       gid: number;
     };
     worker: cluster$Worker;
-    workers: Object;
+    workers: {
+        [id: number]: cluster$Worker;
+    };
 
     disconnect(callback?: () => void): void;
     fork(env?: Object): cluster$Worker;


### PR DESCRIPTION
The following diff:

```js
    if (cluster.isMaster) {
        Object.values(cluster.workers).forEach(worker => {
            worker.on('message', msg => {
                if (msg.dumpMasterMemory) {
                    dumpMemory();
                }
            });
        });
    }
```

Produces the following error: (flow 0.53.1)

```
                 v----------------------------
 39:             worker.on('message', msg => {
 40:                 if (msg.dumpMasterMemory) {
 41:                     dumpMemory();
 42:                 }
 43:             });
                 -^ call of method `on`. Method cannot be called on
 39:             worker.on('message', msg => {
                 ^^^^^^ mixed
````

Looking at the def, it shows `workers` as `Object`: https://github.com/facebook/flow/blob/v0.53.1/lib/node.js#L343

The node docs also shows only `Object`, but describes the type of the object:
https://nodejs.org/api/cluster.html#cluster_cluster_workers

Would updating the flow def as such be appropriate?

Thanks!