### PR TITLE
Update assert.fail() definition

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -1831,7 +1831,7 @@ declare module "assert" {
   declare module.exports: {
     (value: any, message?: string): void;
     ok(value: any, message?: string): void;
-    fail(actual: any, expected: any, message: string, operator: string): void;
+    fail(actual: any, expected: any, message?: string, operator?: string, stackStartFunction?: Function): void;
     equal(actual: any, expected: any, message?: string): void;
     notEqual(actual: any, expected: any, message?: string): void;
     deepEqual(actual: any, expected: any, message?: string): void;


### PR DESCRIPTION
Updates type definition for `assert.fail()`, according to [API docs](https://nodejs.org/dist/latest-v8.x/docs/api/assert.html#assert_assert_fail_message).

In addition to current signature, the function can also be called with a single message argument `assert.fail(message)`. I'm not sure how attach both declarations to the `fail` property though.