### PR TITLE
Add Intl types

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -121,19 +121,6 @@ declare class Boolean {
     toString(): string;
 }
 
-type Number$LocaleOptions = {
-  localeMatcher?: string,
-  style?: string,
-  currency?: string,
-  currencyDisplay?: string,
-  useGrouping?: boolean,
-  minimumIntegerDigits?: number,
-  minimumFractionDigits?: number,
-  maximumFractionDigits?: number,
-  minimumSignificantDigits?: number,
-  maximumSignificantDigits?: number,
-};
-
 declare class Number {
     static EPSILON: number;
     static MAX_SAFE_INTEGER: number;
@@ -153,7 +140,7 @@ declare class Number {
     constructor(value?: mixed): void;
     toExponential(fractionDigits?: number): string;
     toFixed(fractionDigits?: number): string;
-    toLocaleString(locales?: string | Array<string>, options?: Number$LocaleOptions): string;
+    toLocaleString(locales?: string | Array<string>, options?: Intl$NumberFormatOptions): string;
     toPrecision(precision?: number): string;
     toString(radix?: number): string;
     valueOf(): number;
@@ -311,7 +298,7 @@ declare class String {
     indexOf(searchString: string, position?: number): number;
     lastIndexOf(searchString: string, position?: number): number;
     link(href: string): string;
-    localeCompare(that: string, locales?: string | Array<string>, options?: Object): number;
+    localeCompare(that: string, locales?: string | Array<string>, options?: Intl$CollatorOptions): number;
     match(regexp: string | RegExp): ?Array<string>;
     normalize(format?: string): string;
     padEnd(targetLength: number, padString?: string): string;
@@ -360,22 +347,6 @@ declare class RegExp {
     toString(): string;
 }
 
-type Date$LocaleOptions = {
-  localeMatcher?: string,
-  timeZone?: string,
-  hour12?: boolean,
-  formatMatcher?: string,
-  weekday?: string,
-  era?: string,
-  year?: string,
-  month?: string,
-  day?: string,
-  hour?: string,
-  minute?: string,
-  second?: string,
-  timeZoneName?: string,
-};
-
 declare class Date {
     constructor(): void;
     constructor(timestamp: number): void;
@@ -417,9 +388,9 @@ declare class Date {
     toDateString(): string;
     toISOString(): string;
     toJSON(key?: any): string;
-    toLocaleDateString(locales?: string | Array<string>, options?: Date$LocaleOptions): string;
-    toLocaleString(locales?: string | Array<string>, options?: Date$LocaleOptions): string;
-    toLocaleTimeString(locales?: string | Array<string>, options?: Date$LocaleOptions): string;
+    toLocaleDateString(locales?: string | Array<string>, options?: Intl$DateTimeFormatOptions): string;
+    toLocaleString(locales?: string | Array<string>, options?: Intl$DateTimeFormatOptions): string;
+    toLocaleTimeString(locales?: string | Array<string>, options?: Intl$DateTimeFormatOptions): string;
     toTimeString(): string;
     toUTCString(): string;
     valueOf(): number;

--- a/lib/intl.js
+++ b/lib/intl.js
@@ -1,0 +1,179 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+declare var Intl: {
+  Collator: Class<Intl$Collator>,
+  DateTimeFormat: Class<Intl$DateTimeFormat>,
+  NumberFormat: Class<Intl$NumberFormat>,
+  PluralRules: ?Class<Intl$PluralRules>,
+
+  getCanonicalLocales?: (locales?: Intl$Locales) => Intl$Locale[]
+}
+
+type Intl$Locale = string
+type Intl$Locales = Intl$Locale | Intl$Locale[]
+
+declare class Intl$Collator {
+  constructor (
+    locales?: Intl$Locales,
+    options?: Intl$CollatorOptions
+  ): Intl$Collator;
+
+  static (
+    locales?: Intl$Locales,
+    options?: Intl$CollatorOptions
+  ): Intl$Collator;
+
+  compare (string, string): number;
+
+  resolvedOptions (): {
+    locale: Intl$Locale,
+    usage: 'sort' | 'search',
+    sensitivity: 'base' | 'accent' | 'case' | 'variant',
+    ignorePunctuation: boolean,
+    collation: string,
+    numeric: boolean,
+    caseFirst?: 'upper' | 'lower' | 'false'
+  };
+
+  static supportedLocalesOf (locales?: Intl$Locales): Intl$Locale[];
+}
+
+declare type Intl$CollatorOptions = {
+  localeMatcher?: 'lookup' | 'best fit',
+  usage?: 'sort' | 'search',
+  sensitivity?: 'base' | 'accent' | 'case' | 'variant',
+  ignorePunctuation?: boolean,
+  numeric?: boolean,
+  caseFirst?: 'upper' | 'lower' | 'false'
+}
+
+declare class Intl$DateTimeFormat {
+  constructor (
+    locales?: Intl$Locales,
+    options?: Intl$DateTimeFormatOptions
+  ): Intl$DateTimeFormat;
+
+  static (
+    locales?: Intl$Locales,
+    options?: Intl$DateTimeFormatOptions
+  ): Intl$DateTimeFormat;
+
+  format (value?: Date | number): string;
+
+  resolvedOptions (): {
+    locale: Intl$Locale,
+    calendar: string,
+    numberingSystem: string,
+    timeZone?: string,
+    hour12: boolean,
+    weekday?: 'narrow' | 'short' | 'long',
+    era?: 'narrow' | 'short' | 'long',
+    year?: 'numeric' | '2-digit',
+    month?: 'numeric' | '2-digit' | 'narrow' | 'short' | 'long',
+    day?: 'numeric' | '2-digit',
+    hour?: 'numeric' | '2-digit',
+    minute?: 'numeric' | '2-digit',
+    second?: 'numeric' | '2-digit',
+    timeZoneName?: 'short' | 'long'
+  };
+
+  static supportedLocalesOf (locales?: Intl$Locales): Intl$Locale[];
+}
+
+declare type Intl$DateTimeFormatOptions = {
+  localeMatcher?: 'lookup' | 'best fit',
+  timeZone?: string,
+  hour12?: boolean,
+  formatMatcher?: 'basic' | 'best fit',
+  weekday?: 'narrow' | 'short' | 'long',
+  era?: 'narrow' | 'short' | 'long',
+  year?: 'numeric' | '2-digit',
+  month?: 'numeric' | '2-digit' | 'narrow' | 'short' | 'long',
+  day?: 'numeric' | '2-digit',
+  hour?: 'numeric' | '2-digit',
+  minute?: 'numeric' | '2-digit',
+  second?: 'numeric' | '2-digit',
+  timeZoneName?: 'short' | 'long'
+}
+
+declare class Intl$NumberFormat {
+  constructor (
+    locales?: Intl$Locales,
+    options?: Intl$NumberFormatOptions
+  ): Intl$NumberFormat;
+
+  static (
+    locales?: Intl$Locales,
+    options?: Intl$NumberFormatOptions
+  ): Intl$NumberFormat;
+
+  format (number): string;
+
+  resolvedOptions (): {
+    locale: Intl$Locale,
+    numberingSystem: string,
+    style: 'decimal' | 'currency' | 'percent',
+    currency?: string,
+    currencyDisplay?: 'symbol' | 'code' | 'name',
+    useGrouping: boolean,
+    minimumIntegerDigits?: number,
+    minimumFractionDigits?: number,
+    maximumFractionDigits?: number,
+    minimumSignificantDigits?: number,
+    maximumSignificantDigits?: number
+  };
+
+  static supportedLocalesOf (locales?: Intl$Locales): Intl$Locale[];
+}
+
+declare type Intl$NumberFormatOptions = {
+  localeMatcher?: 'lookup' | 'best fit',
+  style?: 'decimal' | 'currency' | 'percent',
+  currency?: string,
+  currencyDisplay?: 'symbol' | 'code' | 'name',
+  useGrouping?: boolean,
+  minimumIntegerDigits?: number,
+  minimumFractionDigits?: number,
+  maximumFractionDigits?: number,
+  minimumSignificantDigits?: number,
+  maximumSignificantDigits?: number
+}
+
+declare class Intl$PluralRules {
+  constructor (
+    locales?: Intl$Locales,
+    options?: Intl$PluralRulesOptions
+  ): Intl$PluralRules;
+
+  select (number): Intl$PluralRule;
+
+  resolvedOptions (): {
+    locale: Intl$Locale,
+    type: 'cardinal' | 'ordinal',
+    minimumIntegerDigits?: number,
+    minimumFractionDigits?: number,
+    maximumFractionDigits?: number,
+    minimumSignificantDigits?: number,
+    maximumSignificantDigits?: number,
+    pluralCategories: Intl$PluralRule[],
+  };
+
+  static supportedLocalesOf (locales?: Intl$Locales): Intl$Locale[];
+}
+
+type Intl$PluralRule = 'zero' | 'one' | 'two' | 'few' | 'many' | 'other'
+
+declare type Intl$PluralRulesOptions = {
+  localeMatcher?: 'lookup' | 'best fit',
+  type?: 'cardinal' | 'ordinal',
+  minimumIntegerDigits?: number,
+  minimumFractionDigits?: number,
+  maximumFractionDigits?: number,
+  minimumSignificantDigits?: number,
+  maximumSignificantDigits?: number
+}

--- a/tests/arrows/arrows.exp
+++ b/tests/arrows/arrows.exp
@@ -45,8 +45,8 @@ References:
    arrows.js:7:36
      7|     images = images.sort((a, b) => (a.width - b.width) + "");
                                            ^^^^^^^^^^^^^^^^^^^^^^^^ [1]
-   <BUILTINS>/core.js:283:38
-   283|     sort(compareFn?: (a: T, b: T) => number): Array<T>;
+   <BUILTINS>/core.js:270:38
+   270|     sort(compareFn?: (a: T, b: T) => number): Array<T>;
                                              ^^^^^^ [2]
 
 

--- a/tests/async/async.exp
+++ b/tests/async/async.exp
@@ -10,8 +10,8 @@ References:
    async.js:11:30
     11| async function f1(): Promise<bool> {
                                      ^^^^ [2]
-   <BUILTINS>/core.js:605:24
-   605| declare class Promise<+R> {
+   <BUILTINS>/core.js:576:24
+   576| declare class Promise<+R> {
                                ^ [3]
 
 
@@ -30,8 +30,8 @@ References:
    async.js:30:48
     30| async function f4(p: Promise<number>): Promise<bool> {
                                                        ^^^^ [2]
-   <BUILTINS>/core.js:605:24
-   605| declare class Promise<+R> {
+   <BUILTINS>/core.js:576:24
+   576| declare class Promise<+R> {
                                ^ [3]
 
 
@@ -100,8 +100,8 @@ References:
    async2.js:57:13
     57|   : Promise<number> { // error, number != void
                     ^^^^^^ [1]
-   <BUILTINS>/core.js:605:24
-   605| declare class Promise<+R> {
+   <BUILTINS>/core.js:576:24
+   576| declare class Promise<+R> {
                                ^ [2]
 
 
@@ -134,8 +134,8 @@ References:
    async_return_void.js:3:32
      3| async function foo1(): Promise<string> {
                                        ^^^^^^ [2]
-   <BUILTINS>/core.js:605:24
-   605| declare class Promise<+R> {
+   <BUILTINS>/core.js:576:24
+   576| declare class Promise<+R> {
                                ^ [3]
 
 
@@ -151,8 +151,8 @@ References:
    async_return_void.js:7:32
      7| async function foo2(): Promise<string> {
                                        ^^^^^^ [2]
-   <BUILTINS>/core.js:605:24
-   605| declare class Promise<+R> {
+   <BUILTINS>/core.js:576:24
+   576| declare class Promise<+R> {
                                ^ [3]
 
 
@@ -171,8 +171,8 @@ References:
    async_return_void.js:11:32
     11| async function foo3(): Promise<string> {
                                        ^^^^^^ [2]
-   <BUILTINS>/core.js:605:24
-   605| declare class Promise<+R> {
+   <BUILTINS>/core.js:576:24
+   576| declare class Promise<+R> {
                                ^ [3]
 
 

--- a/tests/async_iteration/async_iteration.exp
+++ b/tests/async_iteration/async_iteration.exp
@@ -99,8 +99,8 @@ Cannot cast `result.value` to string because:
              ^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:507:28
-   507|   | { done: true, +value?: Return }
+   <BUILTINS>/core.js:478:28
+   478|   | { done: true, +value?: Return }
                                    ^^^^^^ [1]
    return.js:20:20
     20|     (result.value: string); // error: number | void ~> string

--- a/tests/autocomplete/autocomplete.exp
+++ b/tests/autocomplete/autocomplete.exp
@@ -112,8 +112,8 @@ str.js = {
       "type":"() => Iterator<string>",
       "func_details":{"return_type":"Iterator<string>","params":[]},
       "path":"[LIB] core.js",
-      "line":302,
-      "endline":302,
+      "line":289,
+      "endline":289,
       "start":5,
       "end":34
     },
@@ -122,8 +122,8 @@ str.js = {
       "type":"(name: string) => string",
       "func_details":{"return_type":"string","params":[{"name":"name","type":"string"}]},
       "path":"[LIB] core.js",
-      "line":303,
-      "endline":303,
+      "line":290,
+      "endline":290,
       "start":5,
       "end":32
     },
@@ -132,8 +132,8 @@ str.js = {
       "type":"(pos: number) => string",
       "func_details":{"return_type":"string","params":[{"name":"pos","type":"number"}]},
       "path":"[LIB] core.js",
-      "line":304,
-      "endline":304,
+      "line":291,
+      "endline":291,
       "start":5,
       "end":31
     },
@@ -142,8 +142,8 @@ str.js = {
       "type":"(index: number) => number",
       "func_details":{"return_type":"number","params":[{"name":"index","type":"number"}]},
       "path":"[LIB] core.js",
-      "line":305,
-      "endline":305,
+      "line":292,
+      "endline":292,
       "start":5,
       "end":37
     },
@@ -152,8 +152,8 @@ str.js = {
       "type":"(index: number) => number",
       "func_details":{"return_type":"number","params":[{"name":"index","type":"number"}]},
       "path":"[LIB] core.js",
-      "line":306,
-      "endline":306,
+      "line":293,
+      "endline":293,
       "start":5,
       "end":38
     },
@@ -165,8 +165,8 @@ str.js = {
         "params":[{"name":"...strings","type":"Array<string>"}]
       },
       "path":"[LIB] core.js",
-      "line":307,
-      "endline":307,
+      "line":294,
+      "endline":294,
       "start":5,
       "end":45
     },
@@ -178,8 +178,8 @@ str.js = {
         "params":[{"name":"searchString","type":"string"},{"name":"position?","type":"number"}]
       },
       "path":"[LIB] core.js",
-      "line":309,
-      "endline":309,
+      "line":296,
+      "endline":296,
       "start":5,
       "end":62
     },
@@ -191,8 +191,8 @@ str.js = {
         "params":[{"name":"searchString","type":"string"},{"name":"position?","type":"number"}]
       },
       "path":"[LIB] core.js",
-      "line":310,
-      "endline":310,
+      "line":297,
+      "endline":297,
       "start":5,
       "end":62
     },
@@ -204,8 +204,8 @@ str.js = {
         "params":[{"name":"searchString","type":"string"},{"name":"position?","type":"number"}]
       },
       "path":"[LIB] core.js",
-      "line":311,
-      "endline":311,
+      "line":298,
+      "endline":298,
       "start":5,
       "end":60
     },
@@ -217,8 +217,8 @@ str.js = {
         "params":[{"name":"searchString","type":"string"},{"name":"position?","type":"number"}]
       },
       "path":"[LIB] core.js",
-      "line":312,
-      "endline":312,
+      "line":299,
+      "endline":299,
       "start":5,
       "end":64
     },
@@ -227,8 +227,8 @@ str.js = {
       "type":"number",
       "func_details":null,
       "path":"[LIB] core.js",
-      "line":336,
-      "endline":336,
+      "line":323,
+      "endline":323,
       "start":13,
       "end":18
     },
@@ -237,27 +237,27 @@ str.js = {
       "type":"(href: string) => string",
       "func_details":{"return_type":"string","params":[{"name":"href","type":"string"}]},
       "path":"[LIB] core.js",
-      "line":313,
-      "endline":313,
+      "line":300,
+      "endline":300,
       "start":5,
       "end":30
     },
     {
       "name":"localeCompare",
-      "type":"(that: string, locales?: (string | Array<string>), options?: Object) => number",
+      "type":"(that: string, locales?: (string | Array<string>), options?: Intl$CollatorOptions) => number",
       "func_details":{
         "return_type":"number",
         "params":[
           {"name":"that","type":"string"},
           {"name":"locales?","type":"string | Array<string>"},
-          {"name":"options?","type":"Object"}
+          {"name":"options?","type":"Intl$CollatorOptions"}
         ]
       },
       "path":"[LIB] core.js",
-      "line":314,
-      "endline":314,
+      "line":301,
+      "endline":301,
       "start":5,
-      "end":91
+      "end":105
     },
     {
       "name":"match",
@@ -267,8 +267,8 @@ str.js = {
         "params":[{"name":"regexp","type":"string | RegExp"}]
       },
       "path":"[LIB] core.js",
-      "line":315,
-      "endline":315,
+      "line":302,
+      "endline":302,
       "start":5,
       "end":50
     },
@@ -277,8 +277,8 @@ str.js = {
       "type":"(format?: string) => string",
       "func_details":{"return_type":"string","params":[{"name":"format?","type":"string"}]},
       "path":"[LIB] core.js",
-      "line":316,
-      "endline":316,
+      "line":303,
+      "endline":303,
       "start":5,
       "end":38
     },
@@ -290,8 +290,8 @@ str.js = {
         "params":[{"name":"targetLength","type":"number"},{"name":"padString?","type":"string"}]
       },
       "path":"[LIB] core.js",
-      "line":317,
-      "endline":317,
+      "line":304,
+      "endline":304,
       "start":5,
       "end":60
     },
@@ -303,8 +303,8 @@ str.js = {
         "params":[{"name":"targetLength","type":"number"},{"name":"padString?","type":"string"}]
       },
       "path":"[LIB] core.js",
-      "line":318,
-      "endline":318,
+      "line":305,
+      "endline":305,
       "start":5,
       "end":62
     },
@@ -313,8 +313,8 @@ str.js = {
       "type":"(count: number) => string",
       "func_details":{"return_type":"string","params":[{"name":"count","type":"number"}]},
       "path":"[LIB] core.js",
-      "line":319,
-      "endline":319,
+      "line":306,
+      "endline":306,
       "start":5,
       "end":33
     },
@@ -332,8 +332,8 @@ str.js = {
         ]
       },
       "path":"[LIB] core.js",
-      "line":320,
-      "endline":320,
+      "line":307,
+      "endline":307,
       "start":5,
       "end":124
     },
@@ -342,8 +342,8 @@ str.js = {
       "type":"(regexp: (string | RegExp)) => number",
       "func_details":{"return_type":"number","params":[{"name":"regexp","type":"string | RegExp"}]},
       "path":"[LIB] core.js",
-      "line":321,
-      "endline":321,
+      "line":308,
+      "endline":308,
       "start":5,
       "end":43
     },
@@ -355,8 +355,8 @@ str.js = {
         "params":[{"name":"start?","type":"number"},{"name":"end?","type":"number"}]
       },
       "path":"[LIB] core.js",
-      "line":322,
-      "endline":322,
+      "line":309,
+      "endline":309,
       "start":5,
       "end":47
     },
@@ -371,8 +371,8 @@ str.js = {
         ]
       },
       "path":"[LIB] core.js",
-      "line":323,
-      "endline":323,
+      "line":310,
+      "endline":310,
       "start":5,
       "end":69
     },
@@ -384,8 +384,8 @@ str.js = {
         "params":[{"name":"searchString","type":"string"},{"name":"position?","type":"number"}]
       },
       "path":"[LIB] core.js",
-      "line":324,
-      "endline":324,
+      "line":311,
+      "endline":311,
       "start":5,
       "end":64
     },
@@ -397,8 +397,8 @@ str.js = {
         "params":[{"name":"from","type":"number"},{"name":"length?","type":"number"}]
       },
       "path":"[LIB] core.js",
-      "line":325,
-      "endline":325,
+      "line":312,
+      "endline":312,
       "start":5,
       "end":49
     },
@@ -410,8 +410,8 @@ str.js = {
         "params":[{"name":"start","type":"number"},{"name":"end?","type":"number"}]
       },
       "path":"[LIB] core.js",
-      "line":326,
-      "endline":326,
+      "line":313,
+      "endline":313,
       "start":5,
       "end":50
     },
@@ -420,8 +420,8 @@ str.js = {
       "type":"() => string",
       "func_details":{"return_type":"string","params":[]},
       "path":"[LIB] core.js",
-      "line":327,
-      "endline":327,
+      "line":314,
+      "endline":314,
       "start":5,
       "end":31
     },
@@ -430,8 +430,8 @@ str.js = {
       "type":"() => string",
       "func_details":{"return_type":"string","params":[]},
       "path":"[LIB] core.js",
-      "line":328,
-      "endline":328,
+      "line":315,
+      "endline":315,
       "start":5,
       "end":31
     },
@@ -440,8 +440,8 @@ str.js = {
       "type":"() => string",
       "func_details":{"return_type":"string","params":[]},
       "path":"[LIB] core.js",
-      "line":329,
-      "endline":329,
+      "line":316,
+      "endline":316,
       "start":5,
       "end":25
     },
@@ -450,8 +450,8 @@ str.js = {
       "type":"() => string",
       "func_details":{"return_type":"string","params":[]},
       "path":"[LIB] core.js",
-      "line":335,
-      "endline":335,
+      "line":322,
+      "endline":322,
       "start":5,
       "end":22
     },
@@ -460,8 +460,8 @@ str.js = {
       "type":"() => string",
       "func_details":{"return_type":"string","params":[]},
       "path":"[LIB] core.js",
-      "line":330,
-      "endline":330,
+      "line":317,
+      "endline":317,
       "start":5,
       "end":25
     },
@@ -470,8 +470,8 @@ str.js = {
       "type":"() => string",
       "func_details":{"return_type":"string","params":[]},
       "path":"[LIB] core.js",
-      "line":331,
-      "endline":331,
+      "line":318,
+      "endline":318,
       "start":5,
       "end":18
     },
@@ -480,8 +480,8 @@ str.js = {
       "type":"() => string",
       "func_details":{"return_type":"string","params":[]},
       "path":"[LIB] core.js",
-      "line":332,
-      "endline":332,
+      "line":319,
+      "endline":319,
       "start":5,
       "end":22
     },
@@ -490,8 +490,8 @@ str.js = {
       "type":"() => string",
       "func_details":{"return_type":"string","params":[]},
       "path":"[LIB] core.js",
-      "line":333,
-      "endline":333,
+      "line":320,
+      "endline":320,
       "start":5,
       "end":23
     },
@@ -500,8 +500,8 @@ str.js = {
       "type":"() => string",
       "func_details":{"return_type":"string","params":[]},
       "path":"[LIB] core.js",
-      "line":334,
-      "endline":334,
+      "line":321,
+      "endline":321,
       "start":5,
       "end":21
     }
@@ -514,8 +514,8 @@ num.js = {
       "type":"(fractionDigits?: number) => string",
       "func_details":{"return_type":"string","params":[{"name":"fractionDigits?","type":"number"}]},
       "path":"[LIB] core.js",
-      "line":154,
-      "endline":154,
+      "line":141,
+      "endline":141,
       "start":5,
       "end":50
     },
@@ -524,34 +524,34 @@ num.js = {
       "type":"(fractionDigits?: number) => string",
       "func_details":{"return_type":"string","params":[{"name":"fractionDigits?","type":"number"}]},
       "path":"[LIB] core.js",
-      "line":155,
-      "endline":155,
+      "line":142,
+      "endline":142,
       "start":5,
       "end":44
     },
     {
       "name":"toLocaleString",
-      "type":"(locales?: (string | Array<string>), options?: Number$LocaleOptions) => string",
+      "type":"(locales?: (string | Array<string>), options?: Intl$NumberFormatOptions) => string",
       "func_details":{
         "return_type":"string",
         "params":[
           {"name":"locales?","type":"string | Array<string>"},
-          {"name":"options?","type":"Number$LocaleOptions"}
+          {"name":"options?","type":"Intl$NumberFormatOptions"}
         ]
       },
       "path":"[LIB] core.js",
-      "line":156,
-      "endline":156,
+      "line":143,
+      "endline":143,
       "start":5,
-      "end":92
+      "end":96
     },
     {
       "name":"toPrecision",
       "type":"(precision?: number) => string",
       "func_details":{"return_type":"string","params":[{"name":"precision?","type":"number"}]},
       "path":"[LIB] core.js",
-      "line":157,
-      "endline":157,
+      "line":144,
+      "endline":144,
       "start":5,
       "end":43
     },
@@ -560,8 +560,8 @@ num.js = {
       "type":"(radix?: number) => string",
       "func_details":{"return_type":"string","params":[{"name":"radix?","type":"number"}]},
       "path":"[LIB] core.js",
-      "line":158,
-      "endline":158,
+      "line":145,
+      "endline":145,
       "start":5,
       "end":36
     },
@@ -570,8 +570,8 @@ num.js = {
       "type":"() => number",
       "func_details":{"return_type":"number","params":[]},
       "path":"[LIB] core.js",
-      "line":159,
-      "endline":159,
+      "line":146,
+      "endline":146,
       "start":5,
       "end":21
     }
@@ -1066,8 +1066,8 @@ typeparams.js = {
       "type":"(fractionDigits?: number) => string",
       "func_details":{"return_type":"string","params":[{"name":"fractionDigits?","type":"number"}]},
       "path":"[LIB] core.js",
-      "line":154,
-      "endline":154,
+      "line":141,
+      "endline":141,
       "start":5,
       "end":50
     },
@@ -1076,34 +1076,34 @@ typeparams.js = {
       "type":"(fractionDigits?: number) => string",
       "func_details":{"return_type":"string","params":[{"name":"fractionDigits?","type":"number"}]},
       "path":"[LIB] core.js",
-      "line":155,
-      "endline":155,
+      "line":142,
+      "endline":142,
       "start":5,
       "end":44
     },
     {
       "name":"toLocaleString",
-      "type":"(locales?: (string | Array<string>), options?: Number$LocaleOptions) => string",
+      "type":"(locales?: (string | Array<string>), options?: Intl$NumberFormatOptions) => string",
       "func_details":{
         "return_type":"string",
         "params":[
           {"name":"locales?","type":"string | Array<string>"},
-          {"name":"options?","type":"Number$LocaleOptions"}
+          {"name":"options?","type":"Intl$NumberFormatOptions"}
         ]
       },
       "path":"[LIB] core.js",
-      "line":156,
-      "endline":156,
+      "line":143,
+      "endline":143,
       "start":5,
-      "end":92
+      "end":96
     },
     {
       "name":"toPrecision",
       "type":"(precision?: number) => string",
       "func_details":{"return_type":"string","params":[{"name":"precision?","type":"number"}]},
       "path":"[LIB] core.js",
-      "line":157,
-      "endline":157,
+      "line":144,
+      "endline":144,
       "start":5,
       "end":43
     },
@@ -1112,8 +1112,8 @@ typeparams.js = {
       "type":"(radix?: number) => string",
       "func_details":{"return_type":"string","params":[{"name":"radix?","type":"number"}]},
       "path":"[LIB] core.js",
-      "line":158,
-      "endline":158,
+      "line":145,
+      "endline":145,
       "start":5,
       "end":36
     },
@@ -1122,8 +1122,8 @@ typeparams.js = {
       "type":"() => number",
       "func_details":{"return_type":"number","params":[]},
       "path":"[LIB] core.js",
-      "line":159,
-      "endline":159,
+      "line":146,
+      "endline":146,
       "start":5,
       "end":21
     }
@@ -1607,8 +1607,8 @@ if.js = {
       "type":"() => Iterator<string>",
       "func_details":{"return_type":"Iterator<string>","params":[]},
       "path":"[LIB] core.js",
-      "line":302,
-      "endline":302,
+      "line":289,
+      "endline":289,
       "start":5,
       "end":34
     },
@@ -1617,8 +1617,8 @@ if.js = {
       "type":"(name: string) => string",
       "func_details":{"return_type":"string","params":[{"name":"name","type":"string"}]},
       "path":"[LIB] core.js",
-      "line":303,
-      "endline":303,
+      "line":290,
+      "endline":290,
       "start":5,
       "end":32
     },
@@ -1627,8 +1627,8 @@ if.js = {
       "type":"(pos: number) => string",
       "func_details":{"return_type":"string","params":[{"name":"pos","type":"number"}]},
       "path":"[LIB] core.js",
-      "line":304,
-      "endline":304,
+      "line":291,
+      "endline":291,
       "start":5,
       "end":31
     },
@@ -1637,8 +1637,8 @@ if.js = {
       "type":"(index: number) => number",
       "func_details":{"return_type":"number","params":[{"name":"index","type":"number"}]},
       "path":"[LIB] core.js",
-      "line":305,
-      "endline":305,
+      "line":292,
+      "endline":292,
       "start":5,
       "end":37
     },
@@ -1647,8 +1647,8 @@ if.js = {
       "type":"(index: number) => number",
       "func_details":{"return_type":"number","params":[{"name":"index","type":"number"}]},
       "path":"[LIB] core.js",
-      "line":306,
-      "endline":306,
+      "line":293,
+      "endline":293,
       "start":5,
       "end":38
     },
@@ -1660,8 +1660,8 @@ if.js = {
         "params":[{"name":"...strings","type":"Array<string>"}]
       },
       "path":"[LIB] core.js",
-      "line":307,
-      "endline":307,
+      "line":294,
+      "endline":294,
       "start":5,
       "end":45
     },
@@ -1673,8 +1673,8 @@ if.js = {
         "params":[{"name":"searchString","type":"string"},{"name":"position?","type":"number"}]
       },
       "path":"[LIB] core.js",
-      "line":309,
-      "endline":309,
+      "line":296,
+      "endline":296,
       "start":5,
       "end":62
     },
@@ -1686,8 +1686,8 @@ if.js = {
         "params":[{"name":"searchString","type":"string"},{"name":"position?","type":"number"}]
       },
       "path":"[LIB] core.js",
-      "line":310,
-      "endline":310,
+      "line":297,
+      "endline":297,
       "start":5,
       "end":62
     },
@@ -1699,8 +1699,8 @@ if.js = {
         "params":[{"name":"searchString","type":"string"},{"name":"position?","type":"number"}]
       },
       "path":"[LIB] core.js",
-      "line":311,
-      "endline":311,
+      "line":298,
+      "endline":298,
       "start":5,
       "end":60
     },
@@ -1712,8 +1712,8 @@ if.js = {
         "params":[{"name":"searchString","type":"string"},{"name":"position?","type":"number"}]
       },
       "path":"[LIB] core.js",
-      "line":312,
-      "endline":312,
+      "line":299,
+      "endline":299,
       "start":5,
       "end":64
     },
@@ -1722,8 +1722,8 @@ if.js = {
       "type":"number",
       "func_details":null,
       "path":"[LIB] core.js",
-      "line":336,
-      "endline":336,
+      "line":323,
+      "endline":323,
       "start":13,
       "end":18
     },
@@ -1732,27 +1732,27 @@ if.js = {
       "type":"(href: string) => string",
       "func_details":{"return_type":"string","params":[{"name":"href","type":"string"}]},
       "path":"[LIB] core.js",
-      "line":313,
-      "endline":313,
+      "line":300,
+      "endline":300,
       "start":5,
       "end":30
     },
     {
       "name":"localeCompare",
-      "type":"(that: string, locales?: (string | Array<string>), options?: Object) => number",
+      "type":"(that: string, locales?: (string | Array<string>), options?: Intl$CollatorOptions) => number",
       "func_details":{
         "return_type":"number",
         "params":[
           {"name":"that","type":"string"},
           {"name":"locales?","type":"string | Array<string>"},
-          {"name":"options?","type":"Object"}
+          {"name":"options?","type":"Intl$CollatorOptions"}
         ]
       },
       "path":"[LIB] core.js",
-      "line":314,
-      "endline":314,
+      "line":301,
+      "endline":301,
       "start":5,
-      "end":91
+      "end":105
     },
     {
       "name":"match",
@@ -1762,8 +1762,8 @@ if.js = {
         "params":[{"name":"regexp","type":"string | RegExp"}]
       },
       "path":"[LIB] core.js",
-      "line":315,
-      "endline":315,
+      "line":302,
+      "endline":302,
       "start":5,
       "end":50
     },
@@ -1772,8 +1772,8 @@ if.js = {
       "type":"(format?: string) => string",
       "func_details":{"return_type":"string","params":[{"name":"format?","type":"string"}]},
       "path":"[LIB] core.js",
-      "line":316,
-      "endline":316,
+      "line":303,
+      "endline":303,
       "start":5,
       "end":38
     },
@@ -1785,8 +1785,8 @@ if.js = {
         "params":[{"name":"targetLength","type":"number"},{"name":"padString?","type":"string"}]
       },
       "path":"[LIB] core.js",
-      "line":317,
-      "endline":317,
+      "line":304,
+      "endline":304,
       "start":5,
       "end":60
     },
@@ -1798,8 +1798,8 @@ if.js = {
         "params":[{"name":"targetLength","type":"number"},{"name":"padString?","type":"string"}]
       },
       "path":"[LIB] core.js",
-      "line":318,
-      "endline":318,
+      "line":305,
+      "endline":305,
       "start":5,
       "end":62
     },
@@ -1808,8 +1808,8 @@ if.js = {
       "type":"(count: number) => string",
       "func_details":{"return_type":"string","params":[{"name":"count","type":"number"}]},
       "path":"[LIB] core.js",
-      "line":319,
-      "endline":319,
+      "line":306,
+      "endline":306,
       "start":5,
       "end":33
     },
@@ -1827,8 +1827,8 @@ if.js = {
         ]
       },
       "path":"[LIB] core.js",
