### PR TITLE
Adding DefaultProps Typing Back

### DIFF
--- a/lib/react.js
+++ b/lib/react.js
@@ -26,9 +26,9 @@ declare type React$Node =
  * Base class of ES6 React classes, modeled as a polymorphic class whose main
  * type parameters are Props and State.
  */
-declare class React$Component<Props, State = void> {
+declare class React$Component<Props, DefaultProps = *, State = void> {
   // fields
-
+  static defaultProps: DefaultProps;
   props: Props;
   state: State;
 
@@ -78,20 +78,15 @@ declare class React$Component<Props, State = void> {
   static contextTypes: any;
   static propTypes: $Subtype<{[_: $Keys<Props>]: any}>;
 
-  // We don't add a type for `defaultProps` so that its type may be entirely
-  // inferred when we diff the type for `defaultProps` with `Props`. Otherwise
-  // the user would need to define a type (which would be redundant) to override
-  // the type we provide here in the base class.
-  //
-  // static defaultProps: $Shape<Props>;
 }
 
-declare class React$PureComponent<Props, State = void>
-  extends React$Component<Props, State> {
+declare class React$PureComponent<Props, DefaultProps = *, State = void>
+  extends React$Component<Props, DefaultProps, State> {
   // TODO: Due to bugs in Flow's handling of React.createClass, some fields
   // already declared in the base class need to be redeclared below. Ideally
   // they should simply be inherited.
 
+  static defaultProps: DefaultProps;
   props: Props;
   state: State;
 }
@@ -100,8 +95,8 @@ declare class React$PureComponent<Props, State = void>
  * Base class of legacy React classes, which extends the base class of ES6 React
  * classes and supports additional methods.
  */
-declare class LegacyReactComponent<Props, State>
-  extends React$Component<Props, State> {
+declare class LegacyReactComponent<Props, DefaultProps, State>
+  extends React$Component<Props, DefaultProps, State> {
   // additional methods
 
   replaceState(state: State, callback?: () => void): void;
@@ -112,6 +107,7 @@ declare class LegacyReactComponent<Props, State>
   // already declared in the base class need to be redeclared below. Ideally
   // they should simply be inherited.
 
+  static defaultProps: DefaultProps;
   props: Props;
   state: State;
 }
@@ -121,8 +117,9 @@ declare class LegacyReactComponent<Props, State>
  * are a single function. However, they may have some static properties that we
  * can type check.
  */
-declare type React$StatelessFunctionalComponent<Props> = {
+declare type React$StatelessFunctionalComponent<Props, DefaultProps = *> = {
   (props: Props, context: any): React$Node,
+  defaultProps: DefaultProps,
   displayName?: ?string,
   propTypes?: $Subtype<{[_: $Keys<Props>]: any}>,
   contextTypes?: any
@@ -136,9 +133,9 @@ declare type React$StatelessFunctionalComponent<Props> = {
  * - ES6 class component. Components with state defined either using the ES6
  *   class syntax, or with the legacy `React.createClass()` helper.
  */
-declare type React$ComponentType<Props> =
-  | React$StatelessFunctionalComponent<Props>
-  | Class<React$Component<Props, any>>;
+declare type React$ComponentType<Props, DefaultProps = *> =
+  | React$StatelessFunctionalComponent<Props, DefaultProps>
+  | Class<React$Component<Props, DefaultProps, *>>;
 
 /**
  * The type of an element in React. A React element may be a:
@@ -150,7 +147,7 @@ declare type React$ComponentType<Props> =
  */
 declare type React$ElementType =
   | $Keys<$JSXIntrinsics>
-  | React$ComponentType<any>;
+  | React$ComponentType<*, *>;
 
 /**
  * Type of a React element. React elements are commonly created using JSX
@@ -202,9 +199,9 @@ declare module react {
 
   declare export var Component: typeof React$Component;
   declare export var PureComponent: typeof React$PureComponent;
-  declare export type StatelessFunctionalComponent<P> =
-    React$StatelessFunctionalComponent<P>;
-  declare export type ComponentType<P> = React$ComponentType<P>;
+  declare export type StatelessFunctionalComponent<P, D = *> =
+    React$StatelessFunctionalComponent<P, D>;
+  declare export type ComponentType<P, D = *> = React$ComponentType<P, D>;
   declare export type ElementType = React$ElementType;
   declare export type Element<C> = React$Element<C>;
   declare export type Key = React$Key;
@@ -256,7 +253,7 @@ declare module React {
 
 declare module 'react-dom' {
   declare function findDOMNode(
-    componentOrElement : Element | ?React$Component<any, any>,
+    componentOrElement : Element | ?React$Component<*, *, *>,
   ): null | Element | Text;
 
   declare function render<ElementType: React$ElementType>(
@@ -279,7 +276,7 @@ declare module 'react-dom' {
   declare function unstable_renderSubtreeIntoContainer<
     ElementType: React$ElementType,
   >(
-    parentComponent: React$Component<any, any>,
+    parentComponent: React$Component<*, *, *>,
     nextElement: React$Element<ElementType>,
     container: any,
     callback?: () => void


### PR DESCRIPTION
After doing a pretty large [Styled Components](https://github.com/styled-components/styled-components) refactor (PR [#1194](https://github.com/flowtype/flow-typed/pull/1194/)), which includes updates for Flow v0.53+, I started started to view HOCs differently.

For the following example, let's consider a ``React$StatelessFunctionalComponent `` supertype for simplicity.

```js
declare type SimpleComponent<Props> = {
  (Props): React$Node,
}
```
A HOC is a pure function that takes a callable object as input and returns a callable object as output. With the current set of library definitions, a HOC would be typed as:

```js
declare type Foo = { foo: 'foo' }
declare var HOC:
  <Props: Foo>(SimpleComponent<Props>) => SimpleComponent<$Diff<Props, Foo>>
```
This is effectively a transformation from ``{ $call: Foo => React$Node }`` to ``{ $call: void => React$Node }``.

This is a lossy type morphism that throws away information related to ``Foo``.

I'd like to _politely_ 😀 disagree with...
```js
  // We don't add a type for `defaultProps` so that its type may be entirely
  // inferred when we diff the type for `defaultProps` with `Props`. Otherwise
  // the user would need to define a type (which would be redundant) to override
  // the type we provide here in the base class.
```
https://github.com/facebook/flow/blob/master/lib/react.js#L81-L84

Is there any reason ``DefaultProps`` has to be a supertype of ``Props``?

---

Let's look at a new example & consider modeling ``DefaultProps`` orthogonally to ``Props`` for a moment...
```js
declare type Component<Props, DefaultProps> = {
  (Props): React$Node,
  defaultProps: DefaultProps,
}
```
```js
declare type Foo = { foo: 'foo' }
declare var HOC:
  <Props: Foo, DefaultProps: {}>(Component<Props, DefaultProps>) =>
    Component<$Diff<Props, Foo>, DefaultProps & Foo>
```

This is effectively a transformation from ``{ $call: Foo => React$Node, defaultProps: {} }`` to ``{ $call: void => React$Node, defaultProps: Foo }``.

This is now a lossless type morphism that retains all type information related to ``Foo``.

---

Contrived Example:

```js
declare type DB = { database: * }

declare var needsComponentWithDatabaseConnectionDependency: <Props: DB>(
   | Component<Props, *>
   | Component<*, Props>
) => void

declare var providesDatabaseConnection: <Props: DB>(SimpleComponent<Props>) => SimpleComponent<$Diff<Props, DB>>

declare var NeedsDBComponent: SimpleComponent<DB>

var TestComponent = providesDatabaseConnection(NeedsDBComponent)
// <TestComponent /> // <— valid

needsComponentWithDatabaseConnectionDependency(TestComponent) // ERROR
```