### PR TITLE
Adds support for digest('buffer')

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -428,6 +428,7 @@ declare class crypto$Decipher extends stream$Duplex {
 
 declare class crypto$Hash extends stream$Duplex {
   digest(encoding: 'hex' | 'latin1' | 'binary' | 'base64'): string;
+  digest(encoding: 'buffer'): Buffer;
   digest(encoding: void): Buffer;
   update(data: string | Buffer, input_encoding?: 'utf8' | 'ascii' | 'latin1' |
   'binary'): crypto$Hash;
@@ -435,6 +436,7 @@ declare class crypto$Hash extends stream$Duplex {
 
 declare class crypto$Hmac extends stream$Duplex {
   digest(encoding: 'hex' | 'latin1' | 'binary' | 'base64'): string;
+  digest(encoding: 'buffer'): Buffer;
   digest(encoding: void): Buffer;
   update(data: string | Buffer, input_encoding?: 'utf8' | 'ascii' | 'latin1' |
   'binary'): crypto$Hmac;


### PR DESCRIPTION
`"buffer"` is a valid parameter for the `digest` function (in fact, it's the default value), but it is currently not recognized by Flow.