### PR TITLE
Support inline annotations of function class fields

### DIFF
--- a/src/parser/ast_utils.mli
+++ b/src/parser/ast_utils.mli
@@ -19,3 +19,7 @@ val bindings_of_variable_declarations:
 val partition_directives:
   Loc.t Ast.Statement.t list ->
   Loc.t Ast.Statement.t list * Loc.t Ast.Statement.t list
+
+(* Extract function type AST from fully-annotated function AST *)
+val function_type_of_function:
+  Loc.t -> Loc.t Ast.Function.t -> Loc.t Ast.Type.t option

--- a/src/typing/class_sig.mli
+++ b/src/typing/class_sig.mli
@@ -3,7 +3,7 @@
 type t
 
 type field = Loc.t option * Type.polarity * field'
-and field' = Annot of Type.t | Infer of Func_sig.t
+and field' = Decl of Type.t | Init of Func_sig.t
 
 type super =
   | Interface of {

--- a/tests/classes/classes.exp
+++ b/tests/classes/classes.exp
@@ -108,6 +108,18 @@ Error: expr.js:30
  30: var alias2: Alias = _Alias.factory(); // error: bad pun
                  ^^^^^ Alias
 
+Error: field_init.js:21
+ 21:   m(x: T): T { return this.f(x) } // error: incompatible instantiation
+                           ^^^^^^^^^ T. This type is incompatible with the expected return type of
+ 21:   m(x: T): T { return this.f(x) } // error: incompatible instantiation
+                ^ T
+
+Error: field_init.js:21
+ 21:   m(x: T): T { return this.f(x) } // error: incompatible instantiation
+                                  ^ T. This type is incompatible with the expected param type of
+ 20:   f = (x: T) => x;
+               ^ T
+
 Error: loc.js:5
   5: class Foo {} // error, shadows type Foo
            ^^^ Foo. name is already bound
@@ -144,4 +156,4 @@ Error: statics.js:25
               ^^^^^ empty
 
 
-Found 19 errors
+Found 21 errors

--- a/tests/classes/field_init.js
+++ b/tests/classes/field_init.js
@@ -1,0 +1,28 @@
+/* @flow */
+
+/* Field initializers without annotations are checked for every instantiation of
+ * any type parameters (including `this`). This can cause problems if the field
+ * initializers internally references the type param. It will see the various
+ * instantiations and likely cause errors downstream.
+ *
+ * The simple solution to this is to add an annotation to the field. For
+ * functions, you can fully annotate the parameters/return type inline instead
+ * of adding a separate, redundant function type annotation on the field */
+
+// OK, `f` is fully annotated, so we extract a `T => T` type annotation
+class C1<T> {
+  f = (x: T): T => x;
+  m(x: T): T { return this.f(x) }
+}
+
+// Error: `f` is not fully annotated
+class C2<T> {
+  f = (x: T) => x;
+  m(x: T): T { return this.f(x) } // error: incompatible instantiation
+}
+
+// OK: Can still provide separate annotation
+class C3<T> {
+  f: T => T = (x: T) => x;
+  m(x: T): T { return this.f(x) }
+}


### PR DESCRIPTION
This helps mitigate an issue that people run into, where the following code is an error:

```
class C<T> {
  f = (x: T): T => x;
  m(x: T): T { return this.f(x); }
}
```

Because `f` is unannotated, we infer it's type. We check the bodies of polymorphic classes (and functions) by instantiating their type parameters with their bounds, usually `empty` and `mixed`.

This is normally fine, but In the code above, `f` is inferred to be `(empty => empty) | (mixed => mixed)`. Before this change, the only reasonable work-around was to add an annotation the code like this:

```
class C<T> {
  f: T => T = (x: T): T => x; // note the T => T annotation here
  m(x: T): T { return this.f(x); }
}
```

The insight here is that the initialization value for `f` is fully annotated. When that is the case, we can "lift" the annotation from the function expression into a function type annotation.
  