### PR TITLE
Add Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,3 @@
+# Code of Conduct
+
+Facebook has adopted a Code of Conduct that we expect project participants to adhere to. Please [read the full text](https://code.facebook.com/codeofconduct) so that you can understand what actions will and will not be tolerated.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,5 @@
-We require contributors to sign our Contributor License Agreement. In order for us to review and merge your code, please sign up at https://code.facebook.com/cla. If you have any questions, please drop us a line at cla@fb.com. Thanks!
+We require contributors to sign our Contributor License Agreement. In order for us to review and merge your code, please sign up at https://code.facebook.com/cla. If you have any questions, please drop us a line at cla@fb.com. 
+
+You are also expected to follow the [Code of Conduct](CODE_OF_CONDUCT.md), so please read that if you are a new contributor. 
+
+Thanks!


### PR DESCRIPTION
In the past Facebook didn't promote including a Code of Conduct when creating new projects, and many projects skipped this important document. 

The Flow docs website links to the Code of Conduct in the website footer, which is great! :)

It can be even more clear to contributors if also mentioned in the `CONTRIBUTING.md` and in a `CODE_OF_CONDUCT.md`, as per the Github community guidelines.

**why make this change?:**
Facebook Open Source provides a Code of Conduct statement for all
projects to follow, to promote a welcoming and safe open source community.

Exposing the COC via a separate markdown file is a standard being
promoted by Github via the Community Profile in order to meet their Open
Source Guide's recommended community standards.

As you can see, adding this file will improve [the Flow community profile](https://github.com/facebook/flow/community)
checklist and increase the visibility of our COC.

**test plan:**
Viewing it on my branch -
<img width="1497" alt="screen shot 2018-01-14 at 3 33 30 pm" src="https://user-images.githubusercontent.com/1114467/34922133-9e0942f2-f940-11e7-938d-2e8cb5ca2748.png">
<img width="1510" alt="screen shot 2018-01-14 at 3 33 51 pm" src="https://user-images.githubusercontent.com/1114467/34922134-9e288248-f940-11e7-9193-2d9f88b08d1c.png">

**issue:**
internal task t23481323