### PR TITLE
Make IDBRequest's result property any

### DIFF
--- a/lib/indexeddb.js
+++ b/lib/indexeddb.js
@@ -13,7 +13,7 @@ declare interface IDBFactory {
 }
 
 declare interface IDBRequest extends EventTarget {
-  result: IDBObjectStore;
+  result: any;
   error: Error;
   source: ?(IDBIndex | IDBObjectStore | IDBCursor);
   transaction: IDBTransaction;


### PR DESCRIPTION
[`IDBRequest`'s also come from `IDBObjectStore.get()`](https://developer.mozilla.org/en-US/docs/Web/API/IDBObjectStore/get), so their `result` parameter could be anything stored in the database.