### PR TITLE
Docs: Fix predicate functions anchor link

### DIFF
--- a/website/en/docs/types/functions.md
+++ b/website/en/docs/types/functions.md
@@ -213,7 +213,7 @@ var num: number = method.call(42);
 var str: string = method.call(42);
 ```
 
-### Predicate Functions <a class="toc" id="toc-function-checks" href="#toc-predicate-functions"></a>
+### Predicate Functions <a class="toc" id="toc-predicate-functions" href="#toc-predicate-functions"></a>
 
 Sometimes you will want to move the condition from an `if` statement into a function:
 


### PR DESCRIPTION
Usually clicking the `#` symbol next to a heading in the docs links to that section. However this is broken for the "Predicate functions" section on https://flow.org/en/docs/types/functions/