### PR TITLE
Add `componentDidCatch` React lifecycle

### DIFF
--- a/lib/react.js
+++ b/lib/react.js
@@ -74,6 +74,12 @@ declare class React$Component<Props, State = void> {
     prevContext: any,
   ): mixed;
   componentWillUnmount(): mixed;
+  componentDidCatch(
+    error: mixed,
+    info: {
+      componentStack: string,
+    }
+  ): mixed;
 
   // long tail of other stuff not modeled very well
 

--- a/tests/getters_and_setters/getters_and_setters.exp
+++ b/tests/getters_and_setters/getters_and_setters.exp
@@ -489,8 +489,8 @@ References:
    react.js:17:13
     17| (<Example a="bad" />); // error: number ~> string
                     ^^^^^ [1]
-   <BUILTINS>/react.js:313:36
-   313|   number: React$PropType$Primitive<number>;
+   <BUILTINS>/react.js:319:36
+   319|   number: React$PropType$Primitive<number>;
                                            ^^^^^^ [2]
 
 
@@ -506,8 +506,8 @@ References:
    react.js:18:20
     18| (<Example a={0} c={0} />); // error: number ~> string
                            ^ [1]
-   <BUILTINS>/react.js:315:36
-   315|   string: React$PropType$Primitive<string>;
+   <BUILTINS>/react.js:321:36
+   321|   string: React$PropType$Primitive<string>;
                                            ^^^^^^ [2]
 
 

--- a/tests/more_react/more_react.exp
+++ b/tests/more_react/more_react.exp
@@ -58,15 +58,15 @@ Cannot call `checkPropTypes` because function [1] requires another argument.
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/react.js:199:41
+   <BUILTINS>/react.js:205:41
                                                 v---
-   199|   declare export function checkPropTypes<V>(
-   200|     propTypes: $Subtype<{[_: $Keys<V>]: ReactPropsCheckType}>,
-   201|     values: V,
-   202|     location: string,
-   203|     componentName: string,
-   204|     getStack: ?(() => ?string)
-   205|   ) : void;
+   205|   declare export function checkPropTypes<V>(
+   206|     propTypes: $Subtype<{[_: $Keys<V>]: ReactPropsCheckType}>,
+   207|     values: V,
+   208|     location: string,
+   209|     componentName: string,
+   210|     getStack: ?(() => ?string)
+   211|   ) : void;
           -------^ [1]
 
 
@@ -79,15 +79,15 @@ Cannot call `checkPropTypes` because function [1] requires another argument.
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/react.js:199:41
+   <BUILTINS>/react.js:205:41
                                                 v---
-   199|   declare export function checkPropTypes<V>(
-   200|     propTypes: $Subtype<{[_: $Keys<V>]: ReactPropsCheckType}>,
-   201|     values: V,
-   202|     location: string,
-   203|     componentName: string,
-   204|     getStack: ?(() => ?string)
-   205|   ) : void;
+   205|   declare export function checkPropTypes<V>(
+   206|     propTypes: $Subtype<{[_: $Keys<V>]: ReactPropsCheckType}>,
+   207|     values: V,
+   208|     location: string,
+   209|     componentName: string,
+   210|     getStack: ?(() => ?string)
+   211|   ) : void;
           -------^ [1]
 
 
@@ -113,8 +113,8 @@ References:
    checkPropTypes.js:12:91
     12| checkPropTypes({ foo: PropTypes.string }, { foo: 'foo' }, 'value', 'TestComponent', () => 123); // error: number ~> string
                                                                                                   ^^^ [1]
-   <BUILTINS>/react.js:204:24
-   204|     getStack: ?(() => ?string)
+   <BUILTINS>/react.js:210:24
+   210|     getStack: ?(() => ?string)
                                ^^^^^^ [2]
 
 

--- a/tests/new_react/new_react.exp
+++ b/tests/new_react/new_react.exp
@@ -175,8 +175,8 @@ References:
    classes.js:39:15
     39| var foo: $jsx<number> = <Foo/>;
                       ^^^^^^ [1]
-   <BUILTINS>/react.js:159:5
-   159|   | string
+   <BUILTINS>/react.js:165:5
+   165|   | string
             ^^^^^^ [2]
 
 
@@ -189,8 +189,8 @@ Cannot assign `this.props.x` to `_` because number [1] is incompatible with stri
                             ^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/react.js:313:36
-   313|   number: React$PropType$Primitive<number>;
+   <BUILTINS>/react.js:319:36
+   319|   number: React$PropType$Primitive<number>;
                                            ^^^^^^ [1]
    classes.js:57:12
     57|     var _: string = this.props.x;
@@ -316,8 +316,8 @@ References:
    classes.js:79:22
     79| var foo_legacy: $jsx<number> = <FooLegacy/>;
                              ^^^^^^ [1]
-   <BUILTINS>/react.js:159:5
-   159|   | string
+   <BUILTINS>/react.js:165:5
+   165|   | string
             ^^^^^^ [2]
 
 
@@ -388,8 +388,8 @@ Cannot assign `this.props.z` to `qux` because:
                                   ^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/react.js:313:36
-   313|   number: React$PropType$Primitive<number>;
+   <BUILTINS>/react.js:319:36
+   319|   number: React$PropType$Primitive<number>;
                                            ^^^^^^ [1]
    new_react.js:19:18
     19|         var qux: string = this.props.z;
@@ -405,8 +405,8 @@ Cannot assign `this.props.x` to `w` because string [1] is incompatible with numb
                                ^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/react.js:315:36
-   315|   string: React$PropType$Primitive<string>;
+   <BUILTINS>/react.js:321:36
+   321|   string: React$PropType$Primitive<string>;
                                            ^^^^^^ [1]
    new_react.js:20:15
     20|         var w:number = this.props.x;
