### PR TITLE
Make process.umask's argument optional

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -1980,7 +1980,7 @@ declare class Process extends events$EventEmitter {
   stdin : stream$Readable | tty$ReadStream;
   stdout : stream$Writable | tty$WriteStream;
   title : string;
-  umask(mask : number) : number;
+  umask(mask? : number) : number;
   uptime() : number;
   version : string;
   versions : {


### PR DESCRIPTION
>  Invoked without an argument, the current mask is returned, otherwise the umask is set to the argument value...

https://nodejs.org/api/process.html#process_process_umask_mask