### PR TITLE
fix: return parameter for writable.setDefaultEncoding()

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -1442,7 +1442,7 @@ declare class stream$Writable extends stream$Stream {
     encodingOrCallback?: string | Function,
     callback?: Function
   ): void;
-  setDefaultEncoding(encoding: string): boolean;
+  setDefaultEncoding(encoding: string): this;
   uncork() : void;
   write(
     chunk: Buffer | string,
@@ -1473,7 +1473,7 @@ declare class stream$Duplex extends stream$Readable mixins stream$Writable {
     encodingOrCallback?: string | Function,
     callback?: Function
   ): void;
-  setDefaultEncoding(encoding: string): boolean;
+  setDefaultEncoding(encoding: string): this;
   uncork() : void;
   write(
     chunk: Buffer | string,


### PR DESCRIPTION
fix return parameter for node Writeable.setDefaultEncoding():

since v6.1.0, method returns 'this'

https://nodejs.org/api/stream.html#stream_writable_setdefaultencoding_encoding

speaking of which, what is the reason that the node.js type library (and others) are not versioned, e.g. with flow-typed?