### PR TITLE
Allow React lifecycle methods to return mixed

### DIFF
--- a/lib/react.js
+++ b/lib/react.js
@@ -43,12 +43,12 @@ declare class React$Component<Props, State = void> {
 
   constructor(props?: Props, context?: any): void;
   render(): React$Node;
-  componentWillMount(): void;
-  componentDidMount(): void;
+  componentWillMount(): mixed;
+  componentDidMount(): mixed;
   componentWillReceiveProps(
     nextProps: Props,
     nextContext: any,
-  ): void;
+  ): mixed;
   shouldComponentUpdate(
     nextProps: Props,
     nextState: State,
@@ -58,13 +58,13 @@ declare class React$Component<Props, State = void> {
     nextProps: Props,
     nextState: State,
     nextContext: any,
-  ): void;
+  ): mixed;
   componentDidUpdate(
     prevProps: Props,
     prevState: State,
     prevContext: any,
-  ): void;
-  componentWillUnmount(): void;
+  ): mixed;
+  componentWillUnmount(): mixed;
 
   // long tail of other stuff not modeled very well
 


### PR DESCRIPTION
Resolves #1803

This will allow people to write stuff like:

```js
class Component extends React.Component {
  async componentDidMount() {
    // ...
  }
}
```