### PR TITLE
Add test-utils to ReactDOM definitions

### DIFF
--- a/lib/react-dom.js
+++ b/lib/react-dom.js
@@ -49,6 +49,26 @@ declare module 'react-dom/server' {
   declare function renderToStaticMarkup(element: React$Node): string;
 }
 
+declare module 'react-dom/test-utils' {
+  declare var Simulate: {
+    [eventName: string]: (element: Element, eventData?: Object) => void;
+  };
+  declare function renderIntoDocument(instance: React$Element<any>): React$Component;
+  declare function mockComponent(componentClass: React$ElementType, mockTagName?: string): Object;
+  declare function isElement(element: React$Element<any>): boolean;
+  declare function isElementOfType(element: React$Element<any>, componentClass: React$ElementType): boolean;
+  declare function isDOMComponent(instance: React$Component): boolean;
+  declare function isCompositeComponent(instance: React$Component): boolean;
+  declare function isCompositeComponentWithType(instance: React$Component, componentClass: React$ElementType): boolean;
+  declare function findAllInRenderedTree(tree: React$Component, test: (child: React$Component) => boolean): Array<React$Component>;
+  declare function scryRenderedDOMComponentsWithClass(tree: React$Component, className: string): Array<Element>;
+  declare function findRenderedDOMComponentWithClass(tree: React$Component, className: string): ?Element;
+  declare function scryRenderedDOMComponentsWithTag(tree: React$Component, tagName: string): Array<Element>;
+  declare function findRenderedDOMComponentWithTag(tree: React$Component, tagName: string): ?Element;
+  declare function scryRenderedComponentsWithType(tree: React$Component, componentClass: React$ElementType): Array<React$Component>;
+  declare function findRenderedComponentWithType(tree: React$Component, componentClass: React$ElementType): ?React$Component;
+}
+
 declare class SyntheticEvent<+T: EventTarget = EventTarget> {
   bubbles: boolean;
   cancelable: boolean;

--- a/tests/react/test-utils.js
+++ b/tests/react/test-utils.js
@@ -1,0 +1,36 @@
+// @flow
+
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+import TestUtils from 'react-dom/test-utils';
+
+class MyTestingComponent extends React.Component<{}> {
+  _node: ?HTMLButtonElement;
+
+  componentDidMount() {
+    TestUtils.Simulate.click(this._node);
+  }
+
+  render() {
+    return (
+      <button className="my-button" ref={node => this._node = node} />
+    );
+  }
+}
+
+const tree = TestUtils.renderIntoDocument(<MyTestingComponent />);
+TestUtils.mockComponent(MyTestingComponent);
+TestUtils.mockComponent(MyTestingComponent, 'span');
+(TestUtils.isElement(<MyTestingComponent />): boolean);
+(TestUtils.isElementOfType(<MyTestingComponent />, MyTestingComponent): boolean);
+const myButtonComponent = TestUtils.findRenderedDOMComponentWithClass(tree, 'my-button');
+(TestUtils.isDOMComponent(myButtonComponent): boolean);
+(TestUtils.isCompositeComponent(tree): boolean);
+(TestUtils.isCompositeComponentWithType(tree, MyTestingComponent): boolean);
+(TestUtils.findAllInRenderedTree(tree, child => child.tagName === 'BUTTON'): Array<React.Component>);
+(TestUtils.scryRenderedDOMComponentsWithClass(tree, 'my-button'): Array<Element>);
+(TestUtils.findRenderedDOMComponentsWithClass(tree, 'my-button'): ?Element);
+(TestUtils.scryRenderedDOMComponentsWithTag(tree, 'button'): Array<Element>);
+(TestUtils.findRenderedDOMComponentsWithTag(tree, 'button'): ?Element);
+(TestUtils.scryRenderedComponentsWithType(tree, MyTestingComponent): Array<React.Component>);
+(TestUtils.findRenderedComponentsWithType(tree, MyTestingComponent): ?React.Component);


### PR DESCRIPTION
react-addons-test-utils was deprecated with React 16, as most of its functionality was merged into `react-dom/test-utils`. The shallow renderer is now a separate package that can be typed on `flow-typed`, but these other definitions likely belong here as they're now part of react-dom.

This adds lib definitions to react-dom/test-utils, mostly borrowed from [the flow-typed definitions for the now-deprecated react-addons-test-utils](https://github.com/flowtype/flow-typed/blob/0bdbd3d3e8537541baf762d93e2b7c25fc38a024/definitions/npm/react-addons-test-utils_v15.x.x/flow_v0.15.x-/react-addons-test-utils_v15.x.x.js).

I haven't interacted directly with this API much, so a quick sanity check on the tests for this would be much appreciated :)