@@ -439,8 +439,8 @@ References:
    new_react.js:29:23
     29| var element = <C x = {0}/>;
                               ^ [1]
-   <BUILTINS>/react.js:315:36
-   315|   string: React$PropType$Primitive<string>;
+   <BUILTINS>/react.js:321:36
+   321|   string: React$PropType$Primitive<string>;
                                            ^^^^^^ [2]
 
 
@@ -475,14 +475,14 @@ Cannot assign `C.displayName` to `x` because:
                        ^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/react.js:83:24
-   83|   static displayName?: ?string;
+   <BUILTINS>/react.js:89:24
+   89|   static displayName?: ?string;
                               ^^^^^^^ [1]
    new_react.js:32:8
    32| var x: number = C.displayName;
               ^^^^^^ [2]
-   <BUILTINS>/react.js:83:25
-   83|   static displayName?: ?string;
+   <BUILTINS>/react.js:89:25
+   89|   static displayName?: ?string;
                                ^^^^^^ [3]
 
 
@@ -545,8 +545,8 @@ Cannot assign `this.props.x` to `a` because:
                                 ^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/react.js:315:36
-   315|   string: React$PropType$Primitive<string>;
+   <BUILTINS>/react.js:321:36
+   321|   string: React$PropType$Primitive<string>;
                                            ^^^^^^ [1]
    props.js:14:16
     14|         var a: number = this.props.x; // error
@@ -582,8 +582,8 @@ Cannot assign `this.props.z` to `c` because:
                                 ^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/react.js:313:36
-   313|   number: React$PropType$Primitive<number>;
+   <BUILTINS>/react.js:319:36
+   319|   number: React$PropType$Primitive<number>;
                                            ^^^^^^ [1]
    props.js:16:16
     16|         var c: string = this.props.z; // error
@@ -604,14 +604,14 @@ References:
    props.js:20:29
     20| var element = <TestProps x={false} y={false} z={false} />; // 3 errors
                                     ^^^^^ [1]
-   <BUILTINS>/react.js:315:36
-   315|   string: React$PropType$Primitive<string>;
+   <BUILTINS>/react.js:321:36
+   321|   string: React$PropType$Primitive<string>;
                                            ^^^^^^ [2]
    props.js:20:49
     20| var element = <TestProps x={false} y={false} z={false} />; // 3 errors
                                                         ^^^^^ [3]
-   <BUILTINS>/react.js:313:36
-   313|   number: React$PropType$Primitive<number>;
+   <BUILTINS>/react.js:319:36
+   319|   number: React$PropType$Primitive<number>;
                                            ^^^^^^ [4]
 
 
