### PR TITLE
further restrict property descriptor type definitions

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -21,17 +21,52 @@ declare function decodeURIComponent(encodedURIComponent: string): string;
 declare function encodeURI(uri: string): string;
 declare function encodeURIComponent(uriComponent: string): string;
 
-type PropertyDescriptor<T> = {
+type ContraPropertyDescriptor<T> = {
     enumerable?: boolean;
     configurable?: boolean;
     writable?: boolean;
-    value?: T;
-    get?: () => T;
-    set?: (value: T) => void;
+    value: T;
+} | {
+    enumerable?: boolean;
+    configurable?: boolean;
+    get: () => T;
+    set: (value: T) => void;
+} | {
+    enumerable?: boolean;
+    configurable?: boolean;
+    get: () => T;
+} | {
+    enumerable?: boolean;
+    configurable?: boolean;
+    set: (value: T) => void;
 };
 
-type PropertyDescriptorMap = {
-  [s: string]: PropertyDescriptor<any>;
+type CoPropertyDescriptor<T> = {
+    enumerable: boolean;
+    configurable: boolean;
+    writable: boolean;
+    value: T;
+} | {
+    enumerable: boolean;
+    configurable: boolean;
+    get: () => T;
+    set: (value: T) => void;
+} | {
+    enumerable: boolean;
+    configurable: boolean;
+    get: () => T;
+} | {
+    enumerable: boolean;
+    configurable: boolean;
+    set: (value: T) => void;
+};
+
+type ContraPropertyDescriptorMap = {
+  [s: string]: ContraPropertyDescriptor<any>;
+}
+
+type CoPropertyDescriptorMap = {
+  [s: string]: CoPropertyDescriptor<any>;
 }
 
 // TODO: instance
@@ -42,12 +77,12 @@ declare class Object {
     static (o: string): String;
     static <T: Object>(o: T): T;
     static assign: Object$Assign;
-    static create(o: any, properties?: PropertyDescriptorMap): any; // compiler magic
-    static defineProperties(o: any, properties: PropertyDescriptorMap): any;
-    static defineProperty<T>(o: any, p: any, attributes: PropertyDescriptor<T>): any;
+    static create(o: any, properties?: ContraPropertyDescriptorMap): any; // compiler magic
+    static defineProperties(o: any, properties: ContraPropertyDescriptorMap): any;
+    static defineProperty<T>(o: any, p: any, attributes: ContraPropertyDescriptor<T>): any;
     static entries(object: any): Array<[string, mixed]>;
     static freeze<T>(o: T): T;
-    static getOwnPropertyDescriptor<T>(o: any, p: any): PropertyDescriptor<T> | void;
+    static getOwnPropertyDescriptor<T>(o: any, p: any): CoPropertyDescriptor<T> | void;
     static getOwnPropertyNames(o: any): Array<string>;
     static getOwnPropertySymbols(o: any): Symbol[];
     static getPrototypeOf: Object$GetPrototypeOf;
@@ -760,8 +795,8 @@ type Proxy$traps<T> = {
   setPrototypeOf?: (target: T, prototype: Object|null) => boolean;
   isExtensible?: (target: T) => boolean;
   preventExtensions?: (target: T) => boolean;
-  getOwnPropertyDescriptor?: <T>(target: T, property: string) => void | PropertyDescriptor<T>;
-  defineProperty?: <T>(target: T, property: string, descriptor: PropertyDescriptor<T>) => boolean;
+  getOwnPropertyDescriptor?: <T>(target: T, property: string) => void | CoPropertyDescriptor<T>;
+  defineProperty?: <T>(target: T, property: string, descriptor: ContraPropertyDescriptor<T>) => boolean;
   has?: (target: T, key: string) => boolean;
   get?: (target: T, property: string, receiver: Proxy<T>) => any;
   set?: (target: T, property: string, value: any, receiver: Proxy<T>) => boolean;


### PR DESCRIPTION
I was getting an error on this code due to a loose definition of property descriptors:

```js
function safeWrite(obj: {}, prop: string, value: any) {
  let desc = Object.getOwnPropertyDescriptor(obj, prop);
  if (desc && 'value' in desc && (desc.writable || desc.configurable)) {
    desc.value = value;
    Object.defineProperty(obj, prop, desc);
  }
}
```

The error message was

```
Sketchy null check on boolean [1] which is potentially false. Perhaps you meant to check for null or undefined [1]?
(sketchy-null-bool)

     xxx.js
      8│
      9│ function safeWrite(obj: {}, prop: string, value: any) {
     10│   let desc = Object.getOwnPropertyDescriptor(obj, prop);
     11│   if (desc && 'value' in desc && (desc.writable || desc.configurable)) {
     12│     desc.value = value;
     13│     Object.defineProperty(obj, prop, desc);
     14│   }

     /tmp/flow/flowlib_16ab40eb/core.js
 [1] 27│     writable?: boolean;

```