### PR TITLE
Add types for Object.getOwnPropertyDescriptors

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -48,6 +48,7 @@ declare class Object {
     static entries(object: any): Array<[string, mixed]>;
     static freeze<T>(o: T): T;
     static getOwnPropertyDescriptor<T>(o: any, p: any): PropertyDescriptor<T> | void;
+    static getOwnPropertyDescriptors(o: any): PropertyDescriptorMap;
     static getOwnPropertyNames(o: any): Array<string>;
     static getOwnPropertySymbols(o: any): Symbol[];
     static getPrototypeOf: Object$GetPrototypeOf;


### PR DESCRIPTION
Adds support for [Object.getOwnPropertyDescriptors](https://tc39.github.io/ecma262/#sec-object.getownpropertydescriptors)