### PR TITLE
Extend MediaStreamTrack class with EventTarget

### DIFF
--- a/lib/bom.js
+++ b/lib/bom.js
@@ -765,7 +765,7 @@ declare class MediaStream extends EventTarget {
   removeTrack(track: MediaStreamTrack): void;
 }
 
-declare class MediaStreamTrack {
+declare class MediaStreamTrack extends EventTarget {
   enabled: bool;
   id: string;
   kind: string;


### PR DESCRIPTION
According to the spec the MediaStreamTrack class should Extend event target. At the moment there are flow errors you try to use `addEventListener` and `removeEventListener` on a MediaStreamTrack object.


> ```
> interface MediaStreamTrack : EventTarget { ... }
> ```

https://www.w3.org/TR/mediacapture-streams/#media-stream-track-interface-definition