### PR TITLE
Add BaseAudioContext.createStereoPanner types

### DIFF
--- a/lib/bom.js
+++ b/lib/bom.js
@@ -673,6 +673,7 @@ declare class AudioContext {
   createPeriodicWave(real: Float32Array, img: Float32Array, options?: {
     disableNormalization: bool,
   }): PeriodicWave;
+  createStereoPanner(): StereoPannerNode;
   createWaveShaper(): WaveShaperNode;
   decodeAudioData(arrayBuffer: ArrayBuffer, decodeSuccessCallback: Function, decodeErrorCallback: Function): void;
   decodeAudioData(arrayBuffer: ArrayBuffer): Promise<AudioBuffer>;
@@ -852,6 +853,10 @@ declare class OscillatorNode extends AudioNode {
   start(when?: number): void;
   stop(when?: number): void;
   setPeriodicWave(periodicWave: PeriodicWave): void;
+}
+
+declare class StereoPannerNode extends AudioNode {
+  pan: AudioParam;
 }
 
 declare class PannerNode extends AudioNode {


### PR DESCRIPTION

Spec References:

[`AudioContext` Factory Method](https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-createstereopanner)
[Class Definition](https://webaudio.github.io/web-audio-api/#stereopannernode)