### PR TITLE
Add validationMessage to HTMLSelectElement

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -2869,6 +2869,7 @@ declare class HTMLSelectElement extends HTMLElement {
   selectedIndex: number;
   size: number;
   type: string;
+  validationMessage: string;
   value: string;
 
   add(element: HTMLElement, before?: HTMLElement): void;


### PR DESCRIPTION
This adds the `validationMessage` property to the `HTMLSelectElement`.

* MDN – https://developer.mozilla.org/en-US/docs/Web/API/HTMLSelectElement
* Apple Webkit – https://developer.apple.com/documentation/webkitjs/htmlselectelement/1632209-validationmessage?changes=latest_major