### PR TITLE
[PR] Remove deprecation of flow --version

### DIFF
--- a/src/commands/statusCommands.ml
+++ b/src/commands/statusCommands.ml
@@ -84,7 +84,7 @@ module Impl (CommandList : COMMAND_LIST) (Config : CONFIG) = struct
         |> strip_root_flag
         |> from_flag
         |> flag "--version" no_arg
-            ~doc:"(Deprecated, use `flow version` instead) Print version number and exit"
+            ~doc:"Print version number and exit"
         |> anon "root" (optional string)
       )
     }
@@ -166,8 +166,6 @@ module Impl (CommandList : COMMAND_LIST) (Config : CONFIG) = struct
   let main server_flags json pretty json_version error_flags strip_root from version root () =
     FlowEventLogger.set_from from;
     if version then (
-      prerr_endline "Warning: \
-        `flow --version` is deprecated in favor of `flow version`";
       print_version ();
       FlowExitStatus.(exit No_error)
     );

--- a/website/en/docs/cli/index.md
+++ b/website/en/docs/cli/index.md
@@ -62,7 +62,7 @@ Status command options:
   --strip-root         Print paths without the root
   --temp-dir           Directory in which to store temp files (default: /tmp/flow/)
   --timeout            Maximum time to wait, in seconds
-  --version            (Deprecated, use `flow version` instead) Print version number and exit
+  --version            Print version number and exit
 ```
 
 You can then, further dig into particular COMMANDs by adding the `--help` flag.


### PR DESCRIPTION
#4330 discusses keeping the command `--version`. This PR removes the deprecation notice from the command line and the documentation.