### PR TITLE
Add "external" property to `process.memoryUsage`

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -1936,7 +1936,7 @@ declare class Process extends events$EventEmitter {
     rss : number;
     heapTotal : number;
     heapUsed : number;
-    external: number;
+    external : number;
   };
   nextTick: <T>(cb: (...T) => mixed, ...T) => void;
   pid : number;

--- a/lib/node.js
+++ b/lib/node.js
@@ -1936,6 +1936,7 @@ declare class Process extends events$EventEmitter {
     rss : number;
     heapTotal : number;
     heapUsed : number;
+    external: number;
   };
   nextTick: <T>(cb: (...T) => mixed, ...T) => void;
   pid : number;


### PR DESCRIPTION
According to the documentation of node.js the `process.memoryUsage()` returns a property `external`. [More info](https://nodejs.org/dist/latest-v4.x/docs/api/process.html#process_process_memoryusage)

This property, however, was missing from the nodejs type declarations, causing type errors when used.