### PR TITLE
[DOCS] Improve Type System docs

### DIFF
--- a/website/en/docs/lang/nominal-structural.md
+++ b/website/en/docs/lang/nominal-structural.md
@@ -2,8 +2,8 @@
 layout: guide
 ---
 
-An important attribute of every type system is whether they are structural or
-nominal, they can even be mixed within a single type system. So it's important
+An important attribute of a type system is whether it is structural or
+nominal (or sometimes a combination of both). It's important
 to know the difference.
 
 A type is something like a string, a boolean, an object, or a class. They have
@@ -34,7 +34,7 @@ different names.
 
 #### Structural typing <a class="toc" id="toc-structural-typing" href="#toc-structural-typing"></a>
 
-Languages like OCaml, Haskell, and Elm have primarily structural type systems.
+Languages like OCaml, Scala, and Elm sometimes use structural typing.
 
 ```js
 class Foo { method(input: string) { /* ... */ } }
@@ -44,7 +44,7 @@ let foo: Foo = new Bar(); // Works!
 ```
 
 Here you can see a pseudo-example of a structural type system passing when
-you're trying to put a Bar where a `Foo` is required because their structure is
+you're trying to put a `Bar` where a `Foo` is required because their structure is
 exactly the same.
 
 But as soon as you change the shape it will start to cause errors.
@@ -59,7 +59,7 @@ let foo: Foo = new Bar(); // Error!
 It can get a little bit more complicated than this.
 
 We've demonstrated both nominal and structure typing of classes, but there are
-also other complex types like objects and functions which can also be either
+other complex types like objects and functions which can also be either
 nominal or structural. Even further, they can be different within the same type
 system (most of the languages listed before has features of both).
 
@@ -123,19 +123,18 @@ chosen based on how objects, functions, and classes are already used in
 JavaScript.
 
 The JavaScript language is a bunch of object-oriented ideas and functional
-ideas mixed together. Developer's usage of JavaScript tends to be mixed as
-well. Classes (or constructor functions) being the more object-oriented side
-and functions (as lambdas) and objects tend to be more on the functional side,
-developers use both simultaneously.
+ideas mixed together. JavaScript developers tend to use both simultaneously,
+with classes (or constructor functions) being more object-oriented, and
+functions (as lambdas) and objects being more functional.
 
