### PR TITLE
Add Buffer property to buffer module

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -117,6 +117,7 @@ declare module "buffer" {
   declare var kMaxLength: number;
   declare var INSPECT_MAX_BYTES: number;
   declare function transcode(source: Buffer, fromEnc: buffer$Encoding, toEnc: buffer$Encoding): Buffer;
+  declare var Buffer: typeof global.Buffer;
 }
 
 type child_process$execOpts = {

--- a/tests/node_tests/buffer/buffer.js
+++ b/tests/node_tests/buffer/buffer.js
@@ -55,3 +55,7 @@ buffer = Buffer.from("foo", "utf8");
 // flow didn't used to support a subclass hiding a superclass member, so this
 // used to check out as ok, even though it is not correct.
 buffer = Buffer.from([0x62, 0x75, 0x66, 0x66, 0x65, 0x72], (a:number) => a + 1, {}); // error
+
+// Explicitly importing Buffer is rarely needed, but correct.
+let ImportedBuffer = require("buffer").Buffer;
+buffer = new ImportedBuffer(0);

--- a/tests/node_tests/node_tests.exp
+++ b/tests/node_tests/node_tests.exp
@@ -27,8 +27,8 @@ References:
    child_process/execSync.js:8:27
      8| (execSync('ls', {timeout: '250'})); // error, no signatures match
                                   ^^^^^ [1]
-   <BUILTINS>/node.js:149:13
-   149|   timeout?: number;
+   <BUILTINS>/node.js:150:13
+   150|   timeout?: number;
                     ^^^^^^ [2]
 
 
@@ -44,17 +44,17 @@ Cannot cast `hmac.read()` to number because:
                 ^^^^^^^^^^^
 
 References:
-   <BUILTINS>/node.js:1434:24
-   1434|   read(size?: number): ?(string | Buffer);
+   <BUILTINS>/node.js:1435:24
+   1435|   read(size?: number): ?(string | Buffer);
                                 ^^^^^^^^^^^^^^^^^^ [1]
    crypto/crypto.js:12:21
      12|       (hmac.read(): number); // 4 errors: null, void, string, Buffer
                              ^^^^^^ [2]
-   <BUILTINS>/node.js:1434:26
-   1434|   read(size?: number): ?(string | Buffer);
+   <BUILTINS>/node.js:1435:26
+   1435|   read(size?: number): ?(string | Buffer);
                                   ^^^^^^ [3]
-   <BUILTINS>/node.js:1434:35
-   1434|   read(size?: number): ?(string | Buffer);
+   <BUILTINS>/node.js:1435:35
+   1435|   read(size?: number): ?(string | Buffer);
                                            ^^^^^^ [4]
 
 
@@ -67,8 +67,8 @@ Cannot call `hmac.write` with `123` bound to `chunk` because number [1] is incom
                         ^^^ [1]
 
 References:
-   <BUILTINS>/node.js:1485:21
-   1485|     chunk: Buffer | string,
+   <BUILTINS>/node.js:1486:21
+   1486|     chunk: Buffer | string,
                              ^^^^^^ [2]
 
 
@@ -81,10 +81,10 @@ Cannot call `hmac.update` with `'bogus'` bound to `input_encoding` because strin
                                ^^^^^^^ [1]
 
 References:
-   <BUILTINS>/node.js:441:50
+   <BUILTINS>/node.js:442:50
                                                          v----------------------------
-   441|   update(data: string | Buffer, input_encoding?: 'utf8' | 'ascii' | 'latin1' |
-   442|   'binary'): crypto$Hmac;
+   442|   update(data: string | Buffer, input_encoding?: 'utf8' | 'ascii' | 'latin1' |
+   443|   'binary'): crypto$Hmac;
           -------^ [2]
 
 
@@ -97,10 +97,10 @@ Cannot call `hmac.update` with `'bogus'` bound to `input_encoding` because strin
                              ^^^^^^^ [1]
 
 References:
-   <BUILTINS>/node.js:441:50
+   <BUILTINS>/node.js:442:50
                                                          v----------------------------
-   441|   update(data: string | Buffer, input_encoding?: 'utf8' | 'ascii' | 'latin1' |
-   442|   'binary'): crypto$Hmac;
+   442|   update(data: string | Buffer, input_encoding?: 'utf8' | 'ascii' | 'latin1' |
+   443|   'binary'): crypto$Hmac;
           -------^ [2]
 
 
@@ -113,8 +113,8 @@ Cannot cast `hmac.digest(...)` to undefined because string [1] is incompatible w
              ^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/node.js:438:61
-   438|   digest(encoding: 'hex' | 'latin1' | 'binary' | 'base64'): string;
+   <BUILTINS>/node.js:439:61
+   439|   digest(encoding: 'hex' | 'latin1' | 'binary' | 'base64'): string;
                                                                     ^^^^^^ [1]
    crypto/crypto.js:36:26
     36|     (hmac.digest('hex'): void); // 1 error
@@ -130,8 +130,8 @@ Cannot cast `hmac.digest()` to undefined because `Buffer` [1] is incompatible wi
              ^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/node.js:440:27
-   440|   digest(encoding: void): Buffer;
+   <BUILTINS>/node.js:441:27
+   441|   digest(encoding: void): Buffer;
                                   ^^^^^^ [1]
    crypto/crypto.js:37:21
     37|     (hmac.digest(): void); // 1 error
@@ -151,21 +151,21 @@ fix add a type annotation to `_` [3] or to `data` [4].
         -^
 
 References:
-   <BUILTINS>/node.js:909:28
+   <BUILTINS>/node.js:910:28
                                    v
-   909|   declare function readFile(
-   910|     path: string | Buffer | URL | number,
-   911|     options: { encoding: string; flag?: string },
-   912|     callback: (err: ?ErrnoError, data: string) => void
-   913|   ): void;
+   910|   declare function readFile(
+   911|     path: string | Buffer | URL | number,
+   912|     options: { encoding: string; flag?: string },
+   913|     callback: (err: ?ErrnoError, data: string) => void
+   914|   ): void;
           ------^ [1]
-   <BUILTINS>/node.js:914:28
+   <BUILTINS>/node.js:915:28
                                    v
-   914|   declare function readFile(
-   915|     path: string | Buffer | URL | number,
-   916|     options: { flag?: string },
-   917|     callback: (err: ?ErrnoError, data: Buffer) => void
-   918|   ): void;
+   915|   declare function readFile(
+   916|     path: string | Buffer | URL | number,
+   917|     options: { flag?: string },
+   918|     callback: (err: ?ErrnoError, data: Buffer) => void
+   919|   ): void;
           ------^ [2]
    fs/fs.js:13:48
     13| fs.readFile("file.exp", { encoding: "blah" }, (_, data) => {
@@ -184,8 +184,8 @@ Cannot cast `fs.readFileSync(...)` to string because `Buffer` [1] is incompatibl
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/node.js:921:6
-   921|   ): Buffer;
+   <BUILTINS>/node.js:922:6
+   922|   ): Buffer;
              ^^^^^^ [1]
    fs/fs.js:28:32
     28| (fs.readFileSync("file.exp") : string); // error
@@ -201,8 +201,8 @@ Cannot cast `fs.readFileSync(...)` to `Buffer` because string [1] is incompatibl
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/node.js:925:6
-   925|   ): string;
+   <BUILTINS>/node.js:926:6
+   926|   ): string;
              ^^^^^^ [1]
    fs/fs.js:31:40
     31| (fs.readFileSync("file.exp", "blah") : Buffer); // error