-      "line":320,
-      "endline":320,
+      "line":307,
+      "endline":307,
       "start":5,
       "end":124
     },
@@ -1837,8 +1837,8 @@ if.js = {
       "type":"(regexp: (string | RegExp)) => number",
       "func_details":{"return_type":"number","params":[{"name":"regexp","type":"string | RegExp"}]},
       "path":"[LIB] core.js",
-      "line":321,
-      "endline":321,
+      "line":308,
+      "endline":308,
       "start":5,
       "end":43
     },
@@ -1850,8 +1850,8 @@ if.js = {
         "params":[{"name":"start?","type":"number"},{"name":"end?","type":"number"}]
       },
       "path":"[LIB] core.js",
-      "line":322,
-      "endline":322,
+      "line":309,
+      "endline":309,
       "start":5,
       "end":47
     },
@@ -1866,8 +1866,8 @@ if.js = {
         ]
       },
       "path":"[LIB] core.js",
-      "line":323,
-      "endline":323,
+      "line":310,
+      "endline":310,
       "start":5,
       "end":69
     },
@@ -1879,8 +1879,8 @@ if.js = {
         "params":[{"name":"searchString","type":"string"},{"name":"position?","type":"number"}]
       },
       "path":"[LIB] core.js",
-      "line":324,
-      "endline":324,
+      "line":311,
+      "endline":311,
       "start":5,
       "end":64
     },
