### PR TITLE
Update type definition of `module`

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -783,19 +783,21 @@ declare class Proxy<T> {
 declare var global: any;
 
 declare var module: {
-    exports: any;
-    require(id: string): any;
+    exports: typeof exports;
+    require(id: string): typeof exports;
     id: string;
-    filename: string;
+    filename: ?string;
     loaded: boolean;
-    parent: any;
-    children: Array<any>;
+    paths: Array<string>;
+    parent?: typeof module;
+    children: Array<typeof module>;
 };
 declare var require: {
-  (id: string): any;
+  (id: string): typeof exports;
   resolve: (id: string) => string;
   cache: any;
-  main: typeof module;
+  main?: typeof module;
+  extensions: {[string]: Function}
 };
 declare var exports: any;
 


### PR DESCRIPTION
What I really wanted was `module.paths`, ended up tweaking more though.

I _think_ it's correct, but I might be wrong.

https://nodejs.org/api/modules.html