### PR TITLE
Add lib declaration for BroadcastChannel

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -382,6 +382,17 @@ declare class AnimationEvent extends UIEvent {
   ) => void;
 }
 
+// https://html.spec.whatwg.org/multipage/web-messaging.html#broadcasting-to-other-browsing-contexts
+declare class BroadcastChannel {
+  name: string;
+  onmessage: ?(event: MessageEvent) => void;
+  onmessageerror: ?(event: MessageEvent) => void;
+
+  constructor(name: string): void;
+  postMessage(msg: mixed): void;
+  close(): void;
+}
+
 // https://www.w3.org/TR/touch-events/#idl-def-Touch
 declare class Touch {
   clientX: number,


### PR DESCRIPTION
The BroadcastChannel API allows for communication between different documents of the same origin(tabs/windows/frames/iframes). For more information, see https://html.spec.whatwg.org/multipage/web-messaging.html#broadcasting-to-other-browsing-contexts