@@ -1892,8 +1892,8 @@ if.js = {
         "params":[{"name":"from","type":"number"},{"name":"length?","type":"number"}]
       },
       "path":"[LIB] core.js",
-      "line":325,
-      "endline":325,
+      "line":312,
+      "endline":312,
       "start":5,
       "end":49
     },
@@ -1905,8 +1905,8 @@ if.js = {
         "params":[{"name":"start","type":"number"},{"name":"end?","type":"number"}]
       },
       "path":"[LIB] core.js",
-      "line":326,
-      "endline":326,
+      "line":313,
+      "endline":313,
       "start":5,
       "end":50
     },
@@ -1915,8 +1915,8 @@ if.js = {
       "type":"() => string",
       "func_details":{"return_type":"string","params":[]},
       "path":"[LIB] core.js",
-      "line":327,
-      "endline":327,
+      "line":314,
+      "endline":314,
       "start":5,
       "end":31
     },
@@ -1925,8 +1925,8 @@ if.js = {
       "type":"() => string",
       "func_details":{"return_type":"string","params":[]},
       "path":"[LIB] core.js",
-      "line":328,
-      "endline":328,
+      "line":315,
+      "endline":315,
       "start":5,
       "end":31
     },
@@ -1935,8 +1935,8 @@ if.js = {
       "type":"() => string",
       "func_details":{"return_type":"string","params":[]},
       "path":"[LIB] core.js",
-      "line":329,
-      "endline":329,
+      "line":316,
+      "endline":316,
       "start":5,
       "end":25
     },
@@ -1945,8 +1945,8 @@ if.js = {
       "type":"() => string",
       "func_details":{"return_type":"string","params":[]},
       "path":"[LIB] core.js",
-      "line":335,
-      "endline":335,
+      "line":322,
+      "endline":322,
       "start":5,
       "end":22
     },
@@ -1955,8 +1955,8 @@ if.js = {
       "type":"() => string",
       "func_details":{"return_type":"string","params":[]},
       "path":"[LIB] core.js",
-      "line":330,
-      "endline":330,
+      "line":317,
+      "endline":317,
       "start":5,
       "end":25
     },
@@ -1965,8 +1965,8 @@ if.js = {
       "type":"() => string",
       "func_details":{"return_type":"string","params":[]},
       "path":"[LIB] core.js",
-      "line":331,
-      "endline":331,
+      "line":318,
+      "endline":318,
       "start":5,
       "end":18
     },
@@ -1975,8 +1975,8 @@ if.js = {
       "type":"() => string",
       "func_details":{"return_type":"string","params":[]},
       "path":"[LIB] core.js",
-      "line":332,
-      "endline":332,
+      "line":319,
+      "endline":319,
       "start":5,
       "end":22
     },
@@ -1985,8 +1985,8 @@ if.js = {
       "type":"() => string",
       "func_details":{"return_type":"string","params":[]},
       "path":"[LIB] core.js",
-      "line":333,
-      "endline":333,
+      "line":320,
+      "endline":320,
       "start":5,
       "end":23
     },
@@ -1995,8 +1995,8 @@ if.js = {
       "type":"() => string",
       "func_details":{"return_type":"string","params":[]},
       "path":"[LIB] core.js",
-      "line":334,
-      "endline":334,
+      "line":321,
+      "endline":321,
       "start":5,
       "end":21
     }

--- a/tests/compose/compose.exp
+++ b/tests/compose/compose.exp
@@ -7,8 +7,8 @@ Cannot cast `compose(...)(...)` to empty because string [1] is incompatible with
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:158:31
-   158|     toString(radix?: number): string;
+   <BUILTINS>/core.js:145:31
+   145|     toString(radix?: number): string;
                                       ^^^^^^ [1]
    basic.js:6:34
      6| (compose(n => n.toString())(42): empty); // Error: string ~> empty
@@ -24,8 +24,8 @@ Cannot cast `composeReverse(...)(...)` to empty because string [1] is incompatib
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:158:31
-   158|     toString(radix?: number): string;
+   <BUILTINS>/core.js:145:31
+   145|     toString(radix?: number): string;
                                       ^^^^^^ [1]
    basic.js:8:41
      8| (composeReverse(n => n.toString())(42): empty); // Error: string ~> empty
@@ -62,8 +62,8 @@ Cannot perform arithmetic operation because string [1] is not a number.
                ^
 
 References:
