### PR TITLE
module.system.node.main_field

### DIFF
--- a/newtests/package_json_changes/irrelevantChangeMainField.json
+++ b/newtests/package_json_changes/irrelevantChangeMainField.json
@@ -1,4 +1,4 @@
 {
   "name":"foo",
-  "other_main":"foo",
+  "other_main":"foo"
 }

--- a/newtests/package_json_changes/irrelevantChangeMainField.json
+++ b/newtests/package_json_changes/irrelevantChangeMainField.json
@@ -1,0 +1,4 @@
+{
+  "name":"foo",
+  "other_main":"foo",
+}

--- a/newtests/package_json_changes/node_flowconfig_with_main_field
+++ b/newtests/package_json_changes/node_flowconfig_with_main_field
@@ -1,0 +1,11 @@
+[ignore]
+
+[include]
+
+[libs]
+
+[options]
+all=true
+module.system=node
+module.system.node.main_field=main
+module.system.node.main_field=other_main

--- a/newtests/package_json_changes/test.js
+++ b/newtests/package_json_changes/test.js
@@ -69,4 +69,12 @@ export default suite(({addFile, removeFile, exitCode, flowCmd}) => [
       .waitForServerToDie(2000)
       .serverRunning(true)
   ]).flowConfig('haste_flowconfig'),
+
+  test('node - When using main_fields, a change which resolves to '+
+    'the same main file should NOT kill the server', [
+    addFile('start.json', 'package.json'),
+    addFile('irrelevantChangeMainField.json', 'package.json')
+      .waitForServerToDie(2000)
+      .serverRunning(true)
+  ]).flowConfig('node_flowconfig_with_main_field'),
 ]);

--- a/ocp_build_flow.ocp.fb
+++ b/ocp_build_flow.ocp.fb
@@ -255,6 +255,7 @@ begin library "flow-parser-utils"
   end
   requires = [
     "dtoa"
+    "flow-common"
     "flow-common-utils"
     "flow-parser"
     "hh-utils"

--- a/src/commands/commandUtils.ml
+++ b/src/commands/commandUtils.ml
@@ -682,6 +682,7 @@ let make_options ~flowconfig ~lazy_mode ~root (options_flags: Options_flags.t) =
     opt_module = FlowConfig.module_system flowconfig;
     opt_munge_underscores =
       options_flags.munge_underscore_members || FlowConfig.munge_underscores flowconfig;
+    opt_node_main_fields = FlowConfig.node_main_fields flowconfig;
     opt_temp_dir = temp_dir;
     opt_max_workers =
       Option.value options_flags.max_workers ~default:(FlowConfig.max_workers flowconfig)

--- a/src/commands/config/flowConfig.ml
+++ b/src/commands/config/flowConfig.ml
@@ -49,6 +49,7 @@ module Opts = struct
     include_warnings: bool;
     module_system: Options.module_system;
     module_name_mappers: (Str.regexp * string) list;
+    node_main_fields: string list;
     node_resolver_dirnames: string list;
     merge_timeout: int option;
     munge_underscores: bool;
@@ -152,6 +153,7 @@ module Opts = struct
     merge_timeout = Some 100;
     module_system = Options.Node;
     module_name_mappers = [];
+    node_main_fields = ["main"];
     node_resolver_dirnames = ["node_modules"];
     munge_underscores = false;
     module_file_exts;
@@ -676,6 +678,18 @@ let parse_options config lines =
       });
     }
 
