### PR TITLE
Fix Http_lite to work on Windows

### DIFF
--- a/hack/utils/http_lite.ml
+++ b/hack/utils/http_lite.ml
@@ -85,6 +85,9 @@ let read_message_utf8 (reader: Buffered_line_reader.t) : string =
 
 (** write_message: writes "Content-Length:...body" *)
 let write_message (outchan: out_channel) (body: string) : unit =
+  (* Without this, Windows will change the \r\n to \r\r\n *)
+  Pervasives.set_binary_mode_out outchan true;
+
   Printf.fprintf outchan "Content-Length: %n\r\n" (String.length body);
   Printf.fprintf outchan "\r\n";
   Printf.fprintf outchan "%s" body;


### PR DESCRIPTION
`flow ide` wasn't working on Windows because our HTTP headers output CRCRLF instead of CRLF. This is because the output channel was in text mode, which converts LF to CRLF on output ([Microsoft docs](https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/setmode)).

Anyway, hopefully this fixes.