### PR TITLE
Type ReactDOM.render to correctly indicate that it may return null

### DIFF
--- a/lib/react-dom.js
+++ b/lib/react-dom.js
@@ -17,7 +17,7 @@ declare module 'react-dom' {
     element: React$Element<ElementType>,
     container: Element,
     callback?: () => void,
-  ): React$ElementRef<ElementType>;
+  ): ?React$ElementRef<ElementType>;
 
   declare function createPortal(
     node: React$Node,


### PR DESCRIPTION
It's possible for `ReactDOM.render` to return null.

See issue: https://github.com/facebook/react/issues/10309#issuecomment-318392589
And demo: https://jsfiddle.net/x7c7bdh0/