### PR TITLE
fix(lib/core.js): remove required @@asyncIterator method from $AsyncIterator

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -530,7 +530,6 @@ declare function $iterate<T>(p: Iterable<T>): T;
 /* Async Iterable/Iterator/Generator */
 
 interface $AsyncIterator<+Yield,+Return,-Next> {
-    @@asyncIterator(): $AsyncIterator<Yield,Return,Next>;
     next(value?: Next): Promise<IteratorResult<Yield,Return>>;
 }
 type AsyncIterator<+T> = $AsyncIterator<T,void,void>;


### PR DESCRIPTION
AsyncIterators are not required to be AsyncIterables, AFAIK