### PR TITLE
Non-integer indexing into tuples yields VoidT (instead of flooring the index)

### DIFF
--- a/src/typing/flow_js.ml
+++ b/src/typing/flow_js.ml
@@ -5051,7 +5051,8 @@ let rec __flow cx ((l: Type.t), (u: Type.use_t)) trace =
           | None -> false, value
           | Some ts ->
               let index = int_of_float float_value in
-              begin
+              if float_value = (float_of_int index)
+              then begin
                 try true, List.nth ts index
                 with _ ->
                 if is_tuple then begin
@@ -5062,6 +5063,8 @@ let rec __flow cx ((l: Type.t), (u: Type.use_t)) trace =
                   add_output cx ~trace error;
                   true, DefT (mk_reason RTupleOutOfBoundsAccess (loc_of_reason reason), VoidT)
                 end else true, value
+              end else begin
+                true, DefT (mk_reason RTupleOutOfBoundsAccess (loc_of_reason reason), VoidT)
               end
           end
       | _ -> false, value

--- a/tests/tuples/tuples.exp
+++ b/tests/tuples/tuples.exp
@@ -40,5 +40,11 @@ Error: tuples.js:6
   6: var f: [number, string] = [123, 456];
                      ^^^^^^ string
 
+Error: tuples.js:7
+  7: (f[0.5]: number);
+      ^^^^^^ undefined (out of bounds tuple access). This type is incompatible with
+  7: (f[0.5]: number);
+              ^^^^^^ number
 
-Found 7 errors
+
+Found 8 errors

--- a/tests/tuples/tuples.js
+++ b/tests/tuples/tuples.js
@@ -4,3 +4,5 @@ var c: [number] = []; // nope
 var d: [number, string] = [123,'duck'];
 var e: [number, string,] = [123,'duck'];
 var f: [number, string] = [123, 456];
+(f[0.5]: number);
+(f[0.9999999999999999999999999999999999999999999]: string);


### PR DESCRIPTION
Fixes #4472.