### PR TITLE
MessagePort onmessage should receive MessageEvent

### DIFF
--- a/lib/bom.js
+++ b/lib/bom.js
@@ -1243,7 +1243,7 @@ declare class MessagePort extends EventTarget {
   start(): void;
   close(): void;
 
-  onmessage: (ev: Event) => any;
+  onmessage: (ev: MessageEvent) => any;
 }
 
 declare class MessageChannel {


### PR DESCRIPTION
I noticed `MessagePort.onmessage`'s `event` was missing `data`