### PR TITLE
lib: Improve Object.values and Object.entries

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -32,7 +32,7 @@ declare class Object {
     static create(o: any, properties?: any): any; // compiler magic
     static defineProperties(o: any, properties: any): any;
     static defineProperty(o: any, p: any, attributes: any): any;
-    static entries(object: any): Array<[string, mixed]>;
+    static entries<T: Object>(object: T): Array<[$Keys<T>, $Values<T>]>;
     static freeze<T>(o: T): T;
     static getOwnPropertyDescriptor(o: any, p: any): any;
     static getOwnPropertyNames(o: any): Array<string>;
@@ -46,7 +46,7 @@ declare class Object {
     static preventExtensions(o: any): any;
     static seal(o: any): any;
     static setPrototypeOf(o: any, proto: ?Object): any;
-    static values(object: any): Array<mixed>;
+    static values<T: Object>(object: T): Array<$Values<T>>;
     hasOwnProperty(prop: any): boolean;
     isPrototypeOf(o: any): boolean;
     propertyIsEnumerable(prop: any): boolean;

--- a/tests/dump-types/dump-types.exp
+++ b/tests/dump-types/dump-types.exp
@@ -2958,8 +2958,8 @@
         "def_loc":{
           "source":"[LIB] core.js",
           "type":"LibFile",
-          "start":{"line":238,"column":15,"offset":8585},
-          "end":{"line":238,"column":19,"offset":8590}
+          "start":{"line":238,"column":15,"offset":8615},
+          "end":{"line":238,"column":19,"offset":8620}
         },
         "path":"predicates.js",
         "line":9,
@@ -2994,8 +2994,8 @@
         "def_loc":{
           "source":"[LIB] core.js",
           "type":"LibFile",
-          "start":{"line":277,"column":5,"offset":10460},
-          "end":{"line":277,"column":34,"offset":10490}
+          "start":{"line":277,"column":5,"offset":10490},
+          "end":{"line":277,"column":34,"offset":10520}
         },
         "path":"predicates.js",
         "line":9,

--- a/tests/object_api/object_api.exp
+++ b/tests/object_api/object_api.exp
@@ -27,6 +27,24 @@ Error: object_create.js:17
  17: (o: C);
          ^ C
 
+Error: object_entries.js:7
+  7:   (v: string) // error: boolean ~> string
+        ^ boolean. This type is incompatible with
+  7:   (v: string) // error: boolean ~> string
+           ^^^^^^ string
+
+Error: object_entries.js:23
+ 23:     (v: 1); // error: 1 ~> 2
+          ^ number literal `2`. Expected number literal `1`, got `2` instead
+ 23:     (v: 1); // error: 1 ~> 2
+             ^ number literal `1`
+
+Error: object_entries.js:27
+ 27:     (v: 2); // error: 2 ~> 1
+          ^ number literal `1`. Expected number literal `2`, got `1` instead
+ 27:     (v: 2); // error: 2 ~> 1
+             ^ number literal `2`
+
 Error: object_keys.js:5
   5: (Object.keys(sealed): void); // error, Array<string>
       ^^^^^^^^^^^^^^^^^^^ array type. This type is incompatible with
@@ -258,6 +276,24 @@ Error: object_prototype.js:155
 155: var yToLocaleString : number = y.toLocaleString; // error
                            ^^^^^^ number
 
+Error: object_values.js:6
+  6:   (v: string) // error: boolean ~> string
+        ^ boolean. This type is incompatible with
+  6:   (v: string) // error: boolean ~> string
+           ^^^^^^ string
+
+Error: object_values.js:19
+ 19:     (v: 3); // error: 2 ~> 3
+          ^ number literal `2`. Expected number literal `3`, got `2` instead
+ 19:     (v: 3); // error: 2 ~> 3
+             ^ number literal `3`
+
+Error: object_values.js:23
+ 23:     (v: 3); // error: 1 ~> 3
+          ^ number literal `1`. Expected number literal `3`, got `1` instead
+ 23:     (v: 3); // error: 1 ~> 3
+             ^ number literal `3`
+
 Error: proto.js:3
   3: (o1_proto.toString: empty); // error: function ~> empty
       ^^^^^^^^^^^^^^^^^ function type. This type is incompatible with
@@ -283,4 +319,4 @@ Error: proto.js:17
       ^^^^^^^^^^^ super of `C1`
 
 
-Found 39 errors
+Found 45 errors

--- a/tests/object_api/object_entries.js
+++ b/tests/object_api/object_entries.js
@@ -1,0 +1,29 @@
+/* @flow */
+
+declare var o1: {[string]: boolean};
+for (const [k, v] of Object.entries(o1)) {
+  (k: string);
+  (v: boolean);
+  (v: string) // error: boolean ~> string
+}
+
+declare var o2: {['a' | 'b']: 1 | 2};
+for (const [k, v] of Object.entries(o2)) {
+  (k: 'a' | 'b');
+  (k: string);
+  (v: 1 | 2);
+  (v: number);
+}
+
+declare var o3: {a: 1, b: 2};
+for (const [k, v] of Object.entries(o3)) {
+  // hopefully these refinements will work one day
+  if (k === 'a') {
+    (v: 1 | 2);
+    (v: 1); // error: 1 ~> 2
+  }
+  if (k === 'b') {
+    (v: 1 | 2);
+    (v: 2); // error: 2 ~> 1
+  }
+}

--- a/tests/object_api/object_values.js
+++ b/tests/object_api/object_values.js
@@ -1,0 +1,25 @@
+/* @flow */
+
+declare var o1: {[string]: boolean};
+for (const v of Object.values(o1)) {
+  (v: boolean);
+  (v: string) // error: boolean ~> string
+}
+
+declare var o2: {[string]: 1 | 2};
+for (const v of Object.values(o2)) {
+  (v: 1 | 2);
+  (v: number);
+}
+
+declare var o3: {a: 1, b: 2};
+for (const v of Object.values(o3)) {
+  if (v !== 1) {
+    (v: 2);
+    (v: 3); // error: 2 ~> 3
+  }
+  if (v !== 2) {
+    (v: 1);
+    (v: 3); // error: 1 ~> 3
+  }
+}


### PR DESCRIPTION
Use `$Keys` and `$Values` to better reflect that actual types of `Object.values` and `Object.entries`. Fixes #2804.