### PR TITLE
Fix scrollbar color

### DIFF
--- a/website/_assets/css/_base.scss
+++ b/website/_assets/css/_base.scss
@@ -4,7 +4,6 @@ html {
 
 body {
   padding-top: 53px;
-  background: $flow-gray-darkest;
   min-height: 100%;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
Body's background color affects scrollbar color in certain operating systems (macOS, iOS…). In this case the background was dark, so the OS flips the scrollbar color to white, which is almost invisible on website's mostly light background.

This change brings back the dark scrollbar, which is completely visible on darker parts of the website.

## Before:
<img width="285" alt="screen shot 2017-11-12 at 20 41 21" src="https://user-images.githubusercontent.com/471278/32702621-1ccd2a78-c7ea-11e7-8fe7-0143b5f94fa8.png">

## After:
<img width="289" alt="screen shot 2017-11-12 at 20 41 33" src="https://user-images.githubusercontent.com/471278/32702623-1fdf4034-c7ea-11e7-90f0-919f9627a11a.png">
