### PR TITLE
Add tuple types to WebGL uniform**v setters

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -2386,27 +2386,35 @@ declare class WebGLRenderingContext {
   uniform1f(location: ?WebGLUniformLocation, x: number): void;
   uniform1fv(location: ?WebGLUniformLocation, v: Float32Array): void;
   uniform1fv(location: ?WebGLUniformLocation, v: Array<number>): void;
+  uniform1fv(location: ?WebGLUniformLocation, v: [number]): void;
   uniform1i(location: ?WebGLUniformLocation, x: number): void;
   uniform1iv(location: ?WebGLUniformLocation, v: Int32Array): void;
   uniform1iv(location: ?WebGLUniformLocation, v: Array<number>): void;
+  uniform1iv(location: ?WebGLUniformLocation, v: [number]): void;
   uniform2f(location: ?WebGLUniformLocation, x: number, y: number): void;
   uniform2fv(location: ?WebGLUniformLocation, v: Float32Array): void;
   uniform2fv(location: ?WebGLUniformLocation, v: Array<number>): void;
+  uniform2fv(location: ?WebGLUniformLocation, v: [number, number]): void;
   uniform2i(location: ?WebGLUniformLocation, x: number, y: number): void;
   uniform2iv(location: ?WebGLUniformLocation, v: Int32Array): void;
   uniform2iv(location: ?WebGLUniformLocation, v: Array<number>): void;
+  uniform2iv(location: ?WebGLUniformLocation, v: [number, number]): void;
   uniform3f(location: ?WebGLUniformLocation, x: number, y: number, z: number): void;
   uniform3fv(location: ?WebGLUniformLocation, v: Float32Array): void;
   uniform3fv(location: ?WebGLUniformLocation, v: Array<number>): void;
+  uniform3fv(location: ?WebGLUniformLocation, v: [number, number, number]): void;
   uniform3i(location: ?WebGLUniformLocation, x: number, y: number, z: number): void;
   uniform3iv(location: ?WebGLUniformLocation, v: Int32Array): void;
   uniform3iv(location: ?WebGLUniformLocation, v: Array<number>): void;
+  uniform3iv(location: ?WebGLUniformLocation, v: [number, number, number]): void;
   uniform4f(location: ?WebGLUniformLocation, x: number, y: number, z: number, w: number): void;
   uniform4fv(location: ?WebGLUniformLocation, v: Float32Array): void;
   uniform4fv(location: ?WebGLUniformLocation, v: Array<number>): void;
+  uniform4fv(location: ?WebGLUniformLocation, v: [number, number, number, number]): void;
   uniform4i(location: ?WebGLUniformLocation, x: number, y: number, z: number, w: number): void;
   uniform4iv(location: ?WebGLUniformLocation, v: Int32Array): void;
   uniform4iv(location: ?WebGLUniformLocation, v: Array<number>): void;
+  uniform4iv(location: ?WebGLUniformLocation, v: [number, number, number, number]): void;
 
   uniformMatrix2fv(location: ?WebGLUniformLocation, transpose: bool,
                         value: Float32Array): void;


### PR DESCRIPTION
This adds tuple types for WebGL uniform vector methods.