@@ -668,8 +668,8 @@ References:
    props2.js:9:41
      9|     getInitialState: function(): { bar: number } {
                                                 ^^^^^^ [1]
-   <BUILTINS>/react.js:315:36
-   315|   string: React$PropType$Primitive<string>;
+   <BUILTINS>/react.js:321:36
+   321|   string: React$PropType$Primitive<string>;
                                            ^^^^^^ [2]
    props2.js:15:42
     15|         return <C {...this.state} foo = {0} />;
@@ -685,8 +685,8 @@ Cannot get `React.PropTypes.imaginaryType` because property `imaginaryType` is m
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/react.js:196:33
-   196|   declare export var PropTypes: ReactPropTypes;
+   <BUILTINS>/react.js:202:33
+   202|   declare export var PropTypes: ReactPropTypes;
                                         ^^^^^^^^^^^^^^ [1]
 
 
@@ -700,12 +700,12 @@ Cannot get `React.PropTypes.string.inRequired` because property `inRequired` is 
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/react.js:289:39
+   <BUILTINS>/react.js:295:39
                                               v
-   289| type ReactPropsChainableTypeChecker = {
-   290|   isRequired: ReactPropsCheckType;
-   291|   (props: any, propName: string, componentName: string, href?: string): ?Error;
-   292| };
+   295| type ReactPropsChainableTypeChecker = {
+   296|   isRequired: ReactPropsCheckType;
+   297|   (props: any, propName: string, componentName: string, href?: string): ?Error;
+   298| };
         ^ [1]
 
 

--- a/tests/react/react.exp
+++ b/tests/react/react.exp
@@ -21,8 +21,8 @@ Cannot cast `this.props.foo` to empty because string [1] is incompatible with em
              ^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/react.js:315:36
-   315|   string: React$PropType$Primitive<string>;
+   <BUILTINS>/react.js:321:36
+   321|   string: React$PropType$Primitive<string>;
                                            ^^^^^^ [1]
    create_class.js:7:22
      7|     (this.props.foo: empty); // error: string ~> empty
@@ -38,8 +38,8 @@ Cannot cast `this.props.bar` to empty because number [1] is incompatible with em
              ^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/react.js:313:36
-   313|   number: React$PropType$Primitive<number>;
+   <BUILTINS>/react.js:319:36
+   319|   number: React$PropType$Primitive<number>;
                                            ^^^^^^ [1]
    create_class.js:8:22
      8|     (this.props.bar: empty); // error: number ~> empty
@@ -192,8 +192,8 @@ Cannot cast `this.props.foo` to empty because string [1] is incompatible with em
              ^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/react.js:315:36
-   315|   string: React$PropType$Primitive<string>;
+   <BUILTINS>/react.js:321:36
+   321|   string: React$PropType$Primitive<string>;
                                            ^^^^^^ [1]
    create_class.js:117:22
    117|     (this.props.foo: empty); // string ~> empty
@@ -209,8 +209,8 @@ Cannot cast `this.state.foo` to empty because string [1] is incompatible with em
              ^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/react.js:315:36
-   315|   string: React$PropType$Primitive<string>;
+   <BUILTINS>/react.js:321:36
+   321|   string: React$PropType$Primitive<string>;
                                            ^^^^^^ [1]
    create_class.js:118:22
    118|     (this.state.foo: empty); // string ~> empty
@@ -226,8 +226,8 @@ Cannot cast `this.props.foo` to empty because string [1] is incompatible with em
              ^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/react.js:315:36
-   315|   string: React$PropType$Primitive<string>;
+   <BUILTINS>/react.js:321:36
+   321|   string: React$PropType$Primitive<string>;
                                            ^^^^^^ [1]
    create_class.js:133:22
    133|     (this.props.foo: empty); // string ~> empty
@@ -243,8 +243,8 @@ Cannot cast `this.props.foo` to empty because string [1] is incompatible with em
              ^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/react.js:315:36
-   315|   string: React$PropType$Primitive<string>;
+   <BUILTINS>/react.js:321:36
+   321|   string: React$PropType$Primitive<string>;
                                            ^^^^^^ [1]
    create_class.js:137:22
    137|     (this.props.foo: empty); // string ~> empty
@@ -260,8 +260,8 @@ Cannot cast `this.props.foo` to empty because string [1] is incompatible with em
              ^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/react.js:315:36
-   315|   string: React$PropType$Primitive<string>;
+   <BUILTINS>/react.js:321:36
+   321|   string: React$PropType$Primitive<string>;
                                            ^^^^^^ [1]
    create_class.js:141:22
    141|     (this.props.foo: empty); // string ~> empty
@@ -277,8 +277,8 @@ Cannot cast `nextProps.foo` to empty because string [1] is incompatible with emp
              ^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/react.js:315:36
-   315|   string: React$PropType$Primitive<string>;
+   <BUILTINS>/react.js:321:36
+   321|   string: React$PropType$Primitive<string>;
                                            ^^^^^^ [1]
    create_class.js:142:21
    142|     (nextProps.foo: empty); // string ~> empty
@@ -294,8 +294,8 @@ Cannot cast `this.props.foo` to empty because string [1] is incompatible with em
              ^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/react.js:315:36
-   315|   string: React$PropType$Primitive<string>;
+   <BUILTINS>/react.js:321:36
+   321|   string: React$PropType$Primitive<string>;
                                            ^^^^^^ [1]
    create_class.js:146:22
    146|     (this.props.foo: empty); // string ~> empty
@@ -328,8 +328,8 @@ Cannot cast `nextProps.foo` to empty because string [1] is incompatible with emp
              ^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/react.js:315:36
-   315|   string: React$PropType$Primitive<string>;
+   <BUILTINS>/react.js:321:36
+   321|   string: React$PropType$Primitive<string>;
                                            ^^^^^^ [1]
    create_class.js:148:21
    148|     (nextProps.foo: empty); // string ~> empty
@@ -376,8 +376,8 @@ Cannot cast `this.props.foo` to empty because string [1] is incompatible with em
              ^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/react.js:315:36
-   315|   string: React$PropType$Primitive<string>;
+   <BUILTINS>/react.js:321:36
+   321|   string: React$PropType$Primitive<string>;
                                            ^^^^^^ [1]
    create_class.js:153:22
    153|     (this.props.foo: empty); // string ~> empty
@@ -410,8 +410,8 @@ Cannot cast `nextProps.foo` to empty because string [1] is incompatible with emp
              ^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/react.js:315:36
-   315|   string: React$PropType$Primitive<string>;
+   <BUILTINS>/react.js:321:36
+   321|   string: React$PropType$Primitive<string>;
                                            ^^^^^^ [1]
    create_class.js:155:21
    155|     (nextProps.foo: empty); // string ~> empty
@@ -444,8 +444,8 @@ Cannot cast `this.props.foo` to empty because string [1] is incompatible with em
              ^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/react.js:315:36
-   315|   string: React$PropType$Primitive<string>;
+   <BUILTINS>/react.js:321:36
+   321|   string: React$PropType$Primitive<string>;
                                            ^^^^^^ [1]
    create_class.js:160:22
    160|     (this.props.foo: empty); // string ~> empty
@@ -478,8 +478,8 @@ Cannot cast `nextProps.foo` to empty because string [1] is incompatible with emp
              ^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/react.js:315:36
-   315|   string: React$PropType$Primitive<string>;
+   <BUILTINS>/react.js:321:36
+   321|   string: React$PropType$Primitive<string>;
                                            ^^^^^^ [1]
    create_class.js:162:21
    162|     (nextProps.foo: empty); // string ~> empty
@@ -512,8 +512,8 @@ Cannot cast `this.props.foo` to empty because string [1] is incompatible with em
              ^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/react.js:315:36
-   315|   string: React$PropType$Primitive<string>;
+   <BUILTINS>/react.js:321:36
+   321|   string: React$PropType$Primitive<string>;
                                            ^^^^^^ [1]
    create_class.js:167:22
    167|     (this.props.foo: empty); // string ~> empty
@@ -1845,8 +1845,8 @@ References:
    jsx_spread.js:10:19
     10| var props = {bar: 42};
                           ^^ [1]
-   <BUILTINS>/react.js:315:36
-   315|   string: React$PropType$Primitive<string>;
+   <BUILTINS>/react.js:321:36
+   321|   string: React$PropType$Primitive<string>;
                                            ^^^^^^ [2]
 
 
@@ -1864,11 +1864,11 @@ References:
    key.js:12:11
     12| <Foo key={true} />; // Error
                   ^^^^ [1]
-   <BUILTINS>/react.js:178:26
-   178| declare type React$Key = string | number;
+   <BUILTINS>/react.js:184:26
+   184| declare type React$Key = string | number;
                                  ^^^^^^ [2]
-   <BUILTINS>/react.js:178:35
-   178| declare type React$Key = string | number;
+   <BUILTINS>/react.js:184:35
+   184| declare type React$Key = string | number;
                                           ^^^^^^ [3]
 
 
@@ -1886,11 +1886,11 @@ References:
    key.js:21:16
     21| <FooExact key={true} />; // Error
                        ^^^^ [1]
-   <BUILTINS>/react.js:178:26
-   178| declare type React$Key = string | number;
+   <BUILTINS>/react.js:184:26
+   184| declare type React$Key = string | number;
                                  ^^^^^^ [2]
-   <BUILTINS>/react.js:178:35
-   178| declare type React$Key = string | number;
+   <BUILTINS>/react.js:184:35
+   184| declare type React$Key = string | number;
                                           ^^^^^^ [3]
 
 
@@ -1959,8 +1959,8 @@ References:
    proptype_arrayOf.js:15:45
     15| var fail_mistyped_elems = <Example arr={[1, "foo"]} />
                                                     ^^^^^ [1]
-   <BUILTINS>/react.js:313:36
-   313|   number: React$PropType$Primitive<number>;
+   <BUILTINS>/react.js:319:36
+   319|   number: React$PropType$Primitive<number>;
                                            ^^^^^^ [2]
 
 
@@ -1976,8 +1976,8 @@ References:
    proptype_arrayOf.js:20:36
     20| var todo_required = <Example arr={[null]} />
                                            ^^^^ [1]
-   <BUILTINS>/react.js:313:36
-   313|   number: React$PropType$Primitive<number>;
+   <BUILTINS>/react.js:319:36
+   319|   number: React$PropType$Primitive<number>;
                                            ^^^^^^ [2]
 
 
@@ -1994,8 +1994,8 @@ References:
    proptype_arrayOf.js:30:25
     30| (<OptionalExample arr={[""]} />); // error: string ~> number
                                 ^^ [1]
-   <BUILTINS>/react.js:313:36
-   313|   number: React$PropType$Primitive<number>;
+   <BUILTINS>/react.js:319:36
+   319|   number: React$PropType$Primitive<number>;
                                            ^^^^^^ [2]
 
 
@@ -2033,8 +2033,8 @@ Cannot cast `propName` to empty because string [1] is incompatible with empty [2
                ^^^^^^^^
 
 References:
-   <BUILTINS>/react.js:285:13
-   285|   propName: string,
+   <BUILTINS>/react.js:291:13
+   291|   propName: string,
                     ^^^^^^ [1]
    proptype_custom_validator.js:8:18
      8|       (propName: empty); // error: propName is a string
@@ -2050,8 +2050,8 @@ Cannot cast `componentName` to empty because string [1] is incompatible with emp
                ^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/react.js:286:18
-   286|   componentName: string,
+   <BUILTINS>/react.js:292:18
+   292|   componentName: string,
                          ^^^^^^ [1]
    proptype_custom_validator.js:9:23
      9|       (componentName: empty); // error: componentName is a string
@@ -2069,8 +2069,8 @@ Cannot cast `href` to empty because:
                ^^^^
 
 References:
-   <BUILTINS>/react.js:287:10
-   287|   href?: string) => ?Error;
+   <BUILTINS>/react.js:293:10
+   293|   href?: string) => ?Error;
                  ^^^^^^ [1]
    proptype_custom_validator.js:10:14
     10|       (href: empty); // error: href is an optional string
