### PR TITLE
Fix static declarations for XMLHttpRequest

### DIFF
--- a/lib/bom.js
+++ b/lib/bom.js
@@ -543,6 +543,11 @@ declare class XDomainRequest {
 
 
 declare class XMLHttpRequest extends EventTarget {
+    static LOADING: number;
+    static DONE: number;
+    static UNSENT: number;
+    static OPENED: number;
+    static HEADERS_RECEIVED: number;
     responseBody: any;
     status: number;
     readyState: number;
@@ -580,12 +585,6 @@ declare class XMLHttpRequest extends EventTarget {
 
     statics: {
         create(): XMLHttpRequest;
-
-        LOADING: number;
-        DONE: number;
-        UNSENT: number;
-        OPENED: number;
-        HEADERS_RECEIVED: number;
     }
 }
 


### PR DESCRIPTION
Encountered this error while use static values for XMLHttpRequest:
```
Cannot get `XMLHttpRequest.DONE` because property `DONE` is missing in statics of `XMLHttpRequest`
```
I think they were never declared properly in the [bom.js](https://github.com/facebook/flow/blob/master/lib/bom.js#L584) file . Here's a [stripped down tryflow](https://flow.org/try/#0CYUwxgNghgTiAEkoGdnwMIFcZwHYBcANAWQBkAJffABwCUQBHTEZfedgbwCh32ARAPIA5AKIAueLkwBbAEYgYAbi49erKPgCWYZBO68DiOBpAAKAJQSsOEARIUqdRs1bKAkAcGiJUuQuUGAL5cwVygSHCI0KjwAAowAPbUCcggwABimgAe9pQ09EwsbJxcbupaYPBe4pIy8kqq-MI1vvXKjfDl2rrw+obsYMb4ZpZxicmpGdm5jgUu+AG8waFgCbis8MOsAIzwALwY2HhEZHlOhawAdNVcq+tsW-gATPtjSSlpmTmns85F180gA) demonstrating the issue as well as the fix.


On a related note, I'm not sure what the `create()` declaration in the `statics` block is for either.
