### PR TITLE
Make `Array.of` typesafe

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -282,7 +282,7 @@ declare class Array<T> extends $ReadOnlyArray<T> {
     static from<A>(iter: Iterator<A>, mapFn: void): Array<A>;
     static from<A>(arrayLike: {length: number}, mapFn: (elem: void, index: number) => A, thisArg?: any): Array<A>;
     static from(arrayLike: {length: number}, mapFn: void): Array<void>;
-    static of(...values: any[]): any[];
+    static of<T>(...values: Array<T>): Array<T>;
 }
 
 declare class String {

--- a/tests/arraylib/array_lib.js
+++ b/tests/arraylib/array_lib.js
@@ -55,3 +55,10 @@ function from_test() {
     return String(val);
   });
 }
+
+function of_test() {
+  var emptyArrayOkay: Array<empty> = Array.of();
+  var exactMatchOkay: Array<string> = Array.of("hello", "world");
+  var upcastOkay: Array<string | number> = Array.of("hello", "world");
+  var incompatibleTypeNotOkay: Array<string> = Array.of(1, 2);
+}

--- a/tests/arraylib/arraylib.exp
+++ b/tests/arraylib/arraylib.exp
@@ -131,6 +131,28 @@ References:
                                         ^^^^^^^^^^^^^^^^ [1]
 
 
+Error ----------------------------------------------------------------------------------------------- array_lib.js:63:48
+
+Cannot assign `Array.of(...)` to `incompatibleTypeNotOkay` because:
+ - number [1] is incompatible with string [2] in array element.
+ - number [3] is incompatible with string [2] in array element.
+
+   array_lib.js:63:48
+   63|   var incompatibleTypeNotOkay: Array<string> = Array.of(1, 2);
+                                                      ^^^^^^^^^^^^^^
+
+References:
+   array_lib.js:63:57
+   63|   var incompatibleTypeNotOkay: Array<string> = Array.of(1, 2);
+                                                               ^ [1]
+   array_lib.js:63:38
+   63|   var incompatibleTypeNotOkay: Array<string> = Array.of(1, 2);
+                                            ^^^^^^ [2]
+   array_lib.js:63:60
+   63|   var incompatibleTypeNotOkay: Array<string> = Array.of(1, 2);
+                                                                  ^ [3]
+
+
 Error ---------------------------------------------------------------------------------------------------- length.js:7:1
 
 Cannot assign `6` to `r.length` because property `length` is not writable.
@@ -148,4 +170,4 @@ Cannot assign `7` to `t.length` because property `length` is not writable.
 
 
 
-Found 12 errors
+Found 14 errors


### PR DESCRIPTION
Summary:
The static method `Array.of` can have a well-defined type, without
resorting to `any`. Fixes #6359.

Test Plan:
Added a test case to the `arraylib` suite. Running `make test` passes,
and the tests properly fail when the patch to `lib/core.js` is reverted.

wchargin-branch: polymorphic-array-of