### PR TITLE
add RegExp.prototype.match() return type

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -334,7 +334,7 @@ declare class RegExp {
     static (pattern: string | RegExp, flags?: RegExp$flags): RegExp;
     compile(): RegExp;
     constructor(pattern: string | RegExp, flags?: RegExp$flags): RegExp;
-    exec(string: string): any;
+    exec(string: string): Array<string> | null;
     flags: string;
     global: boolean;
     ignoreCase: boolean;


### PR DESCRIPTION
"If the match succeeds, the exec() method returns an array and updates properties of the regular expression object. The returned array has the matched text as the first item, and then one item for each capturing parenthesis that matched containing the text that was captured. If the match fails, the exec() method returns null."
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/exec