### PR TITLE
Adding cells property to HTMLTableRowElement

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -1459,6 +1459,7 @@ declare class HTMLTableCellElement extends HTMLElement {
 declare class HTMLTableRowElement extends HTMLElement {
   align: 'left' | 'right' | 'center';
   rowIndex: number;
+  cells: HTMLCollection<HTMLTableCellElement>;
   deleteCell(index: number): void;
   insertCell(index: number): HTMLTableCellElement;
 }

--- a/tests/dom/dom.exp
+++ b/tests/dom/dom.exp
@@ -7,8 +7,8 @@ Cannot call `ctx.moveTo` with `'0'` bound to `x` because string [1] is incompati
                         ^^^ [1]
 
 References:
-   <BUILTINS>/dom.js:1697:13
-   1697|   moveTo(x: number, y: number): void;
+   <BUILTINS>/dom.js:1698:13
+   1698|   moveTo(x: number, y: number): void;
                      ^^^^^^ [2]
 
 
@@ -21,8 +21,8 @@ Cannot call `ctx.moveTo` with `'1'` bound to `y` because string [1] is incompati
                              ^^^ [1]
 
 References:
-   <BUILTINS>/dom.js:1697:24
-   1697|   moveTo(x: number, y: number): void;
+   <BUILTINS>/dom.js:1698:24
+   1698|   moveTo(x: number, y: number): void;
                                 ^^^^^^ [2]
 
 
@@ -135,8 +135,8 @@ Cannot get `el.className` because property `className` is missing in null [1].
          ^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/dom.js:2625:43
-   2625|   [index: number | string]: HTMLElement | null;
+   <BUILTINS>/dom.js:2626:43
+   2626|   [index: number | string]: HTMLElement | null;
                                                    ^^^^ [1]
 
 
@@ -149,8 +149,8 @@ Cannot get `el.className` because property `className` is missing in null [1].
          ^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/dom.js:2625:43
-   2625|   [index: number | string]: HTMLElement | null;
+   <BUILTINS>/dom.js:2626:43
+   2626|   [index: number | string]: HTMLElement | null;
                                                    ^^^^ [1]
 
 
@@ -166,8 +166,8 @@ References:
    HTMLInputElement.js:7:28
       7|     el.setRangeText('foo', 123); // end is required
                                     ^^^ [1]
-   <BUILTINS>/dom.js:2963:45
-   2963|   setRangeText(replacement: string, start?: void, end?: void, selectMode?: void): void;
+   <BUILTINS>/dom.js:2964:45
+   2964|   setRangeText(replacement: string, start?: void, end?: void, selectMode?: void): void;
                                                      ^^^^ [2]
 
 
@@ -183,8 +183,8 @@ References:
    HTMLInputElement.js:10:38
      10|     el.setRangeText('foo', 123, 234, 'bogus'); // invalid value
                                               ^^^^^^^ [1]
-   <BUILTINS>/dom.js:2964:78
-   2964|   setRangeText(replacement: string, start: number, end: number, selectMode?: SelectionMode): void;
+   <BUILTINS>/dom.js:2965:78
+   2965|   setRangeText(replacement: string, start: number, end: number, selectMode?: SelectionMode): void;
                                                                                       ^^^^^^^^^^^^^ [2]
 
 
@@ -197,8 +197,8 @@ Cannot get `form.action` because property `action` is missing in null [1].
          ^^^^^^^^^^^
 
 References:
-   <BUILTINS>/dom.js:3017:27
-   3017|   form: HTMLFormElement | null;
+   <BUILTINS>/dom.js:3018:27
+   3018|   form: HTMLFormElement | null;
                                    ^^^^ [1]
 
 
@@ -211,8 +211,8 @@ Cannot get `item.value` because property `value` is missing in null [1].
          ^^^^^^^^^^
 
 References:
-   <BUILTINS>/dom.js:3032:44
-   3032|   item(index: number): HTMLOptionElement | null;
+   <BUILTINS>/dom.js:3033:44
+   3033|   item(index: number): HTMLOptionElement | null;
                                                     ^^^^ [1]
 
 
@@ -225,8 +225,8 @@ Cannot get `item.value` because property `value` is missing in null [1].
          ^^^^^^^^^^
 
 References:
-   <BUILTINS>/dom.js:3033:48
-   3033|   namedItem(name: string): HTMLOptionElement | null;
+   <BUILTINS>/dom.js:3034:48
+   3034|   namedItem(name: string): HTMLOptionElement | null;
                                                         ^^^^ [1]
 
 
@@ -284,8 +284,8 @@ References:
    path2d.js:9:33
       9|     (path.arcTo(0, 0, 0, 0, 10, '20', 5): void); // invalid
                                          ^^^^ [1]
-   <BUILTINS>/dom.js:1566:83
-   1566|   arcTo(x1: number, y1: number, x2: number, y2: number, radiusX: number, radiusY: number, rotation: number): void;
+   <BUILTINS>/dom.js:1567:83
+   1567|   arcTo(x1: number, y1: number, x2: number, y2: number, radiusX: number, radiusY: number, rotation: number): void;
                                                                                            ^^^^^^ [2]
 
 
@@ -692,11 +692,11 @@ References:
    traversal.js:186:60
     186|     document.createNodeIterator(document_body, -1, node => 'accept'); // invalid
                                                                     ^^^^^^^^ [1]
-   <BUILTINS>/dom.js:3495:1
+   <BUILTINS>/dom.js:3496:1
          v--------------------------------
-   3495| typeof NodeFilter.FILTER_ACCEPT |
-   3496| typeof NodeFilter.FILTER_REJECT |
-   3497| typeof NodeFilter.FILTER_SKIP;
+   3496| typeof NodeFilter.FILTER_ACCEPT |
+   3497| typeof NodeFilter.FILTER_REJECT |
+   3498| typeof NodeFilter.FILTER_SKIP;
          ----------------------------^ [2]
 
 
@@ -713,11 +713,11 @@ References:
    traversal.js:188:74
     188|     document.createNodeIterator(document_body, -1, { acceptNode: node => 'accept' }); // invalid
                                                                                   ^^^^^^^^ [1]
-   <BUILTINS>/dom.js:3495:1
+   <BUILTINS>/dom.js:3496:1
          v--------------------------------
-   3495| typeof NodeFilter.FILTER_ACCEPT |
-   3496| typeof NodeFilter.FILTER_REJECT |
-   3497| typeof NodeFilter.FILTER_SKIP;
+   3496| typeof NodeFilter.FILTER_ACCEPT |
+   3497| typeof NodeFilter.FILTER_REJECT |
+   3498| typeof NodeFilter.FILTER_SKIP;
          ----------------------------^ [2]
 
 
@@ -776,11 +776,11 @@ References:
    traversal.js:193:58
     193|     document.createTreeWalker(document_body, -1, node => 'accept'); // invalid
                                                                   ^^^^^^^^ [1]
-   <BUILTINS>/dom.js:3495:1
+   <BUILTINS>/dom.js:3496:1
          v--------------------------------
-   3495| typeof NodeFilter.FILTER_ACCEPT |
-   3496| typeof NodeFilter.FILTER_REJECT |
-   3497| typeof NodeFilter.FILTER_SKIP;
+   3496| typeof NodeFilter.FILTER_ACCEPT |
+   3497| typeof NodeFilter.FILTER_REJECT |
+   3498| typeof NodeFilter.FILTER_SKIP;
          ----------------------------^ [2]
 
 
@@ -797,11 +797,11 @@ References:
    traversal.js:195:72
     195|     document.createTreeWalker(document_body, -1, { acceptNode: node => 'accept' }); // invalid
                                                                                 ^^^^^^^^ [1]
-   <BUILTINS>/dom.js:3495:1
+   <BUILTINS>/dom.js:3496:1
          v--------------------------------
-   3495| typeof NodeFilter.FILTER_ACCEPT |
-   3496| typeof NodeFilter.FILTER_REJECT |
-   3497| typeof NodeFilter.FILTER_SKIP;
+   3496| typeof NodeFilter.FILTER_ACCEPT |
+   3497| typeof NodeFilter.FILTER_REJECT |
+   3498| typeof NodeFilter.FILTER_SKIP;
          ----------------------------^ [2]
 
 


### PR DESCRIPTION
Fixes #6264

Adds the property `cells` to `HTMLTableRowElement`, as stated on https://developer.mozilla.org/en-US/docs/Web/API/HTMLTableRowElement