@@ -218,8 +218,8 @@ Cannot cast `fs.readFileSync(...)` to `Buffer` because string [1] is incompatibl
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/node.js:926:118
-   926|   declare function readFileSync(path: string | Buffer | URL | number, options: { encoding: string, flag?: string }): string;
+   <BUILTINS>/node.js:927:118
+   927|   declare function readFileSync(path: string | Buffer | URL | number, options: { encoding: string, flag?: string }): string;
                                                                                                                              ^^^^^^ [1]
    fs/fs.js:34:54
     34| (fs.readFileSync("file.exp", { encoding: "blah" }) : Buffer); // error
@@ -235,8 +235,8 @@ Cannot cast `fs.readFileSync(...)` to string because `Buffer` [1] is incompatibl
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/node.js:927:117
-   927|   declare function readFileSync(path: string | Buffer | URL | number, options: { encoding?: void, flag?: string }): Buffer;
+   <BUILTINS>/node.js:928:117
+   928|   declare function readFileSync(path: string | Buffer | URL | number, options: { encoding?: void, flag?: string }): Buffer;
                                                                                                                             ^^^^^^ [1]
    fs/fs.js:37:36
     37| (fs.readFileSync("file.exp", {}) : string); // error
@@ -256,8 +256,8 @@ References:
    http/server.js:67:25
      67| server.listen(() => {}, {});
                                  ^^ [1]
-   <BUILTINS>/node.js:1104:39
-   1104|     listen(handle: Object, callback?: Function): Server;
+   <BUILTINS>/node.js:1105:39
+   1105|     listen(handle: Object, callback?: Function): Server;
                                                ^^^^^^^^ [2]
 
 
@@ -274,8 +274,8 @@ References:
    http/server.js:68:30
      68| server.listen(function() {}, {});
                                       ^^ [1]
-   <BUILTINS>/node.js:1104:39
-   1104|     listen(handle: Object, callback?: Function): Server;
+   <BUILTINS>/node.js:1105:39
+   1105|     listen(handle: Object, callback?: Function): Server;
                                                ^^^^^^^^ [2]
 
 
@@ -291,8 +291,8 @@ References:
    http/server.js:69:15
      69| server.listen({}, () => {}, 'localhost', 123);
                        ^^ [1]
-   <BUILTINS>/node.js:1098:19
-   1098|     listen(port?: number, hostname?: string, backlog?: number, callback?: Function): Server;
+   <BUILTINS>/node.js:1099:19
+   1099|     listen(port?: number, hostname?: string, backlog?: number, callback?: Function): Server;
                            ^^^^^^ [2]
 
 
@@ -308,8 +308,8 @@ References:
    http/server.js:70:15
      70| server.listen({}, function() {}, 'localhost', 123);
                        ^^ [1]
-   <BUILTINS>/node.js:1098:19
-   1098|     listen(port?: number, hostname?: string, backlog?: number, callback?: Function): Server;
+   <BUILTINS>/node.js:1099:19
+   1099|     listen(port?: number, hostname?: string, backlog?: number, callback?: Function): Server;
                            ^^^^^^ [2]
 
 
