### PR TITLE
Model indexer keys as contravariant

### DIFF
--- a/src/typing/class_sig.ml
+++ b/src/typing/class_sig.ml
@@ -698,10 +698,9 @@ let add_interface_properties cx properties s =
     | Indexer (_, { Indexer.key; value; static; variance; _ }) ->
       let k = Anno.convert cx tparams_map key in
       let v = Anno.convert cx tparams_map value in
-      let polarity = Anno.polarity variance in
       x
-        |> add_field ~static "$key" (None, polarity, Annot k)
-        |> add_field ~static "$value" (None, polarity, Annot v)
+        |> add_field ~static "$key" (None, Type.Negative, Annot k)
+        |> add_field ~static "$value" (None, Anno.polarity variance, Annot v)
     | Property (loc, { Property.key; value; static; _method; optional; variance; }) ->
       if optional && _method
       then Flow.add_output cx Flow_error.(EInternal (loc, OptionalMethod));

--- a/src/typing/flow_error.ml
+++ b/src/typing/flow_error.ml
@@ -1439,7 +1439,7 @@ let rec error_of_msg ~trace_reasons ~source_file =
         | PredicateVoidReturn ->
             "Predicate functions need to return non-void."
         | MultipleIndexers ->
-            "multiple indexers are not supported"
+            "multiple indexer properties are not supported"
         | SpreadArgument ->
             "A spread argument is unsupported here"
       in

--- a/src/typing/flow_error.ml
+++ b/src/typing/flow_error.ml
@@ -649,6 +649,7 @@ let rec error_of_msg ~trace_reasons ~source_file =
 
   let prop_polarity_error_msg x reasons p1 p2 =
     let prop_name = match x with
+    | Some "$value" -> "indexer property value"
     | Some x -> spf "property `%s`" x
     | None -> "computed property"
     in

--- a/src/typing/flow_error.ml
+++ b/src/typing/flow_error.ml
@@ -774,7 +774,7 @@ let rec error_of_msg ~trace_reasons ~source_file =
     unwrap_use_ops (obj_reasons, extra, msg) use_op
   | Frame (IndexerKeyCompatibility {lower=rl'; upper=ru'}, use_op) ->
     let extra =
-      extra_info_of_use_op reasons extra msg "Indexer key is incompatible:"
+      extra_info_of_use_op reasons extra msg "Indexer property key is incompatible:"
     in
     let obj_reasons = ordered_reasons (rl', ru') in
     let msg = "This type is incompatible with" in

--- a/src/typing/flow_error.ml
+++ b/src/typing/flow_error.ml
@@ -762,7 +762,8 @@ let rec error_of_msg ~trace_reasons ~source_file =
       let prop =
         match x with
         | Some "$call" -> "Callable property"
-        | None | Some "$key" | Some "$value" -> "Indexable signature"
+        | Some "$key" -> "Indexer property key"
+        | None | Some "$value" -> "Indexer property value"
         | Some x -> spf "Property `%s`" x
       in
       extra_info_of_use_op reasons extra msg

--- a/src/typing/flow_error.ml
+++ b/src/typing/flow_error.ml
@@ -1083,7 +1083,7 @@ let rec error_of_msg ~trace_reasons ~source_file =
     else
       let msg = match x with
       | Some "$call" -> "Callable signature not found in"
-      | Some "$key" | Some "$value" -> "Indexable signature not found in"
+      | Some "$key" | Some "$value" -> "Indexer property not found in"
       | _ -> "Property not found in"
       in
       begin match use_op with

