### PR TITLE
Normalize `;` vs `,` in interface separators

### DIFF
--- a/website/en/docs/types/interfaces.md
+++ b/website/en/docs/types/interfaces.md
@@ -48,7 +48,7 @@ class.
 ```js
 // @flow
 interface Serializable {
-  serialize(): string
+  serialize(): string;
 }
 
 class Foo implements Serializable {
@@ -89,7 +89,7 @@ You can add methods to interfaces following the same syntax as object methods.
 
 ```js
 interface MyInterface {
-  method(value: string): number
+  method(value: string): number;
 }
 ```
 
@@ -100,7 +100,7 @@ properties.
 
 ```js
 interface MyInterface {
-  property: string
+  property: string;
 }
 ```
 
@@ -108,7 +108,7 @@ Interface properties can be optional as well.
 
 ```js
 interface MyInterface {
-  property?: string
+  property?: string;
 }
 ```
 
@@ -119,7 +119,7 @@ way as with objects.
 
 ```js
 interface MyInterface {
-  [key: string]: number
+  [key: string]: number;
 }
 ```
 
@@ -129,8 +129,8 @@ Interfaces can also have their own [generics](../generics/).
 
 ```js
 interface MyInterface<A, B, C> {
-  property: A,
-  method(val: B): C,
+  property: A;
+  method(val: B): C;
 }
 ```
 
@@ -140,9 +140,9 @@ When you use an interface you need to pass parameters for each of its generics.
 ```js
 // @flow
 interface MyInterface<A, B, C> {
-  foo: A,
-  bar: B,
-  baz: C,
+  foo: A;
+  bar: B;
+  baz: C;
 }
 
 var val: MyInterface<number, boolean, string> = {
@@ -162,8 +162,8 @@ can add modifiers to make them covariant (read-only) or contravariant
 
 ```js
 interface MyInterface {
-  +covariant: number,     // read-only
-  -contravariant: number  // write-only
+  +covariant: number;     // read-only
+  -contravariant: number; // write-only
 }
 ```
 
@@ -174,7 +174,7 @@ property name.
 
 ```js
 interface MyInterface {
-  +readOnly: number | string
+  +readOnly: number | string;
 }
 ```
 

--- a/website/en/docs/types/interfaces.md
+++ b/website/en/docs/types/interfaces.md
@@ -48,7 +48,7 @@ class.
 ```js
 // @flow
 interface Serializable {
-  serialize(): string;
+  serialize(): string
 }
 
 class Foo implements Serializable {
@@ -89,7 +89,7 @@ You can add methods to interfaces following the same syntax as object methods.
 
 ```js
 interface MyInterface {
-  method(value: string): number;
+  method(value: string): number
 }
 ```
 
@@ -100,7 +100,7 @@ properties.
 
 ```js
 interface MyInterface {
-  property: string;
+  property: string
 }
 ```
 
@@ -108,7 +108,7 @@ Interface properties can be optional as well.
 
 ```js
 interface MyInterface {
-  property?: string;
+  property?: string
 }
 ```
 
@@ -119,7 +119,7 @@ way as with objects.
 
 ```js
 interface MyInterface {
-  [key: string]: number;
+  [key: string]: number
 }
 ```
 
@@ -162,8 +162,8 @@ can add modifiers to make them covariant (read-only) or contravariant
 
 ```js
 interface MyInterface {
-  +covariant: number;     // read-only
-  -contravariant: number; // write-only
+  +covariant: number,     // read-only
+  -contravariant: number  // write-only
 }
 ```
 
@@ -174,7 +174,7 @@ property name.
 
 ```js
 interface MyInterface {
-  +readOnly: number | string;
+  +readOnly: number | string
 }
 ```
 
@@ -183,8 +183,8 @@ This allows you to pass a more specific type in place of that property.
 ```js
 // @flow
 // $ExpectError
-interface Invariant {  property: number | string; }
-interface Covariant { +readOnly: number | string; }
+interface Invariant {  property: number | string }
+interface Covariant { +readOnly: number | string }
 
 var value1: Invariant = { property: 42 }; // Error!
 var value2: Covariant = { readOnly: 42 }; // Works!
@@ -195,8 +195,8 @@ when used. Which can be useful over normal properties.
 
 ```js
 // @flow
-interface Invariant {  property: number | string; }
-interface Covariant { +readOnly: number | string; }
+interface Invariant {  property: number | string }
+interface Covariant { +readOnly: number | string }
 
 function method1(value: Invariant) {
   value.property;        // Works!
@@ -225,8 +225,8 @@ This allows you to pass a less specific type in place of that property.
 
 ```js
 // @flow
-interface Invariant     {  property: number; }
-interface Contravariant { -writeOnly: number; }
+interface Invariant     {  property: number }
+interface Contravariant { -writeOnly: number }
 
 var numberOrString = Math.random() > 0.5 ? 42 : 'forty-two';
 
@@ -239,8 +239,8 @@ Because of how contravariance works, contravariant properties also become
 write-only when used. Which can be useful over normal properties.
 
 ```js
-interface Invariant     {   property: number; }
-interface Contravariant { -writeOnly: number; }
+interface Invariant     {   property: number }
+interface Contravariant { -writeOnly: number }
 
 function method1(value: Invariant) {
   value.property;        // Works!


### PR DESCRIPTION
The interface docs was inconsistent, it uses `;` and `,` as separators interchangeably. This PR normalizes the entire document to use `,`, which is what prettier does and what I've seen most used in flow codebases.