@@ -2089,8 +2089,8 @@ References:
    proptype_custom_validator.js:11:18
     11|       return (0: mixed); // error: should return ?Error
                          ^^^^^ [1]
-   <BUILTINS>/react.js:287:22
-   287|   href?: string) => ?Error;
+   <BUILTINS>/react.js:293:22
+   293|   href?: string) => ?Error;
                              ^^^^^ [2]
 
 
@@ -2106,8 +2106,8 @@ References:
    proptype_func.js:14:36
     14| var fail_mistyped = <Example func={2} />
                                            ^ [1]
-   <BUILTINS>/react.js:312:34
-   312|   func: React$PropType$Primitive<Function>;
+   <BUILTINS>/react.js:318:34
+   318|   func: React$PropType$Primitive<Function>;
                                          ^^^^^^^^ [2]
 
 
@@ -2165,8 +2165,8 @@ References:
    proptype_object.js:13:38
     13| var fail_mistyped = <Example object={2} />
                                              ^ [1]
-   <BUILTINS>/react.js:314:36
-   314|   object: React$PropType$Primitive<Object>;
+   <BUILTINS>/react.js:320:36
+   320|   object: React$PropType$Primitive<Object>;
                                            ^^^^^^ [2]
 
 
@@ -2217,8 +2217,8 @@ References:
    proptype_objectOf.js:15:47
     15| var fail_mistyped_props = <Example obj={{foo: "foo"}} />
                                                       ^^^^^ [1]
-   <BUILTINS>/react.js:313:36
-   313|   number: React$PropType$Primitive<number>;
+   <BUILTINS>/react.js:319:36
+   319|   number: React$PropType$Primitive<number>;
                                            ^^^^^^ [2]
 
 
@@ -2234,8 +2234,8 @@ References:
    proptype_objectOf.js:20:38
     20| var todo_required = <Example obj={{p:null}} />
                                              ^^^^ [1]
-   <BUILTINS>/react.js:313:36
-   313|   number: React$PropType$Primitive<number>;
+   <BUILTINS>/react.js:319:36
+   319|   number: React$PropType$Primitive<number>;
                                            ^^^^^^ [2]
 
 
@@ -2251,8 +2251,8 @@ References:
    proptype_objectOf.js:30:27
     30| (<OptionalExample obj={{p:""}} />); // error: string ~> number
                                   ^^ [1]
-   <BUILTINS>/react.js:313:36
-   313|   number: React$PropType$Primitive<number>;
+   <BUILTINS>/react.js:319:36
+   319|   number: React$PropType$Primitive<number>;
                                            ^^^^^^ [2]
 
 