+    |> define_opt "module.system.node.main_field" {
+      initializer_ = INIT_FN (fun opts -> {
+        opts with node_main_fields = [];
+      });
+      flags = [ALLOW_DUPLICATE];
+      optparser = optparse_string;
+      setter = (fun opts v ->
+        let node_main_fields = v::opts.node_main_fields in
+        Ok {opts with node_main_fields;}
+      );
+    }
+
     |> define_opt "module.system.node.resolve_dirname" {
       initializer_ = INIT_FN (fun opts -> {
         opts with node_resolver_dirnames = [];
@@ -1001,6 +1015,7 @@ let module_system c = c.options.Opts.module_system
 let modules_are_use_strict c = c.options.Opts.modules_are_use_strict
 let munge_underscores c = c.options.Opts.munge_underscores
 let no_flowlib c = c.options.Opts.no_flowlib
+let node_main_fields c = c.options.Opts.node_main_fields
 let node_resolver_dirnames c = c.options.Opts.node_resolver_dirnames
 let shm_dep_table_pow c = c.options.Opts.shm_dep_table_pow
 let shm_dirs c = c.options.Opts.shm_dirs

--- a/src/commands/config/flowConfig.mli
+++ b/src/commands/config/flowConfig.mli
@@ -59,6 +59,7 @@ val module_resource_exts: config -> SSet.t
 val module_system: config -> Options.module_system
 val modules_are_use_strict: config -> bool
 val munge_underscores: config -> bool
+val node_main_fields: config -> string list
 val no_flowlib: config -> bool
 val node_resolver_dirnames: config -> string list
 val shm_dep_table_pow: config -> int

--- a/src/common/options.ml
+++ b/src/common/options.ml
@@ -55,6 +55,7 @@ type t = {
   opt_module_name_mappers: (Str.regexp * string) list;
   opt_modules_are_use_strict: bool;
   opt_munge_underscores: bool;
+  opt_node_main_fields: string list;
   opt_profile : bool;
   opt_lazy_mode: lazy_mode option;
   opt_quiet : bool;
@@ -96,6 +97,7 @@ let merge_timeout opts = opts.opt_merge_timeout
 let module_name_mappers opts = opts.opt_module_name_mappers
 let module_system opts = opts.opt_module
 let modules_are_use_strict opts = opts.opt_modules_are_use_strict
+let node_main_fields opts = opts.opt_node_main_fields
 let root opts = opts.opt_root
 let facebook_fbt opts = opts.opt_facebook_fbt
 let should_ignore_non_literal_requires opts =

--- a/src/parser_utils/package_json.ml
+++ b/src/parser_utils/package_json.ml
@@ -37,27 +37,39 @@ let properties_of_object = function
   | (_, Ast.Expression.Object {Ast.Expression.Object.properties}) -> Ok properties
   | _ -> Error "Expected an object literal"
 
-let parse ast =
+(* Given a list of JSON properties, extract the string properties and turn it into a string SMap.t
+ *)
+let extract_property map property =
+  let open Ast in
+  let open Expression.Object in
+  match property with
+  | Property (_, Property.Init {
+      key = Property.Literal(_, { Literal.value = Literal.String key; _ });
+      value = (_, Expression.Literal { Literal.
+        value = Literal.String value;
+        _
+      });
+      _;
+    }) -> SMap.add key value map
+  | _ -> map
+
+(* prop_map is [ "main" ] by default but could be something like [ "foo", "bar" ]. In that case
+ * we treat the "foo" property like the main property if it exists. If not, we fall back to the
+ * "bar" property
+ *
+ * Spec'd on https://github.com/facebook/flow/issues/5725 *)
+let rec find_main_property prop_map = function
+| prop::rest ->
+  let ret = SMap.get prop prop_map in
+  if ret = None then find_main_property prop_map rest else ret
+| [] -> None
+
+let parse ~options ast =
   statement_of_program ast
   >>= object_of_statement
   >>= properties_of_object
   >>= fun properties ->
-    let open Ast in
-    let open Expression.Object in
-    let extract_property package = function
-      | Property (_, Property.Init {
-          key = Property.Literal(_, { Literal.value = Literal.String key; _ });
-          value = (_, Expression.Literal { Literal.
-            value = Literal.String value;
-            _
-          });
-          _;
-        }) ->
-          begin match key with
-          | "name" -> { package with name = Some value }
-          | "main" -> { package with main = Some value }
-          | _ -> package
-          end
-      | _ -> package
-    in
-    Ok (List.fold_left extract_property empty properties)
+    let prop_map = List.fold_left extract_property SMap.empty properties in
+    let name = SMap.get "name" prop_map in
+    let main = find_main_property prop_map (Options.node_main_fields options) in
+    Ok { name; main }

--- a/src/parser_utils/package_json.mli
+++ b/src/parser_utils/package_json.mli
@@ -9,4 +9,4 @@ type t
 val empty: t
 val name: t -> string option
 val main: t -> string option
-val parse: Loc.t Ast.program -> (t, string) result
+val parse: options:Options.t -> Loc.t Ast.program -> (t, string) result

--- a/src/server/rechecker.ml
+++ b/src/server/rechecker.ml
@@ -34,7 +34,7 @@ let process_updates genv env updates =
     FlowExitStatus.(exit Flowconfig_changed)
   end;
 
-  let is_incompatible filename_str =
+  let is_incompatible ~options filename_str =
     let filename = File_key.JsonFile filename_str in
     let filename_set = FilenameSet.singleton filename in
     let ast_opt =
@@ -59,7 +59,7 @@ let process_updates genv env updates =
     in
     match ast_opt with
       | None -> true
-      | Some ast -> Module_js.package_incompatible filename_str ast
+      | Some ast -> Module_js.package_incompatible ~options filename_str ast
   in
 
   (* Die if a package.json changed in an incompatible way *)
@@ -68,7 +68,7 @@ let process_updates genv env updates =
       Files.is_included file_options f)
     && (Filename.basename f) = "package.json"
     && want f
-    && is_incompatible f
+    && is_incompatible ~options f
   ) updates in
   if not (SSet.is_empty incompatible_packages)
   then begin

--- a/src/services/inference/module_js.ml
+++ b/src/services/inference/module_js.ml
@@ -166,8 +166,8 @@ module ReversePackageHeap = SharedMem_js.WithCache (StringKey) (struct
     let description = "ReversePackage"
   end)
 
-let add_package filename ast =
-  match Package_json.parse ast with
+let add_package ~options filename ast =
+  match Package_json.parse ~options ast with
   | Ok package ->
     PackageHeap.add filename package;
     begin match Package_json.name package with
@@ -178,8 +178,8 @@ let add_package filename ast =
   | Error parse_err ->
     assert_false (spf "%s: %s" filename parse_err)
 
-let package_incompatible filename ast =
-  match Package_json.parse ast with
+let package_incompatible ~options filename ast =
+  match Package_json.parse ~options ast with
   | Ok new_package ->
     begin match PackageHeap.get filename with
     | None -> true

--- a/src/services/inference/module_js.mli
+++ b/src/services/inference/module_js.mli
@@ -105,9 +105,9 @@ val add_parsed_resolved_requires: (
 (* remove resolved requires from store *)
 val remove_batch_resolved_requires: FilenameSet.t -> unit
 
-val add_package: string -> Loc.t Ast.program -> unit
+val add_package: options:Options.t -> string -> Loc.t Ast.program -> unit
 
-val package_incompatible: string -> Loc.t Ast.program -> bool
+val package_incompatible: options:Options.t -> string -> Loc.t Ast.program -> bool
 
 (***************************************************)
 

--- a/src/services/inference/types_js.ml
+++ b/src/services/inference/types_js.ml
@@ -606,7 +606,7 @@ let init_package_heap ~options ~profiling parsed =
       match filename with
       | File_key.JsonFile str when Filename.basename str = "package.json" ->
         let ast = Parsing_service_js.get_ast_unsafe filename in
-        Module_js.add_package str ast
+        Module_js.add_package ~options str ast
       | _ -> ()
     ) parsed;
   )

--- a/tests/node_main_fields/.flowconfig
+++ b/tests/node_main_fields/.flowconfig
@@ -1,0 +1,13 @@
+[ignore]
+
+[include]
+
+[libs]
+
+[lints]
+
+[options]
+module.system.node.main_field=foo
+module.system.node.main_field=bar
+
+[strict]

--- a/tests/node_main_fields/node_main_fields.exp
+++ b/tests/node_main_fields/node_main_fields.exp
@@ -1,0 +1,18 @@
+Error: test.js:3
+  3: import C from 'C'; // Error - this module has neither a foo nor bar property
+                   ^^^ C. Required module not found
+
+Error: test.js:5
+  5: (A: empty); // Error: string ~> empty
+      ^ string. This type is incompatible with
+  5: (A: empty); // Error: string ~> empty
+         ^^^^^ empty
+
+Error: test.js:6
+  6: (B: empty); // Error: boolean ~> empty
+      ^ boolean. This type is incompatible with
+  6: (B: empty); // Error: boolean ~> empty
+         ^^^^^ empty
+
+
+Found 3 errors

--- a/tests/node_main_fields/node_modules/A/bar.js
+++ b/tests/node_main_fields/node_modules/A/bar.js
@@ -1,0 +1,1 @@
+export default true;

--- a/tests/node_main_fields/node_modules/A/foo.js
+++ b/tests/node_main_fields/node_modules/A/foo.js
@@ -1,0 +1,1 @@
+export default "hello";

--- a/tests/node_main_fields/node_modules/A/main.js
+++ b/tests/node_main_fields/node_modules/A/main.js
@@ -1,0 +1,1 @@
+export default 123;

--- a/tests/node_main_fields/node_modules/A/package.json
+++ b/tests/node_main_fields/node_modules/A/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "A",
+  "main": "main.js",
+  "foo": "foo.js",
+  "bar": "bar.js"
+}

--- a/tests/node_main_fields/node_modules/B/bar.js
+++ b/tests/node_main_fields/node_modules/B/bar.js
@@ -1,0 +1,1 @@
+export default true;

--- a/tests/node_main_fields/node_modules/B/foo.js
+++ b/tests/node_main_fields/node_modules/B/foo.js
@@ -1,0 +1,1 @@
+export default "hello";

--- a/tests/node_main_fields/node_modules/B/main.js
+++ b/tests/node_main_fields/node_modules/B/main.js
@@ -1,0 +1,1 @@
+export default 123;

--- a/tests/node_main_fields/node_modules/B/package.json
+++ b/tests/node_main_fields/node_modules/B/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "B",
+  "main": "main.js",
+  "bar": "bar.js"
+}