@@ -328,14 +328,14 @@ References:
    http/server.js:71:15
      71| server.listen({}, () => {}, 123);
                        ^^ [1]
-   <BUILTINS>/node.js:1098:19
-   1098|     listen(port?: number, hostname?: string, backlog?: number, callback?: Function): Server;
+   <BUILTINS>/node.js:1099:19
+   1099|     listen(port?: number, hostname?: string, backlog?: number, callback?: Function): Server;
                            ^^^^^^ [2]
-   <BUILTINS>/node.js:1100:19
-   1100|     listen(port?: number, backlog?: number, callback?: Function): Server;
-                           ^^^^^^ [3]
    <BUILTINS>/node.js:1101:19
-   1101|     listen(port?: number, hostname?: string, callback?: Function): Server;
+   1101|     listen(port?: number, backlog?: number, callback?: Function): Server;
+                           ^^^^^^ [3]
+   <BUILTINS>/node.js:1102:19
+   1102|     listen(port?: number, hostname?: string, callback?: Function): Server;
                            ^^^^^^ [4]
 
 
@@ -354,14 +354,14 @@ References:
    http/server.js:72:15
      72| server.listen({}, function() {}, 123);
                        ^^ [1]
-   <BUILTINS>/node.js:1098:19
-   1098|     listen(port?: number, hostname?: string, backlog?: number, callback?: Function): Server;
+   <BUILTINS>/node.js:1099:19
+   1099|     listen(port?: number, hostname?: string, backlog?: number, callback?: Function): Server;
                            ^^^^^^ [2]
-   <BUILTINS>/node.js:1100:19
-   1100|     listen(port?: number, backlog?: number, callback?: Function): Server;
-                           ^^^^^^ [3]
    <BUILTINS>/node.js:1101:19
-   1101|     listen(port?: number, hostname?: string, callback?: Function): Server;
+   1101|     listen(port?: number, backlog?: number, callback?: Function): Server;
+                           ^^^^^^ [3]
+   <BUILTINS>/node.js:1102:19
+   1102|     listen(port?: number, hostname?: string, callback?: Function): Server;
                            ^^^^^^ [4]
 
 
@@ -377,8 +377,8 @@ References:
    http/server.js:73:25
      73| server.listen(() => {}, 123);
                                  ^^^ [1]
-   <BUILTINS>/node.js:1104:39
-   1104|     listen(handle: Object, callback?: Function): Server;
+   <BUILTINS>/node.js:1105:39
+   1105|     listen(handle: Object, callback?: Function): Server;
                                                ^^^^^^^^ [2]
 
 
@@ -394,8 +394,8 @@ References:
    http/server.js:74:30
      74| server.listen(function() {}, 123);
                                       ^^^ [1]
-   <BUILTINS>/node.js:1104:39
-   1104|     listen(handle: Object, callback?: Function): Server;
+   <BUILTINS>/node.js:1105:39
+   1105|     listen(handle: Object, callback?: Function): Server;
                                                ^^^^^^^^ [2]
 
 
@@ -414,14 +414,14 @@ References:
    http/server.js:75:15
      75| server.listen(() => {}, 'localhost', 123);
                        ^^^^^^^^ [1]
-   <BUILTINS>/node.js:1098:19
-   1098|     listen(port?: number, hostname?: string, backlog?: number, callback?: Function): Server;
+   <BUILTINS>/node.js:1099:19
+   1099|     listen(port?: number, hostname?: string, backlog?: number, callback?: Function): Server;
                            ^^^^^^ [2]
-   <BUILTINS>/node.js:1100:19
-   1100|     listen(port?: number, backlog?: number, callback?: Function): Server;
-                           ^^^^^^ [3]
    <BUILTINS>/node.js:1101:19
-   1101|     listen(port?: number, hostname?: string, callback?: Function): Server;
+   1101|     listen(port?: number, backlog?: number, callback?: Function): Server;
+                           ^^^^^^ [3]
+   <BUILTINS>/node.js:1102:19
+   1102|     listen(port?: number, hostname?: string, callback?: Function): Server;
                            ^^^^^^ [4]
 
 
@@ -440,14 +440,14 @@ References:
    http/server.js:76:15
      76| server.listen(function() {}, 'localhost', 123);
                        ^^^^^^^^^^ [1]
-   <BUILTINS>/node.js:1098:19
-   1098|     listen(port?: number, hostname?: string, backlog?: number, callback?: Function): Server;
+   <BUILTINS>/node.js:1099:19
+   1099|     listen(port?: number, hostname?: string, backlog?: number, callback?: Function): Server;
                            ^^^^^^ [2]
-   <BUILTINS>/node.js:1100:19
-   1100|     listen(port?: number, backlog?: number, callback?: Function): Server;
-                           ^^^^^^ [3]
    <BUILTINS>/node.js:1101:19
-   1101|     listen(port?: number, hostname?: string, callback?: Function): Server;
+   1101|     listen(port?: number, backlog?: number, callback?: Function): Server;
+                           ^^^^^^ [3]
+   <BUILTINS>/node.js:1102:19
+   1102|     listen(port?: number, hostname?: string, callback?: Function): Server;
                            ^^^^^^ [4]
 
 