@@ -2427,11 +2427,11 @@ References:
    proptype_oneOfType.js:24:32
     24| var fail_bool = <Example prop={true} />;
                                        ^^^^ [1]
-   <BUILTINS>/react.js:315:36
-   315|   string: React$PropType$Primitive<string>;
+   <BUILTINS>/react.js:321:36
+   321|   string: React$PropType$Primitive<string>;
                                            ^^^^^^ [2]
-   <BUILTINS>/react.js:313:36
-   313|   number: React$PropType$Primitive<number>;
+   <BUILTINS>/react.js:319:36
+   319|   number: React$PropType$Primitive<number>;
                                            ^^^^^^ [3]
 
 
@@ -2449,11 +2449,11 @@ References:
    proptype_oneOfType.js:29:36
     29| var todo_required = <Example prop={null} />;
                                            ^^^^ [1]
-   <BUILTINS>/react.js:315:36
-   315|   string: React$PropType$Primitive<string>;
+   <BUILTINS>/react.js:321:36
+   321|   string: React$PropType$Primitive<string>;
                                            ^^^^^^ [2]
-   <BUILTINS>/react.js:313:36
-   313|   number: React$PropType$Primitive<number>;
+   <BUILTINS>/react.js:319:36
+   319|   number: React$PropType$Primitive<number>;
                                            ^^^^^^ [3]
 
 
@@ -2469,8 +2469,8 @@ References:
    proptype_oneOfType.js:41:22
     41| (<OptionalExample p={0} />); // error: number ~> string
                              ^ [1]
-   <BUILTINS>/react.js:315:36
-   315|   string: React$PropType$Primitive<string>;
+   <BUILTINS>/react.js:321:36
+   321|   string: React$PropType$Primitive<string>;
                                            ^^^^^^ [2]
 
 
@@ -2552,14 +2552,14 @@ Cannot cast `React.PropTypes.arrayOf` to `NoFun` because:
          ^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/react.js:295:17
-   295|   (typeChecker: ReactPropsCheckType) => ReactPropsChainableTypeChecker;
+   <BUILTINS>/react.js:301:17
+   301|   (typeChecker: ReactPropsCheckType) => ReactPropsChainableTypeChecker;
                         ^^^^^^^^^^^^^^^^^^^ [1]
    proptypes_builtins.js:3:14
      3| type NoFun = mixed => empty;
                      ^^^^^ [2]
-   <BUILTINS>/react.js:295:41
-   295|   (typeChecker: ReactPropsCheckType) => ReactPropsChainableTypeChecker;
+   <BUILTINS>/react.js:301:41
+   301|   (typeChecker: ReactPropsCheckType) => ReactPropsChainableTypeChecker;
                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [3]
    proptypes_builtins.js:3:23
      3| type NoFun = mixed => empty;
@@ -2576,8 +2576,8 @@ empty [2] in the return value.
          ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/react.js:297:27
-   297|   (expectedClass: any) => ReactPropsChainableTypeChecker;
+   <BUILTINS>/react.js:303:27
+   303|   (expectedClass: any) => ReactPropsChainableTypeChecker;
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
    proptypes_builtins.js:3:23
      3| type NoFun = mixed => empty;
@@ -2595,14 +2595,14 @@ Cannot cast `React.PropTypes.objectOf` to `NoFun` because:
          ^^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/react.js:299:17
-   299|   (typeChecker: ReactPropsCheckType) => ReactPropsChainableTypeChecker;
+   <BUILTINS>/react.js:305:17
+   305|   (typeChecker: ReactPropsCheckType) => ReactPropsChainableTypeChecker;
                         ^^^^^^^^^^^^^^^^^^^ [1]
    proptypes_builtins.js:3:14
      3| type NoFun = mixed => empty;
                      ^^^^^ [2]
-   <BUILTINS>/react.js:299:41
-   299|   (typeChecker: ReactPropsCheckType) => ReactPropsChainableTypeChecker;
+   <BUILTINS>/react.js:305:41
+   305|   (typeChecker: ReactPropsCheckType) => ReactPropsChainableTypeChecker;
                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [3]
    proptypes_builtins.js:3:23
      3| type NoFun = mixed => empty;
@@ -2620,14 +2620,14 @@ Cannot cast `React.PropTypes.oneOf` to `NoFun` because:
          ^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/react.js:301:20
-   301|   (expectedValues: Array<any>) => ReactPropsChainableTypeChecker;
+   <BUILTINS>/react.js:307:20
+   307|   (expectedValues: Array<any>) => ReactPropsChainableTypeChecker;
                            ^^^^^^^^^^ [1]
    proptypes_builtins.js:3:14
      3| type NoFun = mixed => empty;
                      ^^^^^ [2]
-   <BUILTINS>/react.js:301:35
-   301|   (expectedValues: Array<any>) => ReactPropsChainableTypeChecker;
+   <BUILTINS>/react.js:307:35
+   307|   (expectedValues: Array<any>) => ReactPropsChainableTypeChecker;
                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [3]
    proptypes_builtins.js:3:23
      3| type NoFun = mixed => empty;
@@ -2645,14 +2645,14 @@ Cannot cast `React.PropTypes.oneOfType` to `NoFun` because:
          ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/react.js:303:25
-   303|   (arrayOfTypeCheckers: Array<ReactPropsCheckType>) =>
+   <BUILTINS>/react.js:309:25
+   309|   (arrayOfTypeCheckers: Array<ReactPropsCheckType>) =>
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
    proptypes_builtins.js:3:14
      3| type NoFun = mixed => empty;
                      ^^^^^ [2]
-   <BUILTINS>/react.js:304:5
-   304|     ReactPropsChainableTypeChecker;
+   <BUILTINS>/react.js:310:5
+   310|     ReactPropsChainableTypeChecker;
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [3]
    proptypes_builtins.js:3:23
      3| type NoFun = mixed => empty;
