### PR TITLE
Add process.binding

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -1917,6 +1917,7 @@ declare class Process extends events$EventEmitter {
   abort() : void;
   arch : string;
   argv : Array<string>;
+  binding(id: string) : typeof exports;
   chdir(directory : string) : void;
   config : Object;
   connected : boolean;

--- a/tests/node_tests/node_tests.exp
+++ b/tests/node_tests/node_tests.exp
@@ -2275,8 +2275,8 @@ Error: os/userInfo.js:14
 Error: process/nextTick.js:13
  13:   (a: string, b: number, c: boolean) => {},
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function. This type is incompatible with the expected param type of
-1945:   nextTick: <T>(cb: (...T) => mixed, ...T) => void;
-                          ^^^^^^^^^^^^^^^ function type. See lib: <BUILTINS>/node.js:1945
+1946:   nextTick: <T>(cb: (...T) => mixed, ...T) => void;
+                          ^^^^^^^^^^^^^^^ function type. See lib: <BUILTINS>/node.js:1946
   This parameter is incompatible:
      14:   0, // Error: number ~> string
            ^ number. This type is incompatible with
@@ -2286,8 +2286,8 @@ Error: process/nextTick.js:13
 Error: process/nextTick.js:13
  13:   (a: string, b: number, c: boolean) => {},
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function. This type is incompatible with the expected param type of
-1945:   nextTick: <T>(cb: (...T) => mixed, ...T) => void;
-                          ^^^^^^^^^^^^^^^ function type. See lib: <BUILTINS>/node.js:1945
+1946:   nextTick: <T>(cb: (...T) => mixed, ...T) => void;
+                          ^^^^^^^^^^^^^^^ function type. See lib: <BUILTINS>/node.js:1946
   This parameter is incompatible:
      16:   null // Error: null ~> boolean
            ^^^^ null. This type is incompatible with
@@ -2297,8 +2297,8 @@ Error: process/nextTick.js:13
 Error: process/nextTick.js:20
  20:   (a: string, b: number, c: boolean) => {},
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function. This type is incompatible with the expected param type of
-1945:   nextTick: <T>(cb: (...T) => mixed, ...T) => void;
-                          ^^^^^^^^^^^^^^^ function type. See lib: <BUILTINS>/node.js:1945
+1946:   nextTick: <T>(cb: (...T) => mixed, ...T) => void;
+                          ^^^^^^^^^^^^^^^ function type. See lib: <BUILTINS>/node.js:1946
   This parameter is incompatible:
      22:   'y', // Error: string ~> number
            ^^^ string. This type is incompatible with
@@ -2308,20 +2308,20 @@ Error: process/nextTick.js:20
 Error: process/nextTick.js:27
  27:   (a: string, b: number, c: boolean) => {} // Error: too few arguments
            ^^^^^^ string. This type is incompatible with
-1945:   nextTick: <T>(cb: (...T) => mixed, ...T) => void;
-                          ^^^^^^^^^^^^^^^ undefined (too few arguments, expected default/rest parameters). See lib: <BUILTINS>/node.js:1945
+1946:   nextTick: <T>(cb: (...T) => mixed, ...T) => void;
+                          ^^^^^^^^^^^^^^^ undefined (too few arguments, expected default/rest parameters). See lib: <BUILTINS>/node.js:1946
 
 Error: process/nextTick.js:27
  27:   (a: string, b: number, c: boolean) => {} // Error: too few arguments
                       ^^^^^^ number. This type is incompatible with
-1945:   nextTick: <T>(cb: (...T) => mixed, ...T) => void;
-                          ^^^^^^^^^^^^^^^ undefined (too few arguments, expected default/rest parameters). See lib: <BUILTINS>/node.js:1945
+1946:   nextTick: <T>(cb: (...T) => mixed, ...T) => void;
+                          ^^^^^^^^^^^^^^^ undefined (too few arguments, expected default/rest parameters). See lib: <BUILTINS>/node.js:1946
 
 Error: process/nextTick.js:27
  27:   (a: string, b: number, c: boolean) => {} // Error: too few arguments
                                  ^^^^^^^ boolean. This type is incompatible with
-1945:   nextTick: <T>(cb: (...T) => mixed, ...T) => void;
-                          ^^^^^^^^^^^^^^^ undefined (too few arguments, expected default/rest parameters). See lib: <BUILTINS>/node.js:1945
+1946:   nextTick: <T>(cb: (...T) => mixed, ...T) => void;
+                          ^^^^^^^^^^^^^^^ undefined (too few arguments, expected default/rest parameters). See lib: <BUILTINS>/node.js:1946
 
 
 Found 76 errors


### PR DESCRIPTION
It's not documented, but it's there to allow us to access the internal core node C++ bindings.

One common use case is doing `process.bindings('fs').realpath` to access the native `realpath` or `process.bindings('natives')` to get a list of all built-in modules in node.

(I understand if you don't want to add undocumented functions)