-Object oriented languages tend to be more nominally typed (C++, Java, Swift),
-while functional languages tend to be more structurally typed (OCaml, Haskell,
+Object-oriented languages tend to be more nominally typed (C++, Java, Swift),
+while functional languages tend to more often make use of structural typing (OCaml, Scala,
 Elm).
 
 When someone writes a class, they are declaring a _thing_. This thing might
 have the same structure as something else but they still serve different
-purposes. Imagine two component classes that both have `render()` methods,
-these components could still have totally different purposes, but in a
+purposes. Imagine two component classes that both have `render()` methods.
+These components could have totally different purposes, but in a
 structural type system they'd be considered exactly the same.
 
 Flow chooses what is natural for JavaScript, and should behave the way you

--- a/website/en/docs/lang/types-and-expressions.md
+++ b/website/en/docs/lang/types-and-expressions.md
@@ -69,30 +69,30 @@ of values. But still Flow checks _every_ possible value. In this way Flow is
 checking too many things or _over-approximating_ what will be valid code.
 
 By checking every possible value, Flow might catch errors that will not
-actually occur when the code is run. Flow does this in order to be _"complete"_.
+actually occur when the code is run. Flow does this in order to be _"sound"_.
 
-In type systems, ***completeness*** is the ability for a type checker to catch
+In type systems, ***soundness*** is the ability for a type checker to catch
 every single error that _might_ happen at runtime. This comes at the cost of
 sometimes catching errors that will not actually happen at runtime.
 
-On the flip-side, ***soundness*** is the ability for a type checker to only
+On the flip-side, ***completeness*** is the ability for a type checker to only
 ever catch errors that _would_ happen at runtime. This comes at the cost of
 sometimes missing errors that will happen at runtime.
 
-In an ideal world, every type checker would be both complete _and_ sound so
+In an ideal world, every type checker would be both sound _and_ complete so
 that it catches _every_ error that _will_ happen at runtime.
 
 Flow tries to be as sound and complete as possible. But because JavaScript was
 not designed around a type system, Flow sometimes has to make a tradeoff. When
-this happens Flow tends to favor completeness over soundness, ensuring that
+this happens Flow tends to favor soundness over completeness, ensuring that
 code doesn't have any bugs.
 
-Completeness is fine as long as Flow isn't being too noisy and preventing you from
-being productive. Sometimes when completeness would get in your way too much, Flow
-will favor soundness instead. There's only a handful of cases where Flow
+Soundness is fine as long as Flow isn't being too noisy and preventing you from
+being productive. Sometimes when soundness would get in your way too much, Flow
+will favor completeness instead. There's only a handful of cases where Flow
 does this.
 
-Other type systems will favor soundness instead, only reporting real errors
+Other type systems will favor completeness instead, only reporting real errors
 in favor of possibly missing errors. Unit/Integration testing is an extreme
 form of this approach. Often this comes at the cost of missing the errors that
 are the most complicated to find, leaving that part up to the developer.

--- a/website/en/docs/lang/types-and-expressions.md
+++ b/website/en/docs/lang/types-and-expressions.md
@@ -69,30 +69,30 @@ of values. But still Flow checks _every_ possible value. In this way Flow is
 checking too many things or _over-approximating_ what will be valid code.
 
 By checking every possible value, Flow might catch errors that will not
-actually occur when the code is run. Flow does this in order to be _"sound"_.
+actually occur when the code is run. Flow does this in order to be _"complete"_.
 
-In type systems, ***soundness*** is the ability for a type checker to catch
+In type systems, ***completeness*** is the ability for a type checker to catch
 every single error that _might_ happen at runtime. This comes at the cost of
 sometimes catching errors that will not actually happen at runtime.
 
-On the flip-side, ***completeness*** is the ability for a type checker to only
+On the flip-side, ***soundness*** is the ability for a type checker to only
 ever catch errors that _would_ happen at runtime. This comes at the cost of
 sometimes missing errors that will happen at runtime.
 
-In an ideal world, every type checker would be both sound _and_ complete so
+In an ideal world, every type checker would be both complete _and_ sound so
 that it catches _every_ error that _will_ happen at runtime.
 
 Flow tries to be as sound and complete as possible. But because JavaScript was
 not designed around a type system, Flow sometimes has to make a tradeoff. When
-this happens Flow tends to favor soundness over completeness, ensuring that
+this happens Flow tends to favor completeness over soundness, ensuring that
 code doesn't have any bugs.
 
-Soundness is fine as long as Flow isn't being too noisy and preventing you from
-being productive. Sometimes when soundness would get in your way too much, Flow
-will favor completeness instead. There's only a handful of cases where Flow
+Completeness is fine as long as Flow isn't being too noisy and preventing you from
+being productive. Sometimes when completeness would get in your way too much, Flow
+will favor soundness instead. There's only a handful of cases where Flow
 does this.
 
-Other type systems will favor completeness instead, only reporting real errors
+Other type systems will favor soundness instead, only reporting real errors
 in favor of possibly missing errors. Unit/Integration testing is an extreme
 form of this approach. Often this comes at the cost of missing the errors that
 are the most complicated to find, leaving that part up to the developer.

--- a/website/en/docs/lang/variance.md
+++ b/website/en/docs/lang/variance.md
@@ -74,7 +74,7 @@ method(new SanFrancisco()); // okay
 ---
 
 As a result of having weak dynamic typing, JavaScript doesn't have any of
-these, you can use any type at any time.
+these; you can use any type at any time.
 
 ## Variance in Classes <a class="toc" id="toc-variance-in-classes" href="#toc-variance-in-classes"></a>
 
@@ -141,7 +141,7 @@ which could easily cause an error at runtime.
 
 #### Less specific inputs — Good <a class="toc" id="toc-less-specific-inputs-good" href="#toc-less-specific-inputs-good"></a>
 
-Next, we'll have another SubClass that accepts a value of a less specific type.
+Next, we'll have another `SubClass` that accepts a value of a less specific type.
 
 ```js
 class SubClass extends BaseClass {

--- a/website/en/docs/lang/width-subtyping.md
+++ b/website/en/docs/lang/width-subtyping.md
@@ -49,7 +49,7 @@ type.
 
 For cases like this where it's useful to assert the absence of a property,
 Flow provides a special syntax for
-["exact" object types](../../types/objects/#toc-exact-object-types).
+[exact object types](../../types/objects/#toc-exact-object-types).
 
 ```js
 // @flow
@@ -60,17 +60,8 @@ function method(obj: {| foo: string |} | {| bar: number |}) {
 }
 ```
 
-[Exact object types](../../types/objects/#toc-exact-object-types) disable width
-subtyping, and do not allow additional properties to exist.
+Exact object types disable width subtyping, and do not allow additional
+properties to exist.
 
 Using exact object types lets Flow know that no extra properties will exist at
 runtime, which allows [refinements](../refinements/) to get more specific.
-
-```js
-// @flow
-function method(obj: {| foo: string |} | {| bar: number |}) {
-  if (obj.foo) {
-    (obj.foo: string); // Works!
-  }
-}
-```


### PR DESCRIPTION
I made some improvements to the Type System docs while reading through them. Things improved/changed:

- general readability
- description of structural typing (I [don't think it's used in Haskell](https://www.google.ca/search?q=haskell+structural+typing), and in OCaml/Elm it seems to be [just used for record types](https://en.wikipedia.org/wiki/Structural_type_system#Description). Correct me if I've made a mistake)
- ~~description of soundness vs completeness (I think their meanings were reversed)~~