### PR TITLE
update README docs about windows compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Flow works with:
 
 * Mac OS X
 * Linux (64-bit)
-* Windows (64-bit)
+* Windows (64-bit) ( With some problems )
 
 There are [binary distributions](https://github.com/facebook/flow/releases) for each of these platforms and you can also build it from source on any of them as well.
 


### PR DESCRIPTION
in-order to save time for developers who are working on windows without getting exited and try flow on first place. 