### PR TITLE
Fix type information for `Buffer.prototype.write`.

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -78,7 +78,9 @@ declare class Buffer extends Uint8Array {
   toJSON(): buffer$ToJSONRet;
   toString(encoding?: buffer$Encoding, start?: number, end?: number): string;
   values(): Iterator<number>;
-  write(string: string, offset?: number, length?: number, encoding?: buffer$Encoding): void;
+  write(string: string, encoding?: buffer$Encoding): void;
+  write(string: string, offset: number, encoding?: buffer$Encoding): void;
+  write(string: string, offset: number, length: number, encoding?: buffer$Encoding): void;
   writeDoubleBE(value: number, offset: number, noAssert?: boolean): number;
   writeDoubleLE(value: number, offset: number, noAssert?: boolean): number;
   writeFloatBE(value: number, offset: number, noAssert?: boolean): number;


### PR DESCRIPTION
`Buffer.prototype.write` can be called in multiple ways which are not supported by the current type definition.