### PR TITLE
Fix react-dom/test-utils annotations for functions that throw exceptions

### DIFF
--- a/lib/react-dom.js
+++ b/lib/react-dom.js
@@ -91,7 +91,7 @@ declare module 'react-dom/test-utils' {
   declare function findRenderedDOMComponentWithClass(
     tree: React$Component<any, any>,
     className: string,
-  ): ?Element;
+  ): Element;
   declare function scryRenderedDOMComponentsWithTag(
     tree: React$Component<any, any>,
     tagName: string,
@@ -99,7 +99,7 @@ declare module 'react-dom/test-utils' {
   declare function findRenderedDOMComponentWithTag(
     tree: React$Component<any, any>,
     tagName: string,
-  ): ?Element;
+  ): Element;
   declare function scryRenderedComponentsWithType(
     tree: React$Component<any, any>,
     componentClass: React$ElementType,
@@ -107,7 +107,7 @@ declare module 'react-dom/test-utils' {
   declare function findRenderedComponentWithType(
     tree: React$Component<any, any>,
     componentClass: React$ElementType,
-  ): ?React$Component<any, any>;
+  ): React$Component<any, any>;
 }
 
 declare class SyntheticEvent<+T: EventTarget = EventTarget> {

--- a/tests/react/test-utils.js
+++ b/tests/react/test-utils.js
@@ -38,16 +38,14 @@ TestUtils.mockComponent(MyTestingComponent, 'span');
 >);
 
 const buttonEl = TestUtils.findRenderedDOMComponentWithClass(tree, 'my-button');
-if (buttonEl != null) {
-  TestUtils.Simulate.click(buttonEl);
-}
+TestUtils.Simulate.click(buttonEl);
 
 (TestUtils.scryRenderedDOMComponentsWithTag(tree, 'button'): Array<Element>);
-(TestUtils.findRenderedDOMComponentWithTag(tree, 'button'): ?Element);
+(TestUtils.findRenderedDOMComponentWithTag(tree, 'button'): Element);
 (TestUtils.scryRenderedComponentsWithType(tree, MyTestingComponent): Array<
   React.Component<any, any>,
 >);
 (TestUtils.findRenderedComponentWithType(
   tree,
   MyTestingComponent,
-): ?React.Component<any, any>);
+): React.Component<any, any>);


### PR DESCRIPTION
The series of the `find*` functions in test utils for ReactDOM are expected to either return a single element or throw an exception. However the return value is still marked as optional which doesn't make any sense.

I originally raised this issue in https://github.com/flowtype/flow-typed/issues/1852 but it seems that libdefs are contained in this repository.