### PR TITLE
Update clients.matchAll to type Array<Clients>

### DIFF
--- a/lib/serviceworkers.js
+++ b/lib/serviceworkers.js
@@ -53,7 +53,7 @@ type ClientQueryOptions = {
 
 declare class Clients {
   get(id: string): Promise<?Client>,
-  matchAll(options?: ClientQueryOptions): Promise<Iterator<Client>>,
+  matchAll(options?: ClientQueryOptions): Promise<Array<Client>>,
   openWindow(url: string): Promise<?WindowClient>,
   claim(): Promise<void>,
 }


### PR DESCRIPTION
Clients.matchAll returns an array of clients https://www.w3.org/TR/service-workers-1/#clients-getall
Fixes https://github.com/facebook/flow/issues/6262

cc @mrkev