### PR TITLE
Add typings for ReactDOM.hydrate()

### DIFF
--- a/lib/react-dom.js
+++ b/lib/react-dom.js
@@ -17,6 +17,12 @@ declare module 'react-dom' {
     container: Element,
     callback?: () => void,
   ): React$ElementRef<ElementType>;
+  
+  declare function hydrate<ElementType: React$ElementType>(
+    element: React$Element<ElementType>,
+    container: Element,
+    callback?: () => void,
+  ): React$ElementRef<ElementType>;
 
   declare function createPortal(
     node: React$Node,


### PR DESCRIPTION
Fixes issue #5035 by adding typings for the new `ReactDOM.hydrate()` function.