@@ -463,8 +463,8 @@ References:
    http/server.js:77:25
      77| server.listen(() => {}, 'localhost');
                                  ^^^^^^^^^^^ [1]
-   <BUILTINS>/node.js:1104:39
-   1104|     listen(handle: Object, callback?: Function): Server;
+   <BUILTINS>/node.js:1105:39
+   1105|     listen(handle: Object, callback?: Function): Server;
                                                ^^^^^^^^ [2]
 
 
@@ -480,8 +480,8 @@ References:
    http/server.js:78:30
      78| server.listen(function() {}, 'localhost');
                                       ^^^^^^^^^^^ [1]
-   <BUILTINS>/node.js:1104:39
-   1104|     listen(handle: Object, callback?: Function): Server;
+   <BUILTINS>/node.js:1105:39
+   1105|     listen(handle: Object, callback?: Function): Server;
                                                ^^^^^^^^ [2]
 
 
@@ -497,8 +497,8 @@ References:
    http/server.js:79:21
      79| server.listen(8080, () => {}, 'localhost', 123);
                              ^^^^^^^^ [1]
-   <BUILTINS>/node.js:1098:38
-   1098|     listen(port?: number, hostname?: string, backlog?: number, callback?: Function): Server;
+   <BUILTINS>/node.js:1099:38
+   1099|     listen(port?: number, hostname?: string, backlog?: number, callback?: Function): Server;
                                               ^^^^^^ [2]
 
 
@@ -514,8 +514,8 @@ References:
    http/server.js:80:21
      80| server.listen(8080, function() {}, 'localhost', 123);
                              ^^^^^^^^^^ [1]
-   <BUILTINS>/node.js:1098:38
-   1098|     listen(port?: number, hostname?: string, backlog?: number, callback?: Function): Server;
+   <BUILTINS>/node.js:1099:38
+   1099|     listen(port?: number, hostname?: string, backlog?: number, callback?: Function): Server;
                                               ^^^^^^ [2]
 
 
@@ -534,14 +534,14 @@ References:
    http/server.js:81:21
      81| server.listen(8080, () => {}, 123);
                              ^^^^^^^^ [1]
-   <BUILTINS>/node.js:1098:38
-   1098|     listen(port?: number, hostname?: string, backlog?: number, callback?: Function): Server;
+   <BUILTINS>/node.js:1099:38
+   1099|     listen(port?: number, hostname?: string, backlog?: number, callback?: Function): Server;
                                               ^^^^^^ [2]
-   <BUILTINS>/node.js:1100:37
-   1100|     listen(port?: number, backlog?: number, callback?: Function): Server;
+   <BUILTINS>/node.js:1101:37
+   1101|     listen(port?: number, backlog?: number, callback?: Function): Server;
                                              ^^^^^^ [3]
-   <BUILTINS>/node.js:1101:38
-   1101|     listen(port?: number, hostname?: string, callback?: Function): Server;
+   <BUILTINS>/node.js:1102:38
+   1102|     listen(port?: number, hostname?: string, callback?: Function): Server;
                                               ^^^^^^ [4]
 
 
@@ -560,14 +560,14 @@ References:
    http/server.js:82:21
      82| server.listen(8080, function() {}, 123);
                              ^^^^^^^^^^ [1]
-   <BUILTINS>/node.js:1098:38
-   1098|     listen(port?: number, hostname?: string, backlog?: number, callback?: Function): Server;
+   <BUILTINS>/node.js:1099:38
+   1099|     listen(port?: number, hostname?: string, backlog?: number, callback?: Function): Server;
                                               ^^^^^^ [2]
-   <BUILTINS>/node.js:1100:37
-   1100|     listen(port?: number, backlog?: number, callback?: Function): Server;
+   <BUILTINS>/node.js:1101:37
+   1101|     listen(port?: number, backlog?: number, callback?: Function): Server;
                                              ^^^^^^ [3]
-   <BUILTINS>/node.js:1101:38
-   1101|     listen(port?: number, hostname?: string, callback?: Function): Server;
+   <BUILTINS>/node.js:1102:38
+   1102|     listen(port?: number, hostname?: string, callback?: Function): Server;
                                               ^^^^^^ [4]
 
 
@@ -586,14 +586,14 @@ References:
    http/server.js:83:21
      83| server.listen(8080, () => {}, 'localhost');
                              ^^^^^^^^ [1]
-   <BUILTINS>/node.js:1098:38
-   1098|     listen(port?: number, hostname?: string, backlog?: number, callback?: Function): Server;
+   <BUILTINS>/node.js:1099:38
+   1099|     listen(port?: number, hostname?: string, backlog?: number, callback?: Function): Server;
                                               ^^^^^^ [2]
-   <BUILTINS>/node.js:1100:37
-   1100|     listen(port?: number, backlog?: number, callback?: Function): Server;
+   <BUILTINS>/node.js:1101:37
+   1101|     listen(port?: number, backlog?: number, callback?: Function): Server;
                                              ^^^^^^ [3]
-   <BUILTINS>/node.js:1101:38
-   1101|     listen(port?: number, hostname?: string, callback?: Function): Server;
+   <BUILTINS>/node.js:1102:38
+   1102|     listen(port?: number, hostname?: string, callback?: Function): Server;
                                               ^^^^^^ [4]
 
 
