### PR TITLE
fix(lib/core.js): remove required @@iterator method from Iterator

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -508,7 +508,6 @@ type IteratorResult<+Yield,+Return> =
   | { done: false, +value: Yield };
 
 interface $Iterator<+Yield,+Return,-Next> {
-    @@iterator(): $Iterator<Yield,Return,Next>;
     next(value?: Next): IteratorResult<Yield,Return>;
 }
 type Iterator<+T> = $Iterator<T,void,void>;


### PR DESCRIPTION
`Iterators` are not required to be `Iterables`:
http://devdocs.io/javascript/iteration_protocols

> An object is an iterator when it implements a next() method with the following semantics

> *Some* iterators are in turn iterables