### PR TITLE
Fix compile error with js_of_ocaml 3.0.0

### DIFF
--- a/src/flow_dot_js.ml
+++ b/src/flow_dot_js.ml
@@ -319,7 +319,7 @@ let exports =
     exports
   end
 let () = Js.Unsafe.set exports "registerFile" (
-  Js.wrap_callback (fun name content -> Sys_js.register_file ~name ~content)
+  Js.wrap_callback (fun name content -> Sys_js.create_file ~name ~content)
 )
 let () = Js.Unsafe.set exports
   "setLibs" (Js.wrap_callback set_libs_js)


### PR DESCRIPTION
- fix the compilation due to js_of_ocaml release 3.0.0
- function `register_file ` has been rename to `create_file` from [this commit](https://github.com/ocsigen/js_of_ocaml/commit/0ec170a1e99a2a46c77e27acec3819f23ee26d3c#diff-d2e23ea6522b0a11150fef3a2214cc08)