### PR TITLE
Update React libdefs for createContext, createRef

### DIFF
--- a/lib/react.js
+++ b/lib/react.js
@@ -171,6 +171,7 @@ declare type React$Key = string | number;
  * The type of the ref prop available on all React components.
  */
 declare type React$Ref<ElementType: React$ElementType> =
+  | {value: React$ElementRef<ElementType> | null}
   | ((React$ElementRef<ElementType> | null) => mixed)
   | string;
 
@@ -185,8 +186,6 @@ declare module react {
   declare export var PropTypes: ReactPropTypes;
   declare export var version: string;
 
-  declare export function initializeTouchEvents(shouldUseTouch: boolean): void;
-
   declare export function checkPropTypes<V>(
     propTypes: $Subtype<{[_: $Keys<V>]: ReactPropsCheckType}>,
     values: V,
@@ -196,11 +195,19 @@ declare module react {
   ) : void;
 
   declare export var createClass: React$CreateClass;
+  declare export function createContext<T>(
+    defaultValue: T,
+  ): {
+    Provider: React$ComponentType<{value: T}>,
+    Consumer: React$ComponentType<{children: (value: T) => React$Node}>,
+  };
   declare export var createElement: React$CreateElement;
   declare export var cloneElement: React$CloneElement;
   declare export function createFactory<ElementType: React$ElementType>(
     type: ElementType,
   ): React$ElementFactory<ElementType>;
+  declare export function createRef<ElementType: React$ElementType>(
+  ): {value: null | React$ElementRef<ElementType>};
 
   declare export function isValidElement(element: any): boolean;
 
@@ -242,7 +249,6 @@ declare module react {
     +DOM: typeof DOM,
     +PropTypes: typeof PropTypes,
     +version: typeof version,
-    +initializeTouchEvents: typeof initializeTouchEvents,
     +checkPropTypes: typeof checkPropTypes,
     +createClass: typeof createClass,
     +createElement: typeof createElement,


### PR DESCRIPTION
Tested by checking this script:

```js
// @flow

var React = require('react');

var X = React.createContext('div');

class Foo extends React.Component<{}> {
  // Removing this type annotation should give an error on line 25 (div isn't
  // an HTMLImageElement) but it doesn't.
  divRef: {value: null | HTMLDivElement} = React.createRef();

  render() {
    return (
      // Changing this to 'spam' correctly triggers an error
      <X.Provider value='span'>
        <div ref={this.divRef}>
          <X.Consumer>
            {(Tag: 'div' | 'span' | 'img') => <Tag />}
          </X.Consumer>
        </div>
      </X.Provider>
    );
  }

  componentDidMount() {
    var div: null | HTMLImageElement = this.divRef.value;
  }
}
```

This correctly gives a type error in componentDidMount. But removing the divRef annotation also should have an error but it doesn't. What did I do wrong?