### PR TITLE
Allow Promise.race() to accept an Iterable

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -606,7 +606,7 @@ declare class Promise<+R> {
     static resolve<T>(object: Promise<T> | T): Promise<T>;
     static reject<T>(error?: any): Promise<T>;
     static all<T: Iterable<mixed>>(promises: T): Promise<$TupleMap<T, typeof $await>>;
-    static race<T, Elem: Promise<T> | T>(promises: Array<Elem>): Promise<T>;
+    static race<T>(promises: Iterable<Promise<T> | T>): Promise<T>;
 }
 
 // we use this signature when typing await expressions


### PR DESCRIPTION
See https://tc39.github.io/ecma262/#sec-promise.race
Also since Iterable<T> is covariant in T, the Elem type parameter to Promise.race() is no longer needed.