### PR TITLE
Add missed methods to crypto module

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -470,11 +470,18 @@ declare class crypto$Verify extends stream$Writable {
   'binary' ): crypto$Verify;
   verify(
     object: string,
-    signature: string,
+    signature: string | Buffer | $TypedArray | DataView,
     signature_format: 'latin1' | 'binary' | 'hex' | 'base64'
   ): boolean;
   verify(object: string, signature: Buffer, signature_format: void): boolean;
 }
+
+
+type crypto$key = string | {
+  key: string,
+  passphrase?: string,
+  padding?: string // TODO: enum type in crypto.constants
+};
 
 declare module "crypto" {
   declare var DEFAULT_ENCODING: string;
@@ -520,6 +527,22 @@ declare module "crypto" {
     iterations: number,
     keylen: number,
     digest?: string
+  ): Buffer;
+  declare function privateDecrypt(
+    private_key: crypto$key,
+    buffer: Buffer
+  ): Buffer;
+  declare function privateEncrypt(
+    private_key: crypto$key,
+    buffer: Buffer
+  ): Buffer;
+  declare function publicDecrypt(
+    key: crypto$key,
+    buffer: Buffer
+  ): Buffer;
+  declare function publicDecrypt(
+    key: crypto$key,
+    buffer: Buffer
   ): Buffer;
   // `UNUSED` argument strictly enforces arity to enable overloading this
   // function with 1-arg and 2-arg variants.


### PR DESCRIPTION
Add some missed methods to `crypto` module

related urls:
- [`verify.verify`](https://nodejs.org/api/crypto.html#crypto_verify_verify_object_signature_signatureformat)
- [`crypto.privateDecrypt`](https://nodejs.org/api/crypto.html#crypto_crypto_privatedecrypt_privatekey_buffer)
- [`crypto.privateEncrypt`](https://nodejs.org/api/crypto.html#crypto_crypto_privateencrypt_privatekey_buffer)
- [`crypto.publicDecrypt`](https://nodejs.org/api/crypto.html#crypto_crypto_publicdecrypt_key_buffer)
- [`crypto.publicEncrypt`](https://nodejs.org/api/crypto.html#crypto_crypto_publicencrypt_key_buffer)