### PR TITLE
Add typings for globalAgent of Node.js http and https

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -1118,6 +1118,7 @@ declare module "http" {
 
   declare var METHODS: Array<string>;
   declare var STATUS_CODES: {[key: number]: string};
+  declare var globalAgent: Agent;
 }
 
 declare module "https" {
@@ -1153,6 +1154,7 @@ declare module "https" {
     callback?: (response: IncomingMessage) => void
   ): ClientRequest;
 
+  declare var globalAgent: Agent;
 }
 
 declare class net$Socket extends stream$Duplex {


### PR DESCRIPTION
Adding missing `globalAgent`s to `http` module and `https` module of Node.js

Corresponding documentations are:

- https://nodejs.org/api/http.html#http_http_globalagent
- https://nodejs.org/api/https.html#https_https_globalagent