### PR TITLE
offsetParent Lib Type

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -1209,7 +1209,7 @@ declare class HTMLElement extends Element {
   lang: string;
   offsetHeight: number;
   offsetLeft: number;
-  offsetParent: Element;
+  offsetParent: ?Element;
   offsetTop: number;
   offsetWidth: number;
   onabort: ?Function;


### PR DESCRIPTION
@billschaller: fixes #4407

@miguel-guedes said
> offsetParent is declared as returning a Element, however the specifications seem to suggest that offsetParent is an extension to HTMLElement itself.

However, the [drafts specifications](https://drafts.csswg.org/cssom-view/#extensions-to-the-htmlelement-interface) show that `offsetParent` is a maybe type since it can return a `null` and returns an `Element`, not a `HTMLElement`.

```
partial interface HTMLElement {
  readonly attribute Element? offsetParent;
  ...
}
```

Moreover, the [current specifications](https://www.w3.org/TR/2009/WD-cssom-view-20090804/) dictate that `offsetParent` is a maybe type since they use language about it returning a `null`.

> The offsetParent attribute must return the result of running these steps: 1. If any of the following holds true return null and terminate this algorithm: ...


