### PR TITLE
allow async functions for react lifecycle hooks CWM, CDM and CWUN

### DIFF
--- a/lib/react.js
+++ b/lib/react.js
@@ -44,8 +44,8 @@ declare class React$Component<Props, State = void> {
 
   constructor(props?: Props, context?: any): void;
   render(): React$Node;
-  componentWillMount(): void;
-  componentDidMount(): void;
+  componentWillMount(): void | Promise<void>;
+  componentDidMount(): void | Promise<void>;
   componentWillReceiveProps(
     nextProps: Props,
     nextContext: any,
@@ -65,7 +65,7 @@ declare class React$Component<Props, State = void> {
     prevState: State,
     prevContext: any,
   ): void;
-  componentWillUnmount(): void;
+  componentWillUnmount(): void | Promise<void>;
 
   // long tail of other stuff not modeled very well
 


### PR DESCRIPTION
currently a an `async` hook is a flow error. Yes you can work around by defining a extra method and calling it from the hook, but it's cumbersome.