### PR TITLE
Add types for File and Directory Entries API

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -52,6 +52,7 @@ declare class File extends Blob {
   ): void;
   lastModifiedDate: any;
   name: string;
+  webkitRelativePath: string; // readonly
 }
 
 declare class FileList {
@@ -60,6 +61,52 @@ declare class FileList {
   item(index: number): File;
   [index: number]: File;
 }
+
+/* 
+ * File and Directory Entries API 
+ * https://wicg.github.io/entries-api/ 
+ */
+
+declare class FileSystemEntry {
+  isFile: boolean;  // readonly
+  isDirectory: boolean;  // readonly
+  name: string;  // readonly
+  fullPath: string;  // readonly
+  filesystem: FileSystem; // readonly
+}
+
+declare type FileSystemFlags = {
+  /* The create member of FileSystemFlags and the associated behavior are included for compatibility with existing implementations, even though there is no useful behavior when the flag is specified. Similarly, the exclusive member is not explicitly referenced, but the binding behavior is observable from script if an object with a getter is passed. */
+  create?: bool;
+  exclusive?: bool;
+};
+
+declare class FileSystem {
+  name: string; // readonly
+  root: FileSystemDirectoryEntry; // readonly
+};
+
+declare class FileSystemFileEntry extends FileSystemEntry {
+  file(successCallback: File => void, errorCallback?: DOMError => void): void,
+}
+
+declare class FileSystemDirectoryEntry extends FileSystemEntry {
+  createReader(): FileSystemDirectoryReader;
+
+  getFile(path?: string,
+    options?: FileSystemFlags,
+    successCallback?: FileSystemFlieEntry => void,
+    errorCallback?: DOMError => void): void;
+
+  getDirectory(path?: string,
+    options?: FileSystemFlags,
+    successCallback?: FileSystemDirectoryEntry => void,
+    errorCallback?: DOMError => void): void;
+}
+
+declare class FileSystemDirectoryReader {
+  readEntries(successCallback?: FileSystemEntry[] => void, errorCallback?: DOMError => void): void;
+};
 
 /* DataTransfer */
 
@@ -90,12 +137,14 @@ declare class DataTransferItem {
   type: string; // readonly
   getAsString(_callback: ?(data: string) => mixed): void;
   getAsFile(): ?File;
+  webkitGetAsEntry(): ?FileSystemEntry;
+  getAsEntry(): ?FileSystemEntry;
 };
 
 /* DOM */
 
-declare class DOMError {
-  name: string;
+declare class DOMError extends Error {
+  code: number;
 }
 
 declare type ElementDefinitionOptions = {
@@ -2752,6 +2801,8 @@ declare class HTMLInputElement extends HTMLElement {
   dirname: string;
   disabled: boolean;
   dynsrc: string;
+  webkitDirectory: boolean;
+  webkitEntries: $ReadOnlyArray<FileSystemEntry>; // readonly
   files: FileList;
   form: HTMLFormElement | null;
   formAction: string;


### PR DESCRIPTION
I am not sure whether this is appropriate merge into flow core since it's an experimental API, but I wrote these types for internal use and thought they would be useful to others.

The change to `DOMError` is based on links in specs to IDL  [DOMException](https://heycam.github.io/webidl/#idl-DOMException), though I am not an expert on such matters, would be happy to separate it from this PR.