--- a/tests/node_main_fields/node_modules/C/bar.js
+++ b/tests/node_main_fields/node_modules/C/bar.js
@@ -1,0 +1,1 @@
+export default true;

--- a/tests/node_main_fields/node_modules/C/foo.js
+++ b/tests/node_main_fields/node_modules/C/foo.js
@@ -1,0 +1,1 @@
+export default "hello";

--- a/tests/node_main_fields/node_modules/C/main.js
+++ b/tests/node_main_fields/node_modules/C/main.js
@@ -1,0 +1,1 @@
+export default 123;

--- a/tests/node_main_fields/node_modules/C/package.json
+++ b/tests/node_main_fields/node_modules/C/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "C",
+  "main": "main.js",
+}

--- a/tests/node_main_fields/test.js
+++ b/tests/node_main_fields/test.js
@@ -1,0 +1,6 @@
+import A from 'A'; // This module has a foo property
+import B from 'B'; // This module has a bar property
+import C from 'C'; // Error - this module has neither a foo nor bar property
+
+(A: empty); // Error: string ~> empty
+(B: empty); // Error: boolean ~> empty

--- a/website/en/docs/config/options.md
+++ b/website/en/docs/config/options.md
@@ -31,6 +31,7 @@ can be overridden with command line flags.
 * [`module.name_mapper`](#toc-module-name-mapper-regex-string)
 * [`module.name_mapper.extension`](#toc-module-name-mapper-extension-string-string)
 * [`module.system`](#toc-module-system-node-haste)
+* [`module.system.node.main_field`](#toc-module-system-node-main-field-string)
 * [`module.system.node.resolve_dirname`](#toc-module-system-node-resolve-dirname-string)
 * [`module.use_strict`](#toc-module-use-strict-boolean)
 * [`munge_underscores`](#toc-munge-underscores-boolean)
@@ -202,6 +203,38 @@ The module system to use to resolve `import` and `require`.
 [Haste](https://github.com/facebook/node-haste) is used in React Native.
 
 The default is `node`.
+
+#### `module.system.node.main_field` _`(string)`_ <a class="toc" id="toc-module-system-node-main-field-string" href="#toc-module-system-node-main-field-string"></a>
+
+Flow reads `package.json` files for the `"name"` and `"main"` fields to figure
+out the name of the module and which file should be used to provide that
+module.
+
+So if Flow sees this in the `.flowconfig`:
+
+```
+[options]
+module.system.node.main_field=foo
+module.system.node.main_field=bar
+module.system.node.main_field=baz
+```
+
+and then it comes across a `package.json` with
+
+```
+{
+  "name": "kittens",
+  "main": "main.js",
+  "bar": "bar.js",
+  "baz": "baz.js"
+}
+```
+
+Flow will use `bar.js` to provide the `"kittens"` module.
+
+If this option is unspecified, Flow will always use the `"main"` field.
+
+See [this GitHub issue for the original motivation](https://github.com/facebook/flow/issues/5725)
 
 #### `module.system.node.resolve_dirname` _`(string)`_ <a class="toc" id="toc-module-system-node-resolve-dirname-string" href="#toc-module-system-node-resolve-dirname-string"></a>
 


### PR DESCRIPTION
(Copy pasting docs for commit message 😛 )

Flow reads `package.json` files for the `"name"` and `"main"` fields to figure
out the name of the module and which file should be used to provide that
module.

So if Flow sees this in the `.flowconfig`:

```
[options]
module.system.node.main_field=foo
module.system.node.main_field=bar
module.system.node.main_field=baz
```

and then it comes across a `package.json` with

```
{
  "name": "kittens",
  "main": "main.js",
  "bar": "bar.js",
  "baz": "baz.js"
}
```

Flow will use `bar.js` to provide the `"kittens"` module.

If this option is unspecified, Flow will always use the `"main"` field.

See [this GitHub issue for the original motivation](https://github.com/facebook/flow/issues/5725)

Resolves #5725