### PR TITLE
feat(u2f): add u2f types to dom

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -3258,6 +3258,44 @@ declare class TreeWalker<RootNodeT, WhatToShowT> {
   nextNode(): WhatToShowT | null;
 }
 
+declare type u2f$Transport = 'bt'|'ble'|'nfc'|'usb'
+declare type utf$SignResponse = {
+  keyHandle: string;
+  signatureData: string;
+  clientData: string;
+}
+declare type u2f$RegisteredKey = {
+  version: string;
+  keyHandle: string;
+  transports:? u2f$Transport[],
+  appId:? string;
+}
+declare type u2f$RegisterResponse = {
+  version: string;
+  registrationData: string;
+  clientData: string;
+}
+declare type u2f$RegisterRequest = {
+  version: string;
+  challenge: string;
+}
+declare type u2f$ErrorCode = {
+  OK: 0;
+  OTHER_ERROR: 1;
+  BAD_REQUEST: 2;
+  CONFIGURATION_UNSUPPORTED: 3;
+  DEVICE_INELIGIBLE: 4;
+  TIMEOUT: 5;
+}
+declare type u2f$Error = {
+  errorCode: $Values(u2f$ErrorCode);
+  errorMessage:? string;
+}
+declare type u2f = {
+  signRequest(appId: string, challenge: string, registeredKeys: u2f$RegisteredKey[], callback: (u2f$SignResponse | u2f$Error) => void, timeout:? number): void,
+  registerRequest(appId: string, registerRequests: RegisterRequest[], registeredKeys: RegisteredKey[], callback: (u2f$RegisterResponse | u2f$Error) => void, timeout:? number): void
+} & u2f$ErrorCode
+
 /* window */
 
 declare type WindowProxy = any;


### PR DESCRIPTION
This PR attempts to add the flow types for FIDO U2F ([standard found here](https://fidoalliance.org/specs/fido-u2f-v1.0-nfc-bt-amendment-20150514/fido-u2f-javascript-api.html). 

This is supported in Chrome and behind a flag in Firefox (see [caniuse](http://caniuse.com/#feat=u2f))

I'm unsure of the best place to "put" this in `dom.js`, so I just put it near the bottom. Feedback welcome on bikeshedding location etc