### PR TITLE
URLSearchParams constructor is missing array tuple and record forms

### DIFF
--- a/lib/bom.js
+++ b/lib/bom.js
@@ -896,7 +896,7 @@ declare class Headers {
 
 declare class URLSearchParams {
     @@iterator(): Iterator<[string, string]>;
-    constructor(query?: string | URLSearchParams): void;
+    constructor(query?: string | URLSearchParams | Array<[string, string]> | {[string]: string} ): void;
     append(name: string, value: string): void;
     delete(name: string): void;
     entries(): Iterator<[string, string]>;

--- a/lib/node.js
+++ b/lib/node.js
@@ -1624,7 +1624,7 @@ declare module "url" {
   declare function domainToASCII(domain: string): string;
   declare function domainToUnicode(domain: string): string;
   declare class URLSearchParams {
-    constructor(init?: string): void;
+    constructor(init?: string | Array<[string, string]> | {[string]: string} ): void;
     append(name: string, value: string): void;
     delete(name: string): void;
     entries(): Iterator<[string, string]>;


### PR DESCRIPTION
See https://nodejs.org/api/url.html#url_class_urlsearchparams and https://url.spec.whatwg.org/#urlsearchparams

Fixed #4944 