@@ -612,14 +612,14 @@ References:
    http/server.js:84:21
      84| server.listen(8080, function() {}, 'localhost');
                              ^^^^^^^^^^ [1]
-   <BUILTINS>/node.js:1098:38
-   1098|     listen(port?: number, hostname?: string, backlog?: number, callback?: Function): Server;
+   <BUILTINS>/node.js:1099:38
+   1099|     listen(port?: number, hostname?: string, backlog?: number, callback?: Function): Server;
                                               ^^^^^^ [2]
-   <BUILTINS>/node.js:1100:37
-   1100|     listen(port?: number, backlog?: number, callback?: Function): Server;
+   <BUILTINS>/node.js:1101:37
+   1101|     listen(port?: number, backlog?: number, callback?: Function): Server;
                                              ^^^^^^ [3]
-   <BUILTINS>/node.js:1101:38
-   1101|     listen(port?: number, hostname?: string, callback?: Function): Server;
+   <BUILTINS>/node.js:1102:38
+   1102|     listen(port?: number, hostname?: string, callback?: Function): Server;
                                               ^^^^^^ [4]
 
 
@@ -636,8 +636,8 @@ References:
    https/server.js:67:25
      67| server.listen(() => {}, {});
                                  ^^ [1]
-   <BUILTINS>/node.js:1144:39
-   1144|     listen(handle: Object, callback?: Function): Server;
+   <BUILTINS>/node.js:1145:39
+   1145|     listen(handle: Object, callback?: Function): Server;
                                                ^^^^^^^^ [2]
 
 
@@ -654,8 +654,8 @@ References:
    https/server.js:68:30
      68| server.listen(function() {}, {});
                                       ^^ [1]
-   <BUILTINS>/node.js:1144:39
-   1144|     listen(handle: Object, callback?: Function): Server;
+   <BUILTINS>/node.js:1145:39
+   1145|     listen(handle: Object, callback?: Function): Server;
                                                ^^^^^^^^ [2]
 
 
@@ -671,8 +671,8 @@ References:
    https/server.js:69:15
      69| server.listen({}, () => {}, 'localhost', 123);
                        ^^ [1]
-   <BUILTINS>/node.js:1138:19
-   1138|     listen(port?: number, hostname?: string, backlog?: number, callback?: Function): Server;
+   <BUILTINS>/node.js:1139:19
+   1139|     listen(port?: number, hostname?: string, backlog?: number, callback?: Function): Server;
                            ^^^^^^ [2]
 
 
@@ -688,8 +688,8 @@ References:
    https/server.js:70:15
      70| server.listen({}, function() {}, 'localhost', 123);
                        ^^ [1]
-   <BUILTINS>/node.js:1138:19
-   1138|     listen(port?: number, hostname?: string, backlog?: number, callback?: Function): Server;
+   <BUILTINS>/node.js:1139:19
+   1139|     listen(port?: number, hostname?: string, backlog?: number, callback?: Function): Server;
                            ^^^^^^ [2]
 
 
@@ -708,14 +708,14 @@ References:
    https/server.js:71:15
      71| server.listen({}, () => {}, 123);
                        ^^ [1]
-   <BUILTINS>/node.js:1138:19
-   1138|     listen(port?: number, hostname?: string, backlog?: number, callback?: Function): Server;
+   <BUILTINS>/node.js:1139:19
+   1139|     listen(port?: number, hostname?: string, backlog?: number, callback?: Function): Server;
                            ^^^^^^ [2]
-   <BUILTINS>/node.js:1140:19
-   1140|     listen(port?: number, backlog?: number, callback?: Function): Server;
-                           ^^^^^^ [3]
    <BUILTINS>/node.js:1141:19
-   1141|     listen(port?: number, hostname?: string, callback?: Function): Server;
+   1141|     listen(port?: number, backlog?: number, callback?: Function): Server;
+                           ^^^^^^ [3]
+   <BUILTINS>/node.js:1142:19
+   1142|     listen(port?: number, hostname?: string, callback?: Function): Server;
                            ^^^^^^ [4]
 
 
@@ -734,14 +734,14 @@ References:
    https/server.js:72:15
      72| server.listen({}, function() {}, 123);
                        ^^ [1]
-   <BUILTINS>/node.js:1138:19
-   1138|     listen(port?: number, hostname?: string, backlog?: number, callback?: Function): Server;
+   <BUILTINS>/node.js:1139:19
+   1139|     listen(port?: number, hostname?: string, backlog?: number, callback?: Function): Server;
                            ^^^^^^ [2]
-   <BUILTINS>/node.js:1140:19
-   1140|     listen(port?: number, backlog?: number, callback?: Function): Server;
-                           ^^^^^^ [3]
    <BUILTINS>/node.js:1141:19
-   1141|     listen(port?: number, hostname?: string, callback?: Function): Server;
+   1141|     listen(port?: number, backlog?: number, callback?: Function): Server;
+                           ^^^^^^ [3]
+   <BUILTINS>/node.js:1142:19
+   1142|     listen(port?: number, hostname?: string, callback?: Function): Server;
                            ^^^^^^ [4]
 
 
@@ -757,8 +757,8 @@ References:
    https/server.js:73:25
      73| server.listen(() => {}, 123);
                                  ^^^ [1]
