### PR TITLE
Disable max-clients check on Windows

### DIFF
--- a/src/monitor/socketAcceptor.ml
+++ b/src/monitor/socketAcceptor.ml
@@ -144,8 +144,18 @@ let perform_handshake_and_get_client_type ~client_fd =
       (* We currently rely on using Unix.select, which doesn't work for fds >= FD_SETSIZE (1024).
        * So we can't have an unlimited number of clients. So if the new fd is too large, let's
        * reject it. Never reject a kill handshake, though. *)
-      let fd_as_int: int = client_fd |> Lwt_unix.unix_file_descr |> Obj.magic in
-      if client_type <> SocketHandshake.StabbityStabStab && fd_as_int > 500 then
+
+      (* TODO (glevi): Figure out whether this check is needed for Windows *)
+      let fd_as_int: int =
+        if Sys.unix
+        then client_fd |> Lwt_unix.unix_file_descr |> Obj.magic
+        else -1
+      in
+      let too_many_clients = Sys.unix && (
+        client_type <> SocketHandshake.StabbityStabStab && fd_as_int > 500
+      ) in
+      if too_many_clients
+      then
         Marshal_tools_lwt.to_fd_with_preamble client_fd SocketHandshake.Too_many_clients
         >|= (fun () -> failwith (spf "Too many clients, so rejecting new connection (%d)" fd_as_int))
       else if is_lsp && not (StatusStream.ever_been_free ()) then


### PR DESCRIPTION
In Unix, fds are small integers that get reused as fds free up. The same is not true on Windows. This check should never have been enabled for Windows as is. My bad!