### PR TITLE
Update docs for 'supress__comment' config option

### DIFF
--- a/website/en/docs/config/options.md
+++ b/website/en/docs/config/options.md
@@ -332,7 +332,7 @@ var x : string = 123;
 ```
 
 and suppress the error. If there is no error on the next line (the suppression
-is unnecessary), an "Unused suppression" error will be shown instead.
+is unnecessary), an "Unused suppression" warning will be shown instead.
 
 If no suppression comments are specified in your config, Flow will apply one
 default: `// $FlowFixMe`.


### PR DESCRIPTION
The docs for the 'suppress_comment' config option currently indicate that "Unused suppression" warnings are in fact errors, which changed in `v0.54.0`. Closes https://github.com/facebook/flow/issues/5612.