### PR TITLE
Update config docs to warn about antipattern

### DIFF
--- a/website/en/docs/config/options.md
+++ b/website/en/docs/config/options.md
@@ -219,6 +219,8 @@ module.system.node.resolve_dirname=custom_node_modules
 Then Flow will look in directories named `node_modules` or
 `custom_node_modules`.
 
+It is important to use `module.system.node.resolve_dirname` only for external dependency sources such as `node_modules`. If your aim is to enable your internal modules to import each other via absolute paths (to avoid long `../../..` relative paths), use [`module.name_mapper`](https://flow.org/en/docs/config/options/#toc-module-name-mapper-regex-string) instead. This is because using `module.system.node.resolve_dirname` opts into a new feature added in v0.57.0 intended for `node_modules`, whereby Flow skips checking any files that aren't direct or transitive dependencies of other files outside this directory—probably not what you want.
+
 > **Note:** you can specify `module.system.node.resolve_dirname` multiple times
 
 #### `module.use_strict` _`(boolean)`_ <a class="toc" id="toc-module-use-strict-boolean" href="#toc-module-use-strict-boolean"></a>


### PR DESCRIPTION
## Problem

This is a common pattern in the Flow community:

```
[options]
module.system.node.resolve_dirname=node_modules
module.system.node.resolve_dirname=src
```

It enables you to write `import foo from 'common/foo'` to get hold of `src/common/foo` from anywhere within your codebase, even from a deeply nested module, so you can avoid having to do `../../../` paths.

The problem is, Flow v0.57.0 added a [new feature](https://github.com/facebook/flow/blob/master/Changelog.md#0570):

> * Flow will now only check the files in `node_modules/` which are direct or transitive dependencies of the non-`node_modules` code.

This is a good feature. But for anyone using the above technique, it breaks Flow in a very confusing way: it stops checking all your `src` files reliably. It reports errors in *some* files, but misses many others. Then while you're developing, the watch-driven Flow server will occasionally discover more errors, which mysteriously disappear next time you do a full `flow check`. It feels totally indeterminate and unpredictable, and it led to days of debugging in my case.

From the number of issues relating to this, it seems it's easy to miss the problem when you first upgrade past 0.57.0 – the weird behaviour only surfaces much later, because everything seems to be working fine at first (`No errors!`).

## Solution

Update the docs to explain that it is now an antipattern to use `module.system.node.resolve_dirname` for internal code, and that you should use `module.name_mapper` instead.

Closes #5180 
Closes #5316 
Relates to #5647
Also closes https://github.com/flowtype/flow-bin/issues/91

(There have been many more issues stemming from this lack of documentation, but most have been closed as duplicates.)
