### PR TITLE
Fix markdown typo

### DIFF
--- a/website/en/docs/types/unions.md
+++ b/website/en/docs/types/unions.md
@@ -54,7 +54,7 @@ type Fish = Numbers | Colors;
 
 When calling our function that accepts a union type we must pass in ***one of
 those types***. But inside of our function we are required to handle ***all of
-the possible types****.
+the possible types***.
 
 Let's rewrite our function to handle each type individually.
 


### PR DESCRIPTION
This fixes a typo in the documentation where there is an extra `*` at the end of an ***italicised bold*** sentence which seems to suggest there is more information on the subject! but it's just a typo!!!

Anyway, I fixed it for you :)