### PR TITLE
Add backgroundPositionX and backgroundPositionY style attributes.

### DIFF
--- a/lib/cssom.js
+++ b/lib/cssom.js
@@ -95,6 +95,8 @@ declare class CSSStyleDeclaration {
   backgroundImage: string;
   backgroundOrigin: string;
   backgroundPosition: string;
+  backgroundPositionX: string;
+  backgroundPositionY: string;
   backgroundRepeat: string;
   backgroundSize: string;
   blockSize: string;


### PR DESCRIPTION
These props are missing and are making Flow throw an arrow when assigning them.