### PR TITLE
Website: Wrap long text

### DIFF
--- a/website/_assets/css/_article.scss
+++ b/website/_assets/css/_article.scss
@@ -1,5 +1,6 @@
 .article {
   line-height: 1.7;
+  word-wrap: break-word;
 
   p {
     margin-bottom: 1.2rem;


### PR DESCRIPTION
On narrow viewports, longer headings and inline code snippets result in horizontal overflow. This can cause some weirdness when scrolling vertically or when zooming in and out. As an example, you can check out the [type reference for React](https://flow.org/en/docs/react/types/) article, or watch [this video](https://cl.ly/0O2u0N2q1Q0u). From what I'm seeing, the simplest fix is to wrap words that overflow the article container. 


