### PR TITLE
Use ocamlbuild on Windows

### DIFF
--- a/resources/appveyor/build.sh
+++ b/resources/appveyor/build.sh
@@ -18,7 +18,5 @@ cd "${APPVEYOR_BUILD_FOLDER}"
 opam pin add flowtype-ci . -n
 opam depext -u flowtype-ci
 opam install flowtype-ci --deps-only
-opam install camlp4
-opam install ocp-build # opam build uses ocamlbuild, so install manually
-make all-ocp
-make build-parser-test-with-ocp
+make all
+make -C src/parser/ ../../_build/src/parser/test/run_tests.native

--- a/resources/appveyor/test.ps1
+++ b/resources/appveyor/test.ps1
@@ -7,7 +7,7 @@ try {
     Throw "node tool test exited with error code: $LASTEXITCODE"
   }
 
-  .\_obuild\flow-parser-hardcoded-test\flow-parser-hardcoded-test.asm.exe .\src\parser\test\flow\
+  .\_build\src\parser\test\run_tests.native .\src\parser\test\flow\
   if ($LASTEXITCODE -gt 0) {
     Throw "flow parser hardcoded ocaml tests exited with error code: $LASTEXITCODE"
   }


### PR DESCRIPTION
Now that we build in cygwin and use make, we can use ocamlbuild instead of ocp-build!

https://ci.appveyor.com/project/mroch/flow/build/217

the tests fail for the exact same reasons as they do in master.