### PR TITLE
Fix return type for Object.setPrototypeOf

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -45,7 +45,7 @@ declare class Object {
     static keys(o: any): Array<string>;
     static preventExtensions(o: any): any;
     static seal(o: any): any;
-    static setPrototypeOf(o: any, proto: ?Object): bool;
+    static setPrototypeOf(o: any, proto: ?Object): any;
     static values(object: any): Array<mixed>;
     hasOwnProperty(prop: any): boolean;
     isPrototypeOf(o: any): boolean;


### PR DESCRIPTION
Fixes https://github.com/facebook/flow/issues/4400

--- 

According to the [ES6 spec](https://www.ecma-international.org/ecma-262/6.0/#sec-object.setprototypeof), `Object.setPrototypeOf(o, proto)` should return the original object `o` (albeit with the modified prototype), but the return type here is a boolean:

https://github.com/facebook/flow/blob/master/lib/core.js#L51

Maybe it's a mixup with the non-static `o.setPrototypeOf(proto)`, which does return a boolean?

Bug reproduced [here](https://flow.org/try/#0PQKgBAAgZgNg9gdzCYAoVB5ARgKwKYDGALgHQDOeRACgE5xH0CeADnhlABQDeUccAXAFYAvgBowXYQEoSvOAG5UQA). It should type-check. If run on the browser's console it returns 5 (which is the correct behaviour).
