### PR TITLE
Document React context

### DIFF
--- a/website/_data/guides.yml
+++ b/website/_data/guides.yml
@@ -111,6 +111,7 @@
     - path: "/docs/react/refs/"
     - path: "/docs/react/children/"
     - path: "/docs/react/hoc/"
+    - path: "/docs/react/context/"
     - path: "/docs/react/redux/"
     - path: "/docs/react/types/"
 

--- a/website/_data/i18n/en.yml
+++ b/website/_data/i18n/en.yml
@@ -309,6 +309,9 @@ docs_additional_reading: "Additional Reading"
 "/docs/react/hoc/":
   title: "Higher-order Components"
   description: "Learn how to use Flow to type React higher-order components"
+"/docs/react/context/":
+  title: "Context"
+  description: "Learn how to use Flow with the React context API"
 "/docs/react/redux/":
   title: "Redux"
   description: "Learn how to use Flow with Redux"

--- a/website/en/docs/react/context.md
+++ b/website/en/docs/react/context.md
@@ -1,0 +1,53 @@
+---
+layout: guide
+---
+
+Flow can typecheck your React components that use the [context API][] introduced
+in React 16.3.
+
+[context API]: https://reactjs.org/docs/context.html
+
+> **Note:** Typing context values requires Flow 0.70 or later.
+
+Flow will infer types from the way you use a context's `{ Provider, Consumer }`
+pair:
+
+```js
+import React from "react";
+
+const Theme = React.createContext();
+
+<Theme.Provider value="light" />;
+
+<Theme.Consumer>{value => value.toUpperCase()}</Theme.Consumer>; // Error! `value` is nullable.
+
+<Theme.Consumer>
+  {value =>
+    value
+      ? value.toUpperCase() // Valid: `value` is a string.
+      : null
+  }
+</Theme.Consumer>;
+```
+
+If your context has a default value, Flow will type your consumer component
+accordingly:
+
+```js
+import React from "react";
+
+const Theme = React.createContext("light");
+
+<Theme.Consumer>{value => value.toUpperCase()}</Theme.Consumer>; // Valid: `value` is a non-nullable string.
+```
+
+To explicitly specify the type of a context value, pass a type parameter to
+`createContext`:
+
+```js
+import React from "react";
+
+const Theme = React.createContext<"light" | "dark">("light");
+
+<Theme.Provider value="blue" />; // Error! "blue" is not one of the allowed values.
+```


### PR DESCRIPTION
I noticed this was missing despite types featuring prominently in the [context RFC](https://github.com/reactjs/rfcs/blob/master/text/0002-new-version-of-context.md), so thought I'd try my hand at writing documentation.

I couldn't get the Jekyll build to run locally, but modeled this very closely on the other `docs/react/` pages so hopefully everything renders fine. Maybe the JS comments that extend over the 80 character mark should be moved? Happy to take suggestions on keeping this pretty and clear.