### PR TITLE
Attempt to pass -ppx flag to ocamldep from ocp-build

### DIFF
--- a/ocp_build_flow.ocp.fb
+++ b/ocp_build_flow.ocp.fb
@@ -377,6 +377,9 @@ begin library "flow-monitor"
   comp = [
       "-ppx" "%{lwt_ppx_FULL_SRC_DIR}%/ppx.exe --as-ppx"
   ]
+  dep = [
+      "-ppx" "%{lwt_ppx_FULL_SRC_DIR}%/ppx.exe --as-ppx"
+  ]
 end
 
 begin library "flow-monitor-logger"


### PR DESCRIPTION
Our OSX travis ocp-builds were failing due to the flow-monitor library
having its source files compiled in the wrong order, even though it has
`sort=true`. This sounds like ocamldep failing to interpret ppx. This is
reinforced by the fact that our travis linux builds are passing and I
can't repro on my local OSX laptop.

I poked around the ocp-build source and found a dep option which seems
to pass flags through to ocamldep. I can confirm my local OSX build
still works. Let's see what travis thinks...