@@ -2670,14 +2670,14 @@ Cannot cast `React.PropTypes.shape` to `NoFun` because:
          ^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/react.js:306:16
-   306|   (shapeTypes: { [key: string]: ReactPropsCheckType }) =>
+   <BUILTINS>/react.js:312:16
+   312|   (shapeTypes: { [key: string]: ReactPropsCheckType }) =>
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
    proptypes_builtins.js:3:14
      3| type NoFun = mixed => empty;
                      ^^^^^ [2]
-   <BUILTINS>/react.js:307:5
-   307|     ReactPropsChainableTypeChecker;
+   <BUILTINS>/react.js:313:5
+   313|     ReactPropsChainableTypeChecker;
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [3]
    proptypes_builtins.js:3:23
      3| type NoFun = mixed => empty;
@@ -2744,8 +2744,8 @@ Cannot cast `foo` to `Foo` because null [1] is incompatible with `Foo` [2].
                           ^^^
 
 References:
-   <BUILTINS>/react.js:185:39
-   185|   | ((React$ElementRef<ElementType> | null) => mixed)
+   <BUILTINS>/react.js:191:39
+   191|   | ((React$ElementRef<ElementType> | null) => mixed)
                                               ^^^^ [1]
    ref.js:13:24
     13| <Foo ref={foo => (foo: Foo)} />; // Error: `Foo` may be null.
@@ -2796,8 +2796,8 @@ Cannot cast `foo` to `FooExact` because null [1] is incompatible with `FooExact`
                                ^^^
 
 References:
-   <BUILTINS>/react.js:185:39
-   185|   | ((React$ElementRef<ElementType> | null) => mixed)
+   <BUILTINS>/react.js:191:39
+   191|   | ((React$ElementRef<ElementType> | null) => mixed)
                                               ^^^^ [1]
    ref.js:24:29
     24| <FooExact ref={foo => (foo: FooExact)} />; // Error: `FooExact` may be null.

--- a/tests/react_children/react_children.exp
+++ b/tests/react_children/react_children.exp
@@ -68,8 +68,8 @@ References:
    api.js:14:25
     14| Children.forEach(a, (x: number) => {}); // Error
                                 ^^^^^^ [2]
-   <BUILTINS>/react.js:241:38
-   241|   declare export type ChildrenArray<+T> = $ReadOnlyArray<ChildrenArray<T>> | T;
+   <BUILTINS>/react.js:247:38
+   247|   declare export type ChildrenArray<+T> = $ReadOnlyArray<ChildrenArray<T>> | T;
                                              ^ [3]
 
 
@@ -90,8 +90,8 @@ References:
    api.js:16:25
     16| Children.forEach(a, (x: string) => {}); // Error
                                 ^^^^^^ [2]
