### PR TITLE
Expose `implements` and `mixins` of `DeclareClass` AST

### DIFF
--- a/packages/flow-parser/test/esprima_test_runner.js
+++ b/packages/flow-parser/test/esprima_test_runner.js
@@ -267,6 +267,15 @@ function handleSpecialObjectCompare(esprima, flow, env) {
     case 'CallExpression':
       delete flow.optional;
       break;
+
+    case 'DeclareClass':
+      if (esprima.implements === undefined) {
+        esprima.implements = [];
+      }
+      if (esprima.mixins === undefined) {
+        esprima.mixins = [];
+      }
+      break;
   }
 
   switch (esprima.type) {

--- a/src/parser/estree_translator.ml
+++ b/src/parser/estree_translator.ml
@@ -642,6 +642,8 @@ end with type t = Impl.t) = struct
       "typeParameters", option type_parameter_declaration d.tparams;
       "body", object_type d.body;
       "extends", extends;
+      "implements", array_of_list class_implements d.implements;
+      "mixins", array_of_list interface_extends d.mixins;
     ]
   )
 


### PR DESCRIPTION
Closes #5463
Closes #6096

Updates `estree_translator.ml` to expose those two fields of `DeclareClass` as we need those for Prettier. I fixed esprima compatibility tests that broke, but I'm not sure if/how I should add regression tests when the declaration includes an interface or mixin.

I'm not familiar with this codebase, let me know if I should do anything differently.

Thanks!

cc @mroch 