### PR TITLE
Add missing declarations for node copyFile and copyFileSync

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -949,6 +949,26 @@ declare module "fs" {
       flag?: string
     }
   ): void;
+  declare function copyFile(
+    src: string | Buffer | number,
+    dest: string | Buffer | number,
+    flags: number,
+    callback: (err: ?ErrnoError) => void
+  ): void;
+  declare function copyFile(
+    src: string | Buffer | number,
+    dest: string | Buffer | number,
+    callback: (err: ?ErrnoError) => void
+  ): void;
+  declare function copyFileSync(
+    src: string | Buffer | number,
+    dest: string | Buffer | number,
+    flags: number
+  ): void;
+  declare function copyFileSync(
+    src: string | Buffer | number,
+    dest: string | Buffer | number
+  ): void;
   declare function appendFile(
     filename: string | Buffer | number,
     data: string | Buffer,
@@ -1028,6 +1048,8 @@ declare module "fs" {
     S_IROTH: number, // 4
     S_IWOTH: number, // 2
     S_IXOTH: number, // 1
+    UV_FS_COPYFILE_EXCL: number, //1
+    COPYFILE_EXCL: number // 1
   };
 }
 


### PR DESCRIPTION
From node 8.5.0 copyFile and copyFileSync were added. This path aims for adding missing functions declarations.

https://nodejs.org/api/fs.html#fs_fs_copyfile_src_dest_flags_callback