### PR TITLE
Add 'as' property to HTMLLinkElement

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -3098,6 +3098,7 @@ declare class HTMLLinkElement extends HTMLElement {
   rel: string;
   sizes: DOMTokenList;
   type: string;
+  as: string;
 }
 
 declare class HTMLScriptElement extends HTMLElement {


### PR DESCRIPTION
As documented in https://developer.mozilla.org/en-US/docs/Web/API/HTMLLinkElement/as 

> The as property of the HTMLLinkElement interface returns a DOMString representing the type of content being loaded by the HTML link, one of "script", "style", "image", "video", "audio", "track", "font", "fetch".