### PR TITLE
correct type for readdir

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -779,16 +779,16 @@ declare module "fs" {
   declare function readdir(
     path: string,
     options: string | { encoding: string },
-    callback: (err: ?ErrnoError, files: Array<string>) => void
+    callback: (err: ?ErrnoError, files: Array<string|Buffer>) => void
   ): void;
   declare function readdir(
     path: string,
-    callback: (err: ?ErrnoError, files: Array<string>) => void
+    callback: (err: ?ErrnoError, files: Array<string|Buffer>) => void
   ): void;
   declare function readdirSync(
     path: string,
     options?: string | { encoding: string }
-  ): Array<string>;
+  ): Array<string|Buffer>;
   declare function close(fd: number, callback: (err: ?ErrnoError) => void): void;
   declare function closeSync(fd: number): void;
   declare function open(


### PR DESCRIPTION
Includes potential for readdir returning an `Array<Buffer>`, which happens when encoding is set to `'buffer'`. https://nodejs.org/api/fs.html#fs_fs_readdir_path_options_callback