### PR TITLE
Add constructor for tty.ReadStream and WriteStream

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -1513,11 +1513,13 @@ declare module "stream" {
 }
 
 declare class tty$ReadStream extends net$Socket {
+  constructor(fd: number, options?: Object): void;
   isRaw : boolean;
   setRawMode(mode : boolean) : void;
   isTTY : true
 }
 declare class tty$WriteStream extends net$Socket {
+  constructor(fd: number) : void;
   columns : number;
   rows : number;
   isTTY : true

--- a/tests/node_tests/node_tests.exp
+++ b/tests/node_tests/node_tests.exp
@@ -1334,8 +1334,8 @@ References:
    process/nextTick.js:27:3
      27|   (a: string, b: number, c: boolean) => {} // Error: too few arguments
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
-   <BUILTINS>/node.js:1967:21
-   1967|   nextTick: <T>(cb: (...T) => mixed, ...T) => void;
+   <BUILTINS>/node.js:1969:21
+   1969|   nextTick: <T>(cb: (...T) => mixed, ...T) => void;
                              ^^^^^^^^^^^^^^^ [2]
 
 
@@ -1353,26 +1353,26 @@ Cannot call `process.emitWarning` because:
          ^^^^^^^^^^^^^^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/node.js:1939:24
-   1939|   emitWarning(warning: string | Error): void;
+   <BUILTINS>/node.js:1941:24
+   1941|   emitWarning(warning: string | Error): void;
                                 ^^^^^^ [2]
-   <BUILTINS>/node.js:1939:33
-   1939|   emitWarning(warning: string | Error): void;
+   <BUILTINS>/node.js:1941:33
+   1941|   emitWarning(warning: string | Error): void;
                                          ^^^^^ [3]
-   <BUILTINS>/node.js:1940:3
-   1940|   emitWarning(warning: string, typeOrCtor: string | Function): void;
-           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [4]
-   <BUILTINS>/node.js:1941:3
-   1941|   emitWarning(warning: string, type: string, codeOrCtor: string | Function): void;
-           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [5]
    <BUILTINS>/node.js:1942:3
+   1942|   emitWarning(warning: string, typeOrCtor: string | Function): void;
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [4]
+   <BUILTINS>/node.js:1943:3
+   1943|   emitWarning(warning: string, type: string, codeOrCtor: string | Function): void;
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [5]
+   <BUILTINS>/node.js:1944:3
            v-----------
-   1942|   emitWarning(
-   1943|     warning: string,
-   1944|     type: string,
-   1945|     code: string,
-   1946|     ctor?: Function
-   1947|   ): void;
+   1944|   emitWarning(
+   1945|     warning: string,
+   1946|     type: string,
+   1947|     code: string,
+   1948|     ctor?: Function
+   1949|   ): void;
            ------^ [6]
 
 
@@ -1391,14 +1391,14 @@ References:
    process/process.js:11:21
      11| process.emitWarning(42); // error
                              ^^ [1]
-   <BUILTINS>/node.js:1940:24
-   1940|   emitWarning(warning: string, typeOrCtor: string | Function): void;
+   <BUILTINS>/node.js:1942:24
+   1942|   emitWarning(warning: string, typeOrCtor: string | Function): void;
                                 ^^^^^^ [2]
-   <BUILTINS>/node.js:1941:24
-   1941|   emitWarning(warning: string, type: string, codeOrCtor: string | Function): void;
+   <BUILTINS>/node.js:1943:24
+   1943|   emitWarning(warning: string, type: string, codeOrCtor: string | Function): void;
                                 ^^^^^^ [3]
-   <BUILTINS>/node.js:1943:14
-   1943|     warning: string,
+   <BUILTINS>/node.js:1945:14
+   1945|     warning: string,
                       ^^^^^^ [4]
 
 
@@ -1416,11 +1416,11 @@ References:
    process/process.js:12:29
      12| process.emitWarning("blah", 42); // error
                                      ^^ [1]
-   <BUILTINS>/node.js:1941:38
-   1941|   emitWarning(warning: string, type: string, codeOrCtor: string | Function): void;
+   <BUILTINS>/node.js:1943:38
+   1943|   emitWarning(warning: string, type: string, codeOrCtor: string | Function): void;
                                               ^^^^^^ [2]
-   <BUILTINS>/node.js:1944:11
-   1944|     type: string,
+   <BUILTINS>/node.js:1946:11
+   1946|     type: string,
                    ^^^^^^ [3]
 
 
@@ -1436,8 +1436,8 @@ References:
    process/process.js:13:37
      13| process.emitWarning("blah", "blah", 42); // error
                                              ^^ [1]
-   <BUILTINS>/node.js:1945:11
-   1945|     code: string,
+   <BUILTINS>/node.js:1947:11
+   1947|     code: string,
                    ^^^^^^ [2]
 
 
@@ -1450,8 +1450,8 @@ Cannot cast `process.emitWarning(...)` to string because undefined [1] is incomp
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/node.js:1939:41
-   1939|   emitWarning(warning: string | Error): void;
+   <BUILTINS>/node.js:1941:41
+   1941|   emitWarning(warning: string | Error): void;
                                                  ^^^^ [1]
    process/process.js:14:31
      14| (process.emitWarning("blah"): string); // error


### PR DESCRIPTION
tty.ReadStream and WriteStream has constructor [1] [2], they are rarely used but actually we use them in test code [3]

[1] https://github.com/nodejs/node/blob/1e8d110e640c658e4f6ed7540db62d063269ba6c/lib/tty.js#L43
[2] https://github.com/nodejs/node/blob/1e8d110e640c658e4f6ed7540db62d063269ba6c/lib/tty.js#L75
[3] https://github.com/mozilla/web-ext/blob/783d0e6186995a05fb8eef0e1617d8875ee1042c/tests/unit/test-extension-runners/test.extension-runners.js#L489