### PR TITLE
[circleci] don't rely on -nt of a missing file

### DIFF
--- a/src/parser/Makefile
+++ b/src/parser/Makefile
@@ -58,10 +58,14 @@ libflowparser.native.o:
 
 dist/libflowparser/lib/libflowparser.a: libflowparser.native.o
 	@mkdir -p "$(@D)"
-	if [ "$(OCAML_PATH)/libasmrun_pic.a" -nt "$@" -o  "$(TOP)/_build/$(REL_DIR)/libflowparser.native.o" -nt "$@" ]; then \
+	if [ ! -e "$@" -o "$(OCAML_PATH)/libasmrun_pic.a" -nt "$@" -o  "$(TOP)/_build/$(REL_DIR)/libflowparser.native.o" -nt "$@" ]; then \
+		echo "Rebuilding $@"; \
 		cp "$(OCAML_PATH)/libasmrun_pic.a" "$@"; \
 		ar rcs "$@" "$(TOP)/_build/$(REL_DIR)/libflowparser.native.o"; \
+	else \
+		echo "Not rebuilding $@, already up to date"; \
 	fi
+	test -e "$@" || exit 1
 
 $(OCAML_HEADERS): dist/libflowparser/include/%: $(OCAML_PATH)/%
 	@mkdir -p "$(@D)"


### PR DESCRIPTION
fixes the libflowparser artifact, which wasn't being rebuilt because -nt seems to behave differently when the RHS doesn't exist in the version of bash in circle, than it does on my mac.

Test Plan: https://circleci.com/gh/mroch/flow/472