### PR TITLE
lib: remove window.event

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -1151,7 +1151,6 @@ declare function alert(message?: any): void;
 declare function prompt(message?: any, value?: any): string;
 declare function close(): void;
 declare function confirm(message?: string): boolean;
-declare var event: Event;
 declare function getComputedStyle(elt: Element, pseudoElt?: string): any;
 declare var localStorage: Storage;
 declare function onfocus(ev: Event): any;


### PR DESCRIPTION
Remove the non-standard `event` global. This frequently causes issues
in event handlers where parameter name is something like `e` or `ev`,
and you reference it as `event`. Flow happily thinks it is an `Event`
object, although your code will break completely on sane browsers that
don’t implement it, like Firefox.

For reference, the `event` global is a proprietary Microsoft Internet
Explorer property
(https://developer.mozilla.org/en-US/docs/Web/API/Window/event), that
just happens to be implemented by Chrome and Edge as well :(.