-   <BUILTINS>/react.js:241:38
-   241|   declare export type ChildrenArray<+T> = $ReadOnlyArray<ChildrenArray<T>> | T;
+   <BUILTINS>/react.js:247:38
+   247|   declare export type ChildrenArray<+T> = $ReadOnlyArray<ChildrenArray<T>> | T;
                                              ^ [3]
    api.js:5:25
      5| const a: ChildrenArray<?number> = [
@@ -107,8 +107,8 @@ Cannot call `s` with `Children.count(...)` bound to `x` because number [1] is in
           ^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/react.js:253:42
-   253|     count(children: ChildrenArray<any>): number;
+   <BUILTINS>/react.js:259:42
+   259|     count(children: ChildrenArray<any>): number;
                                                  ^^^^^^ [1]
    api.js:29:15
     29| function s(x: string) {}

--- a/tests/react_custom_funs/react_custom_funs.exp
+++ b/tests/react_custom_funs/react_custom_funs.exp
@@ -23,14 +23,14 @@ Property `key` is missing in object literal [1] but exists in `React.Element` [2
                            ^^^^^^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/react.js:167:63
+   <BUILTINS>/react.js:173:63
                                                                       v-
-   167| declare type React$Element<+ElementType: React$ElementType> = {|
-   168|   +type: ElementType,
-   169|   +props: React$ElementProps<ElementType>,
-   170|   +key: React$Key | null,
-   171|   +ref: any,
-   172| |};
+   173| declare type React$Element<+ElementType: React$ElementType> = {|
+   174|   +type: ElementType,
+   175|   +props: React$ElementProps<ElementType>,
+   176|   +key: React$Key | null,
+   177|   +ref: any,
+   178| |};
         -^ [2]
 
 
@@ -43,14 +43,14 @@ Property `props` is missing in object literal [1] but exists in `React.Element` 
                            ^^^^^^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/react.js:167:63
+   <BUILTINS>/react.js:173:63
                                                                       v-
-   167| declare type React$Element<+ElementType: React$ElementType> = {|
-   168|   +type: ElementType,
-   169|   +props: React$ElementProps<ElementType>,
-   170|   +key: React$Key | null,
-   171|   +ref: any,
-   172| |};
+   173| declare type React$Element<+ElementType: React$ElementType> = {|
+   174|   +type: ElementType,
+   175|   +props: React$ElementProps<ElementType>,
+   176|   +key: React$Key | null,
+   177|   +ref: any,
+   178| |};
         -^ [2]
 
 
@@ -63,14 +63,14 @@ Property `ref` is missing in object literal [1] but exists in `React.Element` [2
                            ^^^^^^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/react.js:167:63
+   <BUILTINS>/react.js:173:63
                                                                       v-
-   167| declare type React$Element<+ElementType: React$ElementType> = {|
-   168|   +type: ElementType,
-   169|   +props: React$ElementProps<ElementType>,
-   170|   +key: React$Key | null,
-   171|   +ref: any,
-   172| |};
+   173| declare type React$Element<+ElementType: React$ElementType> = {|
+   174|   +type: ElementType,
+   175|   +props: React$ElementProps<ElementType>,
+   176|   +key: React$Key | null,
+   177|   +ref: any,
+   178| |};
         -^ [2]
 
 

--- a/tests/react_imports/react_imports.exp
+++ b/tests/react_imports/react_imports.exp
@@ -47,8 +47,8 @@ Cannot get `React.Missing` because property `Missing` is missing in module `reac
                ^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/react.js:280:27
-   280|   declare module.exports: $Exports<'react'>;
+   <BUILTINS>/react.js:286:27
+   286|   declare module.exports: $Exports<'react'>;
                                   ^^^^^^^^^^^^^^^^^ [1]
 
 
@@ -155,8 +155,8 @@ Cannot get `React.Missing` because property `Missing` is missing in module `reac
                ^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/react.js:280:27
-   280|   declare module.exports: $Exports<'react'>;
+   <BUILTINS>/react.js:286:27
+   286|   declare module.exports: $Exports<'react'>;
                                   ^^^^^^^^^^^^^^^^^ [1]
 
 
@@ -186,25 +186,25 @@ Cannot get `React.Node` because property `Node` is missing in object type [1].
                           ^^^^^^^^^^
 
 References:
-   <BUILTINS>/react.js:258:26
+   <BUILTINS>/react.js:264:26
                                  v-
-   258|   declare export default {|
-   259|     +DOM: typeof DOM,
-   260|     +PropTypes: typeof PropTypes,
-   261|     +version: typeof version,
-   262|     +checkPropTypes: typeof checkPropTypes,
-   263|     +createClass: typeof createClass,
-   264|     +createContext: typeof createContext,
-   265|     +createElement: typeof createElement,
-   266|     +cloneElement: typeof cloneElement,
-   267|     +createFactory: typeof createFactory,
-   268|     +createRef: typeof createRef,
-   269|     +isValidElement: typeof isValidElement,
-   270|     +Component: typeof Component,
-   271|     +PureComponent: typeof PureComponent,
-   272|     +Fragment: typeof Fragment,
-   273|     +Children: typeof Children,
-   274|   |};
+   264|   declare export default {|
+   265|     +DOM: typeof DOM,
+   266|     +PropTypes: typeof PropTypes,
+   267|     +version: typeof version,
+   268|     +checkPropTypes: typeof checkPropTypes,
+   269|     +createClass: typeof createClass,
+   270|     +createContext: typeof createContext,
+   271|     +createElement: typeof createElement,
+   272|     +cloneElement: typeof cloneElement,
+   273|     +createFactory: typeof createFactory,
+   274|     +createRef: typeof createRef,
+   275|     +isValidElement: typeof isValidElement,
+   276|     +Component: typeof Component,
+   277|     +PureComponent: typeof PureComponent,
+   278|     +Fragment: typeof Fragment,
+   279|     +Children: typeof Children,
+   280|   |};
           -^ [1]
 
 
@@ -217,25 +217,25 @@ Cannot get `React.Node` because property `Node` is missing in object type [1].
              ^^^^^^^^^^
 
 References:
-   <BUILTINS>/react.js:258:26
+   <BUILTINS>/react.js:264:26
                                  v-
-   258|   declare export default {|
-   259|     +DOM: typeof DOM,
-   260|     +PropTypes: typeof PropTypes,
-   261|     +version: typeof version,
-   262|     +checkPropTypes: typeof checkPropTypes,
-   263|     +createClass: typeof createClass,
-   264|     +createContext: typeof createContext,
-   265|     +createElement: typeof createElement,
-   266|     +cloneElement: typeof cloneElement,
-   267|     +createFactory: typeof createFactory,
-   268|     +createRef: typeof createRef,
-   269|     +isValidElement: typeof isValidElement,
-   270|     +Component: typeof Component,
-   271|     +PureComponent: typeof PureComponent,
-   272|     +Fragment: typeof Fragment,
-   273|     +Children: typeof Children,
-   274|   |};
+   264|   declare export default {|
+   265|     +DOM: typeof DOM,
+   266|     +PropTypes: typeof PropTypes,
+   267|     +version: typeof version,
+   268|     +checkPropTypes: typeof checkPropTypes,
+   269|     +createClass: typeof createClass,
+   270|     +createContext: typeof createContext,
+   271|     +createElement: typeof createElement,
+   272|     +cloneElement: typeof cloneElement,
+   273|     +createFactory: typeof createFactory,
+   274|     +createRef: typeof createRef,
+   275|     +isValidElement: typeof isValidElement,
+   276|     +Component: typeof Component,
+   277|     +PureComponent: typeof PureComponent,
+   278|     +Fragment: typeof Fragment,
+   279|     +Children: typeof Children,
+   280|   |};
           -^ [1]
 
 
@@ -248,25 +248,25 @@ Cannot get `React.Missing` because property `Missing` is missing in object type 
                ^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/react.js:258:26
+   <BUILTINS>/react.js:264:26
                                  v-
-   258|   declare export default {|
-   259|     +DOM: typeof DOM,
-   260|     +PropTypes: typeof PropTypes,
-   261|     +version: typeof version,
-   262|     +checkPropTypes: typeof checkPropTypes,
-   263|     +createClass: typeof createClass,
-   264|     +createContext: typeof createContext,
-   265|     +createElement: typeof createElement,
-   266|     +cloneElement: typeof cloneElement,
-   267|     +createFactory: typeof createFactory,
-   268|     +createRef: typeof createRef,
-   269|     +isValidElement: typeof isValidElement,
-   270|     +Component: typeof Component,
-   271|     +PureComponent: typeof PureComponent,
-   272|     +Fragment: typeof Fragment,
-   273|     +Children: typeof Children,
-   274|   |};
+   264|   declare export default {|
+   265|     +DOM: typeof DOM,
+   266|     +PropTypes: typeof PropTypes,
+   267|     +version: typeof version,
+   268|     +checkPropTypes: typeof checkPropTypes,
+   269|     +createClass: typeof createClass,
+   270|     +createContext: typeof createContext,
+   271|     +createElement: typeof createElement,
+   272|     +cloneElement: typeof cloneElement,
+   273|     +createFactory: typeof createFactory,
+   274|     +createRef: typeof createRef,
+   275|     +isValidElement: typeof isValidElement,
+   276|     +Component: typeof Component,
+   277|     +PureComponent: typeof PureComponent,
+   278|     +Fragment: typeof Fragment,
+   279|     +Children: typeof Children,
+   280|   |};
           -^ [1]
 
 

--- a/tests/react_jsx/react_jsx.exp
+++ b/tests/react_jsx/react_jsx.exp
@@ -93,8 +93,8 @@ References:
    test.js:105:12
    105|   string1={null}
                    ^^^^ [1]
-   <BUILTINS>/react.js:315:36
-   315|   string: React$PropType$Primitive<string>;
+   <BUILTINS>/react.js:321:36
+   321|   string: React$PropType$Primitive<string>;
                                            ^^^^^^ [2]
    test.js:106:12
    106|   string2={null}
@@ -102,8 +102,8 @@ References:
    test.js:107:13
    107|   boolean1={null}
                     ^^^^ [4]
-   <BUILTINS>/react.js:311:34
-   311|   bool: React$PropType$Primitive<boolean>;
+   <BUILTINS>/react.js:317:34
+   317|   bool: React$PropType$Primitive<boolean>;
                                          ^^^^^^^ [5]
    test.js:108:13
    108|   boolean2={null}
@@ -111,8 +111,8 @@ References:
    test.js:109:11
    109|   number={null}
                   ^^^^ [7]
-   <BUILTINS>/react.js:313:36
-   313|   number: React$PropType$Primitive<number>;
+   <BUILTINS>/react.js:319:36
+   319|   number: React$PropType$Primitive<number>;
                                            ^^^^^^ [8]
 
 
@@ -161,8 +161,8 @@ References:
    test.js:135:54
    135|   {...{string1: 'foo', string2: 'bar', number: (any: ?number)}}
                                                              ^^^^^^^ [1]
-   <BUILTINS>/react.js:313:36
-   313|   number: React$PropType$Primitive<number>;
+   <BUILTINS>/react.js:319:36
+   319|   number: React$PropType$Primitive<number>;
                                            ^^^^^^ [2]
 
 
@@ -1654,8 +1654,8 @@ References:
    <BUILTINS>/core.js:13:24
     13| declare var undefined: void;
                                ^^^^ [1]
-   <BUILTINS>/react.js:313:36
-   313|   number: React$PropType$Primitive<number>;
+   <BUILTINS>/react.js:319:36
+   319|   number: React$PropType$Primitive<number>;
                                            ^^^^^^ [2]
 
 
@@ -1675,8 +1675,8 @@ References:
    test.js:788:7
    788|   foo="nope"
               ^^^^^^ [1]
-   <BUILTINS>/react.js:313:36
-   313|   number: React$PropType$Primitive<number>;
+   <BUILTINS>/react.js:319:36
+   319|   number: React$PropType$Primitive<number>;
                                            ^^^^^^ [2]
 
 
@@ -1696,8 +1696,8 @@ References:
    test.js:793:7
    793|   bar="nope"
               ^^^^^^ [1]
-   <BUILTINS>/react.js:313:36
-   313|   number: React$PropType$Primitive<number>;
+   <BUILTINS>/react.js:319:36
+   319|   number: React$PropType$Primitive<number>;
                                            ^^^^^^ [2]
 
 

--- a/tests/type-at-pos/type-at-pos.exp
+++ b/tests/type-at-pos/type-at-pos.exp
@@ -2502,7 +2502,7 @@ react_component.js:32:13 = {
     "kind":"Generic",
     "typeArgs":[{"kind":"Num"}],
     "type":{
-      "provenance":{"kind":"Library","loc":"[LIB] react.js:228:42-63"},
+      "provenance":{"kind":"Library","loc":"[LIB] react.js:234:42-63"},
       "name":"ComponentType"
     },
     "structural":false
@@ -2525,7 +2525,7 @@ react_component.js:32:29 = {
   "expanded_type":{
     "kind":"TypeAlias",
     "name":{
-      "provenance":{"kind":"Library","loc":"[LIB] react.js:228:42-63"},
+      "provenance":{"kind":"Library","loc":"[LIB] react.js:234:42-63"},
       "name":"ComponentType"
     },
     "typeParams":[{"name":"P","bound":null,"polarity":"Neutral"}],
@@ -2533,7 +2533,7 @@ react_component.js:32:29 = {
       "kind":"Generic",
       "typeArgs":[{"kind":"Bound","bound":"P"}],
       "type":{
-        "provenance":{"kind":"Library","loc":"[LIB] react.js:147:5,148:38"},
+        "provenance":{"kind":"Library","loc":"[LIB] react.js:153:5,154:38"},
         "name":"React$ComponentType"
       },
       "structural":false


### PR DESCRIPTION
Closes #5139

Adds type that [matches callsite for `componentDidCatch`](https://github.com/facebook/react/blob/b52a5624e95f77166ffa520476d68231640692f9/packages/react-reconciler/src/ReactFiberScheduler.js#L1309)

The Flow type for `info` is defined here as well: https://github.com/facebook/react/blob/b52a5624e95f77166ffa520476d68231640692f9/packages/react-reconciler/src/ReactFiberScheduler.js#L29-L31