### PR TITLE
Adding missing function declarations in node.fs

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -982,6 +982,16 @@ declare module "fs" {
   declare function accessSync(path: string, mode?: number): void;
   declare function createReadStream(path: string, options?: Object): ReadStream;
   declare function createWriteStream(path: string, options?: Object): WriteStream;
+  declare function copyFile(
+    src: string | Buffer,
+    dest: string | Buffer,
+    flags: number,
+    callback: (err: ?ErrnoError) => void,
+  ): void;
+  declare function copyFile(src: string | Buffer, dest: string | Buffer, callback: (err: ?ErrnoError) => void): void;
+  declare function copyFileSync(src: string | Buffer, dest: string | Buffer, flags?: number): void;
+  declare function fdatasync(fd: number, callback: (err: ?ErrnoError) => void): void;
+  declare function fdatasyncSync(fd: number): void;
 
   declare var F_OK: number;
   declare var R_OK: number;


### PR DESCRIPTION
node's fs module was missing:

- copyFile
- copyFileSync
- fdatasync
- fdatasyncSync

Closes #5998 