### PR TITLE
Add `onmessageerror` to `Worker` interface

### DIFF
--- a/lib/bom.js
+++ b/lib/bom.js
@@ -474,6 +474,7 @@ declare class Worker extends EventTarget {
     constructor(stringUrl: string): void;
     onerror: (ev: Event) => any;
     onmessage: (ev: MessageEvent) => any;
+    onmessageerror: (ev: MessageEvent) => any;
     postMessage(message: any, ports?: any): void;
     terminate(): void;
 }


### PR DESCRIPTION
Fix #6191.

I didn't make any changes to any tests. It didn't look like the `Worker` interface is tested. Let me know if I missed something.

---

🎉 **Thanks for all the great work on flow!**