### PR TITLE
Fix return types for WebGL is* methods

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -2344,13 +2344,13 @@ declare class WebGLRenderingContext {
   getVertexAttribOffset(index: number, pname: number): number;
 
   hint(target: number, mode: number): void;
-  isBuffer(buffer: ?WebGLBuffer): void;
-  isEnabled(cap: number): void;
-  isFramebuffer(framebuffer: ?WebGLFramebuffer): void;
-  isProgram(program: ?WebGLProgram): void;
-  isRenderbuffer(renderbuffer: ?WebGLRenderbuffer): void;
-  isShader(shader: ?WebGLShader): void;
-  isTexture(texture: ?WebGLTexture): void;
+  isBuffer(buffer: ?WebGLBuffer): boolean;
+  isEnabled(cap: number): boolean;
+  isFramebuffer(framebuffer: ?WebGLFramebuffer): boolean;
+  isProgram(program: ?WebGLProgram): boolean;
+  isRenderbuffer(renderbuffer: ?WebGLRenderbuffer): boolean;
+  isShader(shader: ?WebGLShader): boolean;
+  isTexture(texture: ?WebGLTexture): boolean;
   lineWidth(width: number): void;
   linkProgram(program: WebGLProgram): void;
   pixelStorei(pname: number, param: number): void;


### PR DESCRIPTION
Fixes return types for `WebGLRenderingContext#is*` methods, which should all return booleans (confirmable at the [IDL](https://www.khronos.org/registry/webgl/specs/latest/1.0/webgl.idl) linked from [`dom.js#L1566`](https://github.com/facebook/flow/blob/7f2680cd89fab009b69c03961fc9213a97ff9d05/lib/dom.js#L1566)).