### PR TITLE
Process .mjs files by default

### DIFF
--- a/src/commands/config/flowConfig.ml
+++ b/src/commands/config/flowConfig.ml
@@ -121,6 +121,7 @@ module Opts = struct
     |> SSet.add ".js"
     |> SSet.add ".jsx"
     |> SSet.add ".json"
+    |> SSet.add ".mjs"
 
   let module_resource_exts = SSet.empty
     |> SSet.add ".css"

--- a/website/en/docs/config/options.md
+++ b/website/en/docs/config/options.md
@@ -150,8 +150,8 @@ The default value of `max_header_tokens` is 10.
 
 #### `module.file_ext` _`(string)`_ <a class="toc" id="toc-module-file-ext-string" href="#toc-module-file-ext-string"></a>
 
-By default, Flow will look for files with the extensions `.js`, `.jsx`, and
-`.json`. You can override this behavior with this option.
+By default, Flow will look for files with the extensions `.js`, `.jsx`, `.mjs`
+and `.json`. You can override this behavior with this option.
 
 For example, if you do:
 


### PR DESCRIPTION
Modules in node > 9.6.1 can use import syntax when ran with a flag on and using`.mjs` extension