### PR TITLE
Fix send type

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -239,7 +239,7 @@ declare class child_process$ChildProcess extends events$EventEmitter {
   disconnect(): void;
   kill(signal?: string): void;
   send(
-    message: Object,
+    message: any,
     sendHandleOrCallback?: child_process$Handle,
     optionsOrCallback?: Object | Function,
     callback?: Function


### PR DESCRIPTION
`ChildProcess#send` can accept any object, since it will be serialized to JSON. Passing an `Array` now throws, but by using `any` it will work.