### PR TITLE
Fix the build

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -732,12 +732,12 @@ declare opaque type IntervalID;
 declare function clearInterval(intervalId?: IntervalID): void;
 declare function clearTimeout(timeoutId?: TimeoutID): void;
 declare function setTimeout<TArguments: Array<mixed>>(
-  callback: (...args: TArguments) => void,
+  callback: (...args: TArguments) => any,
   ms?: number,
   ...args: TArguments
 ): TimeoutID;
 declare function setInterval<TArguments: Array<mixed>>(
-  callback: (...args: TArguments) => void,
+  callback: (...args: TArguments) => any,
   ms?: number,
   ...args: TArguments
 ): IntervalID;


### PR DESCRIPTION
A function's side effects may make it useful as a callback regardless of its return type. `setTimeout` and `setInterval` should admit such functions.