### PR TITLE
add filter to CanvasRenderingContext2D

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -1616,6 +1616,9 @@ declare class CanvasRenderingContext2D {
   // image smoothing
   imageSmoothingEnabled: boolean;
 
+  // filters
+  filter: string;
+
   // colours and styles
   strokeStyle: string | CanvasGradient | CanvasPattern;
   fillStyle: string | CanvasGradient | CanvasPattern;


### PR DESCRIPTION
This allows using the filter attribute on 2d canvas contexts. The feature is still marked as experimental in MDN.

https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/filter