### PR TITLE
Fix arity of clearInterval, clearTimeout

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -729,8 +729,8 @@ declare function unescape(str: string): string;
 
 declare opaque type TimeoutID;
 declare opaque type IntervalID;
-declare function clearInterval(intervalId?: IntervalID): void;
-declare function clearTimeout(timeoutId?: TimeoutID): void;
+declare function clearInterval(intervalId: ?IntervalID): void;
+declare function clearTimeout(timeoutId: ?TimeoutID): void;
 declare function setTimeout<TArguments: Array<mixed>>(
   callback: (...args: TArguments) => mixed,
   ms?: number,


### PR DESCRIPTION
It's okay for their argument to be null/undefined, which appears to have been the intended type, but `clearTimeout()` does not make sense.

Fixes type errors in 0.63.x where (valid) code that passed an `?IntervalID` or `?TimeoutID` threw errors.