### PR TITLE
Fix for setState definition

### DIFF
--- a/website/en/docs/react/events.md
+++ b/website/en/docs/react/events.md
@@ -26,9 +26,9 @@ class MyComponent extends React.Component<{}, { count: number }> {
     // To access your button instance use `event.currentTarget`.
     (event.currentTarget: HTMLButtonElement);
 
-    this.setState(prevState => ({
+    this.setState(prevState => {
       count: prevState.count + 1,
-    }));
+    });
   };
 
   render() {


### PR DESCRIPTION
Does not match the specs removed to pass latest flow check.

  setState(
    partialState: $Shape<State> | ((State, Props) => $Shape<State> | void),
    callback?: () => mixed,
  ): void;