### PR TITLE
Document async function return type

### DIFF
--- a/website/en/docs/types/functions.md
+++ b/website/en/docs/types/functions.md
@@ -195,6 +195,15 @@ function method(): boolean {
 }
 ```
 
+Async functions implicitly return a promise, so the return type must always be a `Promise`.
+
+```js
+// @flow
+async function method(): Promise<number> {
+  return 123;
+}
+```
+
 ### Function `this` <a class="toc" id="toc-function-this" href="#toc-function-this"></a>
 
 Every function in JavaScript can be called with a special context named `this`.


### PR DESCRIPTION
Adds a note about how to type the return value of an async function. 

Fixes #6001