### PR TITLE
Add optional error type param to the Promise

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -584,29 +584,103 @@ declare class WeakSet<T: Object> {
     has(value: T): boolean;
 }
 
-/* Promises
-   cf. https://github.com/borisyankov/DefinitelyTyped/blob/master/es6-promises/es6-promises.d.ts
-*/
+// For backwards compatibility make error type optional with default being mixed.
+// That way `onReject` handler for `Promise<a>` won't be able to assume any type
+// instead it will have to refine a type.
+declare class Promise<R, E = mixed> {
+    constructor(
+      callback: (
+        resolve: (result: Promise<R, E> | R) => void,
+        reject: (error: E) => void
+      ) => mixed
+    ): void;
 
-declare class Promise<+R> {
-    constructor(callback: (
-      resolve: (result: Promise<R> | R) => void,
-      reject:  (error: any) => void
-    ) => mixed): void;
+    // If both handlers are omitted return promise has the same type as this.
+    then(): Promise<R, E>;
+    // then(f) can not affect error type of `this` promise neither it can return
+    // promise with completely different error type. Instead it can return
+    // promise with extended error type. For example if `this` has type
+    // `Promise<number, string>` and `onFulfill: number => Promise<number, Error>`
+    // is passed return promise will have type of `Promise<number, string|Error>`
+    // which makes sense becouse if `this` is rejected then `onFulfill` will never
+    // run and there for returne promise will be of type `Promise<empty, string>`
+    // but if `this` is fulfilled then `onFulfill` will run and returned promise
+    // will have type of `Promise<number, Error>` which is why return promise for
+    // either case would be of type `Promise<number, string|Error>`.
+    //
+    // then(f) can return promise with completely different value type though,
+    // consider same `this` promise type `Promise<number, string>` and different
+    // `onFulfill: number => string` handler. If this is resolved then returned
+    // promise type will be of `Promise<string, empty>` but if `this` is rejected
+    // then returned promise will be of type `Promise<empty, string>` there for
+    // return type for either case would be `Promise<string, string>`.
+    //
+    // then(f) could actually do both of the things described above - return a
+    // promise with competely different value type and extended error type that is
+    // when `onFulfill: string => Promise<string, Error>` returns promise with
+    // both different value & different error type. Resulting promise in that
+    // case will be hybrid of both cases: `Promise<string, string|Error>` due to
+    // reasons explained above.
+    then<U, Y>(onFulfill: (value: R) => Promise<U, Y> | U): Promise<U, E | Y>;
+    // catch can not affect value type of `this` promise neither it can return
+    // promise with a completely different value type instead it can return
+    // promise with extended value type. For example if `this` has type
+    // `Promise<number, string>` and `onReject: string => string` is passed
+    // returned promise type will be `Promise<number|string, any>` which makes sense
+    // because if `this` is resolved `onReject` never runs so value type is
+    // number. If this is rejected then `onReject` runs and resulting promise will
+    // have value of type `string` there for resulting promise value has type of
+    // `number|string` also since in both cases returned promise is resolved it's
+    // error type `empty` but for convenience it's left open.
+    //
+    // catch can return promise with a different error type though that is if it
+    // returns rejected promise. Let's consider same example but this time around
+    // with `onReject: string => Promise<string, Error>` being passed. Returned
+    // promise will have type of `Promise<number|string, Error>` which maske sense
+    // because if `this` is resolved onReject never runs so returne promise will
+    // be of type `Promise<number, empty>`, but if `this` is rejected then return
+    // promise wil have type of `Promise<string, Error>` there for resulting
+    // promise for either case would be `Promise<number|string, Error>`.
+    catch<T, Y>(onReject: (error: E) => Promise<T, Y> | T): Promise<R | T, Y>;
+    // Please note that `then(void, f)` is equivalent of `catch` and that is
+    // reflected in type signature.
+    then<T, Y>(
+      onFulfill: void | null,
+      onReject: (error: E) => Promise<T, Y> | T
+    ): Promise<R | T, Y>;
+    // then(f, g) unlike `catch(f)` and `then(f)` can return promise that has
+    // completely different value and error types (not just extensions) that is
+    // because `value` and `error` types from `this` promise never flow through.
+    // Which is why return types of `onFulfill` and `onReject` contain all the
+    // info about returned promise type.
+    then<U, Y>(
+      onFulfill: (value: R) => Promise<U, Y> | U,
+      onReject: (error: E) => Promise<U, Y> | U
+    ): Promise<U, Y>;
 
-    then<U>(
-      onFulfill?: (value: R) => Promise<U> | U,
-      onReject?: (error: any) => Promise<U> | U
-    ): Promise<U>;
+    // Promise.resolve() produces `Promise<void, empty>` but for convenience we
+    // keep error type open.
+    static resolve<E>(): Promise<void, E>;
+    // Promise.resolve(a) returns Promise<a, empty> if `a` isn't a promise and for
+    // convenience we keep error type open. If `a` is a promise then resolve
+    // returns promise of the same type.
+    static resolve<T, E>(object: Promise<T, E> | T): Promise<T, E>;
+    // Promise.reject() returns `Promise<empty, void>` but for convenience we keep
+    // value type open.
+    static reject<T>(): Promise<T, void>;
+    // Promise.reject(e) return `Promise<empty, e>` but again for convenience we
+    // keep value type open.
+    static reject<T, E>(error: E): Promise<T, E>;
+  
+    static all<T, E>(promises: Array<Promise<T, E>>): Promise<Array<T>, E>;
+    static race<T, E>(promises: Array<Promise<T, E>>): Promise<T, E>;
+  
+    // Non-standard APIs common in some libraries
 
-    catch<U>(
-      onReject?: (error: any) => Promise<U> | U
-    ): Promise<R | U>;
+    done(onFulfill?: (value: R) => mixed, onReject?: (error: E) => mixed): void;
 
-    static resolve<T>(object: Promise<T> | T): Promise<T>;
-    static reject<T>(error?: any): Promise<T>;
-    static all<T: Iterable<mixed>>(promises: T): Promise<$TupleMap<T, typeof $await>>;
-    static race<T, Elem: Promise<T> | T>(promises: Array<Elem>): Promise<T>;
+    static cast<E>(): Promise<void, E>;
+    static cast<T, E>(object: T): Promise<T, E>;
 }
 
 // we use this signature when typing await expressions


### PR DESCRIPTION
Unfortunately the way currently promises are typed does not allows authors to type possible errors, which in many cases can be very useful. Furthermore methods like `.catch` and `.then(null, onReject)` allow users to recover from possible errors or type out exactly what errors could happen in the resulting chain but again the way promises are typed flow assumes any error type is possible. This is attempt to provide an optional error type parameter so authors can encode error types and flow could infer that most of the time & if error type is not specified it defaults to `mixed` so that `onReject` would have to refine error to a specific type rather than assume it to be **any**thing it wants.

## Caveat

Given the promise APIs thrown exception could leak through into error type but given that flow does not really handles exceptions I think it is fare to assume that author takes care of encoding error type if exceptions may be thrown. And in other all other cases `Promise<T>` would do the job.

## Next steps

I am willing to do the work to fix up the tests and write new ones to make sure this change works and delivers on it's premise, but I wanted to submit the changes I'd like to make to get an initial feedback & find out whether such a change would be welcome or rejected.