-   <BUILTINS>/core.js:158:31
-   158|     toString(radix?: number): string;
+   <BUILTINS>/core.js:145:31
+   145|     toString(radix?: number): string;
                                       ^^^^^^ [1]
 
 
@@ -80,8 +80,8 @@ Cannot cast `composeReverse(...)(...)` to empty because string [1] is incompatib
         ----^
 
 References:
-   <BUILTINS>/core.js:158:31
-   158|     toString(radix?: number): string;
+   <BUILTINS>/core.js:145:31
+   145|     toString(radix?: number): string;
                                       ^^^^^^ [1]
    basic.js:18:8
     18| )(42): empty); // Error: string ~> empty
@@ -100,8 +100,8 @@ References:
    recompose.js:20:8
     20|     p: `${props.p * 3}`,
                ^^^^^^^^^^^^^^^^ [1]
-   <BUILTINS>/core.js:198:14
-   198|     round(x: number): number;
+   <BUILTINS>/core.js:185:14
+   185|     round(x: number): number;
                      ^^^^^^ [2]
 
 

--- a/tests/computed_props/computed_props.exp
+++ b/tests/computed_props/computed_props.exp
@@ -114,8 +114,8 @@ Cannot assign `arr[0]()` to `y` because number [1] is incompatible with string [
                         ^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:289:13
-   289|     length: number;
+   <BUILTINS>/core.js:276:13
+   276|     length: number;
                     ^^^^^^ [1]
    test7.js:5:8
      5| var y: string = arr[0](); // error: number ~> string

--- a/tests/core_tests/core_tests.exp
+++ b/tests/core_tests/core_tests.exp
@@ -14,11 +14,11 @@ References:
    map.js:23:22
     23|     let x = new Map(['foo', 123]); // error
                              ^^^^^ [1]
-   <BUILTINS>/core.js:556:37
-   556|     constructor(iterable: ?Iterable<[K, V]>): void;
+   <BUILTINS>/core.js:527:37
+   527|     constructor(iterable: ?Iterable<[K, V]>): void;
                                             ^^^^^^ [2]
-   <BUILTINS>/core.js:510:22
-   510| interface $Iterator<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:481:22
+   481| interface $Iterator<+Yield,+Return,-Next> {
                              ^^^^^ [3]
    map.js:23:29
     23|     let x = new Map(['foo', 123]); // error
@@ -42,8 +42,8 @@ References:
    map.js:24:16
     24|     let y: Map<number, string> = new Map([['foo', 123]]); // error
                        ^^^^^^ [2]
-   <BUILTINS>/core.js:554:19
-   554| declare class Map<K, V> {
+   <BUILTINS>/core.js:525:19
+   525| declare class Map<K, V> {
                           ^ [3]
    map.js:24:51
     24|     let y: Map<number, string> = new Map([['foo', 123]]); // error
@@ -51,8 +51,8 @@ References:
    map.js:24:24
     24|     let y: Map<number, string> = new Map([['foo', 123]]); // error
                                ^^^^^^ [5]
-   <BUILTINS>/core.js:554:22
-   554| declare class Map<K, V> {
+   <BUILTINS>/core.js:525:22
+   525| declare class Map<K, V> {
                              ^ [6]
 
 
@@ -67,8 +67,8 @@ Cannot cast `x.get(...)` to boolean because:
              ^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:561:22
-   561|     get(key: K): V | void;
+   <BUILTINS>/core.js:532:22
+   532|     get(key: K): V | void;
                              ^^^^ [1]
    map.js:29:20
     29|     (x.get('foo'): boolean); // error, string | void
@@ -102,8 +102,8 @@ since `z` is not a member of the set.
                           ^^^ [1]
 
 References:
-   <BUILTINS>/core.js:344:21
-   344| type RegExp$flags = $CharSet<"gimsuy">
+   <BUILTINS>/core.js:331:21
+   331| type RegExp$flags = $CharSet<"gimsuy">
                             ^^^^^^^^^^^^^^^^^^ [2]
 
 
@@ -117,8 +117,8 @@ since `z` is not a member of the set.
                               ^^^ [1]
 
 References:
-   <BUILTINS>/core.js:344:21
-   344| type RegExp$flags = $CharSet<"gimsuy">
+   <BUILTINS>/core.js:331:21
+   331| type RegExp$flags = $CharSet<"gimsuy">
                             ^^^^^^^^^^^^^^^^^^ [2]
 
 
@@ -140,11 +140,11 @@ References:
    weakset.js:19:24
     19| let ws3 = new WeakSet([1, 2, 3]); // error, must be objects
                                ^ [1]
-   <BUILTINS>/core.js:594:26
-   594| declare class WeakSet<T: Object> {
+   <BUILTINS>/core.js:565:26
+   565| declare class WeakSet<T: Object> {
                                  ^^^^^^ [2]
-   <BUILTINS>/core.js:510:22
-   510| interface $Iterator<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:481:22
+   481| interface $Iterator<+Yield,+Return,-Next> {
                              ^^^^^ [3]
    weakset.js:19:27
     19| let ws3 = new WeakSet([1, 2, 3]); // error, must be objects
@@ -167,11 +167,11 @@ References:
    weakset.js:29:31
     29| function* numbers(): Iterable<number> {
                                       ^^^^^^ [1]
-   <BUILTINS>/core.js:594:26
-   594| declare class WeakSet<T: Object> {
+   <BUILTINS>/core.js:565:26
+   565| declare class WeakSet<T: Object> {
                                  ^^^^^^ [2]
-   <BUILTINS>/core.js:516:22
-   516| interface $Iterable<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:487:22
+   487| interface $Iterable<+Yield,+Return,-Next> {
                              ^^^^^ [3]
 
 

--- a/tests/date/date.exp
+++ b/tests/date/date.exp
@@ -7,8 +7,8 @@ Cannot assign `d.getTime()` to `x` because number [1] is incompatible with strin
                        ^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:392:16
-   392|     getTime(): number;
+   <BUILTINS>/core.js:363:16
+   363|     getTime(): number;
                        ^^^^^^ [1]
    date.js:2:7
      2| var x:string = d.getTime();
@@ -30,14 +30,14 @@ References:
    date.js:18:10
     18| new Date({});
                  ^^ [1]
-   <BUILTINS>/core.js:381:28
-   381|     constructor(timestamp: number): void;
+   <BUILTINS>/core.js:352:28
+   352|     constructor(timestamp: number): void;
                                    ^^^^^^ [2]
-   <BUILTINS>/core.js:382:29
-   382|     constructor(dateString: string): void;
+   <BUILTINS>/core.js:353:29
+   353|     constructor(dateString: string): void;
                                     ^^^^^^ [3]
-   <BUILTINS>/core.js:383:23
-   383|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
+   <BUILTINS>/core.js:354:23
+   354|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
                               ^^^^^^ [4]
 
 
@@ -53,8 +53,8 @@ References:
    date.js:19:16
     19| new Date(2015, '6');
                        ^^^ [1]
-   <BUILTINS>/core.js:383:38
-   383|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
+   <BUILTINS>/core.js:354:38
+   354|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
                                              ^^^^^^ [2]
 
 
@@ -70,8 +70,8 @@ References:
    date.js:20:19
     20| new Date(2015, 6, '18');
                           ^^^^ [1]
-   <BUILTINS>/core.js:383:52
-   383|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
+   <BUILTINS>/core.js:354:52
+   354|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
                                                            ^^^^^^ [2]
 
 
@@ -87,8 +87,8 @@ References:
    date.js:21:23
     21| new Date(2015, 6, 18, '11');
                               ^^^^ [1]
-   <BUILTINS>/core.js:383:67
-   383|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
+   <BUILTINS>/core.js:354:67
+   354|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
                                                                           ^^^^^^ [2]
 
 
@@ -104,8 +104,8 @@ References:
    date.js:22:27
     22| new Date(2015, 6, 18, 11, '55');
                                   ^^^^ [1]
-   <BUILTINS>/core.js:383:84
-   383|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
+   <BUILTINS>/core.js:354:84
+   354|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
                                                                                            ^^^^^^ [2]
 
 
@@ -121,8 +121,8 @@ References:
    date.js:23:31
     23| new Date(2015, 6, 18, 11, 55, '42');
                                       ^^^^ [1]
-   <BUILTINS>/core.js:383:101
-   383|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
+   <BUILTINS>/core.js:354:101
+   354|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
                                                                                                             ^^^^^^ [2]
 
 
@@ -138,8 +138,8 @@ References:
    date.js:24:35
     24| new Date(2015, 6, 18, 11, 55, 42, '999');
                                           ^^^^^ [1]
-   <BUILTINS>/core.js:383:123
-   383|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
+   <BUILTINS>/core.js:354:123
+   354|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
                                                                                                                                   ^^^^^^ [2]
 
 
@@ -156,17 +156,17 @@ Cannot call `Date` because:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:380:5
-   380|     constructor(): void;
+   <BUILTINS>/core.js:351:5
+   351|     constructor(): void;
             ^^^^^^^^^^^^^^^^^^^ [1]
-   <BUILTINS>/core.js:381:5
-   381|     constructor(timestamp: number): void;
+   <BUILTINS>/core.js:352:5
+   352|     constructor(timestamp: number): void;
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [2]
-   <BUILTINS>/core.js:382:5
-   382|     constructor(dateString: string): void;
+   <BUILTINS>/core.js:353:5
+   353|     constructor(dateString: string): void;
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [3]
-   <BUILTINS>/core.js:383:5
-   383|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
+   <BUILTINS>/core.js:354:5
+   354|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [4]
 
 
@@ -182,8 +182,8 @@ References:
    date.js:26:10
     26| new Date('2015', 6);
                  ^^^^^^ [1]
-   <BUILTINS>/core.js:383:23
-   383|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
+   <BUILTINS>/core.js:354:23
+   354|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
                               ^^^^^^ [2]
 
 

--- a/tests/fetch/fetch.exp
+++ b/tests/fetch/fetch.exp
@@ -13,8 +13,8 @@ References:
    fetch.js:12:18
      12| const b: Promise<string> = fetch(myRequest); // incorrect
                           ^^^^^^ [2]
-   <BUILTINS>/core.js:605:24
-    605| declare class Promise<+R> {
+   <BUILTINS>/core.js:576:24
+    576| declare class Promise<+R> {
                                 ^ [3]
 
 
@@ -33,8 +33,8 @@ References:
    <BUILTINS>/bom.js:1002:76
    1002| declare function fetch(input: RequestInfo, init?: RequestOptions): Promise<Response>;
                                                                                     ^^^^^^^^ [2]
-   <BUILTINS>/core.js:605:24
-    605| declare class Promise<+R> {
+   <BUILTINS>/core.js:576:24
+    576| declare class Promise<+R> {
                                 ^ [3]
 
 
@@ -500,11 +500,11 @@ References:
    <BUILTINS>/bom.js:924:62
    924| type BodyInit = string | URLSearchParams | FormData | Blob | ArrayBuffer | $ArrayBufferView;
                                                                      ^^^^^^^^^^^ [5]
-   <BUILTINS>/core.js:650:25
-   650| type $ArrayBufferView = $TypedArray | DataView;
+   <BUILTINS>/core.js:621:25
+   621| type $ArrayBufferView = $TypedArray | DataView;
                                 ^^^^^^^^^^^ [6]
-   <BUILTINS>/core.js:650:39
-   650| type $ArrayBufferView = $TypedArray | DataView;
+   <BUILTINS>/core.js:621:39
+   621| type $ArrayBufferView = $TypedArray | DataView;
                                               ^^^^^^^^ [7]
 
 

--- a/tests/forof/forof.exp
+++ b/tests/forof/forof.exp
@@ -41,8 +41,8 @@ Cannot cast `x` to number because string [1] is incompatible with number [2].
              ^
 
 References:
-   <BUILTINS>/core.js:302:28
-   302|     @@iterator(): Iterator<string>;
+   <BUILTINS>/core.js:289:28
+   289|     @@iterator(): Iterator<string>;
                                    ^^^^^^ [1]
    forof.js:25:9
     25|     (x: number); // Error - string ~> number
@@ -58,8 +58,8 @@ Cannot cast `elem` to number because tuple type [1] is incompatible with number 
              ^^^^
 
 References:
-   <BUILTINS>/core.js:555:28
-   555|     @@iterator(): Iterator<[K, V]>;
+   <BUILTINS>/core.js:526:28
+   526|     @@iterator(): Iterator<[K, V]>;
                                    ^^^^^^ [1]
    forof.js:32:12
     32|     (elem: number); // Error - tuple ~> number
@@ -75,8 +75,8 @@ Cannot cast `elem` to number because tuple type [1] is incompatible with number 
              ^^^^
 
 References:
-   <BUILTINS>/core.js:555:28
-   555|     @@iterator(): Iterator<[K, V]>;
+   <BUILTINS>/core.js:526:28
+   526|     @@iterator(): Iterator<[K, V]>;
                                    ^^^^^^ [1]
    forof.js:39:12
     39|     (elem: number); // Error - tuple ~> number

--- a/tests/function/function.exp
+++ b/tests/function/function.exp
@@ -100,8 +100,8 @@ Cannot call `test.apply` because string [1] is incompatible with number [2].
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:302:28
-   302|     @@iterator(): Iterator<string>;
+   <BUILTINS>/core.js:289:28
+   289|     @@iterator(): Iterator<string>;
                                    ^^^^^^ [1]
    apply.js:1:29
      1| function test(a: string, b: number): number {

--- a/tests/generators/generators.exp
+++ b/tests/generators/generators.exp
@@ -41,8 +41,8 @@ References:
    class.js:23:39
     23|   *stmt_return_err(): Generator<void, number, void> {
                                               ^^^^^^ [2]
-   <BUILTINS>/core.js:521:29
-   521| interface Generator<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:492:29
+   492| interface Generator<+Yield,+Return,-Next> {
                                     ^^^^^^ [3]
 
 
@@ -107,14 +107,14 @@ of property `@@iterator`.
                    ^^
 
 References:
-   <BUILTINS>/core.js:514:38
-   514| type Iterator<+T> = $Iterator<T,void,void>;
+   <BUILTINS>/core.js:485:38
+   485| type Iterator<+T> = $Iterator<T,void,void>;
                                              ^^^^ [1]
    class.js:125:42
    125| examples.delegate_next_iterable([]).next(""); // error: Iterator has no next value
                                                  ^^ [2]
-   <BUILTINS>/core.js:510:37
-   510| interface $Iterator<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:481:37
+   481| interface $Iterator<+Yield,+Return,-Next> {
                                             ^^^^ [3]
 
 
@@ -280,8 +280,8 @@ References:
    generators.js:22:46
     22| function *stmt_return_err(): Generator<void, number, void> {
                                                      ^^^^^^ [2]
-   <BUILTINS>/core.js:521:29
-   521| interface Generator<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:492:29
+   492| interface Generator<+Yield,+Return,-Next> {
                                     ^^^^^^ [3]
 
 
@@ -397,14 +397,14 @@ of property `@@iterator`.
                  ^^
 
 References:
-   <BUILTINS>/core.js:514:38
-   514| type Iterator<+T> = $Iterator<T,void,void>;
+   <BUILTINS>/core.js:485:38
+   485| type Iterator<+T> = $Iterator<T,void,void>;
                                              ^^^^ [1]
    generators.js:94:33
     94| delegate_next_iterable([]).next(""); // error: Iterator has no next value
                                         ^^ [2]
-   <BUILTINS>/core.js:510:37
-   510| interface $Iterator<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:481:37
+   481| interface $Iterator<+Yield,+Return,-Next> {
                                             ^^^^ [3]
 
 
@@ -514,8 +514,8 @@ Cannot cast `refuse_return_result.value` to string because:
            ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:507:28
-   507|   | { done: true, +value?: Return }
+   <BUILTINS>/core.js:478:28
+   478|   | { done: true, +value?: Return }
                                    ^^^^^^ [1]
    return.js:20:32
     20|   (refuse_return_result.value: string); // error: number | void ~> string

--- a/tests/intl/.flowconfig
+++ b/tests/intl/.flowconfig
@@ -1,0 +1,3 @@
+[options]
+module.system=haste
+no_flowlib=false

--- a/tests/intl/collator.js
+++ b/tests/intl/collator.js
@@ -1,0 +1,36 @@
+/* @flow */
+
+const a: Intl$Collator = Intl.Collator() // correct
+const b: Intl$Collator = new Intl.Collator() // correct
+const c: Intl$PluralRules = new Intl.Collator() // incorrect
+Intl.Collator(1, {
+  localeMatcher: 'look fit',
+  usage: 'find',
+  sensitivity: '',
+  ignorePunctuation: null,
+  numeric: 1,
+  caseFirst: 'true'
+}) // incorrect
+Intl.Collator('en') // correct
+Intl.Collator([ 'en', 'en-GB' ], {
+  localeMatcher: 'best fit',
+  usage: 'sort',
+  sensitivity: 'accent',
+  ignorePunctuation: false,
+  numeric: true,
+  caseFirst: 'false'
+}) // correct
+
+new Collator().format() // incorrect
+new Collator().compare() // incorrect
+new Collator().compare('a') // incorrect
+
+new Collator().compare('a', 'b') // correct
+
+new Collator().resolvedOptions() // correct
+
+Collator.getCanonicalLocales() // incorrect
+
+Collator.supportedLocalesOf(1) // incorrect
+Collator.supportedLocalesOf('en') // correct
+Collator.supportedLocalesOf([ 'en' ]) // correct

--- a/tests/intl/date_time_format.js
+++ b/tests/intl/date_time_format.js
@@ -1,0 +1,50 @@
+/* @flow */
+
+const a: Intl$DateTimeFormat = Intl.DateTimeFormat() // correct
+const b: Intl$DateTimeFormat = new Intl.DateTimeFormat() // correct
+const c: Intl$NumberFormat = new Intl.DateTimeFormat() // incorrect
+Intl.DateTimeFormat(1, {
+  localeMatcher: 'look',
+  timeZone: 1,
+  hour12: '',
+  formatMatcher: 'basic fit',
+  weekday: '2-digit',
+  era: '',
+  year: '',
+  month: '',
+  day: '',
+  hour: '',
+  minute: 'long',
+  second: 'short',
+  timeZoneName: 'narrow'
+}) // incorrect
+Intl.DateTimeFormat('en') // correct
+Intl.DateTimeFormat([ 'en', 'en-GB' ], {
+  localeMatcher: 'best fit',
+  timeZone: 'America/Pacific',
+  hour12: true,
+  formatMatcher: 'best fit',
+  weekday: 'long',
+  era: 'long',
+  year: 'numeric',
+  month: 'long',
+  day: '2-digit',
+  hour: 'numeric',
+  minute: '2-digit',
+  second: '2-digit',
+  timeZoneName: 'long'
+}) // correct
+
+new DateTimeFormat().select() // incorrect
+
+new DateTimeFormat().format() // correct
+new DateTimeFormat().format(1) // correct
+new DateTimeFormat().format(new Date(2018, 3, 17)) // correct
+
+new DateTimeFormat().resolvedOptions() // correct
+
+DateTimeFormat.getCanonicalLocales() // incorrect
+
+DateTimeFormat.supportedLocalesOf(1) // incorrect
+DateTimeFormat.supportedLocalesOf('en') // correct
+DateTimeFormat.supportedLocalesOf([ 'en' ]) // correct

--- a/tests/intl/intl.exp
+++ b/tests/intl/intl.exp
@@ -1,0 +1,657 @@
+Error ------------------------------------------------------------------------------------------------- collator.js:5:29
+
+Cannot assign `new Intl.Collator()` to `c` because `Intl$Collator` [1] is incompatible with `Intl$PluralRules` [2].
+
+   collator.js:5:29
+   5| const c: Intl$PluralRules = new Intl.Collator() // incorrect
+                                  ^^^^^^^^^^^^^^^^^^^ [1]
+
+References:
+   collator.js:5:10
+   5| const c: Intl$PluralRules = new Intl.Collator() // incorrect
+               ^^^^^^^^^^^^^^^^ [2]
+
+
+Error ------------------------------------------------------------------------------------------------- collator.js:6:15
+
+Cannot call `Intl.Collator` with `1` bound to `locales` because number [1] is incompatible with string [2].
+
+   collator.js:6:15
+    6| Intl.Collator(1, {
+                     ^ [1]
+
+References:
+   <BUILTINS>/intl.js:18:21
+   18| type Intl$Locales = Intl$Locale | Intl$Locale[]
+                           ^^^^^^^^^^^ [2]
+
+
+Error ------------------------------------------------------------------------------------------------- collator.js:6:18
+
+Cannot call `Intl.Collator` with object literal bound to `options` because:
+ - string [1] is incompatible with enum [2] in property `localeMatcher`.
+ - string [3] is incompatible with enum [4] in property `usage`.
+ - string [5] is incompatible with enum [6] in property `sensitivity`.
+ - null [7] is incompatible with boolean [8] in property `ignorePunctuation`.
+ - number [9] is incompatible with boolean [10] in property `numeric`.
+ - string [11] is incompatible with enum [12] in property `caseFirst`.
+
+   collator.js:6:18
+                        v
+    6| Intl.Collator(1, {
+    7|   localeMatcher: 'look fit',
+    8|   usage: 'find',
+    9|   sensitivity: '',
+   10|   ignorePunctuation: null,
+   11|   numeric: 1,
+   12|   caseFirst: 'true'
+   13| }) // incorrect
+       ^
+
+References:
+   collator.js:7:18
+    7|   localeMatcher: 'look fit',
+                        ^^^^^^^^^^ [1]
+   <BUILTINS>/intl.js:47:19
+   47|   localeMatcher?: 'lookup' | 'best fit',
+                         ^^^^^^^^^^^^^^^^^^^^^ [2]
+   collator.js:8:10
+    8|   usage: 'find',
+                ^^^^^^ [3]
+   <BUILTINS>/intl.js:48:11
+   48|   usage?: 'sort' | 'search',
+                 ^^^^^^^^^^^^^^^^^ [4]
+   collator.js:9:16
+    9|   sensitivity: '',
+                      ^^ [5]
+   <BUILTINS>/intl.js:49:17
+   49|   sensitivity?: 'base' | 'accent' | 'case' | 'variant',
+                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [6]
+   collator.js:10:22
+   10|   ignorePunctuation: null,
+                            ^^^^ [7]
+   <BUILTINS>/intl.js:50:23
+   50|   ignorePunctuation?: boolean,
+                             ^^^^^^^ [8]
+   collator.js:11:12
+   11|   numeric: 1,
+                  ^ [9]
+   <BUILTINS>/intl.js:51:13
+   51|   numeric?: boolean,
+                   ^^^^^^^ [10]
+   collator.js:12:14
+   12|   caseFirst: 'true'
+                    ^^^^^^ [11]
+   <BUILTINS>/intl.js:52:15
+   52|   caseFirst?: 'upper' | 'lower' | 'false'
+                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ [12]
+
+
+Error ------------------------------------------------------------------------------------------------- collator.js:24:5
+
+Cannot resolve name `Collator`.
+
+   24| new Collator().format() // incorrect
+           ^^^^^^^^
+
+
+Error ----------------------------------------------------------------------------------------- date_time_format.js:5:30
+
+Cannot assign `new Intl.DateTimeFormat()` to `c` because `Intl$DateTimeFormat` [1] is incompatible with
+`Intl$NumberFormat` [2].
+
+   date_time_format.js:5:30
+   5| const c: Intl$NumberFormat = new Intl.DateTimeFormat() // incorrect
+                                   ^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
+
+References:
+   date_time_format.js:5:10
+   5| const c: Intl$NumberFormat = new Intl.DateTimeFormat() // incorrect
+               ^^^^^^^^^^^^^^^^^ [2]
+
+
+Error ----------------------------------------------------------------------------------------- date_time_format.js:6:21
+
+Cannot call `Intl.DateTimeFormat` with `1` bound to `locales` because number [1] is incompatible with string [2].
+
+   date_time_format.js:6:21
+    6| Intl.DateTimeFormat(1, {
+                           ^ [1]
+
+References:
+   <BUILTINS>/intl.js:18:21
+   18| type Intl$Locales = Intl$Locale | Intl$Locale[]
+                           ^^^^^^^^^^^ [2]
+
+
+Error ----------------------------------------------------------------------------------------- date_time_format.js:6:24
+
+Cannot call `Intl.DateTimeFormat` with object literal bound to `options` because:
+ - string [1] is incompatible with enum [2] in property `localeMatcher`.
+ - number [3] is incompatible with string [4] in property `timeZone`.
+ - string [5] is incompatible with boolean [6] in property `hour12`.
+ - string [7] is incompatible with enum [8] in property `formatMatcher`.
+ - string [9] is incompatible with enum [10] in property `weekday`.
+ - string [11] is incompatible with enum [12] in property `era`.
+ - string [13] is incompatible with enum [14] in property `year`.
+ - string [15] is incompatible with enum [16] in property `month`.
+ - string [17] is incompatible with enum [18] in property `day`.
+ - string [19] is incompatible with enum [20] in property `hour`.
+ - string [21] is incompatible with enum [22] in property `minute`.
+ - string [23] is incompatible with enum [24] in property `second`.
+ - string [25] is incompatible with enum [26] in property `timeZoneName`.
+
+   date_time_format.js:6:24
+                               v
+     6| Intl.DateTimeFormat(1, {
+     7|   localeMatcher: 'look',
+     8|   timeZone: 1,
+     9|   hour12: '',
+    10|   formatMatcher: 'basic fit',
+    11|   weekday: '2-digit',
+    12|   era: '',
+    13|   year: '',
+    14|   month: '',
+    15|   day: '',
+    16|   hour: '',
+    17|   minute: 'long',
+    18|   second: 'short',
+    19|   timeZoneName: 'narrow'
+    20| }) // incorrect
+        ^
+
+References:
+   date_time_format.js:7:18
+     7|   localeMatcher: 'look',
+                         ^^^^^^ [1]
+   <BUILTINS>/intl.js:89:19
+    89|   localeMatcher?: 'lookup' | 'best fit',
+                          ^^^^^^^^^^^^^^^^^^^^^ [2]
+   date_time_format.js:8:13
+     8|   timeZone: 1,
+                    ^ [3]
+   <BUILTINS>/intl.js:90:14
+    90|   timeZone?: string,
+                     ^^^^^^ [4]
+   date_time_format.js:9:11
+     9|   hour12: '',
+                  ^^ [5]
+   <BUILTINS>/intl.js:91:12
+    91|   hour12?: boolean,
+                   ^^^^^^^ [6]
+   date_time_format.js:10:18
+    10|   formatMatcher: 'basic fit',
+                         ^^^^^^^^^^^ [7]
+   <BUILTINS>/intl.js:92:19
+    92|   formatMatcher?: 'basic' | 'best fit',
+                          ^^^^^^^^^^^^^^^^^^^^ [8]
+   date_time_format.js:11:12
+    11|   weekday: '2-digit',
+                   ^^^^^^^^^ [9]
+   <BUILTINS>/intl.js:93:13
+    93|   weekday?: 'narrow' | 'short' | 'long',
+                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^ [10]
+   date_time_format.js:12:8
+    12|   era: '',
+               ^^ [11]
+   <BUILTINS>/intl.js:94:9
+    94|   era?: 'narrow' | 'short' | 'long',
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^ [12]
+   date_time_format.js:13:9
+    13|   year: '',
+                ^^ [13]
+   <BUILTINS>/intl.js:95:10
+    95|   year?: 'numeric' | '2-digit',
+                 ^^^^^^^^^^^^^^^^^^^^^ [14]
+   date_time_format.js:14:10
+    14|   month: '',
+                 ^^ [15]
+   <BUILTINS>/intl.js:96:11
+    96|   month?: 'numeric' | '2-digit' | 'narrow' | 'short' | 'long',
+                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [16]
+   date_time_format.js:15:8
+    15|   day: '',
+               ^^ [17]
+   <BUILTINS>/intl.js:97:9
+    97|   day?: 'numeric' | '2-digit',
+                ^^^^^^^^^^^^^^^^^^^^^ [18]
+   date_time_format.js:16:9
+    16|   hour: '',
+                ^^ [19]
+   <BUILTINS>/intl.js:98:10
+    98|   hour?: 'numeric' | '2-digit',
+                 ^^^^^^^^^^^^^^^^^^^^^ [20]
+   date_time_format.js:17:11
+    17|   minute: 'long',
+                  ^^^^^^ [21]
+   <BUILTINS>/intl.js:99:12
+    99|   minute?: 'numeric' | '2-digit',
+                   ^^^^^^^^^^^^^^^^^^^^^ [22]
+   date_time_format.js:18:11
+    18|   second: 'short',
+                  ^^^^^^^ [23]
+   <BUILTINS>/intl.js:100:12
+   100|   second?: 'numeric' | '2-digit',
+                   ^^^^^^^^^^^^^^^^^^^^^ [24]
+   date_time_format.js:19:17
+    19|   timeZoneName: 'narrow'
+                        ^^^^^^^^ [25]
+   <BUILTINS>/intl.js:101:18
+   101|   timeZoneName?: 'short' | 'long'
+                         ^^^^^^^^^^^^^^^^ [26]
+
+
+Error ----------------------------------------------------------------------------------------- date_time_format.js:38:5
+
+Cannot resolve name `DateTimeFormat`.
+
+   38| new DateTimeFormat().select() // incorrect
+           ^^^^^^^^^^^^^^
+
+
+Error ----------------------------------------------------------------------------------------------------- intl.js:2:19
+
+Cannot assign `Intl.getCanonicalLocales()` to `a` because array type [1] is incompatible with string [2].
+
+   intl.js:2:19
+    2| const a: string = Intl.getCanonicalLocales(); // incorrect
+                         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+References:
+   <BUILTINS>/intl.js:14:53
+   14|   getCanonicalLocales?: (locales?: Intl$Locales) => Intl$Locale[]
+                                                           ^^^^^^^^^^^^^ [1]
+   intl.js:2:10
+    2| const a: string = Intl.getCanonicalLocales(); // incorrect
+                ^^^^^^ [2]
+
+
+Error ----------------------------------------------------------------------------------------------------- intl.js:2:19
+
+Cannot call `Intl.getCanonicalLocales` because undefined [1] is not a function.
+
+   intl.js:2:19
+    2| const a: string = Intl.getCanonicalLocales(); // incorrect
+                         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+References:
+   <BUILTINS>/intl.js:14:25
+   14|   getCanonicalLocales?: (locales?: Intl$Locales) => Intl$Locale[]
+                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
+
+
+Error ----------------------------------------------------------------------------------------------------- intl.js:5:21
+
+Cannot assign `getCanonicalLocales()` to `b` because array type [1] is incompatible with string [2].
+
+   intl.js:5:21
+    5|   const b: string = getCanonicalLocales(); // incorrect
+                           ^^^^^^^^^^^^^^^^^^^^^
+
+References:
+   <BUILTINS>/intl.js:14:53
+   14|   getCanonicalLocales?: (locales?: Intl$Locales) => Intl$Locale[]
+                                                           ^^^^^^^^^^^^^ [1]
+   intl.js:5:12
+    5|   const b: string = getCanonicalLocales(); // incorrect
+                  ^^^^^^ [2]
+
+
+Error ----------------------------------------------------------------------------------------------------- intl.js:6:43
+
+Cannot call `getCanonicalLocales` with `null` bound to `locales` because:
+ - Either null [1] is incompatible with string [2].
+ - Or null [1] is incompatible with array type [3].
+
+   intl.js:6:43
+    6|   const c: string[] = getCanonicalLocales(null); // incorrect
+                                                 ^^^^ [1]
+
+References:
+   <BUILTINS>/intl.js:18:21
+   18| type Intl$Locales = Intl$Locale | Intl$Locale[]
+                           ^^^^^^^^^^^ [2]
+   <BUILTINS>/intl.js:18:35
+   18| type Intl$Locales = Intl$Locale | Intl$Locale[]
+                                         ^^^^^^^^^^^^^ [3]
+
+
+Error ----------------------------------------------------------------------------------------------------- intl.js:7:43
+
+Cannot call `getCanonicalLocales` with array literal bound to `locales` because:
+ - number [1] is incompatible with string [2] in array element.
+ - number [3] is incompatible with string [2] in array element.
+
+   intl.js:7:43
+    7|   const d: string[] = getCanonicalLocales([ 1, 2 ]); // incorrect
+                                                 ^^^^^^^^
+
+References:
+   intl.js:7:45
+    7|   const d: string[] = getCanonicalLocales([ 1, 2 ]); // incorrect
+                                                   ^ [1]
+   <BUILTINS>/intl.js:18:35
+   18| type Intl$Locales = Intl$Locale | Intl$Locale[]
+                                         ^^^^^^^^^^^ [2]
+   intl.js:7:48
+    7|   const d: string[] = getCanonicalLocales([ 1, 2 ]); // incorrect
+                                                      ^ [3]
+
+
+Error ---------------------------------------------------------------------------------------------------- intl.js:13:11
+
+Cannot get `Intl.Unknown` because property `Unknown` is missing in object type [1].
+
+   intl.js:13:11
+   13| const h = Intl.Unknown; // incorrect
+                 ^^^^^^^^^^^^
+
+References:
+   <BUILTINS>/intl.js:8:19
+                         v
+    8| declare var Intl: {
+    9|   Collator: Class<Intl$Collator>,
+   10|   DateTimeFormat: Class<Intl$DateTimeFormat>,
+   11|   NumberFormat: Class<Intl$NumberFormat>,
+   12|   PluralRules: ?Class<Intl$PluralRules>,
+   13|
+   14|   getCanonicalLocales?: (locales?: Intl$Locales) => Intl$Locale[]
+   15| }
+       ^ [1]
+
+
+Error -------------------------------------------------------------------------------------------- number_format.js:5:32
+
+Cannot assign `new Intl.NumberFormat()` to `c` because `Intl$NumberFormat` [1] is incompatible with
+`Intl$DateTimeFormat` [2].
+
+   number_format.js:5:32
+   5| const c: Intl$DateTimeFormat = new Intl.NumberFormat() // incorrect
+                                     ^^^^^^^^^^^^^^^^^^^^^^^ [1]
+
+References:
+   number_format.js:5:10
+   5| const c: Intl$DateTimeFormat = new Intl.NumberFormat() // incorrect
+               ^^^^^^^^^^^^^^^^^^^ [2]
+
+
+Error -------------------------------------------------------------------------------------------- number_format.js:6:19
+
+Cannot call `Intl.NumberFormat` with `1` bound to `locales` because number [1] is incompatible with string [2].
+
+   number_format.js:6:19
+    6| Intl.NumberFormat(1, {
+                         ^ [1]
+
+References:
+   <BUILTINS>/intl.js:18:21
+   18| type Intl$Locales = Intl$Locale | Intl$Locale[]
+                           ^^^^^^^^^^^ [2]
+
+
+Error -------------------------------------------------------------------------------------------- number_format.js:6:22
+
+Cannot call `Intl.NumberFormat` with object literal bound to `options` because:
+ - string [1] is incompatible with enum [2] in property `localeMatcher`.
+ - string [3] is incompatible with enum [4] in property `style`.
+ - number [5] is incompatible with string [6] in property `currency`.
+ - string [7] is incompatible with enum [8] in property `currencyDisplay`.
+ - number [9] is incompatible with boolean [10] in property `useGrouping`.
+ - object literal [11] is incompatible with number [12] in property `minimumIntegerDigits`.
+ - string [13] is incompatible with number [14] in property `minimumFractionDigits`.
+ - null [15] is incompatible with number [16] in property `maximumFractionDigits`.
+ - string [17] is incompatible with number [18] in property `minimumSignificantDigits`.
+ - null [19] is incompatible with number [20] in property `maximumSignificantDigits`.
+
+   number_format.js:6:22
+                             v
+     6| Intl.NumberFormat(1, {
+     7|   localeMatcher: 'best',
+     8|   style: 'octal',
+     9|   currency: 123,
+    10|   currencyDisplay: 'sym',
+    11|   useGrouping: 5,
+    12|   minimumIntegerDigits: {},
+    13|   minimumFractionDigits: '',
+    14|   maximumFractionDigits: null,
+    15|   minimumSignificantDigits: '',
+    16|   maximumSignificantDigits: null
+    17| }) // incorrect
+        ^
+
+References:
+   number_format.js:7:18
+     7|   localeMatcher: 'best',
+                         ^^^^^^ [1]
+   <BUILTINS>/intl.js:135:19
+   135|   localeMatcher?: 'lookup' | 'best fit',
+                          ^^^^^^^^^^^^^^^^^^^^^ [2]
+   number_format.js:8:10
+     8|   style: 'octal',
+                 ^^^^^^^ [3]
+   <BUILTINS>/intl.js:136:11
+   136|   style?: 'decimal' | 'currency' | 'percent',
+                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [4]
+   number_format.js:9:13
+     9|   currency: 123,
+                    ^^^ [5]
+   <BUILTINS>/intl.js:137:14
+   137|   currency?: string,
+                     ^^^^^^ [6]
+   number_format.js:10:20
+    10|   currencyDisplay: 'sym',
+                           ^^^^^ [7]
+   <BUILTINS>/intl.js:138:21
+   138|   currencyDisplay?: 'symbol' | 'code' | 'name',
+                            ^^^^^^^^^^^^^^^^^^^^^^^^^^ [8]
+   number_format.js:11:16
+    11|   useGrouping: 5,
+                       ^ [9]
+   <BUILTINS>/intl.js:139:17
+   139|   useGrouping?: boolean,
+                        ^^^^^^^ [10]
+   number_format.js:12:25
+    12|   minimumIntegerDigits: {},
+                                ^^ [11]
+   <BUILTINS>/intl.js:140:26
+   140|   minimumIntegerDigits?: number,
+                                 ^^^^^^ [12]
+   number_format.js:13:26
+    13|   minimumFractionDigits: '',
+                                 ^^ [13]
+   <BUILTINS>/intl.js:141:27
+   141|   minimumFractionDigits?: number,
+                                  ^^^^^^ [14]
+   number_format.js:14:26
+    14|   maximumFractionDigits: null,
+                                 ^^^^ [15]
+   <BUILTINS>/intl.js:142:27
+   142|   maximumFractionDigits?: number,
+                                  ^^^^^^ [16]
+   number_format.js:15:29
+    15|   minimumSignificantDigits: '',
+                                    ^^ [17]
+   <BUILTINS>/intl.js:143:30
+   143|   minimumSignificantDigits?: number,
+                                     ^^^^^^ [18]
+   number_format.js:16:29
+    16|   maximumSignificantDigits: null
+                                    ^^^^ [19]
+   <BUILTINS>/intl.js:144:30
+   144|   maximumSignificantDigits?: number
+                                     ^^^^^^ [20]
+
+
+Error -------------------------------------------------------------------------------------------- number_format.js:32:5
+
+Cannot resolve name `NumberFormat`.
+
+   32| new NumberFormat().select() // incorrect
+           ^^^^^^^^^^^^
+
+
+Error --------------------------------------------------------------------------------------------- plural_rules.js:3:11
+
+Cannot call `Intl.PluralRules` because:
+ - null or undefined [1] is not a function.
+ - a callable signature is missing in statics of `Intl$PluralRules` [2].
+
+   plural_rules.js:3:11
+    3| const a = Intl.PluralRules(); // incorrect
+                 ^^^^^^^^^^^^^^^^^^
+
+References:
+   <BUILTINS>/intl.js:12:16
+   12|   PluralRules: ?Class<Intl$PluralRules>,
+                      ^^^^^^^^^^^^^^^^^^^^^^^^ [1]
+   <BUILTINS>/intl.js:12:23
+   12|   PluralRules: ?Class<Intl$PluralRules>,
+                             ^^^^^^^^^^^^^^^^ [2]
+
+
+Error --------------------------------------------------------------------------------------------- plural_rules.js:6:13
+
+Cannot call `PluralRules` because a callable signature is missing in statics of `Intl$PluralRules` [1].
+
+   plural_rules.js:6:13
+    6|   const b = PluralRules(); // incorrect
+                   ^^^^^^^^^^^^^
+
+References:
+   <BUILTINS>/intl.js:12:23
+   12|   PluralRules: ?Class<Intl$PluralRules>,
+                             ^^^^^^^^^^^^^^^^ [1]
+
+
+Error --------------------------------------------------------------------------------------------- plural_rules.js:8:19
+
+Cannot call `PluralRules` with `1` bound to `locales` because number [1] is incompatible with string [2].
+
+   plural_rules.js:8:19
+    8|   new PluralRules(1); // incorrect
+                         ^ [1]
+
+References:
+   <BUILTINS>/intl.js:18:21
+   18| type Intl$Locales = Intl$Locale | Intl$Locale[]
+                           ^^^^^^^^^^^ [2]
+
+
+Error -------------------------------------------------------------------------------------------- plural_rules.js:11:25
+
+Cannot call `PluralRules` with object literal bound to `options` because:
+ - string [1] is incompatible with enum [2] in property `localeMatcher`.
+ - string [3] is incompatible with enum [4] in property `type`.
+ - string [5] is incompatible with number [6] in property `minimumIntegerDigits`.
+ - `Intl$PluralRules` [7] is incompatible with number [8] in property `minimumSignificantDigits`.
+ - string [9] is incompatible with number [10] in property `maximumSignificantDigits`.
+
+   plural_rules.js:11:25
+                                v
+    11|   new PluralRules('en', {
+    12|     localeMatcher: 'best one',
+    13|     type: 'count',
+    14|     minimumIntegerDigits: '',
+    15|     minimumFractionDigits: a,
+    16|     maximumFractionDigits: b,
+    17|     minimumSignificantDigits: c,
+    18|     maximumSignificantDigits: ''
+    19|   }); // all kinds of incorrect
+          ^
+
+References:
+   plural_rules.js:12:20
+    12|     localeMatcher: 'best one',
+                           ^^^^^^^^^^ [1]
+   <BUILTINS>/intl.js:172:19
+   172|   localeMatcher?: 'lookup' | 'best fit',
+                          ^^^^^^^^^^^^^^^^^^^^^ [2]
+   plural_rules.js:13:11
+    13|     type: 'count',
+                  ^^^^^^^ [3]
+   <BUILTINS>/intl.js:173:10
+   173|   type?: 'cardinal' | 'ordinal',
+                 ^^^^^^^^^^^^^^^^^^^^^^ [4]
+   plural_rules.js:14:27
+    14|     minimumIntegerDigits: '',
+                                  ^^ [5]
+   <BUILTINS>/intl.js:174:26
+   174|   minimumIntegerDigits?: number,
+                                 ^^^^^^ [6]
+   plural_rules.js:7:13
+     7|   const c = new PluralRules(); // correct
+                    ^^^^^^^^^^^^^^^^^ [7]
+   <BUILTINS>/intl.js:177:30
+   177|   minimumSignificantDigits?: number,
+                                     ^^^^^^ [8]
+   plural_rules.js:18:31
+    18|     maximumSignificantDigits: ''
+                                      ^^ [9]
+   <BUILTINS>/intl.js:178:30
+   178|   maximumSignificantDigits?: number
+                                     ^^^^^^ [10]
+
+
+Error --------------------------------------------------------------------------------------------- plural_rules.js:30:3
+
+Cannot call `new PluralRules().format` because property `format` is missing in `Intl$PluralRules` [1].
+
+   plural_rules.js:30:3
+   30|   new PluralRules().format() // incorrect
+         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+References:
+   plural_rules.js:30:3
+   30|   new PluralRules().format() // incorrect
+         ^^^^^^^^^^^^^^^^^ [1]
+
+
+Error --------------------------------------------------------------------------------------------- plural_rules.js:31:3
+
+Cannot call `new PluralRules().select` because function [1] requires another argument.
+
+   plural_rules.js:31:3
+    31|   new PluralRules().select() // incorrect
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+References:
+   <BUILTINS>/intl.js:153:3
+   153|   select (number): Intl$PluralRule;
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
+
+
+Error --------------------------------------------------------------------------------------------- plural_rules.js:37:3
+
+Cannot call `PluralRules.getCanonicalLocales` because property `getCanonicalLocales` is missing in statics of
+`Intl$PluralRules` [1].
+
+   plural_rules.js:37:3
+   37|   PluralRules.getCanonicalLocales() // incorrect
+         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+References:
+   <BUILTINS>/intl.js:12:23
+   12|   PluralRules: ?Class<Intl$PluralRules>,
+                             ^^^^^^^^^^^^^^^^ [1]
+
+
+Error -------------------------------------------------------------------------------------------- plural_rules.js:39:34
+
+Cannot call `PluralRules.supportedLocalesOf` with `1` bound to `locales` because number [1] is incompatible with
+string [2].
+
+   plural_rules.js:39:34
+   39|   PluralRules.supportedLocalesOf(1) // incorrect
+                                        ^ [1]
+
+References:
+   <BUILTINS>/intl.js:18:21
+   18| type Intl$Locales = Intl$Locale | Intl$Locale[]
+                           ^^^^^^^^^^^ [2]
+
+
+
+Found 58 errors
+
+Only showing the most relevant union/intersection branches.
+To see all branches, re-run Flow with --show-all-branches

--- a/tests/intl/intl.js
+++ b/tests/intl/intl.js
@@ -1,0 +1,17 @@
+/* @flow */
+const a: string = Intl.getCanonicalLocales(); // incorrect
+const getCanonicalLocales = Intl.getCanonicalLocales;
+if (getCanonicalLocales) {
+  const b: string = getCanonicalLocales(); // incorrect
+  const c: string[] = getCanonicalLocales(null); // incorrect
+  const d: string[] = getCanonicalLocales([ 1, 2 ]); // incorrect
+  const e: string[] = getCanonicalLocales(); // correct
+  const f: string[] = getCanonicalLocales('ar'); // correct
+  const g: string[] = getCanonicalLocales([ 'en', 'pt-BR' ]); // correct
+}
+
+const h = Intl.Unknown; // incorrect
+const i = Intl.Collator; // correct
+const j = Intl.DateTimeFormat; // correct
+const k = Intl.NumberFormat; // correct
+const l = Intl.PluralRules; // correct

--- a/tests/intl/number_format.js
+++ b/tests/intl/number_format.js
@@ -1,0 +1,43 @@
+/* @flow */
+
+const a: Intl$NumberFormat = Intl.NumberFormat() // correct
+const b: Intl$NumberFormat = new Intl.NumberFormat() // correct
+const c: Intl$DateTimeFormat = new Intl.NumberFormat() // incorrect
+Intl.NumberFormat(1, {
+  localeMatcher: 'best',
+  style: 'octal',
+  currency: 123,
+  currencyDisplay: 'sym',
+  useGrouping: 5,
+  minimumIntegerDigits: {},
+  minimumFractionDigits: '',
+  maximumFractionDigits: null,
+  minimumSignificantDigits: '',
+  maximumSignificantDigits: null
+}) // incorrect
+Intl.NumberFormat('en') // correct
+Intl.NumberFormat([ 'en', 'en-GB' ], {
+  localeMatcher: 'best fit',
+  style: 'currency',
+  currency: 'GBP',
+  currencyDisplay: 'code',
+  useGrouping: true,
+  minimumIntegerDigits: 1,
+  minimumFractionDigits: 0,
+  maximumFractionDigits: 21,
+  minimumSignificantDigits: 1,
+  maximumSignificantDigits: 21
+}) // correct
+
+new NumberFormat().select() // incorrect
+new NumberFormat().format() // incorrect
+
+new NumberFormat().format(1) // correct
+
+new NumberFormat().resolvedOptions() // correct
+
+NumberFormat.getCanonicalLocales() // incorrect
+
+NumberFormat.supportedLocalesOf(1) // incorrect
+NumberFormat.supportedLocalesOf('en') // correct
+NumberFormat.supportedLocalesOf([ 'en' ]) // correct

--- a/tests/intl/plural_rules.js
+++ b/tests/intl/plural_rules.js
@@ -1,0 +1,42 @@
+/* @flow */
+
+const a = Intl.PluralRules(); // incorrect
+const PluralRules = Intl.PluralRules
+if (PluralRules) {
+  const b = PluralRules(); // incorrect
+  const c = new PluralRules(); // correct
+  new PluralRules(1); // incorrect
+  new PluralRules('en'); // correct
+  new PluralRules([ 'en', 'pt' ]); // correct
+  new PluralRules('en', {
+    localeMatcher: 'best one',
+    type: 'count',
+    minimumIntegerDigits: '',
+    minimumFractionDigits: a,
+    maximumFractionDigits: b,
+    minimumSignificantDigits: c,
+    maximumSignificantDigits: ''
+  }); // all kinds of incorrect
+  new PluralRules('en', {
+    localeMatcher: 'lookup',
+    type: 'ordinal',
+    minimumIntegerDigits: 2,
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 4,
+    minimumSignificantDigits: 4,
+    maximumSignificantDigits: 6
+  }); // correct
+
+  new PluralRules().format() // incorrect
+  new PluralRules().select() // incorrect
+
+  new PluralRules().select(1) // correct
+
+  new PluralRules().resolvedOptions() // correct
+
+  PluralRules.getCanonicalLocales() // incorrect
+
+  PluralRules.supportedLocalesOf(1) // incorrect
+  PluralRules.supportedLocalesOf('en') // correct
+  PluralRules.supportedLocalesOf([ 'en' ]) // correct
+}

--- a/tests/iterable/iterable.exp
+++ b/tests/iterable/iterable.exp
@@ -14,8 +14,8 @@ References:
    array.js:7:19
      7| (["hi"]: Iterable<number>); // Error string ~> number
                           ^^^^^^ [2]
-   <BUILTINS>/core.js:510:22
-   510| interface $Iterator<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:481:22
+   481| interface $Iterator<+Yield,+Return,-Next> {
                              ^^^^^ [3]
 
 
@@ -35,8 +35,8 @@ References:
    array.js:8:22
      8| (["hi", 1]: Iterable<string>); // Error number ~> string
                              ^^^^^^ [2]
-   <BUILTINS>/core.js:510:22
-   510| interface $Iterator<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:481:22
+   481| interface $Iterator<+Yield,+Return,-Next> {
                              ^^^^^ [3]
 
 
@@ -56,8 +56,8 @@ References:
    caching_bug.js:21:62
     21| function miss_the_cache(x: Array<string | number>): Iterable<string> { return x; }
                                                                      ^^^^^^ [2]
-   <BUILTINS>/core.js:510:22
-   510| interface $Iterator<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:481:22
+   481| interface $Iterator<+Yield,+Return,-Next> {
                              ^^^^^ [3]
 
 
@@ -73,8 +73,8 @@ References:
    iterator_result.js:17:40
     17| function makeIterator(coin_flip: () => boolean ): Iterator<string> {
                                                ^^^^^^^ [1]
-   <BUILTINS>/core.js:508:13
-   508|   | { done: false, +value: Yield };
+   <BUILTINS>/core.js:479:13
+   479|   | { done: false, +value: Yield };
                     ^^^^^ [2]
 
 
@@ -90,8 +90,8 @@ References:
    iterator_result.js:17:40
     17| function makeIterator(coin_flip: () => boolean ): Iterator<string> {
                                                ^^^^^^^ [1]
-   <BUILTINS>/core.js:507:13
-   507|   | { done: true, +value?: Return }
+   <BUILTINS>/core.js:478:13
+   478|   | { done: true, +value?: Return }
                     ^^^^ [2]
 
 
@@ -105,14 +105,14 @@ value of property `@@iterator`.
                  ^^^
 
 References:
-   <BUILTINS>/core.js:555:28
-   555|     @@iterator(): Iterator<[K, V]>;
+   <BUILTINS>/core.js:526:28
+   526|     @@iterator(): Iterator<[K, V]>;
                                    ^^^^^^ [1]
    map.js:13:55
     13| function mapTest4(map: Map<number, string>): Iterable<string> {
                                                               ^^^^^^ [2]
-   <BUILTINS>/core.js:510:22
-   510| interface $Iterator<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:481:22
+   481| interface $Iterator<+Yield,+Return,-Next> {
                              ^^^^^ [3]
 
 
@@ -132,8 +132,8 @@ References:
    set.js:13:47
     13| function setTest4(set: Set<string>): Iterable<number> {
                                                       ^^^^^^ [2]
-   <BUILTINS>/core.js:510:22
-   510| interface $Iterator<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:481:22
+   481| interface $Iterator<+Yield,+Return,-Next> {
                              ^^^^^ [3]
 
 
@@ -147,14 +147,14 @@ return value of property `@@iterator`.
          ^^^^
 
 References:
-   <BUILTINS>/core.js:302:28
-   302|     @@iterator(): Iterator<string>;
+   <BUILTINS>/core.js:289:28
+   289|     @@iterator(): Iterator<string>;
                                    ^^^^^^ [1]
    string.js:5:17
      5| ("hi": Iterable<number>); // Error - string is a Iterable<string>
                         ^^^^^^ [2]
-   <BUILTINS>/core.js:510:22
-   510| interface $Iterator<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:481:22
+   481| interface $Iterator<+Yield,+Return,-Next> {
                              ^^^^^ [3]
 
 

--- a/tests/lib/lib.exp
+++ b/tests/lib/lib.exp
@@ -24,8 +24,8 @@ Cannot assign `Number.MAX_VALUE` to `y` because number [1] is incompatible with 
                        ^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:140:23
-   140|     static MAX_VALUE: number;
+   <BUILTINS>/core.js:127:23
+   127|     static MAX_VALUE: number;
                               ^^^^^^ [1]
    libtest.js:2:7
      2| var y:string = Number.MAX_VALUE;
@@ -41,8 +41,8 @@ Cannot assign `new TypeError().name` to `z` because string [1] is incompatible w
                        ^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:456:11
-   456|     name: string;
+   <BUILTINS>/core.js:427:11
+   427|     name: string;
                   ^^^^^^ [1]
    libtest.js:3:7
      3| var z:number = new TypeError().name;

--- a/tests/misc/misc.exp
+++ b/tests/misc/misc.exp
@@ -134,8 +134,8 @@ Cannot return `x.length` because number [1] is incompatible with string [2].
                  ^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:289:13
-   289|     length: number;
+   <BUILTINS>/core.js:276:13
+   276|     length: number;
                     ^^^^^^ [1]
    F.js:4:33
      4| function foo(x: Array<number>): string {
@@ -179,8 +179,8 @@ Cannot assign `"duck"` to `b.length` because string [1] is incompatible with num
                    ^^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:289:13
-   289|     length: number;
+   <BUILTINS>/core.js:276:13
+   276|     length: number;
                     ^^^^^^ [2]
 
 

--- a/tests/number_constants/number_constants.exp
+++ b/tests/number_constants/number_constants.exp
@@ -7,8 +7,8 @@ Cannot assign `Number.MAX_SAFE_INTEGER` to `b` because number [1] is incompatibl
                         ^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:139:30
-   139|     static MAX_SAFE_INTEGER: number;
+   <BUILTINS>/core.js:126:30
+   126|     static MAX_SAFE_INTEGER: number;
                                      ^^^^^^ [1]
    number_constants.js:2:8
      2| var b: string = Number.MAX_SAFE_INTEGER;
@@ -24,8 +24,8 @@ Cannot assign `Number.MIN_SAFE_INTEGER` to `d` because number [1] is incompatibl
                         ^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:141:30
-   141|     static MIN_SAFE_INTEGER: number;
+   <BUILTINS>/core.js:128:30
+   128|     static MIN_SAFE_INTEGER: number;
                                      ^^^^^^ [1]
    number_constants.js:4:8
      4| var d: string = Number.MIN_SAFE_INTEGER;
@@ -41,8 +41,8 @@ Cannot assign `Number.MAX_VALUE` to `f` because number [1] is incompatible with 
                         ^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:140:23
-   140|     static MAX_VALUE: number;
+   <BUILTINS>/core.js:127:23
+   127|     static MAX_VALUE: number;
                               ^^^^^^ [1]
    number_constants.js:6:8
      6| var f: string = Number.MAX_VALUE;
@@ -58,8 +58,8 @@ Cannot assign `Number.MIN_VALUE` to `h` because number [1] is incompatible with 
                         ^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:142:23
-   142|     static MIN_VALUE: number;
+   <BUILTINS>/core.js:129:23
+   129|     static MIN_VALUE: number;
                               ^^^^^^ [1]
    number_constants.js:8:8
      8| var h: string = Number.MIN_VALUE;
@@ -75,8 +75,8 @@ Cannot assign `Number.NaN` to `j` because number [1] is incompatible with string
                         ^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:143:17
-   143|     static NaN: number;
+   <BUILTINS>/core.js:130:17
+   130|     static NaN: number;
                         ^^^^^^ [1]
    number_constants.js:10:8
     10| var j: string = Number.NaN;
@@ -92,8 +92,8 @@ Cannot assign `Number.EPSILON` to `l` because number [1] is incompatible with st
                         ^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:138:21
-   138|     static EPSILON: number;
+   <BUILTINS>/core.js:125:21
+   125|     static EPSILON: number;
                             ^^^^^^ [1]
    number_constants.js:12:8
     12| var l: string = Number.EPSILON;

--- a/tests/object_api/object_api.exp
+++ b/tests/object_api/object_api.exp
@@ -285,8 +285,8 @@ Cannot call `123.toString` with `'foo'` bound to `radix` because string [1] is i
                        ^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:158:22
-   158|     toString(radix?: number): string;
+   <BUILTINS>/core.js:145:22
+   145|     toString(radix?: number): string;
                              ^^^^^^ [2]
 
 
@@ -299,8 +299,8 @@ Cannot call `123.toString` with `null` bound to `radix` because null [1] is inco
                        ^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:158:22
-   158|     toString(radix?: number): string;
+   <BUILTINS>/core.js:145:22
+   145|     toString(radix?: number): string;
                              ^^^^^^ [2]
 
 
@@ -443,8 +443,8 @@ Cannot assign `x.valueOf` to `xValueOf` because function type [1] is incompatibl
                                 ^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:425:5
-   425|     valueOf(): number;
+   <BUILTINS>/core.js:396:5
+   396|     valueOf(): number;
             ^^^^^^^^^^^^^^^^^ [1]
    object_prototype.js:122:16
    122| var xValueOf : number = x.valueOf; // error
@@ -485,9 +485,9 @@ Cannot assign `x.toLocaleString` to `xToLocaleString` because function type [1] 
                                        ^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:421:5
-   421|     toLocaleString(locales?: string | Array<string>, options?: Date$LocaleOptions): string;
-            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
+   <BUILTINS>/core.js:392:5
+   392|     toLocaleString(locales?: string | Array<string>, options?: Intl$DateTimeFormatOptions): string;
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
    object_prototype.js:150:23
    150| var xToLocaleString : number = x.toLocaleString; // error
                               ^^^^^^ [2]
@@ -503,9 +503,9 @@ value.
                                               ^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:421:85
-   421|     toLocaleString(locales?: string | Array<string>, options?: Date$LocaleOptions): string;
-                                                                                            ^^^^^^ [1]
+   <BUILTINS>/core.js:392:93
+   392|     toLocaleString(locales?: string | Array<string>, options?: Intl$DateTimeFormatOptions): string;
+                                                                                                    ^^^^^^ [1]
    object_prototype.js:151:30
    151| var xToLocaleString2 : () => number = x.toLocaleString; // error
                                      ^^^^^^ [2]

--- a/tests/overload/overload.exp
+++ b/tests/overload/overload.exp
@@ -29,8 +29,8 @@ Cannot assign `"".match(...)[0]` to `x1` because string [1] is incompatible with
                          ^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:315:44
-   315|     match(regexp: string | RegExp): ?Array<string>;
+   <BUILTINS>/core.js:302:44
+   302|     match(regexp: string | RegExp): ?Array<string>;
                                                    ^^^^^^ [1]
    overload.js:7:9
      7| var x1: number = "".match(0)[0];
@@ -46,8 +46,8 @@ Cannot get `"".match(...)[0]` because an indexer property is missing in null or 
                          ^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:315:37
-   315|     match(regexp: string | RegExp): ?Array<string>;
+   <BUILTINS>/core.js:302:37
+   302|     match(regexp: string | RegExp): ?Array<string>;
                                             ^^^^^^^^^^^^^^ [1]
 
 
@@ -60,8 +60,8 @@ Cannot call `"".match` with `0` bound to `regexp` because number [1] is incompat
                                   ^ [1]
 
 References:
-   <BUILTINS>/core.js:315:19
-   315|     match(regexp: string | RegExp): ?Array<string>;
+   <BUILTINS>/core.js:302:19
+   302|     match(regexp: string | RegExp): ?Array<string>;
                           ^^^^^^ [2]
 
 
@@ -74,8 +74,8 @@ Cannot assign `"".match(...)[0]` to `x2` because string [1] is incompatible with
                          ^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:315:44
-   315|     match(regexp: string | RegExp): ?Array<string>;
+   <BUILTINS>/core.js:302:44
+   302|     match(regexp: string | RegExp): ?Array<string>;
                                                    ^^^^^^ [1]
    overload.js:8:9
      8| var x2: number = "".match(/pattern/)[0];
@@ -91,8 +91,8 @@ Cannot get `"".match(...)[0]` because an indexer property is missing in null or 
                          ^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:315:37
-   315|     match(regexp: string | RegExp): ?Array<string>;
+   <BUILTINS>/core.js:302:37
+   302|     match(regexp: string | RegExp): ?Array<string>;
                                             ^^^^^^^^^^^^^^ [1]
 
 
@@ -105,8 +105,8 @@ Cannot assign `"".split(...)[0]` to `x4` because string [1] is incompatible with
                          ^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:323:63
-   323|     split(separator?: string | RegExp, limit?: number): Array<string>;
+   <BUILTINS>/core.js:310:63
+   310|     split(separator?: string | RegExp, limit?: number): Array<string>;
                                                                       ^^^^^^ [1]
    overload.js:10:9
     10| var x4: number = "".split(/pattern/)[0];

--- a/tests/promises/promises.exp
+++ b/tests/promises/promises.exp
@@ -84,8 +84,8 @@ Cannot call `Promise.all` because property `@@iterator` is missing in undefined 
         ^^^^^^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:630:19
-   630|     static all<T: Iterable<mixed>>(promises: T): Promise<$TupleMap<T, typeof $await>>;
+   <BUILTINS>/core.js:601:19
+   601|     static all<T: Iterable<mixed>>(promises: T): Promise<$TupleMap<T, typeof $await>>;
                           ^^^^^^^^^^^^^^^ [2]
 
 
@@ -99,8 +99,8 @@ in `$Iterable` [2].
                     ^ [1]
 
 References:
-   <BUILTINS>/core.js:630:19
-   630|     static all<T: Iterable<mixed>>(promises: T): Promise<$TupleMap<T, typeof $await>>;
+   <BUILTINS>/core.js:601:19
+   601|     static all<T: Iterable<mixed>>(promises: T): Promise<$TupleMap<T, typeof $await>>;
                           ^^^^^^^^^^^^^^^ [2]
 
 
@@ -399,8 +399,8 @@ References:
    resolve_void.js:3:29
      3| (Promise.resolve(): Promise<number>); // error
                                     ^^^^^^ [2]
-   <BUILTINS>/core.js:605:24
-   605| declare class Promise<+R> {
+   <BUILTINS>/core.js:576:24
+   576| declare class Promise<+R> {
                                ^ [3]
 
 
@@ -420,8 +420,8 @@ References:
    resolve_void.js:5:38
      5| (Promise.resolve(undefined): Promise<number>); // error
                                              ^^^^^^ [2]
-   <BUILTINS>/core.js:605:24
-   605| declare class Promise<+R> {
+   <BUILTINS>/core.js:576:24
+   576| declare class Promise<+R> {
                                ^ [3]
 
 

--- a/tests/react_hocs/react_hocs.exp
+++ b/tests/react_hocs/react_hocs.exp
@@ -31,8 +31,8 @@ References:
    Bad.js:8:8
      8|   bar: number,
                ^^^^^^ [1]
-   <BUILTINS>/core.js:158:31
-   158|     toString(radix?: number): string;
+   <BUILTINS>/core.js:145:31
+   145|     toString(radix?: number): string;
                                       ^^^^^^ [2]
 
 

--- a/tests/regexp/regexp.exp
+++ b/tests/regexp/regexp.exp
@@ -7,8 +7,8 @@ Cannot assign `patt.test(...)` to `match` because boolean [1] is incompatible wi
                            ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:359:27
-   359|     test(string: string): boolean;
+   <BUILTINS>/core.js:346:27
+   346|     test(string: string): boolean;
                                   ^^^^^^^ [1]
    regexp.js:2:11
      2| var match:number = patt.test("Hello world!");

--- a/tests/return/return.exp
+++ b/tests/return/return.exp
@@ -43,8 +43,8 @@ References:
    implicit.js:7:30
      7| async function g2(): Promise<number> {}
                                      ^^^^^^ [1]
-   <BUILTINS>/core.js:605:24
-   605| declare class Promise<+R> {
+   <BUILTINS>/core.js:576:24
+   576| declare class Promise<+R> {
                                ^ [2]
 
 

--- a/tests/union/union.exp
+++ b/tests/union/union.exp
@@ -7,8 +7,8 @@ Cannot call `str.toFixed` because property `toFixed` is missing in `String` [1].
                        ^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:155:39
-   155|     toFixed(fractionDigits?: number): string;
+   <BUILTINS>/core.js:142:39
+   142|     toFixed(fractionDigits?: number): string;
                                               ^^^^^^ [1]
 
 


### PR DESCRIPTION
Summary:
Flow provides definitions for built-in language apis for JavaScript, including
the following as specified in ECMA-402 (Internationalization API).

* String#localeCompare
* Date#toLocaleDateString
* Date#toLocaleString
* Date#toLocaleTimeString
* Number#toLocaleString

This adds the corresponding `Intl` object and its associated apis from the same
spec, as implemented in all major browers (including back to IE 11).

Fixes #1270 
Fixes #2801 