### PR TITLE
Facebook DC open source event - fixing typos under flow/src/parser/test/

### DIFF
--- a/newtests/jsx_pragma/test.js
+++ b/newtests/jsx_pragma/test.js
@@ -301,7 +301,7 @@ export default suite(({addFile, addFiles, addCode}) => [
       <Bar x="hi" />;
     `).noNewErrors(),
   ]),
-  test('Exact prop type with spread still doesnt work', [
+  test('Exact prop type with spread still doesn't work', [
     addCode(`
       // @jsx Foo
       function Foo(elem: number, props: {| x: string |}) {}

--- a/newtests/jsx_pragma/test.js
+++ b/newtests/jsx_pragma/test.js
@@ -301,7 +301,7 @@ export default suite(({addFile, addFiles, addCode}) => [
       <Bar x="hi" />;
     `).noNewErrors(),
   ]),
-  test('Exact prop type with spread still doesn't work', [
+  test('Exact prop type with spread still does not work', [
     addCode(`
       // @jsx Foo
       function Foo(elem: number, props: {| x: string |}) {}

--- a/src/common/flowExitStatus.ml
+++ b/src/common/flowExitStatus.ml
@@ -20,7 +20,7 @@ type t =
   | Build_id_mismatch
   (* Generic "Bad Input" kind of error *)
   | Input_error
-  (* Failed to aquire lock or lost lock *)
+  (* Failed to acquire lock or lost lock *)
   | Lock_stolen
   (* Specific error for not being able to find a .flowconfig *)
   | Could_not_find_flowconfig

--- a/src/parser/test/esprima/comment/migrated_0004.js
+++ b/src/parser/test/esprima/comment/migrated_0004.js
@@ -1,1 +1,1 @@
-(a + /* assignmenr */b ) * c
+(a + /* assignment */b ) * c

--- a/src/parser/test/esprima/comment/migrated_0005.js
+++ b/src/parser/test/esprima/comment/migrated_0005.js
@@ -1,2 +1,2 @@
-/* assignmenr */
+/* assignment */
  a = b

--- a/src/parser/test/esprima_tests.js
+++ b/src/parser/test/esprima_tests.js
@@ -483,8 +483,8 @@ module.exports = {
         },
         'var p1;/* block comment 1 */ /* block comment 2 */',
         '/*42*/',
-        '(a + /* assignmenr */b ) * c',
-        '/* assignmenr */\n a = b',
+        '(a + /* assignment */b ) * c',
+        '/* assignment */\n a = b',
         {
           content: '42 /*The*/ /*Answer*/',
           explanation: "Esprima counts comments in its loc, Flow doesn't",


### PR DESCRIPTION
Facebook DC open source event - fixing typos under flow/src/parser/test/