### PR TITLE
Ensure value is added to estree ast for ObjectTypeInternalSlot

### DIFF
--- a/packages/flow-parser/test/custom_ast_types.js
+++ b/packages/flow-parser/test/custom_ast_types.js
@@ -223,7 +223,8 @@ def("ObjectTypeInternalSlot")
   .build("id", "static", "method")
   .field("id", def("Identifier"))
   .field("static", Boolean)
-  .field("method", Boolean);
+  .field("method", Boolean)
+  .field("value", def("Type"));
 
 // https://github.com/benjamn/ast-types/issues/186
 def("ForAwaitStatement")

--- a/src/parser/estree_translator.ml
+++ b/src/parser/estree_translator.ml
@@ -1175,6 +1175,7 @@ end with type t = Impl.t) = struct
       "optional", bool slot.optional;
       "static", bool slot.static;
       "method", bool slot._method;
+      "value", _type slot.value;
     ]
   )
 

--- a/src/parser/test/flow/internal_slot/declare_class.tree.json
+++ b/src/parser/test/flow/internal_slot/declare_class.tree.json
@@ -39,7 +39,21 @@
             },
             "optional":false,
             "static":false,
-            "method":false
+            "method":false,
+            "value":{
+              "type":"GenericTypeAnnotation",
+              "loc":{"source":null,"start":{"line":1,"column":27},"end":{"line":1,"column":28}},
+              "range":[27,28],
+              "id":{
+                "type":"Identifier",
+                "loc":{"source":null,"start":{"line":1,"column":27},"end":{"line":1,"column":28}},
+                "range":[27,28],
+                "name":"T",
+                "typeAnnotation":null,
+                "optional":false
+              },
+              "typeParameters":null
+            }
           }
         ]
       },

--- a/src/parser/test/flow/internal_slot/declare_class_static.tree.json
+++ b/src/parser/test/flow/internal_slot/declare_class_static.tree.json
@@ -39,7 +39,19 @@
             },
             "optional":false,
             "static":true,
-            "method":false
+            "method":false,
+            "value":{
+              "type":"GenericTypeAnnotation",
+              "loc":{"source":null,"start":{"line":1,"column":34},"end":{"line":1,"column":35}},
+              "range":[34,35],
+              "typeParameters":null,
+              "id":{
+                "type":"Identifier",
+                "loc":{"source":null,"start":{"line":1,"column":34},"end":{"line":1,"column":35}},
+                "range":[34,35],
+                "name":"T"
+              }
+            }
           }
         ]
       },

--- a/src/parser/test/flow/internal_slot/interface.tree.json
+++ b/src/parser/test/flow/internal_slot/interface.tree.json
@@ -39,7 +39,21 @@
             },
             "optional":false,
             "static":false,
-            "method":false
+            "method":false,
+            "value":{
+              "type":"GenericTypeAnnotation",
+              "loc":{"source":null,"start":{"line":1,"column":23},"end":{"line":1,"column":24}},
+              "range":[23,24],
+              "id":{
+                "type":"Identifier",
+                "loc":{"source":null,"start":{"line":1,"column":23},"end":{"line":1,"column":24}},
+                "range":[23,24],
+                "name":"X",
+                "typeAnnotation":null,
+                "optional":false
+              },
+              "typeParameters":null
+            }
           }
         ]
       },

--- a/src/parser/test/flow/internal_slot/interface_method.tree.json
+++ b/src/parser/test/flow/internal_slot/interface_method.tree.json
@@ -39,7 +39,29 @@
             },
             "optional":false,
             "static":false,
-            "method":true
+            "method":true,
+            "value":{
+              "type":"FunctionTypeAnnotation",
+              "loc":{"source":null,"start":{"line":1,"column":14},"end":{"line":1,"column":26}},
+              "range":[14,26],
+              "params":[],
+              "returnType":{
+                "type":"GenericTypeAnnotation",
+                "loc":{"source":null,"start":{"line":1,"column":25},"end":{"line":1,"column":26}},
+                "range":[25,26],
+                "id":{
+                  "type":"Identifier",
+                  "loc":{"source":null,"start":{"line":1,"column":25},"end":{"line":1,"column":26}},
+                  "range":[25,26],
+                  "name":"X",
+                  "typeAnnotation":null,
+                  "optional":false
+                },
+                "typeParameters":null
+              },
+              "rest":null,
+              "typeParameters":null
+            }
           }
         ]
       },

--- a/src/parser/test/flow/internal_slot/interface_variance.tree.json
+++ b/src/parser/test/flow/internal_slot/interface_variance.tree.json
@@ -45,7 +45,29 @@
             },
             "optional":false,
             "static":false,
