### PR TITLE
Add max_literal_length option

### DIFF
--- a/src/commands/commandUtils.ml
+++ b/src/commands/commandUtils.ml
@@ -794,6 +794,7 @@ let make_options ~flowconfig ~lazy_mode ~root (options_flags: Options_flags.t) =
       |> min Sys_utils.nbr_procs;
     opt_suppress_comments = FlowConfig.suppress_comments flowconfig;
     opt_suppress_types = FlowConfig.suppress_types flowconfig;
+    opt_max_literal_length = FlowConfig.max_literal_length flowconfig;
     opt_enable_const_params = FlowConfig.enable_const_params flowconfig;
     opt_enforce_strict_call_arity = FlowConfig.enforce_strict_call_arity flowconfig;
     opt_enforce_well_formed_exports = FlowConfig.enforce_well_formed_exports flowconfig;

--- a/src/commands/config/flowConfig.ml
+++ b/src/commands/config/flowConfig.ml
@@ -34,6 +34,7 @@ let error ln msg = multi_error [(ln, msg)]
 module Opts = struct
   type t = {
     emoji: bool;
+    max_literal_length: int;
     enable_const_params: bool;
     enforce_strict_call_arity: bool;
     enforce_well_formed_exports: bool;
@@ -138,6 +139,7 @@ module Opts = struct
 
   let default_options = {
     emoji = false;
+    max_literal_length = 100;
     enable_const_params = false;
     enforce_strict_call_arity = true;
     enforce_well_formed_exports = false;
@@ -836,6 +838,15 @@ let parse_options config lines =
       );
     }
 
+    |> define_opt "max_literal_length" {
+      initializer_ = USE_DEFAULT;
+      flags = [];
+      optparser = optparse_uint;
+      setter = (fun opts v ->
+        Ok {opts with max_literal_length = v;}
+      );
+    }
+
     |> define_opt "experimental.const_params" {
       initializer_ = USE_DEFAULT;
       flags = [];
@@ -998,6 +1009,7 @@ let libs config = config.libs
 (* options *)
 let all c = c.options.Opts.all
 let emoji c = c.options.Opts.emoji
+let max_literal_length c = c.options.Opts.max_literal_length
 let enable_const_params c = c.options.Opts.enable_const_params
 let enforce_strict_call_arity c = c.options.Opts.enforce_strict_call_arity
 let enforce_well_formed_exports c = c.options.Opts.enforce_well_formed_exports

--- a/src/commands/config/flowConfig.mli
+++ b/src/commands/config/flowConfig.mli
@@ -36,6 +36,7 @@ val libs: config -> string list
 (* options *)
 val all: config -> bool
 val emoji: config -> bool
+val max_literal_length: config -> int
 val enable_const_params: config -> bool
 val enforce_strict_call_arity: config -> bool
 val enforce_well_formed_exports: config -> bool

--- a/src/common/options.ml
+++ b/src/common/options.ml
@@ -43,6 +43,7 @@ type file_watcher =
 type t = {
   opt_all : bool;
   opt_debug : bool;
+  opt_max_literal_length: int;
   opt_enable_const_params: bool;
   opt_enforce_strict_call_arity: bool;
   opt_enforce_well_formed_exports: bool;
@@ -83,6 +84,7 @@ type t = {
 }
 
 let all opts = opts.opt_all
+let max_literal_length opts = opts.opt_max_literal_length
 let enable_const_params opts = opts.opt_enable_const_params
 let enforce_strict_call_arity opts = opts.opt_enforce_strict_call_arity
 let enforce_well_formed_exports opts = opts.opt_enforce_well_formed_exports

--- a/src/flow_dot_js.ml
+++ b/src/flow_dot_js.ml
@@ -132,6 +132,7 @@ let stub_metadata ~root ~checked = { Context.
   strict_local = false;
 
   (* global *)
+  max_literal_length = 100;
   enable_const_params = false;
   enforce_strict_call_arity = true;
   esproposal_class_static_fields = Options.ESPROPOSAL_ENABLE;

--- a/src/typing/context.ml
+++ b/src/typing/context.ml
@@ -26,6 +26,7 @@ type metadata = {
   strict_local: bool;
 
   (* global *)
+  max_literal_length: int;
   enable_const_params: bool;
   enforce_strict_call_arity: bool;
   esproposal_class_static_fields: Options.esproposal_feature_mode;
@@ -138,6 +139,7 @@ let metadata_of_options options = {
   strict_local = false;
 
   (* global *)
+  max_literal_length = Options.max_literal_length options;
   enable_const_params = Options.enable_const_params options;
   enforce_strict_call_arity = Options.enforce_strict_call_arity options;
   esproposal_class_instance_fields = Options.esproposal_class_instance_fields options;
@@ -222,6 +224,7 @@ let pop_declare_module cx =
 let all_unresolved cx = cx.sig_cx.all_unresolved
 let annot_table cx = cx.annot_table
 let envs cx = cx.sig_cx.envs
+let max_literal_length cx = cx.metadata.max_literal_length
 let enable_const_params cx =
   cx.metadata.enable_const_params || cx.metadata.strict || cx.metadata.strict_local
 let enforce_strict_call_arity cx = cx.metadata.enforce_strict_call_arity

--- a/src/typing/context.mli
+++ b/src/typing/context.mli
@@ -28,6 +28,7 @@ type metadata = {
   strict: bool;
   strict_local: bool;
   (* global *)
+  max_literal_length: int;
   enable_const_params: bool;
   enforce_strict_call_arity: bool;
   esproposal_class_static_fields: Options.esproposal_feature_mode;
@@ -60,6 +61,7 @@ val find_module_sig: sig_t -> string -> Type.t
 (* accessors *)
 val all_unresolved: t -> ISet.t IMap.t
 val annot_table: t -> (Loc.t, Type.t) Hashtbl.t
+val max_literal_length: t -> int
 val enable_const_params: t -> bool
 val enforce_strict_call_arity: t -> bool
 val envs: t -> env IMap.t

--- a/src/typing/statement.ml
+++ b/src/typing/statement.ml
@@ -3463,8 +3463,9 @@ and identifier cx name loc =
 and literal cx loc lit = Ast.Literal.(match lit.Ast.Literal.value with
   | String s ->
       (* It's too expensive to track literal information for large strings.*)
+      let max_literal_length = Context.max_literal_length cx in
       let lit =
-        if String.length s < 100
+        if max_literal_length = 0 || String.length s < max_literal_length
         then Literal (None, s)
         else AnyLiteral
       in

--- a/testgen/flowtestgen_utils.ml
+++ b/testgen/flowtestgen_utils.ml
@@ -528,6 +528,7 @@ let stub_metadata ~root ~checked = { Context.
   strict = true;
   strict_local = false;
   (* global *)
+  max_literal_length = 100;
   enable_const_params = false;
   enforce_strict_call_arity = true;
   esproposal_class_static_fields = Options.ESPROPOSAL_ENABLE;


### PR DESCRIPTION
Replaces magic 100 in `typing/statement.ml` with new `.flowconfig` option `max_literal_length`. Default value is set to 100. Zero value disables the check. #5897

There are a lot of files involved. I don't know if I really need to duplicate default values in `flow_dot_js.ml` and `testgen/flowtestgen_utils.ml`. I did it just by following the case of `enable_const_params`.

Changes were tested in [v70 based branch](https://github.com/aatatuzov/flow/tree/max_literal_length_v70).