### PR TITLE
Allow passing null or undefined to clear timer functions.

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -729,8 +729,8 @@ declare function unescape(str: string): string;
 
 declare opaque type TimeoutID;
 declare opaque type IntervalID;
-declare function clearInterval(intervalId?: IntervalID): void;
-declare function clearTimeout(timeoutId?: TimeoutID): void;
+declare function clearInterval(intervalId?: ?IntervalID): void;
+declare function clearTimeout(timeoutId?: ?TimeoutID): void;
 declare function setTimeout<TArguments: Array<mixed>>(
   callback: (...args: TArguments) => mixed,
   ms?: number,


### PR DESCRIPTION
When `clearInterval()` and `clearTimeout()` are passed an invalid ID they silently do nothing; no exception is thrown.