--- a/src/typing/flow_js.ml
+++ b/src/typing/flow_js.ml
@@ -6387,13 +6387,10 @@ and flow_obj_to_obj cx trace ~use_op (lreason, l_obj) (ureason, u_obj) =
   (match ldict, udict with
     | Some {key = lk; value = lv; dict_polarity = lpolarity; _},
       Some {key = uk; value = uv; dict_polarity = upolarity; _} ->
-      (* Don't report polarity errors when checking the indexer key. We would
-       * report these errors again a second time when checking values. *)
-      rec_flow_p cx trace ~report_polarity:false ~use_op:(Frame (IndexerKeyCompatibility {
+      rec_flow_t cx trace ~use_op:(Frame (IndexerKeyCompatibility {
         lower = lreason;
         upper = ureason;
-      }, use_op)) lreason ureason (Computed uk)
-        (Field (None, lk, lpolarity), Field (None, uk, upolarity));
+      }, use_op)) (uk, lk);
       rec_flow_p cx trace ~use_op:(Frame (PropertyCompatibility {
         prop = None;
         lower = lreason;
@@ -7177,7 +7174,7 @@ and check_polarity cx ?trace polarity = function
     check_polarity_propmap cx ?trace polarity obj.props_tmap;
     (match obj.dict_t with
     | Some { key; value; dict_polarity; _ } ->
-      check_polarity cx ?trace Neutral key;
+      check_polarity cx ?trace (Polarity.inv polarity) key;
       check_polarity cx ?trace (Polarity.mult (polarity, dict_polarity)) value
     | None -> ())
 

--- a/src/typing/flow_js.ml
+++ b/src/typing/flow_js.ml
@@ -11058,7 +11058,11 @@ and object_kit =
       let (r, props, dict, flags) = slice in
 
       let props = SMap.map (fun (t, _) -> Field (None, t, polarity)) props in
-      let dict = Option.map dict (fun dict -> { dict with dict_polarity = polarity }) in
+      let dict = match dict with
+        | Some { dict_polarity = Negative; _ } -> None
+        | Some dict -> Some { dict with dict_polarity = polarity }
+        | None -> None
+      in
       let id = Context.make_property_map cx props in
       let proto = ObjProtoT reason in
       let t = DefT (r, ObjT (mk_objecttype ~flags dict id proto)) in

--- a/src/typing/flow_js.ml
+++ b/src/typing/flow_js.ml
@@ -10398,8 +10398,7 @@ and rec_flow cx trace (t1, t2) =
 and rec_flow_t cx trace ?(use_op=unknown_use) (t1, t2) =
   rec_flow cx trace (t1, UseT (use_op, t2))
 
-and rec_flow_p cx trace ?(use_op=unknown_use) ?(report_polarity=true)
-  lreason ureason propref = function
+and rec_flow_p cx trace ?(use_op=unknown_use) lreason ureason propref = function
   (* unification cases *)
   | Field (_, lt, Neutral),
     Field (_, ut, Neutral) ->
@@ -10410,7 +10409,7 @@ and rec_flow_p cx trace ?(use_op=unknown_use) ?(report_polarity=true)
     (match Property.read_t lp, Property.read_t up with
     | Some lt, Some ut ->
       rec_flow cx trace (lt, UseT (use_op, ut))
-    | None, Some _ when report_polarity ->
+    | None, Some _ ->
       add_output cx ~trace (FlowError.EPropPolarityMismatch (
         (lreason, ureason), x,
         (Property.polarity lp, Property.polarity up),
@@ -10419,7 +10418,7 @@ and rec_flow_p cx trace ?(use_op=unknown_use) ?(report_polarity=true)
     (match Property.write_t lp, Property.write_t up with
     | Some lt, Some ut ->
       rec_flow cx trace (ut, UseT (use_op, lt))
-    | None, Some _ when report_polarity ->
+    | None, Some _ ->
       add_output cx ~trace (FlowError.EPropPolarityMismatch (
         (lreason, ureason), x,
         (Property.polarity lp, Property.polarity up),

--- a/src/typing/flow_js.ml
+++ b/src/typing/flow_js.ml
@@ -11318,8 +11318,7 @@ and object_kit =
     let id, dict =
       let props = Context.find_props cx id in
       match SMap.get "$key" props, SMap.get "$value" props with
-      | Some (Field (_, key, polarity)), Some (Field (_, value, polarity'))
-        when polarity = polarity' ->
+      | Some (Field (_, key, _)), Some (Field (_, value, polarity)) ->
         let props = props |> SMap.remove "$key" |> SMap.remove "$value" in
         let id = Context.make_property_map cx props in
         let dict = {dict_name = None; key; value; dict_polarity = polarity} in

--- a/tests/dictionary/dictionary.exp
+++ b/tests/dictionary/dictionary.exp
@@ -152,7 +152,7 @@ Error: dictionary.js:159
                     ^^^^^^^^^^^ object type. This type is incompatible with
     159:   let a: Array<{[k:A]:any}> = x; // error
                         ^^^^^^^^^^^ object type
-      Indexer key is incompatible:
+      Indexer property key is incompatible:
         157:   x: Array<{[k:B]:any}>,
                             ^ B. This type is incompatible with
         159:   let a: Array<{[k:A]:any}> = x; // error
@@ -168,7 +168,7 @@ Error: dictionary.js:161
                     ^^^^^^^^^^^ object type. This type is incompatible with
     161:   let c: Array<{[k:C]:any}> = x; // error
                         ^^^^^^^^^^^ object type
-      Indexer key is incompatible:
+      Indexer property key is incompatible:
         157:   x: Array<{[k:B]:any}>,
                             ^ B. This type is incompatible with
         161:   let c: Array<{[k:C]:any}> = x; // error
@@ -179,7 +179,7 @@ Error: dictionary.js:167
                             ^ object type. This type is incompatible with
 167:   let a: {[k:A]:any} = x; // ok
               ^^^^^^^^^^^ object type
-  Indexer key is incompatible:
+  Indexer property key is incompatible:
     167:   let a: {[k:A]:any} = x; // ok
                       ^ A. This type is incompatible with
     165:   x: {[k:B]:any},
@@ -531,7 +531,7 @@ Error: incompatible.js:5
                                        ^ object type. This type is incompatible with
   5: var z : {[key: number]: string} = x; // 2 errors, string !~> number & vice versa
              ^^^^^^^^^^^^^^^^^^^^^^^ object type
-  Indexer key is incompatible:
+  Indexer property key is incompatible:
       5: var z : {[key: number]: string} = x; // 2 errors, string !~> number & vice versa
                         ^^^^^^ number. This type is incompatible with
       3: var x : {[key: string]: string} = {};

--- a/tests/dictionary/dictionary.exp
+++ b/tests/dictionary/dictionary.exp
@@ -38,7 +38,7 @@ Error: dictionary.js:110
                     ^^^^^^^^^^^^^^ object type. This type is incompatible with
     110:   let a: Array<{[k:string]:A}> = x; // error
                         ^^^^^^^^^^^^^^ object type
-      Indexable signature is incompatible:
+      Indexer property value is incompatible:
         108:   x: Array<{[k:string]:B}>,
                                     ^ B. This type is incompatible with
         110:   let a: Array<{[k:string]:A}> = x; // error
@@ -54,7 +54,7 @@ Error: dictionary.js:115
                     ^^^^^^^^^^^^^^ object type. This type is incompatible with
     115:   let c: Array<{[k:string]:C}> = x; // error
                         ^^^^^^^^^^^^^^ object type
-      Indexable signature is incompatible:
+      Indexer property value is incompatible:
         108:   x: Array<{[k:string]:B}>,
                                     ^ B. This type is incompatible with
         115:   let c: Array<{[k:string]:C}> = x; // error
@@ -71,7 +71,7 @@ Error: dictionary.js:122
                                ^ object type. This type is incompatible with
 122:   let a: {[k:string]:A} = x; // error
               ^^^^^^^^^^^^^^ object type
-  Indexable signature is incompatible:
+  Indexer property value is incompatible:
     120:   x: {[k:string]:B},
                           ^ B. This type is incompatible with
     122:   let a: {[k:string]:A} = x; // error
@@ -82,7 +82,7 @@ Error: dictionary.js:127
                                ^ object type. This type is incompatible with
 127:   let c: {[k:string]:C} = x; // error
               ^^^^^^^^^^^^^^ object type
-  Indexable signature is incompatible:
+  Indexer property value is incompatible:
     120:   x: {[k:string]:B},
                           ^ B. This type is incompatible with
     127:   let c: {[k:string]:C} = x; // error
@@ -520,7 +520,7 @@ Error: incompatible.js:4
                                        ^ object type. This type is incompatible with
   4: var y : {[key: string]: number} = x; // 2 errors, number !~> string & vice versa
              ^^^^^^^^^^^^^^^^^^^^^^^ object type
-  Indexable signature is incompatible:
+  Indexer property value is incompatible:
       3: var x : {[key: string]: string} = {};
                                  ^^^^^^ string. This type is incompatible with
       4: var y : {[key: string]: number} = x; // 2 errors, number !~> string & vice versa
@@ -542,7 +542,7 @@ Error: incompatible.js:8
                                        ^ object type. This type is incompatible with
   8: var b : {[key: string]: string} = a; // 2 errors (null & undefined)
              ^^^^^^^^^^^^^^^^^^^^^^^ object type
-  Indexable signature is incompatible:
+  Indexer property value is incompatible:
       7: var a : {[key: string]: ?string} = {};
                                  ^^^^^^^ null or undefined. This type is incompatible with
       8: var b : {[key: string]: string} = a; // 2 errors (null & undefined)
@@ -553,7 +553,7 @@ Error: incompatible.js:9
                                         ^ object type. This type is incompatible with
   9: var c : {[key: string]: ?string} = b; // 2 errors, since c['x'] = null updates b
              ^^^^^^^^^^^^^^^^^^^^^^^^ object type
-  Indexable signature is incompatible:
+  Indexer property value is incompatible:
       8: var b : {[key: string]: string} = a; // 2 errors (null & undefined)
                                  ^^^^^^ string. This type is incompatible with
       9: var c : {[key: string]: ?string} = b; // 2 errors, since c['x'] = null updates b
@@ -569,7 +569,7 @@ Error: incompatible.js:13
                                 ^^^^^^^^^^^^^^^^^^^^^^^ object type. This type is incompatible with
      12: function foo0(x: Array<{[key: string]: number}>): Array<{[key: string]: string}> {
                                                                  ^^^^^^^^^^^^^^^^^^^^^^^ object type
-      Indexable signature is incompatible:
+      Indexer property value is incompatible:
          12: function foo0(x: Array<{[key: string]: number}>): Array<{[key: string]: string}> {
                                                     ^^^^^^ number. This type is incompatible with
          12: function foo0(x: Array<{[key: string]: number}>): Array<{[key: string]: string}> {

--- a/tests/dictionary/dictionary.exp
+++ b/tests/dictionary/dictionary.exp
@@ -175,26 +175,15 @@ Error: dictionary.js:161
                                 ^ C
 
 Error: dictionary.js:167
-167:   let a: {[k:A]:any} = x; // error
+167:   let a: {[k:A]:any} = x; // ok
                             ^ object type. This type is incompatible with
-167:   let a: {[k:A]:any} = x; // error
+167:   let a: {[k:A]:any} = x; // ok
               ^^^^^^^^^^^ object type
   Indexer key is incompatible:
+    167:   let a: {[k:A]:any} = x; // ok
+                      ^ A. This type is incompatible with
     165:   x: {[k:B]:any},
-                  ^ B. This type is incompatible with
-    167:   let a: {[k:A]:any} = x; // error
-                      ^ A
-
-Error: dictionary.js:169
-169:   let c: {[k:C]:any} = x; // error
-                            ^ object type. This type is incompatible with
-169:   let c: {[k:C]:any} = x; // error
-              ^^^^^^^^^^^ object type
-  Indexer key is incompatible:
-    165:   x: {[k:B]:any},
-                  ^ B. This type is incompatible with
-    169:   let c: {[k:C]:any} = x; // error
-                      ^ C
+                  ^ B
 
 Error: dictionary.js:175
 175:   let a: Array<{[k:string]:B, p:A}> = x; // error: A ~> B
@@ -543,10 +532,10 @@ Error: incompatible.js:5
   5: var z : {[key: number]: string} = x; // 2 errors, string !~> number & vice versa
              ^^^^^^^^^^^^^^^^^^^^^^^ object type
   Indexer key is incompatible:
-      3: var x : {[key: string]: string} = {};
-                        ^^^^^^ string. This type is incompatible with
       5: var z : {[key: number]: string} = x; // 2 errors, string !~> number & vice versa
-                        ^^^^^^ number
+                        ^^^^^^ number. This type is incompatible with
+      3: var x : {[key: string]: string} = {};
+                        ^^^^^^ string
 
 Error: incompatible.js:8
   8: var b : {[key: string]: string} = a; // 2 errors (null & undefined)
@@ -690,4 +679,4 @@ Error: test_client.js:3
                                                   ^^^^^^ string. See: test.js:2
 
 
-Found 61 errors
+Found 60 errors

--- a/tests/dictionary/dictionary.js
+++ b/tests/dictionary/dictionary.js
@@ -164,7 +164,7 @@ function unification_dict_keys_invariant(
 function subtype_dict_keys_invariant(
   x: {[k:B]:any},
 ) {
-  let a: {[k:A]:any} = x; // error
+  let a: {[k:A]:any} = x; // ok
   let b: {[k:B]:any} = x; // ok
   let c: {[k:C]:any} = x; // error
 }

--- a/tests/indexer/indexer.exp
+++ b/tests/indexer/indexer.exp
@@ -72,7 +72,7 @@ Error: call.js:4
 
 Error: multiple.js:7
   7:       [k2: number]: number, // error: not supported (yet)
-           ^^^^^^^^^^^^^^^^^^^^ multiple indexers are not supported
+           ^^^^^^^^^^^^^^^^^^^^ multiple indexer properties are not supported
 
 Error: variance.js:5
   5: (w[0]: number); //ng

--- a/tests/indexer/indexer.exp
+++ b/tests/indexer/indexer.exp
@@ -74,5 +74,95 @@ Error: multiple.js:7
   7:       [k2: number]: number, // error: not supported (yet)
            ^^^^^^^^^^^^^^^^^^^^ multiple indexers are not supported
 
+Error: variance.js:5
+  5: (w[0]: number); //ng
+      ^^^^ computed property. Contravariant property `$value` incompatible with covariant use in
+  5: (w[0]: number); //ng
+      ^^^^ computed property
 
-Found 8 errors
+Error: variance.js:8
+  8: w[null] = 3; //ng
+       ^^^^ null. This type is incompatible with
+  8: w[null] = 3; //ng
+     ^^^^^^^ union: number | string
+  Member 1:
+    2:   -[number | string]: number
+           ^^^^^^ number
+  Error:
+    8: w[null] = 3; //ng
+         ^^^^ null. This type is incompatible with
+    2:   -[number | string]: number
+           ^^^^^^ number
+  Member 2:
+    2:   -[number | string]: number
+                    ^^^^^^ string
+  Error:
+    8: w[null] = 3; //ng
+         ^^^^ null. This type is incompatible with
+    2:   -[number | string]: number
+                    ^^^^^^ string
+
+Error: variance.js:15
+ 15: r[5] = 5.5; //ng
+     ^^^^ assignment of computed property/element. Covariant property `$value` incompatible with contravariant use in
+ 15: r[5] = 5.5; //ng
+     ^^^^ assignment of computed property/element
+
+Error: variance.js:16
+ 16: r["another string"] = 6; //ng
+     ^^^^^^^^^^^^^^^^^^^ assignment of computed property/element. Covariant property `$value` incompatible with contravariant use in
+ 16: r["another string"] = 6; //ng
+     ^^^^^^^^^^^^^^^^^^^ assignment of computed property/element
+
+Error: variance.js:17
+ 17: r[null] = 7; //ng
+     ^^^^^^^ assignment of computed property/element. Covariant property `$value` incompatible with contravariant use in
+ 17: r[null] = 7; //ng
+     ^^^^^^^ assignment of computed property/element
+
+Error: variance.js:17
+ 17: r[null] = 7; //ng
+       ^^^^ null. This type is incompatible with
+ 17: r[null] = 7; //ng
+     ^^^^^^^ union: number | string
+  Member 1:
+   11:   +[number | string]: number
+           ^^^^^^ number
+  Error:
+   17: r[null] = 7; //ng
+         ^^^^ null. This type is incompatible with
+   11:   +[number | string]: number
+           ^^^^^^ number
+  Member 2:
+   11:   +[number | string]: number
+                    ^^^^^^ string
+  Error:
+   17: r[null] = 7; //ng
+         ^^^^ null. This type is incompatible with
+   11:   +[number | string]: number
+                    ^^^^^^ string
+
+Error: variance.js:26
+ 26: rw[null] = 11; //ng
+        ^^^^ null. This type is incompatible with
+ 26: rw[null] = 11; //ng
+     ^^^^^^^^ union: number | string
+  Member 1:
+   20:   [number | string]: number
+          ^^^^^^ number
+  Error:
+   26: rw[null] = 11; //ng
+          ^^^^ null. This type is incompatible with
+   20:   [number | string]: number
+          ^^^^^^ number
+  Member 2:
+   20:   [number | string]: number
+                   ^^^^^^ string
+  Error:
+   26: rw[null] = 11; //ng
+          ^^^^ null. This type is incompatible with
+   20:   [number | string]: number
+                   ^^^^^^ string
+
+
+Found 15 errors

--- a/tests/indexer/indexer.exp
+++ b/tests/indexer/indexer.exp
@@ -3,7 +3,7 @@ Error: A.js:13
               ^^^^^^^^^^^^^^ object literal. This type is incompatible with the expected return type of
  12: function foo2(): {[key: number]: string} {
                       ^^^^^^^^^^^^^^^^^^^^^^^ object type
-  Indexer key is incompatible:
+  Indexer property key is incompatible:
      13:   return { foo: "bar" }
                   ^^^^^^^^^^^^^^ string `foo`. This type is incompatible with
      12: function foo2(): {[key: number]: string} {
@@ -25,7 +25,7 @@ Error: A.js:23
               ^^^^^^^^^^^^^^ object literal. This type is incompatible with the expected return type of
  22: function foo4(): {[key: number]: number} {
                       ^^^^^^^^^^^^^^^^^^^^^^^ object type
-  Indexer key is incompatible:
+  Indexer property key is incompatible:
      23:   return { foo: "bar" }
                   ^^^^^^^^^^^^^^ string `foo`. This type is incompatible with
      22: function foo4(): {[key: number]: number} {

--- a/tests/indexer/indexer.exp
+++ b/tests/indexer/indexer.exp
@@ -76,7 +76,7 @@ Error: multiple.js:7
 
 Error: variance.js:5
   5: (w[0]: number); //ng
-      ^^^^ computed property. Contravariant property `$value` incompatible with covariant use in
+      ^^^^ computed property. Contravariant indexer property value incompatible with covariant use in
   5: (w[0]: number); //ng
       ^^^^ computed property
 
@@ -104,19 +104,19 @@ Error: variance.js:8
 
 Error: variance.js:15
  15: r[5] = 5.5; //ng
-     ^^^^ assignment of computed property/element. Covariant property `$value` incompatible with contravariant use in
+     ^^^^ assignment of computed property/element. Covariant indexer property value incompatible with contravariant use in
  15: r[5] = 5.5; //ng
      ^^^^ assignment of computed property/element
 
 Error: variance.js:16
  16: r["another string"] = 6; //ng
-     ^^^^^^^^^^^^^^^^^^^ assignment of computed property/element. Covariant property `$value` incompatible with contravariant use in
+     ^^^^^^^^^^^^^^^^^^^ assignment of computed property/element. Covariant indexer property value incompatible with contravariant use in
  16: r["another string"] = 6; //ng
      ^^^^^^^^^^^^^^^^^^^ assignment of computed property/element
 
 Error: variance.js:17
  17: r[null] = 7; //ng
-     ^^^^^^^ assignment of computed property/element. Covariant property `$value` incompatible with contravariant use in
+     ^^^^^^^ assignment of computed property/element. Covariant indexer property value incompatible with contravariant use in
  17: r[null] = 7; //ng
      ^^^^^^^ assignment of computed property/element
 

--- a/tests/indexer/variance.js
+++ b/tests/indexer/variance.js
@@ -1,0 +1,26 @@
+declare class W {
+  -[number | string]: number
+}
+declare var w: W;
+(w[0]: number); //ng
+w[1] = 1.5;
+w["a string"] = 2;
+w[null] = 3; //ng
+
+declare class R {
+  +[number | string]: number
+}
+declare var r: R;
+(r[4]: number);
+r[5] = 5.5; //ng
+r["another string"] = 6; //ng
+r[null] = 7; //ng
+
+declare class RW {
+  [number | string]: number
+}
+declare var rw: RW;
+(rw[8]: number);
+rw[9] = 9.5;
+rw["yet another string"] = 10;
+rw[null] = 11; //ng

--- a/tests/indexer/variance.js
+++ b/tests/indexer/variance.js
@@ -24,3 +24,16 @@ declare var rw: RW;
 rw[9] = 9.5;
 rw["yet another string"] = 10;
 rw[null] = 11; //ng
+
+type U_W = {
+  -[number | string | null]: number
+};
+type U_R = {
+  +[number | string | null]: number
+};
+type U_RW = {
+  [number | string | null]: number
+};
+(w: U_W);
+(r: U_R);
+(rw: U_RW);

--- a/tests/interface/interface.exp
+++ b/tests/interface/interface.exp
@@ -11,7 +11,7 @@ Error: fun.js:5
 
 Error: indexer.js:9
   9:   [k2: number]: number; // error: not supported (yet)
-       ^^^^^^^^^^^^^^^^^^^^ multiple indexers are not supported
+       ^^^^^^^^^^^^^^^^^^^^ multiple indexer properties are not supported
 
 Error: interface.js:3
   3: var x: string = new C().x;

--- a/tests/intersection/intersection.exp
+++ b/tests/intersection/intersection.exp
@@ -25,7 +25,7 @@ Error: test_obj.js:29
               ^ E. This type is incompatible with
    33: type C = { [key: string]: number } & { [key: string]: number };
                 ^^^^^^^^^^^^^^^^^^^^^^^^^ object type. See lib: lib/lib.js:33
-    Indexable signature is incompatible:
+    Indexer property value is incompatible:
        33: type C = { [key: string]: number } & { [key: string]: number };
                                      ^^^^^^ number. This type is incompatible with. See lib: lib/lib.js:33
        28: type E = { [key: string]: string };
@@ -40,7 +40,7 @@ Error: test_obj.js:29
               ^ E. This type is incompatible with
    33: type C = { [key: string]: number } & { [key: string]: number };
                                             ^^^^^^^^^^^^^^^^^^^^^^^^^ object type. See lib: lib/lib.js:33
-    Indexable signature is incompatible:
+    Indexer property value is incompatible:
        33: type C = { [key: string]: number } & { [key: string]: number };
                                                                  ^^^^^^ number. This type is incompatible with. See lib: lib/lib.js:33
        28: type E = { [key: string]: string };

--- a/tests/new_spread/new_spread.exp
+++ b/tests/new_spread/new_spread.exp
@@ -237,7 +237,7 @@ Error: type_contra.js:12
       ^^ object type. This type is incompatible with
  12: (o2: {[string]:T}); // error: unknown ~> T
           ^^^^^^^^^^^^ object type
-  Indexable signature is incompatible:
+  Indexer property value is incompatible:
       9: type O2 = {...{-[string]:T}};
                        ^^^^^^^^^^^^^ computed property of unknown type. This type is incompatible with
      12: (o2: {[string]:T}); // error: unknown ~> T

--- a/tests/refinements/refinements.exp
+++ b/tests/refinements/refinements.exp
@@ -403,13 +403,13 @@ Error: not.js:11
 
 Error: not.js:11
  11:     x[0]; // should error for null, void and number (0)
-         ^^^^ computed property. Indexable signature not found in
+         ^^^^ computed property. Indexer property not found in
  11:     x[0]; // should error for null, void and number (0)
          ^ Number
 
 Error: not.js:21
  21:     x[0]; // should error for number (0)
-         ^^^^ computed property. Indexable signature not found in
+         ^^^^ computed property. Indexer property not found in
  21:     x[0]; // should error for number (0)
          ^ Number
 
@@ -675,13 +675,13 @@ Error: switch.js:8
 
 Error: switch.js:27
  27:       return text[0]; // error, [0] on number
-                  ^^^^^^^ computed property. Indexable signature not found in
+                  ^^^^^^^ computed property. Indexer property not found in
  27:       return text[0]; // error, [0] on number
                   ^^^^ Number
 
 Error: switch.js:37
  37:       return text[0]; // error, [0] on number
-                  ^^^^^^^ computed property. Indexable signature not found in
+                  ^^^^^^^ computed property. Indexer property not found in
  37:       return text[0]; // error, [0] on number
                   ^^^^ Number
 
@@ -961,7 +961,7 @@ Error: tagged_union.js:265
 
 Error: typeof.js:5
   5:     x[0]; // error for boolean, not number
-         ^^^^ computed property. Indexable signature not found in
+         ^^^^ computed property. Indexer property not found in
   5:     x[0]; // error for boolean, not number
          ^ Boolean
 
@@ -1045,19 +1045,19 @@ Error: undef.js:77
 
 Error: union.js:7
   7:     x[0]; // error on boolean
-         ^^^^ computed property. Indexable signature not found in
+         ^^^^ computed property. Indexer property not found in
   7:     x[0]; // error on boolean
          ^ Boolean
 
 Error: union.js:13
  13:     x[0]; // error on number
-         ^^^^ computed property. Indexable signature not found in
+         ^^^^ computed property. Indexer property not found in
  13:     x[0]; // error on number
          ^ Number
 
 Error: union.js:19
  19:     x[0]; // error on number
-         ^^^^ computed property. Indexable signature not found in
+         ^^^^ computed property. Indexer property not found in
  19:     x[0]; // error on number
          ^ Number
 

--- a/tests/undefined/undefined.exp
+++ b/tests/undefined/undefined.exp
@@ -30,7 +30,7 @@ Error: undefined2.js:13
 
 Error: undefined2.js:22
  22:       x[0]; // should error, could be void
-           ^^^^ computed property. Indexable signature not found in
+           ^^^^ computed property. Indexer property not found in
  22:       x[0]; // should error, could be void
            ^ Number
 

--- a/website/en/docs/types/interfaces.md
+++ b/website/en/docs/types/interfaces.md
@@ -114,7 +114,7 @@ interface MyInterface {
 
 ##### Interfaces as maps <a class="toc" id="toc-interfaces-as-maps" href="#toc-interfaces-as-maps"></a>
 
-You can create ["indexer properties"](../objects/#toc-objects-as-maps) the same
+You can define an [indexer property](../objects/#toc-objects-as-maps) the same
 way as with objects.
 
 ```js

--- a/website/en/docs/types/objects.md
+++ b/website/en/docs/types/objects.md
@@ -231,25 +231,22 @@ var foo: {| foo: string |} = { foo: "Hello", bar: "World!" }; // Error!
 
 ## Objects as maps <a class="toc" id="toc-objects-as-maps" href="#toc-objects-as-maps"></a>
 
-Newer versions of the JavaScript standard include a `Map` class, but it is
-still very common to use objects as maps as well. In this use case, an object
-will likely have properties added to it and retrieved throughout its lifecycle.
-Furthermore, the property keys may not even be known statically, so writing out
-a type annotation would not be possible.
-
-For objects like these, Flow provides a special kind of property, called an
-"indexer property." An indexer property allows reads and writes using any key
-that matches the indexer key type.
+Newer versions of the JavaScript standard include a `Map` class whose instances
+store and lookup values indexed by key. It is still common to use an object
+analogously. These objects may have many keys. Furthermore, some keys may not
+even be known statically. For such objects, Flow provides a special kind of
+property called an "indexer property." An indexer property allows reads and
+writes using any key that matches the indexer property's key type.
 
 ```js
 // @flow
 var o: { [string]: number } = {};
-o["foo"] = 0;
-o["bar"] = 1;
-var foo: number = o["foo"];
+o["key1"] = 0;
+o["key2"] = 1;
+var foo: number = o["key1"];
 ```
 
-An indexer can be optionally named, for documentation purposes:
+An indexer property's key can be optionally named, for documentation purposes:
 
 ```js
 // @flow
@@ -260,17 +257,17 @@ obj[3] = "Justin";
 obj[4] = "Mark";
 ```
 
-When an object type has an indexer property, property accesses are assumed to
-have the annotated type, even if the object does not have a value in that slot
-at runtime. It is the programmer's responsibility to ensure the access is safe,
-as with arrays.
+When an object type has an indexer property, any lookup is assumed to have the
+indexer property's value type, even if the object does not have a value in that
+slot at runtime. It is the programmer's responsibility to ensure the lookup is
+safe, as with arrays.
 
 ```js
 var obj: { [number]: string } = {};
 obj[42].length; // No type error, but will throw at runtime
 ```
 
-Indexer properties can be mixed with named properties:
+An indexer property can be mixed with named properties:
 
 ```js
 // @flow


### PR DESCRIPTION
Currently Flow applies indexer variance to both indexer key and indexer value. Indexer keys should be modelled contravariant regardless of the indexer variance. Fixes #5566.

This variance stuff is somewhat foreign to me. Here's my reasoning....

Suppose that the variance token only imposes variance on the indexer's value. I intend to show that given an indexer composed of key `k` and value `v`, `k` is contravariant for covariant `v`, contravariant `v`, and invariant `v`.

* **Covariant `v`:** The indexer `+[k]: v` is isomorphic to `get(k): v`. Key `k` only appears in contravariant positions, so covariant `v` implies contravariant `k`.

* **Contravariant `v`:** The indexer `-[k]: v` is isomorphic to `set(k, v): void`. Key `k` only appears in contravariant positions, so contravariant `v` implies contravariant `k`.

* **Invariant `v`:** The indexer `[k]: v` is isomorphic to the combination of `get(k): v` and `set(k, v): void`. Key `k` only appears in contravariant positions, so invariant `v` implies contravariant `k`.

Since key `k` is contravariant regardless of value `v` variance (and equivalently indexer variance), indexer keys should always be contravariant.

*Note: By "isomorphic" I mean that given a data structure containing an indexer, there exists a data structure with identical semantics where the indexer has been replaced with `get(k): v`, `set(k, v): void`, or both `get(k): v` and `set(k, v): void` (mangling may be necessary to avoid name collisions).*