-   <BUILTINS>/node.js:1144:39
-   1144|     listen(handle: Object, callback?: Function): Server;
+   <BUILTINS>/node.js:1145:39
+   1145|     listen(handle: Object, callback?: Function): Server;
                                                ^^^^^^^^ [2]
 
 
@@ -774,8 +774,8 @@ References:
    https/server.js:74:30
      74| server.listen(function() {}, 123);
                                       ^^^ [1]
-   <BUILTINS>/node.js:1144:39
-   1144|     listen(handle: Object, callback?: Function): Server;
+   <BUILTINS>/node.js:1145:39
+   1145|     listen(handle: Object, callback?: Function): Server;
                                                ^^^^^^^^ [2]
 
 
@@ -794,14 +794,14 @@ References:
    https/server.js:75:15
      75| server.listen(() => {}, 'localhost', 123);
                        ^^^^^^^^ [1]
-   <BUILTINS>/node.js:1138:19
-   1138|     listen(port?: number, hostname?: string, backlog?: number, callback?: Function): Server;
+   <BUILTINS>/node.js:1139:19
+   1139|     listen(port?: number, hostname?: string, backlog?: number, callback?: Function): Server;
                            ^^^^^^ [2]
-   <BUILTINS>/node.js:1140:19
-   1140|     listen(port?: number, backlog?: number, callback?: Function): Server;
-                           ^^^^^^ [3]
    <BUILTINS>/node.js:1141:19
-   1141|     listen(port?: number, hostname?: string, callback?: Function): Server;
+   1141|     listen(port?: number, backlog?: number, callback?: Function): Server;
+                           ^^^^^^ [3]
+   <BUILTINS>/node.js:1142:19
+   1142|     listen(port?: number, hostname?: string, callback?: Function): Server;
                            ^^^^^^ [4]
 
 
@@ -820,14 +820,14 @@ References:
    https/server.js:76:15
      76| server.listen(function() {}, 'localhost', 123);
                        ^^^^^^^^^^ [1]
-   <BUILTINS>/node.js:1138:19
-   1138|     listen(port?: number, hostname?: string, backlog?: number, callback?: Function): Server;
+   <BUILTINS>/node.js:1139:19
+   1139|     listen(port?: number, hostname?: string, backlog?: number, callback?: Function): Server;
                            ^^^^^^ [2]
-   <BUILTINS>/node.js:1140:19
-   1140|     listen(port?: number, backlog?: number, callback?: Function): Server;
-                           ^^^^^^ [3]
    <BUILTINS>/node.js:1141:19
-   1141|     listen(port?: number, hostname?: string, callback?: Function): Server;
+   1141|     listen(port?: number, backlog?: number, callback?: Function): Server;
+                           ^^^^^^ [3]
+   <BUILTINS>/node.js:1142:19
+   1142|     listen(port?: number, hostname?: string, callback?: Function): Server;
                            ^^^^^^ [4]
 
 
@@ -843,8 +843,8 @@ References:
    https/server.js:77:25
      77| server.listen(() => {}, 'localhost');
                                  ^^^^^^^^^^^ [1]
-   <BUILTINS>/node.js:1144:39
-   1144|     listen(handle: Object, callback?: Function): Server;
+   <BUILTINS>/node.js:1145:39
+   1145|     listen(handle: Object, callback?: Function): Server;
                                                ^^^^^^^^ [2]
 
 
@@ -860,8 +860,8 @@ References:
    https/server.js:78:30
      78| server.listen(function() {}, 'localhost');
                                       ^^^^^^^^^^^ [1]
-   <BUILTINS>/node.js:1144:39
-   1144|     listen(handle: Object, callback?: Function): Server;
+   <BUILTINS>/node.js:1145:39
+   1145|     listen(handle: Object, callback?: Function): Server;
                                                ^^^^^^^^ [2]
 
 
@@ -877,8 +877,8 @@ References:
    https/server.js:79:21
      79| server.listen(8443, () => {}, 'localhost', 123);
                              ^^^^^^^^ [1]
-   <BUILTINS>/node.js:1138:38
-   1138|     listen(port?: number, hostname?: string, backlog?: number, callback?: Function): Server;
+   <BUILTINS>/node.js:1139:38
+   1139|     listen(port?: number, hostname?: string, backlog?: number, callback?: Function): Server;
                                               ^^^^^^ [2]
 
 
@@ -894,8 +894,8 @@ References:
    https/server.js:80:21
      80| server.listen(8443, function() {}, 'localhost', 123);
                              ^^^^^^^^^^ [1]
-   <BUILTINS>/node.js:1138:38
-   1138|     listen(port?: number, hostname?: string, backlog?: number, callback?: Function): Server;
+   <BUILTINS>/node.js:1139:38
+   1139|     listen(port?: number, hostname?: string, backlog?: number, callback?: Function): Server;
                                               ^^^^^^ [2]
 
 
@@ -914,14 +914,14 @@ References:
    https/server.js:81:21
      81| server.listen(8443, () => {}, 123);
                              ^^^^^^^^ [1]
-   <BUILTINS>/node.js:1138:38
-   1138|     listen(port?: number, hostname?: string, backlog?: number, callback?: Function): Server;
+   <BUILTINS>/node.js:1139:38
+   1139|     listen(port?: number, hostname?: string, backlog?: number, callback?: Function): Server;
                                               ^^^^^^ [2]
