### PR TITLE
Add asynchronous Clipboard type

### DIFF
--- a/lib/bom.js
+++ b/lib/bom.js
@@ -138,6 +138,14 @@ declare class Navigator mixins NavigatorCommon {
     mozVibrate?: (pattern: number|number[]) => bool;
     webkitVibrate?: (pattern: number|number[]) => bool;
     share?: (shareData: ShareData) => Promise<void>;
+    clipboard: Clipboard;
+}
+
+type Clipboard = EventTarget & {
+    read: () => Promise<DataTransfer>;
+    readText: () => Promise<string>;
+    write: (data: DataTransfer) => Promise<void>;
+    writeText: (data: string) => Promise<void>;
 }
 
 declare var navigator: Navigator;

--- a/tests/clipboard/.flowconfig
+++ b/tests/clipboard/.flowconfig
@@ -1,0 +1,3 @@
+[options]
+module.system=haste
+no_flowlib=false

--- a/tests/clipboard/clipboard.exp
+++ b/tests/clipboard/clipboard.exp
@@ -1,0 +1,1 @@
+Found 0 errors

--- a/tests/clipboard/clipboard.js
+++ b/tests/clipboard/clipboard.js
@@ -1,0 +1,10 @@
+/* @flow */
+
+const c: Clipboard = navigator.clipboard;
+const t: EventTarget = navigator.clipboard;
+
+navigator.clipboard.read().then(function(data: DataTransfer) {});
+navigator.clipboard.readText().then(function(data: string) {});
+
+const p: Promise<void> = navigator.clipboard.write(new DataTransfer());
+const p2: Promise<void> = navigator.clipboard.writeText('test');


### PR DESCRIPTION
Defines the `Clipboard` type and `navigator.clipboard` accessor from the [Asynchronous Clipboard API](https://w3c.github.io/clipboard-apis/#clipboard-interface). The clipboard API is available for testing in [Chrome 66](https://developers.google.com/web/updates/2018/03/clipboardapi).