### PR TITLE
Update $ObjMap example for Flow v0.57

### DIFF
--- a/website/en/docs/types/utilities.md
+++ b/website/en/docs/types/utilities.md
@@ -258,7 +258,7 @@ Let's see an example. Suppose you have a function called `run` that takes an obj
 
 ```js
 // @flow
-function run<A, O: {[key: string]: () => A}>(o: O) {
+function run<O: {[key: string]: () => any}>(o: O) {
   return Object.keys(o).reduce((acc, k) => Object.assign(acc, { [k]: o[k]() }), {});
 }
 ```
@@ -275,7 +275,7 @@ This is where `ObjMap<T, F>` comes in handy.
 // let's write a typelevel function that takes a `() => V` and returns a `V` (its return type)
 type ExtractReturnType = <V>(() => V) => V
 
-function run<A, O: {[key: string]: () => A}>(o: O): $ObjMap<O, ExtractReturnType> {
+function run<O: {[key: string]: () => any}>(o: O): $ObjMap<O, ExtractReturnType> {
   return Object.keys(o).reduce((acc, k) => Object.assign(acc, { [k]: o[k]() }), {});
 }
 ```


### PR DESCRIPTION
Flow v0.57 is more strict around generic typing. The example here fails because in the passed object the properties' functions' return values have different types.

We use `any` here because we don't need to check the functions' return types in the argument, yet ExtractReturnType can still extract it.

See [the current example failing in Try](https://flow.org/try/#0PTAEBsFMBcHIGdQHcBOBLalQENTQJ4AOkUAbiaAGYCuAdgMbRoD2teAFttHtgNaSJcAAwAUASlABeAHygAakJy0AJqBQxqKWoNBCFoERkTromtgWJiAUBawBRAB7QU2RgCUNWgCpEsk0AA8ctIi4lKychIy8lZWNAxMrGp0AQCCADSgAPIAXKAA3gDa-Ph58M5otADmALp5YdGpAL4hzHlZYnkAJFkARgBWALLYhAFZmY7OrtAept6+svlWoGqebH39kIwAdCXwIsxi2+rK1PSQoa70mbxRshtb0NvY8PBoVbQiV5n5oMV1oGY-zCTTEP1BAG4rE1YvRWOVAVICsscPU7ngUNRIOkUb00eFQLBKMxmLBoVCrCJMZ9Ds88r0SVBsLQxBDQCBsrxKdSDkc8aByuhqqyVhyslyOV1HMRGHYUChmChuXRedt+QzmEyWWyOQA5ZjETK9UBoHSCypVKyS6WPOUKpU82n0NkrV1u0VgfWG0D0ZAvUC0ZjcSocLCK96VbDgQEDR5WIA).

And [now with this change](https://flow.org/try/#0PTAEBsFMBcHIGdQHcBOBLalQENTQJ4AOkUAbiaAGYCuAdgMbRoD2teAFttHtgNaSJcAAwAUASlABeAHygAakJy0AJqBQxqKWoNBCFoERkTromtgWJiAUBawBRAB7QU2RgCUNWgCpEsk0AA8ctIi4lKychIy8lZWNAxMrGp0AQDyAFygAN4A2vz4mfDOaLQA5gC6mWHR2LT4AL4hzJmpYpkAJKkARgBWALLYhGkANKCOzq7QHqbevrJZVqBqnmzdPZCMAHT58CLMYpvqytT0kKGu9KO8UbJrG9Cb2PDwaKW0IhejWaB5laDMvzC9TEX2BAG4rPVYvRWEV-lJsoscFUbngUNRIMMkV0UeFQLBKMxmLBIRCrCJ0e99o9Ml0iVBamIwaAQKBUrxyZS9gccaAiugykylqz2VZWe1HMRGHYUChmChOXRuZteXTmAzaELWQA5ZjEUZdUBoHT8kqlMVgCUOKXQGVyhVc6n0ZlLV1u4VgXX60D0ZBPUC0ZjcEocLDy14lbDgf69e5WIA).