### PR TITLE
Support named imports properly with flow-upgrade codemod

### DIFF
--- a/packages/flow-upgrade/src/upgrades/0.53.0/ReactUtilityTypes/__tests__/__snapshots__/codemod-test.js.snap
+++ b/packages/flow-upgrade/src/upgrades/0.53.0/ReactUtilityTypes/__tests__/__snapshots__/codemod-test.js.snap
@@ -29,7 +29,7 @@ const expression2 = () =>
 `;
 
 exports[`HiddenInSuperClassTypeArgs.js 3`] = `
-"import React, {PropTypes} from 'react';
+"import * as React from 'react';
 
 class Buz {}
 class Foo extends Bar<React.Element<any>> {}
@@ -215,7 +215,7 @@ function create(): React.ComponentType<any> {}
 `;
 
 exports[`ReactClass.js 3`] = `
-"import React, {PropTypes} from 'react';
+"import * as React from 'react';
 
 function create(): React.ComponentType<any> {}
 "
@@ -331,7 +331,7 @@ exports[`ReactComponent.js 2`] = `
 `;
 
 exports[`ReactComponent.js 3`] = `
-"import React, {PropTypes} from 'react';
+"import * as React from 'react';
 
 (any: React.Component<Props, State>);
 (any: React.Component<Props, State>);
@@ -625,7 +625,7 @@ class N extends React.Component {
 `;
 
 exports[`ReactComponentRenderReturn.js 3`] = `
-"import React, {PropTypes} from 'react';
+"import * as React from 'react';
 
 class A extends React.Component {
   render(): React.Node {}
@@ -1435,7 +1435,7 @@ exports[`ReactElement.js 2`] = `
 `;
 
 exports[`ReactElement.js 3`] = `
-"import React, {PropTypes} from 'react';
+"import * as React from 'react';
 
 (any: React.Element<React.ComponentType<Config>>);
 (any: React.Element<React.ComponentType<Props>>);
@@ -1905,7 +1905,7 @@ class X {
 `;
 
 exports[`ReactNodeWithTypeArgs.js 3`] = `
-"import React, {PropTypes} from 'react';
+"import * as React from 'react';
 
 class X {
   render(): ?React.Node {
@@ -2063,7 +2063,7 @@ class X {
 `;
 
 exports[`ReactNodeWithoutTypeArgs.js 3`] = `
-"import React, {PropTypes} from 'react';
+"import * as React from 'react';
 
 class X {
   render(): ?React.Node {
@@ -2243,7 +2243,7 @@ class MyComponent {
 `;
 
 exports[`SyntheticEvent.js 3`] = `
-"import React, {PropTypes} from 'react';
+"import * as React from 'react';
 
 class MyComponent {
   onEvent = (event: SyntheticEvent<>) => console.log('yo');

--- a/packages/flow-upgrade/src/upgrades/0.53.0/ReactUtilityTypes/__tests__/default-import-with-named-imports-test.js
+++ b/packages/flow-upgrade/src/upgrades/0.53.0/ReactUtilityTypes/__tests__/default-import-with-named-imports-test.js
@@ -1,0 +1,43 @@
+/**
+ * @format
+ */
+
+'use strict';
+
+const path = require('path');
+const fs = require('fs');
+const cp = require('child_process');
+const jscodeshiftFlowParser = require('jscodeshift/parser/flow');
+const jscodeshift = require('jscodeshift').withParser(jscodeshiftFlowParser);
+const transform = require('../codemod');
+
+const JSCODESHIFT_BIN = path.resolve(
+  __dirname,
+  '../../node_modules/.bin/jscodeshift',
+);
+
+test('default import with named imports', () => {
+  const source = `
+    import ReactImport, {Component, Element as ReactElement} from 'react';
+
+    class SomeComponent extends Component {
+      props: {
+        children?: ReactElement<any>
+      };
+    }
+  `
+
+  const expectedOutput = `
+    import * as ReactImport from 'react';
+
+    class SomeComponent extends ReactImport.Component {
+      props: {
+        children?: ReactImport.Element<any>
+      };
+    }
+  `
+
+  const root = jscodeshift(source);
+  transform(jscodeshift, root);
+  expect(root.toSource()).toEqual(expectedOutput);
+});

--- a/packages/flow-upgrade/src/upgrades/0.53.0/ReactUtilityTypes/codemod.js
+++ b/packages/flow-upgrade/src/upgrades/0.53.0/ReactUtilityTypes/codemod.js
@@ -73,6 +73,7 @@ module.exports = (j, root) => {
       node.source &&
       node.source.type === 'Literal' &&
       node.source.value === 'react' &&
+      node.specifiers.length >= 1 &&
       node.specifiers[0].type === 'ImportDefaultSpecifier'
     ) {
       const reactImportName = node.specifiers[0].local;

--- a/packages/flow-upgrade/src/upgrades/0.53.0/ReactUtilityTypes/codemod.js
+++ b/packages/flow-upgrade/src/upgrades/0.53.0/ReactUtilityTypes/codemod.js
@@ -87,12 +87,12 @@ module.exports = (j, root) => {
         // import * as React from 'react';
         // class SomeComponent extends React.Component {}
         const namedImportsToQualifiedIdentifiers = new Map();
-        const namedImports = node.specifiers
+        node.specifiers
           .slice(1)
-          .map(sp => [sp.imported.name, sp.local.name]);
-        namedImports.forEach(([importName, localName]) => {
-          namedImportsToQualifiedIdentifiers.set(localName, importName);
-        });
+          .map(sp => [sp.imported.name, sp.local.name])
+          .forEach(([importName, localName]) => {
+            namedImportsToQualifiedIdentifiers.set(localName, importName);
+          });
         node.specifiers = [j.importNamespaceSpecifier(reactImportName)];
 
         root


### PR DESCRIPTION
This PR fixes #4786 by removing named imports and changing the affected identifiers to use `React.X` directly. Basically, this is the solution A specified in the linked issue.

With this fix in place, flow can now find the `React.Element` and other helper types as is documented.