### PR TITLE
Correct flow definitions for Promise

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -608,12 +608,12 @@ declare class Promise<+R> {
       reject:  (error: any) => void
     ) => mixed): void;
 
-    then<U>(
+    then<U, V = empty>(
       onFulfill?: (value: R) => Promise<U> | U,
-      onReject?: (error: any) => Promise<U> | U
-    ): Promise<U>;
+      onReject?: (error: any) => Promise<V> | V
+    ): Promise<U | V>;
 
-    catch<U>(
+    catch<U = empty>(
       onReject?: (error: any) => Promise<U> | U
     ): Promise<R | U>;
 


### PR DESCRIPTION
Check out following code:
https://flow.org/try/#0MYewdgzgLgBAHjAvDACgJxAWwJYQKYB0aeAVnsFABQCUBUAFnmJQFAwwBmArmBduDHAAxLgBtRHbOLwATGjADebdjGJQuaMDAAsAJgDcygL4AaZd15R+W8ACVS5KLPlKVqvOs0wARNDTYwAHNvQ3YjFmpDODpGZj8kAD4YPwIILgAjPwDAygAGExgARmpIliA

```js
const x = Promise.reject().then(
  function onFullfilled() {
    return 42;
  },
  function onRejected() {
    return "string";
  }
);

x.then(str => str.substring(0, 1));
```

`str` should be inferred as a `string` but Flow incorrectly inferred it as a `number`.

This PR adds an additional type`V` for the return value of `onReject` which defaults to be `empty`, so flow can infer the type correctly.

P.S: I'm having difficulties testing flow locally, therefore it is not tested. 😂