### PR TITLE
Add react-preset note to compiler-babel.md

### DIFF
--- a/website/en/docs/_install/compiler-babel.md
+++ b/website/en/docs/_install/compiler-babel.md
@@ -9,6 +9,9 @@ First install `babel-cli` and `babel-preset-flow` with either
 {{include.install_command}} babel-cli babel-preset-flow
 ```
 
+Note that if you're already using `babel-preset-react`, you don't also 
+need `babel-preset-flow`, since the Flow preset is included in the React preset.
+
 Next you need to create a `.babelrc` file at the root of your project with
 `"flow"` in your `"presets"`.
 


### PR DESCRIPTION
I've seen a few instances of people using the `flow` as well as `react` presets unnecessarily. Since many users will already be using the React preset is it worth pointing this out here?

Or has a conscious effort been made to not mention React to counter the preconception that Flow can only be used with React?