-            "method":true
+            "method":true,
+            "value":{
+              "type":"FunctionTypeAnnotation",
+              "loc":{"source":null,"start":{"line":1,"column":14},"end":{"line":1,"column":27}},
+              "range":[14,27],
+              "params":[],
+              "returnType":{
+                "type":"GenericTypeAnnotation",
+                "loc":{"source":null,"start":{"line":1,"column":26},"end":{"line":1,"column":27}},
+                "range":[26,27],
+                "id":{
+                  "type":"Identifier",
+                  "loc":{"source":null,"start":{"line":1,"column":26},"end":{"line":1,"column":27}},
+                  "range":[26,27],
+                  "name":"X",
+                  "typeAnnotation":null,
+                  "optional":false
+                },
+                "typeParameters":null
+              },
+              "rest":null,
+              "typeParameters":null
+            }
           }
         ]
       },

--- a/src/parser/test/flow/internal_slot/object.tree.json
+++ b/src/parser/test/flow/internal_slot/object.tree.json
@@ -39,7 +39,18 @@
             },
             "optional":false,
             "static":false,
-            "method":false
+            "method":false,
+            "value":{
+              "type":"GenericTypeAnnotation",
+              "loc":{"source":null,"start":{"line":1,"column":20},"end":{"line":1,"column":21}},
+              "range":[20,21],
+              "typeParameters":null,
+              "id":{
+                "type":"Identifier",
+                "loc":{"source":null,"start":{"line":1,"column":20},"end":{"line":1,"column":21}},
+                "name":"X"
+              }
+            }
           }
         ]
       }

--- a/src/parser/test/flow/internal_slot/object_method.tree.json
+++ b/src/parser/test/flow/internal_slot/object_method.tree.json
@@ -39,7 +39,29 @@
             },
             "optional":false,
             "static":false,
-            "method":true
+            "method":true,
+            "value":{
+              "type":"FunctionTypeAnnotation",
+              "loc":{"source":null,"start":{"line":1,"column":11},"end":{"line":1,"column":23}},
+              "range":[11,23],
+              "params":[],
+              "returnType":{
+                "type":"GenericTypeAnnotation",
+                "loc":{"source":null,"start":{"line":1,"column":22},"end":{"line":1,"column":23}},
+                "range":[22,23],
+                "id":{
+                  "type":"Identifier",
+                  "loc":{"source":null,"start":{"line":1,"column":22},"end":{"line":1,"column":23}},
+                  "range":[22,23],
+                  "name":"X",
+                  "typeAnnotation":null,
+                  "optional":false
+                },
+                "typeParameters":null
+              },
+              "rest":null,
+              "typeParameters":null
+            }
           }
         ]
       }

--- a/src/parser/test/flow/internal_slot/object_optional.tree.json
+++ b/src/parser/test/flow/internal_slot/object_optional.tree.json
@@ -39,7 +39,21 @@
             },
             "optional":true,
             "static":false,
-            "method":false
+            "method":false,
+            "value":{
+              "type":"GenericTypeAnnotation",
+              "loc":{"source":null,"start":{"line":1,"column":21},"end":{"line":1,"column":22}},
+              "range":[21,22],
+              "id":{
+                "type":"Identifier",
+                "loc":{"source":null,"start":{"line":1,"column":21},"end":{"line":1,"column":22}},
+                "range":[21,22],
+                "name":"X",
+                "typeAnnotation":null,
+                "optional":false
+              },
+              "typeParameters":null
+            }
           }
         ]
       }

--- a/src/parser/test/flow/internal_slot/object_variance.tree.json
+++ b/src/parser/test/flow/internal_slot/object_variance.tree.json
@@ -45,7 +45,21 @@
             },
             "optional":false,
             "static":false,
-            "method":false
+            "method":false,
+            "value":{
+              "type":"GenericTypeAnnotation",
+              "loc":{"source":null,"start":{"line":1,"column":21},"end":{"line":1,"column":22}},
+              "range":[21,22],
+              "id":{
+                "type":"Identifier",
+                "loc":{"source":null,"start":{"line":1,"column":21},"end":{"line":1,"column":22}},
+                "range":[21,22],
+                "name":"X",
+                "typeAnnotation":null,
+                "optional":false
+              },
+              "typeParameters":null
+            }
           }
         ]
       }


### PR DESCRIPTION
While implementing support for new additions to Flow 0.72 in Prettier, I noticed `value` was missing from `ObjectTypeInternalSlot`.

/cc: @samwgoldman 