-   <BUILTINS>/node.js:1140:37
-   1140|     listen(port?: number, backlog?: number, callback?: Function): Server;
+   <BUILTINS>/node.js:1141:37
+   1141|     listen(port?: number, backlog?: number, callback?: Function): Server;
                                              ^^^^^^ [3]
-   <BUILTINS>/node.js:1141:38
-   1141|     listen(port?: number, hostname?: string, callback?: Function): Server;
+   <BUILTINS>/node.js:1142:38
+   1142|     listen(port?: number, hostname?: string, callback?: Function): Server;
                                               ^^^^^^ [4]
 
 
@@ -940,14 +940,14 @@ References:
    https/server.js:82:21
      82| server.listen(8443, function() {}, 123);
                              ^^^^^^^^^^ [1]
-   <BUILTINS>/node.js:1138:38
-   1138|     listen(port?: number, hostname?: string, backlog?: number, callback?: Function): Server;
+   <BUILTINS>/node.js:1139:38
+   1139|     listen(port?: number, hostname?: string, backlog?: number, callback?: Function): Server;
                                               ^^^^^^ [2]
-   <BUILTINS>/node.js:1140:37
-   1140|     listen(port?: number, backlog?: number, callback?: Function): Server;
+   <BUILTINS>/node.js:1141:37
+   1141|     listen(port?: number, backlog?: number, callback?: Function): Server;
                                              ^^^^^^ [3]
-   <BUILTINS>/node.js:1141:38
-   1141|     listen(port?: number, hostname?: string, callback?: Function): Server;
+   <BUILTINS>/node.js:1142:38
+   1142|     listen(port?: number, hostname?: string, callback?: Function): Server;
                                               ^^^^^^ [4]
 
 
@@ -966,14 +966,14 @@ References:
    https/server.js:83:21
      83| server.listen(8443, () => {}, 'localhost');
                              ^^^^^^^^ [1]
-   <BUILTINS>/node.js:1138:38
-   1138|     listen(port?: number, hostname?: string, backlog?: number, callback?: Function): Server;
+   <BUILTINS>/node.js:1139:38
+   1139|     listen(port?: number, hostname?: string, backlog?: number, callback?: Function): Server;
                                               ^^^^^^ [2]
-   <BUILTINS>/node.js:1140:37
-   1140|     listen(port?: number, backlog?: number, callback?: Function): Server;
+   <BUILTINS>/node.js:1141:37
+   1141|     listen(port?: number, backlog?: number, callback?: Function): Server;
                                              ^^^^^^ [3]
-   <BUILTINS>/node.js:1141:38
-   1141|     listen(port?: number, hostname?: string, callback?: Function): Server;
+   <BUILTINS>/node.js:1142:38
+   1142|     listen(port?: number, hostname?: string, callback?: Function): Server;
                                               ^^^^^^ [4]
 
 
@@ -992,14 +992,14 @@ References:
    https/server.js:84:21
      84| server.listen(8443, function() {}, 'localhost');
                              ^^^^^^^^^^ [1]
-   <BUILTINS>/node.js:1138:38
-   1138|     listen(port?: number, hostname?: string, backlog?: number, callback?: Function): Server;
+   <BUILTINS>/node.js:1139:38
+   1139|     listen(port?: number, hostname?: string, backlog?: number, callback?: Function): Server;
                                               ^^^^^^ [2]
-   <BUILTINS>/node.js:1140:37
-   1140|     listen(port?: number, backlog?: number, callback?: Function): Server;
+   <BUILTINS>/node.js:1141:37
+   1141|     listen(port?: number, backlog?: number, callback?: Function): Server;
                                              ^^^^^^ [3]
-   <BUILTINS>/node.js:1141:38
-   1141|     listen(port?: number, hostname?: string, callback?: Function): Server;
+   <BUILTINS>/node.js:1142:38
+   1142|     listen(port?: number, hostname?: string, callback?: Function): Server;
                                               ^^^^^^ [4]
 
 
@@ -1223,8 +1223,8 @@ Cannot cast `u1.username` to `Buffer` because string [1] is incompatible with `B
           ^^^^^^^^^^^
 
 References:
-   <BUILTINS>/node.js:1301:13
-   1301|   username: string,
+   <BUILTINS>/node.js:1302:13
+   1302|   username: string,
                      ^^^^^^ [1]
    os/userInfo.js:7:15
       7| (u1.username: Buffer); // error
@@ -1240,8 +1240,8 @@ Cannot cast `u2.username` to `Buffer` because string [1] is incompatible with `B
           ^^^^^^^^^^^
 
 References:
-   <BUILTINS>/node.js:1301:13
-   1301|   username: string,
+   <BUILTINS>/node.js:1302:13
+   1302|   username: string,
                      ^^^^^^ [1]
    os/userInfo.js:11:15
      11| (u2.username: Buffer); // error
@@ -1257,8 +1257,8 @@ Cannot cast `u3.username` to string because `Buffer` [1] is incompatible with st
           ^^^^^^^^^^^
 
 References:
-   <BUILTINS>/node.js:1293:13
-   1293|   username: Buffer,
+   <BUILTINS>/node.js:1294:13
+   1294|   username: Buffer,
                      ^^^^^^ [1]
    os/userInfo.js:14:15
      14| (u3.username: string); // error
