### PR TITLE
[Doc] add explicitly descriptions `@flow` and `@noflow`

### DIFF
--- a/website/en/docs/config/options.md
+++ b/website/en/docs/config/options.md
@@ -156,6 +156,9 @@ start lexing a file to see if it has `@flow` or `@noflow` in it. This option
 lets you configure how much of the file Flow lexes before it decides there is
 no relevant docblock.
 
+> **Note** `@flow` means "parse the file with types allowed, and run Flow"
+>`@noflow` means "parse the file with types allowed, but suppress all the errors." this is meant as an escape hatch to suppress flow without having to delete all the annotations.
+
 The default value of `max_header_tokens` is 10.
 
 #### `module.file_ext` _`(string)`_ <a class="toc" id="toc-module-file-ext-string" href="#toc-module-file-ext-string"></a>


### PR DESCRIPTION
## overview
a few minuites ago, i want to know certainly `@noflow` effect, so i visit official doc and input search area with `@noflow`, you could see the senario following gif(i'm afraid about image quality😇)

![may-14-2018 06-00-11](https://user-images.githubusercontent.com/5501268/39971772-621dc934-573c-11e8-8a96-400114c55f0f.gif)

but i can't see enough description about `@noflow` in Doc, only mentioned following section(probably  `@flow` also the same situation)

> Flow tries to avoid parsing non-flow files. This means Flow needs to start lexing a file to see if it has @flow or @noflow in it. This option lets you configure how much of the file Flow lexes before it decides there is no relevant docblock.

so, i searched github issue and i just find out @mroch 's excellent descriptions😍
https://github.com/facebook/flow/issues/1321#issuecomment-181541953

then i thought that might be better to add doc, thus i create PR!

thank you😀