### PR TITLE
Add Atom IDE set-up steps to documents

### DIFF
--- a/website/en/docs/editors/atom.md
+++ b/website/en/docs/editors/atom.md
@@ -5,6 +5,31 @@ layout: guide
 If you're using [Atom](https://atom.io) you have a bunch of options to
 integrate Flow into your code base.
 
+### Atom IDE <a class="toc" id="toc-atom-ide-flowtype" href="#toc-atom-ide-flowtype"></a>
+
+```sh
+apm install atom-ide-ui ide-flowtype
+```
+
+Combining [atom-ide-ui](https://atom.io/packages/atom-ide-ui)
+and [ide-flowtype](https://atom.io/packages/ide-flowtype), this is [Flow's
+integration](https://nuclide.io/blog/2017/09/12/Introducing-Atom-IDE-UI/) into the
+[Atom IDE](https://ide.atom.io/) initiative.
+Like Nuclide, it’s a unified package which contains the following features:
+* Diagnostics
+* Definitions
+* Find References
+* Outline View
+* Datatips
+* Code Formatting
+* Code Actions
+* Code Highlight
+* Busy Signal
+
+Note that if you’re already a Nuclide user, all of Atom IDE UI’s features will still
+be bundled inside of Nuclide, so there’s no need to install another package.
+
+
 ### Nuclide <a class="toc" id="toc-nuclide" href="#toc-nuclide"></a>
 
 ```sh

--- a/website/en/docs/editors/atom.md
+++ b/website/en/docs/editors/atom.md
@@ -13,8 +13,8 @@ apm install atom-ide-ui ide-flowtype
 
 Combining [atom-ide-ui](https://atom.io/packages/atom-ide-ui)
 and [ide-flowtype](https://atom.io/packages/ide-flowtype), this is [Flow's
-integration](https://nuclide.io/blog/2017/09/12/Introducing-Atom-IDE-UI/) into the
-[Atom IDE](https://ide.atom.io/) initiative.
+integration](https://nuclide.io/blog/2017/09/12/Introducing-Atom-IDE-UI/)
+into the [Atom IDE](https://ide.atom.io/) initiative.
 Like Nuclide, it’s a unified package which contains the following features:
 * Diagnostics
 * Definitions
@@ -26,9 +26,9 @@ Like Nuclide, it’s a unified package which contains the following features:
 * Code Highlight
 * Busy Signal
 
-Note that if you’re already a Nuclide user, all of Atom IDE UI’s features will still
-be bundled inside of Nuclide, so there’s no need to install another package.
-
+Note that if you’re already a Nuclide user, all of Atom IDE UI’s features
+will still be bundled inside of Nuclide, so there’s no need to install another
+package.
 
 ### Nuclide <a class="toc" id="toc-nuclide" href="#toc-nuclide"></a>
 


### PR DESCRIPTION
[Atom IDE](https://ide.atom.io/) offers support for Flow through [`ide-flowtype`](https://atom.io/packages/ide-flowtype).
I've added a section to the Atom documentation explaining how this can be set up.