@@ -1334,8 +1334,8 @@ References:
    process/nextTick.js:27:3
      27|   (a: string, b: number, c: boolean) => {} // Error: too few arguments
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
-   <BUILTINS>/node.js:1967:21
-   1967|   nextTick: <T>(cb: (...T) => mixed, ...T) => void;
+   <BUILTINS>/node.js:1968:21
+   1968|   nextTick: <T>(cb: (...T) => mixed, ...T) => void;
                              ^^^^^^^^^^^^^^^ [2]
 
 
@@ -1353,26 +1353,26 @@ Cannot call `process.emitWarning` because:
          ^^^^^^^^^^^^^^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/node.js:1939:24
-   1939|   emitWarning(warning: string | Error): void;
+   <BUILTINS>/node.js:1940:24
+   1940|   emitWarning(warning: string | Error): void;
                                 ^^^^^^ [2]
-   <BUILTINS>/node.js:1939:33
-   1939|   emitWarning(warning: string | Error): void;
+   <BUILTINS>/node.js:1940:33
+   1940|   emitWarning(warning: string | Error): void;
                                          ^^^^^ [3]
-   <BUILTINS>/node.js:1940:3
-   1940|   emitWarning(warning: string, typeOrCtor: string | Function): void;
-           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [4]
    <BUILTINS>/node.js:1941:3
-   1941|   emitWarning(warning: string, type: string, codeOrCtor: string | Function): void;
-           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [5]
+   1941|   emitWarning(warning: string, typeOrCtor: string | Function): void;
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [4]
    <BUILTINS>/node.js:1942:3
+   1942|   emitWarning(warning: string, type: string, codeOrCtor: string | Function): void;
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [5]
+   <BUILTINS>/node.js:1943:3
            v-----------
-   1942|   emitWarning(
-   1943|     warning: string,
-   1944|     type: string,
-   1945|     code: string,
-   1946|     ctor?: Function
-   1947|   ): void;
+   1943|   emitWarning(
+   1944|     warning: string,
+   1945|     type: string,
+   1946|     code: string,
+   1947|     ctor?: Function
+   1948|   ): void;
            ------^ [6]
 
 
@@ -1391,14 +1391,14 @@ References:
    process/process.js:11:21
      11| process.emitWarning(42); // error
                              ^^ [1]
-   <BUILTINS>/node.js:1940:24
-   1940|   emitWarning(warning: string, typeOrCtor: string | Function): void;
-                                ^^^^^^ [2]
    <BUILTINS>/node.js:1941:24
-   1941|   emitWarning(warning: string, type: string, codeOrCtor: string | Function): void;
+   1941|   emitWarning(warning: string, typeOrCtor: string | Function): void;
+                                ^^^^^^ [2]
+   <BUILTINS>/node.js:1942:24
+   1942|   emitWarning(warning: string, type: string, codeOrCtor: string | Function): void;
                                 ^^^^^^ [3]
-   <BUILTINS>/node.js:1943:14
-   1943|     warning: string,
+   <BUILTINS>/node.js:1944:14
+   1944|     warning: string,
                       ^^^^^^ [4]
 
 
@@ -1416,11 +1416,11 @@ References:
    process/process.js:12:29
      12| process.emitWarning("blah", 42); // error
                                      ^^ [1]
-   <BUILTINS>/node.js:1941:38
-   1941|   emitWarning(warning: string, type: string, codeOrCtor: string | Function): void;
+   <BUILTINS>/node.js:1942:38
+   1942|   emitWarning(warning: string, type: string, codeOrCtor: string | Function): void;
                                               ^^^^^^ [2]
-   <BUILTINS>/node.js:1944:11
-   1944|     type: string,
+   <BUILTINS>/node.js:1945:11
+   1945|     type: string,
                    ^^^^^^ [3]
 
 
@@ -1436,8 +1436,8 @@ References:
    process/process.js:13:37
      13| process.emitWarning("blah", "blah", 42); // error
                                              ^^ [1]
-   <BUILTINS>/node.js:1945:11
-   1945|     code: string,
+   <BUILTINS>/node.js:1946:11
+   1946|     code: string,
                    ^^^^^^ [2]
 
 
@@ -1450,8 +1450,8 @@ Cannot cast `process.emitWarning(...)` to string because undefined [1] is incomp
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/node.js:1939:41
-   1939|   emitWarning(warning: string | Error): void;
+   <BUILTINS>/node.js:1940:41
+   1940|   emitWarning(warning: string | Error): void;
                                                  ^^^^ [1]
    process/process.js:14:31
      14| (process.emitWarning("blah"): string); // error


### PR DESCRIPTION
Previously discussed or implemented in #5153, #3495, #2938, #3723, #3724 and maybe elsewhere.

This PR refines previous efforts by adding:

1. A correct, unambiguous type for `require("buffer").Buffer`:
```jsx
declare var Buffer: typeof global.Buffer;
```

2. A test.

To be clear: Per the Node [docs](https://nodejs.org/api/buffer.html), explicitly importing `Buffer` is rarely needed, given its availability in the global scope, but correct. It happens to be a viable option in environments where "magic" support for Node globals is either undesirable or broken (the latter is [currently](https://github.com/webpack/webpack/issues/7032) the case for ES modules in Webpack).