### PR TITLE
Another Object.{entries,values} attempt

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -45,6 +45,8 @@ declare class Object {
     static create(o: any, properties?: PropertyDescriptorMap): any; // compiler magic
     static defineProperties(o: any, properties: PropertyDescriptorMap): any;
     static defineProperty<T>(o: any, p: any, attributes: PropertyDescriptor<T>): any;
+    // TODO: I think this could be done a little nicer using $Keys
+    static entries<T>(object: { [any]: T }): Array<[string, T]>;
     static entries(object: any): Array<[string, mixed]>;
     static freeze<T>(o: T): T;
     static getOwnPropertyDescriptor<T>(o: any, p: any): PropertyDescriptor<T> | void;
@@ -59,6 +61,7 @@ declare class Object {
     static preventExtensions<T>(o: T): T;
     static seal<T>(o: T): T;
     static setPrototypeOf(o: any, proto: ?Object): any;
+    static values<T>(object: { [any]: T }): Array<T>;
     static values(object: any): Array<mixed>;
     hasOwnProperty(prop: any): boolean;
     isPrototypeOf(o: any): boolean;

--- a/tests/arrows/arrows.exp
+++ b/tests/arrows/arrows.exp
@@ -45,8 +45,8 @@ References:
    arrows.js:7:36
      7|     images = images.sort((a, b) => (a.width - b.width) + "");
                                            ^^^^^^^^^^^^^^^^^^^^^^^^ [1]
-   <BUILTINS>/core.js:270:38
-   270|     sort(compareFn?: (a: T, b: T) => number): Array<T>;
+   <BUILTINS>/core.js:273:38
+   273|     sort(compareFn?: (a: T, b: T) => number): Array<T>;
                                              ^^^^^^ [2]
 
 

--- a/tests/async/async.exp
+++ b/tests/async/async.exp
@@ -10,8 +10,8 @@ References:
    async.js:11:30
     11| async function f1(): Promise<bool> {
                                      ^^^^ [2]
-   <BUILTINS>/core.js:576:24
-   576| declare class Promise<+R> {
+   <BUILTINS>/core.js:579:24
+   579| declare class Promise<+R> {
                                ^ [3]
 
 
@@ -30,8 +30,8 @@ References:
    async.js:30:48
     30| async function f4(p: Promise<number>): Promise<bool> {
                                                        ^^^^ [2]
-   <BUILTINS>/core.js:576:24
-   576| declare class Promise<+R> {
+   <BUILTINS>/core.js:579:24
+   579| declare class Promise<+R> {
                                ^ [3]
 
 
@@ -100,8 +100,8 @@ References:
    async2.js:57:13
     57|   : Promise<number> { // error, number != void
                     ^^^^^^ [1]
-   <BUILTINS>/core.js:576:24
-   576| declare class Promise<+R> {
+   <BUILTINS>/core.js:579:24
+   579| declare class Promise<+R> {
                                ^ [2]
 
 
@@ -134,8 +134,8 @@ References:
    async_return_void.js:3:32
      3| async function foo1(): Promise<string> {
                                        ^^^^^^ [2]
-   <BUILTINS>/core.js:576:24
-   576| declare class Promise<+R> {
+   <BUILTINS>/core.js:579:24
+   579| declare class Promise<+R> {
                                ^ [3]
 
 
@@ -151,8 +151,8 @@ References:
    async_return_void.js:7:32
      7| async function foo2(): Promise<string> {
                                        ^^^^^^ [2]
-   <BUILTINS>/core.js:576:24
-   576| declare class Promise<+R> {
+   <BUILTINS>/core.js:579:24
+   579| declare class Promise<+R> {
                                ^ [3]
 
 
@@ -171,8 +171,8 @@ References:
    async_return_void.js:11:32
     11| async function foo3(): Promise<string> {
                                        ^^^^^^ [2]
-   <BUILTINS>/core.js:576:24
-   576| declare class Promise<+R> {
+   <BUILTINS>/core.js:579:24
+   579| declare class Promise<+R> {
                                ^ [3]
 
 

--- a/tests/async_iteration/async_iteration.exp
+++ b/tests/async_iteration/async_iteration.exp
@@ -99,8 +99,8 @@ Cannot cast `result.value` to string because:
              ^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:478:28
-   478|   | { done: true, +value?: Return }
+   <BUILTINS>/core.js:481:28
+   481|   | { done: true, +value?: Return }
                                    ^^^^^^ [1]
    return.js:20:20
     20|     (result.value: string); // error: number | void ~> string

--- a/tests/autocomplete/autocomplete.exp
+++ b/tests/autocomplete/autocomplete.exp
@@ -13,8 +13,8 @@ foo.js = {
       "type":"(prop: any) => boolean",
       "func_details":{"return_type":"boolean","params":[{"name":"prop","type":"any"}]},
       "path":"[LIB] core.js",
-      "line":63,
-      "endline":63,
+      "line":66,
+      "endline":66,
       "start":5,
       "end":38
     },
@@ -23,8 +23,8 @@ foo.js = {
       "type":"(o: any) => boolean",
       "func_details":{"return_type":"boolean","params":[{"name":"o","type":"any"}]},
       "path":"[LIB] core.js",
-      "line":64,
-      "endline":64,
+      "line":67,
+      "endline":67,
       "start":5,
       "end":34
     },
@@ -43,8 +43,8 @@ foo.js = {
       "type":"(prop: any) => boolean",
       "func_details":{"return_type":"boolean","params":[{"name":"prop","type":"any"}]},
       "path":"[LIB] core.js",
-      "line":65,
-      "endline":65,
+      "line":68,
+      "endline":68,
       "start":5,
       "end":44
     },
@@ -63,8 +63,8 @@ foo.js = {
       "type":"() => string",
       "func_details":{"return_type":"string","params":[]},
       "path":"[LIB] core.js",
-      "line":66,
-      "endline":66,
+      "line":69,
+      "endline":69,
       "start":5,
       "end":28
     },
@@ -73,8 +73,8 @@ foo.js = {
       "type":"() => string",
       "func_details":{"return_type":"string","params":[]},
       "path":"[LIB] core.js",
-      "line":67,
-      "endline":67,
+      "line":70,
+      "endline":70,
       "start":5,
       "end":22
     },
@@ -83,8 +83,8 @@ foo.js = {
       "type":"() => Object",
       "func_details":{"return_type":"Object","params":[]},
       "path":"[LIB] core.js",
-      "line":68,
-      "endline":68,
+      "line":71,
+      "endline":71,
       "start":5,
       "end":21
     }
@@ -112,8 +112,8 @@ str.js = {
       "type":"() => Iterator<string>",
       "func_details":{"return_type":"Iterator<string>","params":[]},
       "path":"[LIB] core.js",
-      "line":289,
-      "endline":289,
+      "line":292,
+      "endline":292,
       "start":5,
       "end":34
     },
@@ -122,8 +122,8 @@ str.js = {
       "type":"(name: string) => string",
       "func_details":{"return_type":"string","params":[{"name":"name","type":"string"}]},
       "path":"[LIB] core.js",
-      "line":290,
-      "endline":290,
+      "line":293,
+      "endline":293,
       "start":5,
       "end":32
     },
@@ -132,8 +132,8 @@ str.js = {
       "type":"(pos: number) => string",
       "func_details":{"return_type":"string","params":[{"name":"pos","type":"number"}]},
       "path":"[LIB] core.js",
-      "line":291,
-      "endline":291,
+      "line":294,
+      "endline":294,
       "start":5,
       "end":31
     },
@@ -142,8 +142,8 @@ str.js = {
       "type":"(index: number) => number",
       "func_details":{"return_type":"number","params":[{"name":"index","type":"number"}]},
       "path":"[LIB] core.js",
-      "line":292,
-      "endline":292,
+      "line":295,
+      "endline":295,
       "start":5,
       "end":37
     },
@@ -152,8 +152,8 @@ str.js = {
       "type":"(index: number) => number",
       "func_details":{"return_type":"number","params":[{"name":"index","type":"number"}]},
       "path":"[LIB] core.js",
-      "line":293,
-      "endline":293,
+      "line":296,
+      "endline":296,
       "start":5,
       "end":38
     },
@@ -165,8 +165,8 @@ str.js = {
         "params":[{"name":"...strings","type":"Array<string>"}]
       },
       "path":"[LIB] core.js",
-      "line":294,
-      "endline":294,
+      "line":297,
+      "endline":297,
       "start":5,
       "end":45
     },
@@ -178,8 +178,8 @@ str.js = {
         "params":[{"name":"searchString","type":"string"},{"name":"position?","type":"number"}]
       },
       "path":"[LIB] core.js",
-      "line":296,
-      "endline":296,
+      "line":299,
+      "endline":299,
       "start":5,
       "end":62
     },
@@ -191,8 +191,8 @@ str.js = {
         "params":[{"name":"searchString","type":"string"},{"name":"position?","type":"number"}]
       },
       "path":"[LIB] core.js",
-      "line":297,
-      "endline":297,
+      "line":300,
+      "endline":300,
       "start":5,
       "end":62
     },
@@ -204,8 +204,8 @@ str.js = {
         "params":[{"name":"searchString","type":"string"},{"name":"position?","type":"number"}]
       },
       "path":"[LIB] core.js",
-      "line":298,
-      "endline":298,
+      "line":301,
+      "endline":301,
       "start":5,
       "end":60
     },
@@ -217,8 +217,8 @@ str.js = {
         "params":[{"name":"searchString","type":"string"},{"name":"position?","type":"number"}]
       },
       "path":"[LIB] core.js",
-      "line":299,
-      "endline":299,
+      "line":302,
+      "endline":302,
       "start":5,
       "end":64
     },
@@ -227,8 +227,8 @@ str.js = {
       "type":"number",
       "func_details":null,
       "path":"[LIB] core.js",
-      "line":323,
-      "endline":323,
+      "line":326,
+      "endline":326,
       "start":13,
       "end":18
     },
@@ -237,8 +237,8 @@ str.js = {
       "type":"(href: string) => string",
       "func_details":{"return_type":"string","params":[{"name":"href","type":"string"}]},
       "path":"[LIB] core.js",
-      "line":300,
-      "endline":300,
+      "line":303,
+      "endline":303,
       "start":5,
       "end":30
     },
@@ -254,8 +254,8 @@ str.js = {
         ]
       },
       "path":"[LIB] core.js",
-      "line":301,
-      "endline":301,
+      "line":304,
+      "endline":304,
       "start":5,
       "end":105
     },
@@ -267,8 +267,8 @@ str.js = {
         "params":[{"name":"regexp","type":"string | RegExp"}]
       },
       "path":"[LIB] core.js",
-      "line":302,
-      "endline":302,
+      "line":305,
+      "endline":305,
       "start":5,
       "end":50
     },
@@ -277,8 +277,8 @@ str.js = {
       "type":"(format?: string) => string",
       "func_details":{"return_type":"string","params":[{"name":"format?","type":"string"}]},
       "path":"[LIB] core.js",
-      "line":303,
-      "endline":303,
+      "line":306,
+      "endline":306,
       "start":5,
       "end":38
     },
@@ -290,8 +290,8 @@ str.js = {
         "params":[{"name":"targetLength","type":"number"},{"name":"padString?","type":"string"}]
       },
       "path":"[LIB] core.js",
-      "line":304,
-      "endline":304,
+      "line":307,
+      "endline":307,
       "start":5,
       "end":60
     },
@@ -303,8 +303,8 @@ str.js = {
         "params":[{"name":"targetLength","type":"number"},{"name":"padString?","type":"string"}]
       },
       "path":"[LIB] core.js",
-      "line":305,
-      "endline":305,
+      "line":308,
+      "endline":308,
       "start":5,
       "end":62
     },
@@ -313,8 +313,8 @@ str.js = {
       "type":"(count: number) => string",
       "func_details":{"return_type":"string","params":[{"name":"count","type":"number"}]},
       "path":"[LIB] core.js",
-      "line":306,
-      "endline":306,
+      "line":309,
+      "endline":309,
       "start":5,
       "end":33
     },
@@ -332,8 +332,8 @@ str.js = {
         ]
       },
       "path":"[LIB] core.js",
-      "line":307,
-      "endline":307,
+      "line":310,
+      "endline":310,
       "start":5,
       "end":124
     },
@@ -342,8 +342,8 @@ str.js = {
       "type":"(regexp: (string | RegExp)) => number",
       "func_details":{"return_type":"number","params":[{"name":"regexp","type":"string | RegExp"}]},
       "path":"[LIB] core.js",
-      "line":308,
-      "endline":308,
+      "line":311,
+      "endline":311,
       "start":5,
       "end":43
     },
@@ -355,8 +355,8 @@ str.js = {
         "params":[{"name":"start?","type":"number"},{"name":"end?","type":"number"}]
       },
       "path":"[LIB] core.js",
-      "line":309,
-      "endline":309,
+      "line":312,
+      "endline":312,
       "start":5,
       "end":47
     },
@@ -371,8 +371,8 @@ str.js = {
         ]
       },
       "path":"[LIB] core.js",
-      "line":310,
-      "endline":310,
+      "line":313,
+      "endline":313,
       "start":5,
       "end":69
     },
@@ -384,8 +384,8 @@ str.js = {
         "params":[{"name":"searchString","type":"string"},{"name":"position?","type":"number"}]
       },
       "path":"[LIB] core.js",
-      "line":311,
-      "endline":311,
+      "line":314,
+      "endline":314,
       "start":5,
       "end":64
     },
@@ -397,8 +397,8 @@ str.js = {
         "params":[{"name":"from","type":"number"},{"name":"length?","type":"number"}]
       },
       "path":"[LIB] core.js",
-      "line":312,
-      "endline":312,
+      "line":315,
+      "endline":315,
       "start":5,
       "end":49
     },
@@ -410,8 +410,8 @@ str.js = {
         "params":[{"name":"start","type":"number"},{"name":"end?","type":"number"}]
       },
       "path":"[LIB] core.js",
-      "line":313,
-      "endline":313,
+      "line":316,
+      "endline":316,
       "start":5,
       "end":50
     },
@@ -420,8 +420,8 @@ str.js = {
       "type":"() => string",
       "func_details":{"return_type":"string","params":[]},
       "path":"[LIB] core.js",
-      "line":314,
-      "endline":314,
+      "line":317,
+      "endline":317,
       "start":5,
       "end":31
     },
@@ -430,8 +430,8 @@ str.js = {
       "type":"() => string",
       "func_details":{"return_type":"string","params":[]},
       "path":"[LIB] core.js",
-      "line":315,
-      "endline":315,
+      "line":318,
+      "endline":318,
       "start":5,
       "end":31
     },
@@ -440,13 +440,43 @@ str.js = {
       "type":"() => string",
       "func_details":{"return_type":"string","params":[]},
       "path":"[LIB] core.js",
-      "line":316,
-      "endline":316,
+      "line":319,
+      "endline":319,
       "start":5,
       "end":25
     },
     {
       "name":"toString",
+      "type":"() => string",
+      "func_details":{"return_type":"string","params":[]},
+      "path":"[LIB] core.js",
+      "line":325,
+      "endline":325,
+      "start":5,
+      "end":22
+    },
+    {
+      "name":"toUpperCase",
+      "type":"() => string",
+      "func_details":{"return_type":"string","params":[]},
+      "path":"[LIB] core.js",
+      "line":320,
+      "endline":320,
+      "start":5,
+      "end":25
+    },
+    {
+      "name":"trim",
+      "type":"() => string",
+      "func_details":{"return_type":"string","params":[]},
+      "path":"[LIB] core.js",
+      "line":321,
+      "endline":321,
+      "start":5,
+      "end":18
+    },
+    {
+      "name":"trimLeft",
       "type":"() => string",
       "func_details":{"return_type":"string","params":[]},
       "path":"[LIB] core.js",
@@ -456,42 +486,12 @@ str.js = {
       "end":22
     },
     {
-      "name":"toUpperCase",
-      "type":"() => string",
-      "func_details":{"return_type":"string","params":[]},
-      "path":"[LIB] core.js",
-      "line":317,
-      "endline":317,
-      "start":5,
-      "end":25
-    },
-    {
-      "name":"trim",
-      "type":"() => string",
-      "func_details":{"return_type":"string","params":[]},
-      "path":"[LIB] core.js",
-      "line":318,
-      "endline":318,
-      "start":5,
-      "end":18
-    },
-    {
-      "name":"trimLeft",
-      "type":"() => string",
-      "func_details":{"return_type":"string","params":[]},
-      "path":"[LIB] core.js",
-      "line":319,
-      "endline":319,
-      "start":5,
-      "end":22
-    },
-    {
       "name":"trimRight",
       "type":"() => string",
       "func_details":{"return_type":"string","params":[]},
       "path":"[LIB] core.js",
-      "line":320,
-      "endline":320,
+      "line":323,
+      "endline":323,
       "start":5,
       "end":23
     },
@@ -500,8 +500,8 @@ str.js = {
       "type":"() => string",
       "func_details":{"return_type":"string","params":[]},
       "path":"[LIB] core.js",
-      "line":321,
-      "endline":321,
+      "line":324,
+      "endline":324,
       "start":5,
       "end":21
     }
@@ -514,8 +514,8 @@ num.js = {
       "type":"(fractionDigits?: number) => string",
       "func_details":{"return_type":"string","params":[{"name":"fractionDigits?","type":"number"}]},
       "path":"[LIB] core.js",
-      "line":141,
-      "endline":141,
+      "line":144,
+      "endline":144,
       "start":5,
       "end":50
     },
@@ -524,8 +524,8 @@ num.js = {
       "type":"(fractionDigits?: number) => string",
       "func_details":{"return_type":"string","params":[{"name":"fractionDigits?","type":"number"}]},
       "path":"[LIB] core.js",
-      "line":142,
-      "endline":142,
+      "line":145,
+      "endline":145,
       "start":5,
       "end":44
     },
@@ -540,8 +540,8 @@ num.js = {
         ]
       },
       "path":"[LIB] core.js",
-      "line":143,
-      "endline":143,
+      "line":146,
+      "endline":146,
       "start":5,
       "end":96
     },
@@ -550,8 +550,8 @@ num.js = {
       "type":"(precision?: number) => string",
       "func_details":{"return_type":"string","params":[{"name":"precision?","type":"number"}]},
       "path":"[LIB] core.js",
-      "line":144,
-      "endline":144,
+      "line":147,
+      "endline":147,
       "start":5,
       "end":43
     },
@@ -560,8 +560,8 @@ num.js = {
       "type":"(radix?: number) => string",
       "func_details":{"return_type":"string","params":[{"name":"radix?","type":"number"}]},
       "path":"[LIB] core.js",
-      "line":145,
-      "endline":145,
+      "line":148,
+      "endline":148,
       "start":5,
       "end":36
     },
@@ -570,8 +570,8 @@ num.js = {
       "type":"() => number",
       "func_details":{"return_type":"number","params":[]},
       "path":"[LIB] core.js",
-      "line":146,
-      "endline":146,
+      "line":149,
+      "endline":149,
       "start":5,
       "end":21
     }
@@ -584,8 +584,8 @@ bool.js = {
       "type":"() => string",
       "func_details":{"return_type":"string","params":[]},
       "path":"[LIB] core.js",
-      "line":121,
-      "endline":121,
+      "line":124,
+      "endline":124,
       "start":5,
       "end":22
     },
@@ -594,8 +594,8 @@ bool.js = {
       "type":"() => boolean",
       "func_details":{"return_type":"boolean","params":[]},
       "path":"[LIB] core.js",
-      "line":120,
-      "endline":120,
+      "line":123,
+      "endline":123,
       "start":5,
       "end":22
     }
@@ -618,8 +618,8 @@ union.js = {
       "type":"(prop: any) => boolean",
       "func_details":{"return_type":"boolean","params":[{"name":"prop","type":"any"}]},
       "path":"[LIB] core.js",
-      "line":63,
-      "endline":63,
+      "line":66,
+      "endline":66,
       "start":5,
       "end":38
     },
@@ -628,8 +628,8 @@ union.js = {
       "type":"(o: any) => boolean",
       "func_details":{"return_type":"boolean","params":[{"name":"o","type":"any"}]},
       "path":"[LIB] core.js",
-      "line":64,
-      "endline":64,
+      "line":67,
+      "endline":67,
       "start":5,
       "end":34
     },
@@ -638,8 +638,8 @@ union.js = {
       "type":"(prop: any) => boolean",
       "func_details":{"return_type":"boolean","params":[{"name":"prop","type":"any"}]},
       "path":"[LIB] core.js",
-      "line":65,
-      "endline":65,
+      "line":68,
+      "endline":68,
       "start":5,
       "end":44
     },
@@ -648,8 +648,8 @@ union.js = {
       "type":"() => string",
       "func_details":{"return_type":"string","params":[]},
       "path":"[LIB] core.js",
-      "line":66,
-      "endline":66,
+      "line":69,
+      "endline":69,
       "start":5,
       "end":28
     },
@@ -658,8 +658,8 @@ union.js = {
       "type":"() => string",
       "func_details":{"return_type":"string","params":[]},
       "path":"[LIB] core.js",
-      "line":67,
-      "endline":67,
+      "line":70,
+      "endline":70,
       "start":5,
       "end":22
     },
@@ -668,8 +668,8 @@ union.js = {
       "type":"() => Object",
       "func_details":{"return_type":"Object","params":[]},
       "path":"[LIB] core.js",
-      "line":68,
-      "endline":68,
+      "line":71,
+      "endline":71,
       "start":5,
       "end":21
     }
@@ -682,8 +682,8 @@ object_builtins.js = {
       "type":"(prop: any) => boolean",
       "func_details":{"return_type":"boolean","params":[{"name":"prop","type":"any"}]},
       "path":"[LIB] core.js",
-      "line":63,
-      "endline":63,
+      "line":66,
+      "endline":66,
       "start":5,
       "end":38
     },
@@ -692,8 +692,8 @@ object_builtins.js = {
       "type":"(o: any) => boolean",
       "func_details":{"return_type":"boolean","params":[{"name":"o","type":"any"}]},
       "path":"[LIB] core.js",
-      "line":64,
-      "endline":64,
+      "line":67,
+      "endline":67,
       "start":5,
       "end":34
     },
@@ -702,8 +702,8 @@ object_builtins.js = {
       "type":"(prop: any) => boolean",
       "func_details":{"return_type":"boolean","params":[{"name":"prop","type":"any"}]},
       "path":"[LIB] core.js",
-      "line":65,
-      "endline":65,
+      "line":68,
+      "endline":68,
       "start":5,
       "end":44
     },
@@ -712,8 +712,8 @@ object_builtins.js = {
       "type":"() => string",
       "func_details":{"return_type":"string","params":[]},
       "path":"[LIB] core.js",
-      "line":66,
-      "endline":66,
+      "line":69,
+      "endline":69,
       "start":5,
       "end":28
     },
@@ -722,8 +722,8 @@ object_builtins.js = {
       "type":"() => string",
       "func_details":{"return_type":"string","params":[]},
       "path":"[LIB] core.js",
-      "line":67,
-      "endline":67,
+      "line":70,
+      "endline":70,
       "start":5,
       "end":22
     },
@@ -732,8 +732,8 @@ object_builtins.js = {
       "type":"() => Object",
       "func_details":{"return_type":"Object","params":[]},
       "path":"[LIB] core.js",
-      "line":68,
-      "endline":68,
+      "line":71,
+      "endline":71,
       "start":5,
       "end":21
     }
@@ -749,8 +749,8 @@ function_builtins.js = {
         "params":[{"name":"thisArg","type":"any"},{"name":"argArray?","type":"any"}]
       },
       "path":"[LIB] core.js",
-      "line":107,
-      "endline":107,
+      "line":110,
+      "endline":110,
       "start":18,
       "end":41
     },
@@ -759,8 +759,8 @@ function_builtins.js = {
       "type":"any",
       "func_details":null,
       "path":"[LIB] core.js",
-      "line":111,
-      "endline":111,
+      "line":114,
+      "endline":114,
       "start":16,
       "end":18
     },
@@ -772,8 +772,8 @@ function_builtins.js = {
         "params":[{"name":"thisArg","type":"any"},{"name":"...argArray","type":"Array<any>"}]
       },
       "path":"[LIB] core.js",
-      "line":108,
-      "endline":108,
+      "line":111,
+      "endline":111,
       "start":17,
       "end":39
     },
@@ -785,8 +785,8 @@ function_builtins.js = {
         "params":[{"name":"thisArg","type":"any"},{"name":"...argArray","type":"Array<any>"}]
       },
       "path":"[LIB] core.js",
-      "line":109,
-      "endline":109,
+      "line":112,
+      "endline":112,
       "start":17,
       "end":39
     },
@@ -795,8 +795,8 @@ function_builtins.js = {
       "type":"Function | null",
       "func_details":null,
       "path":"[LIB] core.js",
-      "line":112,
-      "endline":112,
+      "line":115,
+      "endline":115,
       "start":13,
       "end":27
     },
@@ -805,8 +805,8 @@ function_builtins.js = {
       "type":"(prop: any) => boolean",
       "func_details":{"return_type":"boolean","params":[{"name":"prop","type":"any"}]},
       "path":"[LIB] core.js",
-      "line":63,
-      "endline":63,
+      "line":66,
+      "endline":66,
       "start":5,
       "end":38
     },
@@ -815,8 +815,8 @@ function_builtins.js = {
       "type":"(o: any) => boolean",
       "func_details":{"return_type":"boolean","params":[{"name":"o","type":"any"}]},
       "path":"[LIB] core.js",
-      "line":64,
-      "endline":64,
+      "line":67,
+      "endline":67,
       "start":5,
       "end":34
     },
@@ -825,8 +825,8 @@ function_builtins.js = {
       "type":"number",
       "func_details":null,
       "path":"[LIB] core.js",
-      "line":113,
-      "endline":113,
+      "line":116,
+      "endline":116,
       "start":13,
       "end":18
     },
@@ -835,8 +835,8 @@ function_builtins.js = {
       "type":"string",
       "func_details":null,
       "path":"[LIB] core.js",
-      "line":114,
-      "endline":114,
+      "line":117,
+      "endline":117,
       "start":11,
       "end":16
     },
@@ -845,8 +845,8 @@ function_builtins.js = {
       "type":"(prop: any) => boolean",
       "func_details":{"return_type":"boolean","params":[{"name":"prop","type":"any"}]},
       "path":"[LIB] core.js",
-      "line":65,
-      "endline":65,
+      "line":68,
+      "endline":68,
       "start":5,
       "end":44
     },
@@ -855,8 +855,8 @@ function_builtins.js = {
       "type":"() => string",
       "func_details":{"return_type":"string","params":[]},
       "path":"[LIB] core.js",
-      "line":66,
-      "endline":66,
+      "line":69,
+      "endline":69,
       "start":5,
       "end":28
     },
@@ -865,8 +865,8 @@ function_builtins.js = {
       "type":"() => string",
       "func_details":{"return_type":"string","params":[]},
       "path":"[LIB] core.js",
-      "line":67,
-      "endline":67,
+      "line":70,
+      "endline":70,
       "start":5,
       "end":22
     },
@@ -875,8 +875,8 @@ function_builtins.js = {
       "type":"() => Object",
       "func_details":{"return_type":"Object","params":[]},
       "path":"[LIB] core.js",
-      "line":68,
-      "endline":68,
+      "line":71,
+      "endline":71,
       "start":5,
       "end":21
     }
@@ -892,8 +892,8 @@ fun.js = {
         "params":[{"name":"thisArg","type":"any"},{"name":"argArray?","type":"any"}]
       },
       "path":"[LIB] core.js",
-      "line":107,
-      "endline":107,
+      "line":110,
+      "endline":110,
       "start":18,
       "end":41
     },
@@ -902,8 +902,8 @@ fun.js = {
       "type":"any",
       "func_details":null,
       "path":"[LIB] core.js",
-      "line":111,
-      "endline":111,
+      "line":114,
+      "endline":114,
       "start":16,
       "end":18
     },
@@ -915,8 +915,8 @@ fun.js = {
         "params":[{"name":"thisArg","type":"any"},{"name":"...argArray","type":"Array<any>"}]
       },
       "path":"[LIB] core.js",
-      "line":108,
-      "endline":108,
+      "line":111,
+      "endline":111,
       "start":17,
       "end":39
     },
@@ -928,8 +928,8 @@ fun.js = {
         "params":[{"name":"thisArg","type":"any"},{"name":"...argArray","type":"Array<any>"}]
       },
       "path":"[LIB] core.js",
-      "line":109,
-      "endline":109,
+      "line":112,
+      "endline":112,
       "start":17,
       "end":39
     },
@@ -938,8 +938,8 @@ fun.js = {
       "type":"Function | null",
       "func_details":null,
       "path":"[LIB] core.js",
-      "line":112,
-      "endline":112,
+      "line":115,
+      "endline":115,
       "start":13,
       "end":27
     },
@@ -948,8 +948,8 @@ fun.js = {
       "type":"(prop: any) => boolean",
       "func_details":{"return_type":"boolean","params":[{"name":"prop","type":"any"}]},
       "path":"[LIB] core.js",
-      "line":63,
-      "endline":63,
+      "line":66,
+      "endline":66,
       "start":5,
       "end":38
     },
@@ -958,8 +958,8 @@ fun.js = {
       "type":"(o: any) => boolean",
       "func_details":{"return_type":"boolean","params":[{"name":"o","type":"any"}]},
       "path":"[LIB] core.js",
-      "line":64,
-      "endline":64,
+      "line":67,
+      "endline":67,
       "start":5,
       "end":34
     },
@@ -968,8 +968,8 @@ fun.js = {
       "type":"number",
       "func_details":null,
       "path":"[LIB] core.js",
-      "line":113,
-      "endline":113,
+      "line":116,
+      "endline":116,
       "start":13,
       "end":18
     },
@@ -978,8 +978,8 @@ fun.js = {
       "type":"string",
       "func_details":null,
       "path":"[LIB] core.js",
-      "line":114,
-      "endline":114,
+      "line":117,
+      "endline":117,
       "start":11,
       "end":16
     },
@@ -988,8 +988,8 @@ fun.js = {
       "type":"(prop: any) => boolean",
       "func_details":{"return_type":"boolean","params":[{"name":"prop","type":"any"}]},
       "path":"[LIB] core.js",
-      "line":65,
-      "endline":65,
+      "line":68,
+      "endline":68,
       "start":5,
       "end":44
     },
@@ -998,8 +998,8 @@ fun.js = {
       "type":"() => string",
       "func_details":{"return_type":"string","params":[]},
       "path":"[LIB] core.js",
-      "line":66,
-      "endline":66,
+      "line":69,
+      "endline":69,
       "start":5,
       "end":28
     },
@@ -1008,8 +1008,8 @@ fun.js = {
       "type":"() => string",
       "func_details":{"return_type":"string","params":[]},
       "path":"[LIB] core.js",
-      "line":67,
-      "endline":67,
+      "line":70,
+      "endline":70,
       "start":5,
       "end":22
     },
@@ -1018,8 +1018,8 @@ fun.js = {
       "type":"() => Object",
       "func_details":{"return_type":"Object","params":[]},
       "path":"[LIB] core.js",
-      "line":68,
-      "endline":68,
+      "line":71,
+      "endline":71,
       "start":5,
       "end":21
     }
@@ -1066,8 +1066,8 @@ typeparams.js = {
       "type":"(fractionDigits?: number) => string",
       "func_details":{"return_type":"string","params":[{"name":"fractionDigits?","type":"number"}]},
       "path":"[LIB] core.js",
-      "line":141,
-      "endline":141,
+      "line":144,
+      "endline":144,
       "start":5,
       "end":50
     },
@@ -1076,8 +1076,8 @@ typeparams.js = {
       "type":"(fractionDigits?: number) => string",
       "func_details":{"return_type":"string","params":[{"name":"fractionDigits?","type":"number"}]},
       "path":"[LIB] core.js",
-      "line":142,
-      "endline":142,
+      "line":145,
+      "endline":145,
       "start":5,
       "end":44
     },
@@ -1092,8 +1092,8 @@ typeparams.js = {
         ]
       },
       "path":"[LIB] core.js",
-      "line":143,
-      "endline":143,
+      "line":146,
+      "endline":146,
       "start":5,
       "end":96
     },
@@ -1102,8 +1102,8 @@ typeparams.js = {
       "type":"(precision?: number) => string",
       "func_details":{"return_type":"string","params":[{"name":"precision?","type":"number"}]},
       "path":"[LIB] core.js",
-      "line":144,
-      "endline":144,
+      "line":147,
+      "endline":147,
       "start":5,
       "end":43
     },
@@ -1112,8 +1112,8 @@ typeparams.js = {
       "type":"(radix?: number) => string",
       "func_details":{"return_type":"string","params":[{"name":"radix?","type":"number"}]},
       "path":"[LIB] core.js",
-      "line":145,
-      "endline":145,
+      "line":148,
+      "endline":148,
       "start":5,
       "end":36
     },
@@ -1122,8 +1122,8 @@ typeparams.js = {
       "type":"() => number",
       "func_details":{"return_type":"number","params":[]},
       "path":"[LIB] core.js",
-      "line":146,
-      "endline":146,
+      "line":149,
+      "endline":149,
       "start":5,
       "end":21
     }
@@ -1146,8 +1146,8 @@ generics.js = {
       "type":"(prop: any) => boolean",
       "func_details":{"return_type":"boolean","params":[{"name":"prop","type":"any"}]},
       "path":"[LIB] core.js",
-      "line":63,
-      "endline":63,
+      "line":66,
+      "endline":66,
       "start":5,
       "end":38
     },
@@ -1156,8 +1156,8 @@ generics.js = {
       "type":"(o: any) => boolean",
       "func_details":{"return_type":"boolean","params":[{"name":"o","type":"any"}]},
       "path":"[LIB] core.js",
-      "line":64,
-      "endline":64,
+      "line":67,
+      "endline":67,
       "start":5,
       "end":34
     },
@@ -1166,8 +1166,8 @@ generics.js = {
       "type":"(prop: any) => boolean",
       "func_details":{"return_type":"boolean","params":[{"name":"prop","type":"any"}]},
       "path":"[LIB] core.js",
-      "line":65,
-      "endline":65,
+      "line":68,
+      "endline":68,
       "start":5,
       "end":44
     },
@@ -1176,8 +1176,8 @@ generics.js = {
       "type":"() => string",
       "func_details":{"return_type":"string","params":[]},
       "path":"[LIB] core.js",
-      "line":66,
-      "endline":66,
+      "line":69,
+      "endline":69,
       "start":5,
       "end":28
     },
@@ -1186,8 +1186,8 @@ generics.js = {
       "type":"() => string",
       "func_details":{"return_type":"string","params":[]},
       "path":"[LIB] core.js",
-      "line":67,
-      "endline":67,
+      "line":70,
+      "endline":70,
       "start":5,
       "end":22
     },
@@ -1196,8 +1196,8 @@ generics.js = {
       "type":"() => Object",
       "func_details":{"return_type":"Object","params":[]},
       "path":"[LIB] core.js",
-      "line":68,
-      "endline":68,
+      "line":71,
+      "endline":71,
       "start":5,
       "end":21
     }
@@ -1220,8 +1220,8 @@ optional.js = {
       "type":"(prop: any) => boolean",
       "func_details":{"return_type":"boolean","params":[{"name":"prop","type":"any"}]},
       "path":"[LIB] core.js",
-      "line":63,
-      "endline":63,
+      "line":66,
+      "endline":66,
       "start":5,
       "end":38
     },
@@ -1230,8 +1230,8 @@ optional.js = {
       "type":"(o: any) => boolean",
       "func_details":{"return_type":"boolean","params":[{"name":"o","type":"any"}]},
       "path":"[LIB] core.js",
-      "line":64,
-      "endline":64,
+      "line":67,
+      "endline":67,
       "start":5,
       "end":34
     },
@@ -1250,8 +1250,8 @@ optional.js = {
       "type":"(prop: any) => boolean",
       "func_details":{"return_type":"boolean","params":[{"name":"prop","type":"any"}]},
       "path":"[LIB] core.js",
-      "line":65,
-      "endline":65,
+      "line":68,
+      "endline":68,
       "start":5,
       "end":44
     },
@@ -1260,8 +1260,8 @@ optional.js = {
       "type":"() => string",
       "func_details":{"return_type":"string","params":[]},
       "path":"[LIB] core.js",
-      "line":66,
-      "endline":66,
+      "line":69,
+      "endline":69,
       "start":5,
       "end":28
     },
@@ -1270,8 +1270,8 @@ optional.js = {
       "type":"() => string",
       "func_details":{"return_type":"string","params":[]},
       "path":"[LIB] core.js",
-      "line":67,
-      "endline":67,
+      "line":70,
+      "endline":70,
       "start":5,
       "end":22
     },
@@ -1280,8 +1280,8 @@ optional.js = {
       "type":"() => Object",
       "func_details":{"return_type":"Object","params":[]},
       "path":"[LIB] core.js",
-      "line":68,
-      "endline":68,
+      "line":71,
+      "endline":71,
       "start":5,
       "end":21
     },
@@ -1304,8 +1304,8 @@ jsx1.js = {
       "type":"(prop: any) => boolean",
       "func_details":{"return_type":"boolean","params":[{"name":"prop","type":"any"}]},
       "path":"[LIB] core.js",
-      "line":63,
-      "endline":63,
+      "line":66,
+      "endline":66,
       "start":5,
       "end":38
     },
@@ -1314,8 +1314,8 @@ jsx1.js = {
       "type":"(o: any) => boolean",
       "func_details":{"return_type":"boolean","params":[{"name":"o","type":"any"}]},
       "path":"[LIB] core.js",
-      "line":64,
-      "endline":64,
+      "line":67,
+      "endline":67,
       "start":5,
       "end":34
     },
@@ -1324,8 +1324,8 @@ jsx1.js = {
       "type":"(prop: any) => boolean",
       "func_details":{"return_type":"boolean","params":[{"name":"prop","type":"any"}]},
       "path":"[LIB] core.js",
-      "line":65,
-      "endline":65,
+      "line":68,
+      "endline":68,
       "start":5,
       "end":44
     },
@@ -1334,8 +1334,8 @@ jsx1.js = {
       "type":"() => string",
       "func_details":{"return_type":"string","params":[]},
       "path":"[LIB] core.js",
-      "line":66,
-      "endline":66,
+      "line":69,
+      "endline":69,
       "start":5,
       "end":28
     },
@@ -1344,8 +1344,8 @@ jsx1.js = {
       "type":"() => string",
       "func_details":{"return_type":"string","params":[]},
       "path":"[LIB] core.js",
-      "line":67,
-      "endline":67,
+      "line":70,
+      "endline":70,
       "start":5,
       "end":22
     },
@@ -1354,8 +1354,8 @@ jsx1.js = {
       "type":"() => Object",
       "func_details":{"return_type":"Object","params":[]},
       "path":"[LIB] core.js",
-      "line":68,
-      "endline":68,
+      "line":71,
+      "endline":71,
       "start":5,
       "end":21
     },
@@ -1378,8 +1378,8 @@ jsx2.js = {
       "type":"(prop: any) => boolean",
       "func_details":{"return_type":"boolean","params":[{"name":"prop","type":"any"}]},
       "path":"[LIB] core.js",
-      "line":63,
-      "endline":63,
+      "line":66,
+      "endline":66,
       "start":5,
       "end":38
     },
@@ -1388,8 +1388,8 @@ jsx2.js = {
       "type":"(o: any) => boolean",
       "func_details":{"return_type":"boolean","params":[{"name":"o","type":"any"}]},
       "path":"[LIB] core.js",
-      "line":64,
-      "endline":64,
+      "line":67,
+      "endline":67,
       "start":5,
       "end":34
     },
@@ -1398,8 +1398,8 @@ jsx2.js = {
       "type":"(prop: any) => boolean",
       "func_details":{"return_type":"boolean","params":[{"name":"prop","type":"any"}]},
       "path":"[LIB] core.js",
-      "line":65,
-      "endline":65,
+      "line":68,
+      "endline":68,
       "start":5,
       "end":44
     },
@@ -1408,8 +1408,8 @@ jsx2.js = {
       "type":"() => string",
       "func_details":{"return_type":"string","params":[]},
       "path":"[LIB] core.js",
-      "line":66,
-      "endline":66,
+      "line":69,
+      "endline":69,
       "start":5,
       "end":28
     },
@@ -1418,8 +1418,8 @@ jsx2.js = {
       "type":"() => string",
       "func_details":{"return_type":"string","params":[]},
       "path":"[LIB] core.js",
-      "line":67,
-      "endline":67,
+      "line":70,
+      "endline":70,
       "start":5,
       "end":22
     },
@@ -1428,8 +1428,8 @@ jsx2.js = {
       "type":"() => Object",
       "func_details":{"return_type":"Object","params":[]},
       "path":"[LIB] core.js",
-      "line":68,
-      "endline":68,
+      "line":71,
+      "endline":71,
       "start":5,
       "end":21
     },
@@ -1549,8 +1549,8 @@ if.js = {
       "type":"() => Iterator<string>",
       "func_details":{"return_type":"Iterator<string>","params":[]},
       "path":"[LIB] core.js",
-      "line":289,
-      "endline":289,
+      "line":292,
+      "endline":292,
       "start":5,
       "end":34
     },
@@ -1559,8 +1559,8 @@ if.js = {
       "type":"(name: string) => string",
       "func_details":{"return_type":"string","params":[{"name":"name","type":"string"}]},
       "path":"[LIB] core.js",
-      "line":290,
-      "endline":290,
+      "line":293,
+      "endline":293,
       "start":5,
       "end":32
     },
@@ -1569,8 +1569,8 @@ if.js = {
       "type":"(pos: number) => string",
       "func_details":{"return_type":"string","params":[{"name":"pos","type":"number"}]},
       "path":"[LIB] core.js",
-      "line":291,
-      "endline":291,
+      "line":294,
+      "endline":294,
       "start":5,
       "end":31
     },
@@ -1579,8 +1579,8 @@ if.js = {
       "type":"(index: number) => number",
       "func_details":{"return_type":"number","params":[{"name":"index","type":"number"}]},
       "path":"[LIB] core.js",
-      "line":292,
-      "endline":292,
+      "line":295,
+      "endline":295,
       "start":5,
       "end":37
     },
@@ -1589,8 +1589,8 @@ if.js = {
       "type":"(index: number) => number",
       "func_details":{"return_type":"number","params":[{"name":"index","type":"number"}]},
       "path":"[LIB] core.js",
-      "line":293,
-      "endline":293,
+      "line":296,
+      "endline":296,
       "start":5,
       "end":38
     },
@@ -1602,8 +1602,8 @@ if.js = {
         "params":[{"name":"...strings","type":"Array<string>"}]
       },
       "path":"[LIB] core.js",
-      "line":294,
-      "endline":294,
+      "line":297,
+      "endline":297,
       "start":5,
       "end":45
     },
@@ -1615,8 +1615,8 @@ if.js = {
         "params":[{"name":"searchString","type":"string"},{"name":"position?","type":"number"}]
       },
       "path":"[LIB] core.js",
-      "line":296,
-      "endline":296,
+      "line":299,
+      "endline":299,
       "start":5,
       "end":62
     },
@@ -1628,8 +1628,8 @@ if.js = {
         "params":[{"name":"searchString","type":"string"},{"name":"position?","type":"number"}]
       },
       "path":"[LIB] core.js",
-      "line":297,
-      "endline":297,
+      "line":300,
+      "endline":300,
       "start":5,
       "end":62
     },
@@ -1641,8 +1641,8 @@ if.js = {
         "params":[{"name":"searchString","type":"string"},{"name":"position?","type":"number"}]
       },
       "path":"[LIB] core.js",
-      "line":298,
-      "endline":298,
+      "line":301,
+      "endline":301,
       "start":5,
       "end":60
     },
@@ -1654,8 +1654,8 @@ if.js = {
         "params":[{"name":"searchString","type":"string"},{"name":"position?","type":"number"}]
       },
       "path":"[LIB] core.js",
-      "line":299,
-      "endline":299,
+      "line":302,
+      "endline":302,
       "start":5,
       "end":64
     },
@@ -1664,8 +1664,8 @@ if.js = {
       "type":"number",
       "func_details":null,
       "path":"[LIB] core.js",
-      "line":323,
-      "endline":323,
+      "line":326,
+      "endline":326,
       "start":13,
       "end":18
     },
@@ -1674,8 +1674,8 @@ if.js = {
       "type":"(href: string) => string",
       "func_details":{"return_type":"string","params":[{"name":"href","type":"string"}]},
       "path":"[LIB] core.js",
-      "line":300,
-      "endline":300,
+      "line":303,
+      "endline":303,
       "start":5,
       "end":30
     },
@@ -1691,8 +1691,8 @@ if.js = {
         ]
       },
       "path":"[LIB] core.js",
-      "line":301,
-      "endline":301,
+      "line":304,
+      "endline":304,
       "start":5,
       "end":105
     },
@@ -1704,8 +1704,8 @@ if.js = {
         "params":[{"name":"regexp","type":"string | RegExp"}]
       },
       "path":"[LIB] core.js",
-      "line":302,
-      "endline":302,
+      "line":305,
+      "endline":305,
       "start":5,
       "end":50
     },
@@ -1714,8 +1714,8 @@ if.js = {
       "type":"(format?: string) => string",
       "func_details":{"return_type":"string","params":[{"name":"format?","type":"string"}]},
       "path":"[LIB] core.js",
-      "line":303,
-      "endline":303,
+      "line":306,
+      "endline":306,
       "start":5,
       "end":38
     },
@@ -1727,8 +1727,8 @@ if.js = {
         "params":[{"name":"targetLength","type":"number"},{"name":"padString?","type":"string"}]
       },
       "path":"[LIB] core.js",
-      "line":304,
-      "endline":304,
+      "line":307,
+      "endline":307,
       "start":5,
       "end":60
     },
@@ -1740,8 +1740,8 @@ if.js = {
         "params":[{"name":"targetLength","type":"number"},{"name":"padString?","type":"string"}]
       },
       "path":"[LIB] core.js",
-      "line":305,
-      "endline":305,
+      "line":308,
+      "endline":308,
       "start":5,
       "end":62
     },
@@ -1750,8 +1750,8 @@ if.js = {
       "type":"(count: number) => string",
       "func_details":{"return_type":"string","params":[{"name":"count","type":"number"}]},
       "path":"[LIB] core.js",
-      "line":306,
-      "endline":306,
+      "line":309,
+      "endline":309,
       "start":5,
       "end":33
     },
@@ -1769,8 +1769,8 @@ if.js = {
         ]
       },
       "path":"[LIB] core.js",
-      "line":307,
-      "endline":307,
+      "line":310,
+      "endline":310,
       "start":5,
       "end":124
     },
@@ -1779,8 +1779,8 @@ if.js = {
       "type":"(regexp: (string | RegExp)) => number",
       "func_details":{"return_type":"number","params":[{"name":"regexp","type":"string | RegExp"}]},
       "path":"[LIB] core.js",
-      "line":308,
-      "endline":308,
+      "line":311,
+      "endline":311,
       "start":5,
       "end":43
     },
@@ -1792,8 +1792,8 @@ if.js = {
         "params":[{"name":"start?","type":"number"},{"name":"end?","type":"number"}]
       },
       "path":"[LIB] core.js",
-      "line":309,
-      "endline":309,
+      "line":312,
+      "endline":312,
       "start":5,
       "end":47
     },
@@ -1808,8 +1808,8 @@ if.js = {
         ]
       },
       "path":"[LIB] core.js",
-      "line":310,
-      "endline":310,
+      "line":313,
+      "endline":313,
       "start":5,
       "end":69
     },
@@ -1821,8 +1821,8 @@ if.js = {
         "params":[{"name":"searchString","type":"string"},{"name":"position?","type":"number"}]
       },
       "path":"[LIB] core.js",
-      "line":311,
-      "endline":311,
+      "line":314,
+      "endline":314,
       "start":5,
       "end":64
     },
@@ -1834,8 +1834,8 @@ if.js = {
         "params":[{"name":"from","type":"number"},{"name":"length?","type":"number"}]
       },
       "path":"[LIB] core.js",
-      "line":312,
-      "endline":312,
+      "line":315,
+      "endline":315,
       "start":5,
       "end":49
     },
@@ -1847,8 +1847,8 @@ if.js = {
         "params":[{"name":"start","type":"number"},{"name":"end?","type":"number"}]
       },
       "path":"[LIB] core.js",
-      "line":313,
-      "endline":313,
+      "line":316,
+      "endline":316,
       "start":5,
       "end":50
     },
@@ -1857,8 +1857,8 @@ if.js = {
       "type":"() => string",
       "func_details":{"return_type":"string","params":[]},
       "path":"[LIB] core.js",
-      "line":314,
-      "endline":314,
+      "line":317,
+      "endline":317,
       "start":5,
       "end":31
     },
@@ -1867,8 +1867,8 @@ if.js = {
       "type":"() => string",
       "func_details":{"return_type":"string","params":[]},
       "path":"[LIB] core.js",
-      "line":315,
-      "endline":315,
+      "line":318,
+      "endline":318,
       "start":5,
       "end":31
     },
@@ -1877,13 +1877,43 @@ if.js = {
       "type":"() => string",
       "func_details":{"return_type":"string","params":[]},
       "path":"[LIB] core.js",
-      "line":316,
-      "endline":316,
+      "line":319,
+      "endline":319,
       "start":5,
       "end":25
     },
     {
       "name":"toString",
+      "type":"() => string",
+      "func_details":{"return_type":"string","params":[]},
+      "path":"[LIB] core.js",
+      "line":325,
+      "endline":325,
+      "start":5,
+      "end":22
+    },
+    {
+      "name":"toUpperCase",
+      "type":"() => string",
+      "func_details":{"return_type":"string","params":[]},
+      "path":"[LIB] core.js",
+      "line":320,
+      "endline":320,
+      "start":5,
+      "end":25
+    },
+    {
+      "name":"trim",
+      "type":"() => string",
+      "func_details":{"return_type":"string","params":[]},
+      "path":"[LIB] core.js",
+      "line":321,
+      "endline":321,
+      "start":5,
+      "end":18
+    },
+    {
+      "name":"trimLeft",
       "type":"() => string",
       "func_details":{"return_type":"string","params":[]},
       "path":"[LIB] core.js",
@@ -1893,42 +1923,12 @@ if.js = {
       "end":22
     },
     {
-      "name":"toUpperCase",
-      "type":"() => string",
-      "func_details":{"return_type":"string","params":[]},
-      "path":"[LIB] core.js",
-      "line":317,
-      "endline":317,
-      "start":5,
-      "end":25
-    },
-    {
-      "name":"trim",
-      "type":"() => string",
-      "func_details":{"return_type":"string","params":[]},
-      "path":"[LIB] core.js",
-      "line":318,
-      "endline":318,
-      "start":5,
-      "end":18
-    },
-    {
-      "name":"trimLeft",
-      "type":"() => string",
-      "func_details":{"return_type":"string","params":[]},
-      "path":"[LIB] core.js",
-      "line":319,
-      "endline":319,
-      "start":5,
-      "end":22
-    },
-    {
       "name":"trimRight",
       "type":"() => string",
       "func_details":{"return_type":"string","params":[]},
       "path":"[LIB] core.js",
-      "line":320,
-      "endline":320,
+      "line":323,
+      "endline":323,
       "start":5,
       "end":23
     },
@@ -1937,8 +1937,8 @@ if.js = {
       "type":"() => string",
       "func_details":{"return_type":"string","params":[]},
       "path":"[LIB] core.js",
-      "line":321,
-      "endline":321,
+      "line":324,
+      "endline":324,
       "start":5,
       "end":21
     }
@@ -1995,8 +1995,8 @@ class.js = {
       "type":"(prop: any) => boolean",
       "func_details":{"return_type":"boolean","params":[{"name":"prop","type":"any"}]},
       "path":"[LIB] core.js",
-      "line":63,
-      "endline":63,
+      "line":66,
+      "endline":66,
       "start":5,
       "end":38
     },
@@ -2005,8 +2005,8 @@ class.js = {
       "type":"(o: any) => boolean",
       "func_details":{"return_type":"boolean","params":[{"name":"o","type":"any"}]},
       "path":"[LIB] core.js",
-      "line":64,
-      "endline":64,
+      "line":67,
+      "endline":67,
       "start":5,
       "end":34
     },
@@ -2025,8 +2025,8 @@ class.js = {
       "type":"(prop: any) => boolean",
       "func_details":{"return_type":"boolean","params":[{"name":"prop","type":"any"}]},
       "path":"[LIB] core.js",
-      "line":65,
-      "endline":65,
+      "line":68,
+      "endline":68,
       "start":5,
       "end":44
     },
@@ -2035,8 +2035,8 @@ class.js = {
       "type":"() => string",
       "func_details":{"return_type":"string","params":[]},
       "path":"[LIB] core.js",
-      "line":66,
-      "endline":66,
+      "line":69,
+      "endline":69,
       "start":5,
       "end":28
     },
@@ -2045,8 +2045,8 @@ class.js = {
       "type":"() => string",
       "func_details":{"return_type":"string","params":[]},
       "path":"[LIB] core.js",
-      "line":67,
-      "endline":67,
+      "line":70,
+      "endline":70,
       "start":5,
       "end":22
     },
@@ -2055,8 +2055,8 @@ class.js = {
       "type":"() => Object",
       "func_details":{"return_type":"Object","params":[]},
       "path":"[LIB] core.js",
-      "line":68,
-      "endline":68,
+      "line":71,
+      "endline":71,
       "start":5,
       "end":21
     }

--- a/tests/compose/compose.exp
+++ b/tests/compose/compose.exp
@@ -7,8 +7,8 @@ Cannot cast `compose(...)(...)` to empty because string [1] is incompatible with
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:145:31
-   145|     toString(radix?: number): string;
+   <BUILTINS>/core.js:148:31
+   148|     toString(radix?: number): string;
                                       ^^^^^^ [1]
    basic.js:6:34
      6| (compose(n => n.toString())(42): empty); // Error: string ~> empty
@@ -24,8 +24,8 @@ Cannot cast `composeReverse(...)(...)` to empty because string [1] is incompatib
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:145:31
-   145|     toString(radix?: number): string;
+   <BUILTINS>/core.js:148:31
+   148|     toString(radix?: number): string;
                                       ^^^^^^ [1]
    basic.js:8:41
      8| (composeReverse(n => n.toString())(42): empty); // Error: string ~> empty
@@ -62,8 +62,8 @@ Cannot perform arithmetic operation because string [1] is not a number.
                ^
 
 References:
-   <BUILTINS>/core.js:145:31
-   145|     toString(radix?: number): string;
+   <BUILTINS>/core.js:148:31
+   148|     toString(radix?: number): string;
                                       ^^^^^^ [1]
 
 
@@ -80,8 +80,8 @@ Cannot cast `composeReverse(...)(...)` to empty because string [1] is incompatib
         ----^
 
 References:
-   <BUILTINS>/core.js:145:31
-   145|     toString(radix?: number): string;
+   <BUILTINS>/core.js:148:31
+   148|     toString(radix?: number): string;
                                       ^^^^^^ [1]
    basic.js:18:8
     18| )(42): empty); // Error: string ~> empty
@@ -100,8 +100,8 @@ References:
    recompose.js:20:8
     20|     p: `${props.p * 3}`,
                ^^^^^^^^^^^^^^^^ [1]
-   <BUILTINS>/core.js:185:14
-   185|     round(x: number): number;
+   <BUILTINS>/core.js:188:14
+   188|     round(x: number): number;
                      ^^^^^^ [2]
 
 

--- a/tests/computed_props/computed_props.exp
+++ b/tests/computed_props/computed_props.exp
@@ -114,8 +114,8 @@ Cannot assign `arr[0]()` to `y` because number [1] is incompatible with string [
                         ^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:276:13
-   276|     length: number;
+   <BUILTINS>/core.js:279:13
+   279|     length: number;
                     ^^^^^^ [1]
    test7.js:5:8
      5| var y: string = arr[0](); // error: number ~> string

--- a/tests/core_tests/core_tests.exp
+++ b/tests/core_tests/core_tests.exp
@@ -14,11 +14,11 @@ References:
    map.js:23:22
     23|     let x = new Map(['foo', 123]); // error
                              ^^^^^ [1]
-   <BUILTINS>/core.js:527:37
-   527|     constructor(iterable: ?Iterable<[K, V]>): void;
+   <BUILTINS>/core.js:530:37
+   530|     constructor(iterable: ?Iterable<[K, V]>): void;
                                             ^^^^^^ [2]
-   <BUILTINS>/core.js:481:22
-   481| interface $Iterator<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:484:22
+   484| interface $Iterator<+Yield,+Return,-Next> {
                              ^^^^^ [3]
    map.js:23:29
     23|     let x = new Map(['foo', 123]); // error
@@ -42,8 +42,8 @@ References:
    map.js:24:16
     24|     let y: Map<number, string> = new Map([['foo', 123]]); // error
                        ^^^^^^ [2]
-   <BUILTINS>/core.js:525:19
-   525| declare class Map<K, V> {
+   <BUILTINS>/core.js:528:19
+   528| declare class Map<K, V> {
                           ^ [3]
    map.js:24:51
     24|     let y: Map<number, string> = new Map([['foo', 123]]); // error
@@ -51,8 +51,8 @@ References:
    map.js:24:24
     24|     let y: Map<number, string> = new Map([['foo', 123]]); // error
                                ^^^^^^ [5]
-   <BUILTINS>/core.js:525:22
-   525| declare class Map<K, V> {
+   <BUILTINS>/core.js:528:22
+   528| declare class Map<K, V> {
                              ^ [6]
 
 
@@ -67,8 +67,8 @@ Cannot cast `x.get(...)` to boolean because:
              ^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:532:22
-   532|     get(key: K): V | void;
+   <BUILTINS>/core.js:535:22
+   535|     get(key: K): V | void;
                              ^^^^ [1]
    map.js:29:20
     29|     (x.get('foo'): boolean); // error, string | void
@@ -102,8 +102,8 @@ since `z` is not a member of the set.
                           ^^^ [1]
 
 References:
-   <BUILTINS>/core.js:331:21
-   331| type RegExp$flags = $CharSet<"gimsuy">
+   <BUILTINS>/core.js:334:21
+   334| type RegExp$flags = $CharSet<"gimsuy">
                             ^^^^^^^^^^^^^^^^^^ [2]
 
 
@@ -117,8 +117,8 @@ since `z` is not a member of the set.
                               ^^^ [1]
 
 References:
-   <BUILTINS>/core.js:331:21
-   331| type RegExp$flags = $CharSet<"gimsuy">
+   <BUILTINS>/core.js:334:21
+   334| type RegExp$flags = $CharSet<"gimsuy">
                             ^^^^^^^^^^^^^^^^^^ [2]
 
 
@@ -140,11 +140,11 @@ References:
    weakset.js:19:24
     19| let ws3 = new WeakSet([1, 2, 3]); // error, must be objects
                                ^ [1]
-   <BUILTINS>/core.js:565:26
-   565| declare class WeakSet<T: Object> {
+   <BUILTINS>/core.js:568:26
+   568| declare class WeakSet<T: Object> {
                                  ^^^^^^ [2]
-   <BUILTINS>/core.js:481:22
-   481| interface $Iterator<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:484:22
+   484| interface $Iterator<+Yield,+Return,-Next> {
                              ^^^^^ [3]
    weakset.js:19:27
     19| let ws3 = new WeakSet([1, 2, 3]); // error, must be objects
@@ -167,11 +167,11 @@ References:
    weakset.js:29:31
     29| function* numbers(): Iterable<number> {
                                       ^^^^^^ [1]
-   <BUILTINS>/core.js:565:26
-   565| declare class WeakSet<T: Object> {
+   <BUILTINS>/core.js:568:26
+   568| declare class WeakSet<T: Object> {
                                  ^^^^^^ [2]
-   <BUILTINS>/core.js:487:22
-   487| interface $Iterable<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:490:22
+   490| interface $Iterable<+Yield,+Return,-Next> {
                              ^^^^^ [3]
 
 

--- a/tests/date/date.exp
+++ b/tests/date/date.exp
@@ -7,8 +7,8 @@ Cannot assign `d.getTime()` to `x` because number [1] is incompatible with strin
                        ^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:363:16
-   363|     getTime(): number;
+   <BUILTINS>/core.js:366:16
+   366|     getTime(): number;
                        ^^^^^^ [1]
    date.js:2:7
      2| var x:string = d.getTime();
@@ -30,14 +30,14 @@ References:
    date.js:18:10
     18| new Date({});
                  ^^ [1]
-   <BUILTINS>/core.js:352:28
-   352|     constructor(timestamp: number): void;
+   <BUILTINS>/core.js:355:28
+   355|     constructor(timestamp: number): void;
                                    ^^^^^^ [2]
-   <BUILTINS>/core.js:353:29
-   353|     constructor(dateString: string): void;
+   <BUILTINS>/core.js:356:29
+   356|     constructor(dateString: string): void;
                                     ^^^^^^ [3]
-   <BUILTINS>/core.js:354:23
-   354|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
+   <BUILTINS>/core.js:357:23
+   357|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
                               ^^^^^^ [4]
 
 
@@ -53,8 +53,8 @@ References:
    date.js:19:16
     19| new Date(2015, '6');
                        ^^^ [1]
-   <BUILTINS>/core.js:354:38
-   354|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
+   <BUILTINS>/core.js:357:38
+   357|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
                                              ^^^^^^ [2]
 
 
@@ -70,8 +70,8 @@ References:
    date.js:20:19
     20| new Date(2015, 6, '18');
                           ^^^^ [1]
-   <BUILTINS>/core.js:354:52
-   354|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
+   <BUILTINS>/core.js:357:52
+   357|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
                                                            ^^^^^^ [2]
 
 
@@ -87,8 +87,8 @@ References:
    date.js:21:23
     21| new Date(2015, 6, 18, '11');
                               ^^^^ [1]
-   <BUILTINS>/core.js:354:67
-   354|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
+   <BUILTINS>/core.js:357:67
+   357|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
                                                                           ^^^^^^ [2]
 
 
@@ -104,8 +104,8 @@ References:
    date.js:22:27
     22| new Date(2015, 6, 18, 11, '55');
                                   ^^^^ [1]
-   <BUILTINS>/core.js:354:84
-   354|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
+   <BUILTINS>/core.js:357:84
+   357|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
                                                                                            ^^^^^^ [2]
 
 
@@ -121,8 +121,8 @@ References:
    date.js:23:31
     23| new Date(2015, 6, 18, 11, 55, '42');
                                       ^^^^ [1]
-   <BUILTINS>/core.js:354:101
-   354|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
+   <BUILTINS>/core.js:357:101
+   357|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
                                                                                                             ^^^^^^ [2]
 
 
@@ -138,8 +138,8 @@ References:
    date.js:24:35
     24| new Date(2015, 6, 18, 11, 55, 42, '999');
                                           ^^^^^ [1]
-   <BUILTINS>/core.js:354:123
-   354|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
+   <BUILTINS>/core.js:357:123
+   357|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
                                                                                                                                   ^^^^^^ [2]
 
 
@@ -156,17 +156,17 @@ Cannot call `Date` because:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:351:5
-   351|     constructor(): void;
-            ^^^^^^^^^^^^^^^^^^^ [1]
-   <BUILTINS>/core.js:352:5
-   352|     constructor(timestamp: number): void;
-            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [2]
-   <BUILTINS>/core.js:353:5
-   353|     constructor(dateString: string): void;
-            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [3]
    <BUILTINS>/core.js:354:5
-   354|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
+   354|     constructor(): void;
+            ^^^^^^^^^^^^^^^^^^^ [1]
+   <BUILTINS>/core.js:355:5
+   355|     constructor(timestamp: number): void;
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [2]
+   <BUILTINS>/core.js:356:5
+   356|     constructor(dateString: string): void;
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [3]
+   <BUILTINS>/core.js:357:5
+   357|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [4]
 
 
@@ -182,8 +182,8 @@ References:
    date.js:26:10
     26| new Date('2015', 6);
                  ^^^^^^ [1]
-   <BUILTINS>/core.js:354:23
-   354|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
+   <BUILTINS>/core.js:357:23
+   357|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
                               ^^^^^^ [2]
 
 

--- a/tests/dictionary/dictionary.exp
+++ b/tests/dictionary/dictionary.exp
@@ -69,8 +69,8 @@ Cannot cast `o.toString()` to boolean because string [1] is incompatible with bo
           ^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:67:17
-   67|     toString(): string;
+   <BUILTINS>/core.js:70:17
+   70|     toString(): string;
                        ^^^^^^ [1]
    dictionary.js:94:18
    94|   (o.toString(): boolean); // error: string ~> boolean

--- a/tests/fetch/fetch.exp
+++ b/tests/fetch/fetch.exp
@@ -13,8 +13,8 @@ References:
    fetch.js:12:18
      12| const b: Promise<string> = fetch(myRequest); // incorrect
                           ^^^^^^ [2]
-   <BUILTINS>/core.js:576:24
-    576| declare class Promise<+R> {
+   <BUILTINS>/core.js:579:24
+    579| declare class Promise<+R> {
                                 ^ [3]
 
 
@@ -33,8 +33,8 @@ References:
    <BUILTINS>/bom.js:1016:76
    1016| declare function fetch(input: RequestInfo, init?: RequestOptions): Promise<Response>;
                                                                                     ^^^^^^^^ [2]
-   <BUILTINS>/core.js:576:24
-    576| declare class Promise<+R> {
+   <BUILTINS>/core.js:579:24
+    579| declare class Promise<+R> {
                                 ^ [3]
 
 
@@ -500,11 +500,11 @@ References:
    <BUILTINS>/bom.js:938:62
    938| type BodyInit = string | URLSearchParams | FormData | Blob | ArrayBuffer | $ArrayBufferView;
                                                                      ^^^^^^^^^^^ [5]
-   <BUILTINS>/core.js:621:25
-   621| type $ArrayBufferView = $TypedArray | DataView;
+   <BUILTINS>/core.js:624:25
+   624| type $ArrayBufferView = $TypedArray | DataView;
                                 ^^^^^^^^^^^ [6]
-   <BUILTINS>/core.js:621:39
-   621| type $ArrayBufferView = $TypedArray | DataView;
+   <BUILTINS>/core.js:624:39
+   624| type $ArrayBufferView = $TypedArray | DataView;
                                               ^^^^^^^^ [7]
 
 

--- a/tests/forof/forof.exp
+++ b/tests/forof/forof.exp
@@ -41,8 +41,8 @@ Cannot cast `x` to number because string [1] is incompatible with number [2].
              ^
 
 References:
-   <BUILTINS>/core.js:289:28
-   289|     @@iterator(): Iterator<string>;
+   <BUILTINS>/core.js:292:28
+   292|     @@iterator(): Iterator<string>;
                                    ^^^^^^ [1]
    forof.js:25:9
     25|     (x: number); // Error - string ~> number
@@ -58,8 +58,8 @@ Cannot cast `elem` to number because tuple type [1] is incompatible with number 
              ^^^^
 
 References:
-   <BUILTINS>/core.js:526:28
-   526|     @@iterator(): Iterator<[K, V]>;
+   <BUILTINS>/core.js:529:28
+   529|     @@iterator(): Iterator<[K, V]>;
                                    ^^^^^^ [1]
    forof.js:32:12
     32|     (elem: number); // Error - tuple ~> number
@@ -75,8 +75,8 @@ Cannot cast `elem` to number because tuple type [1] is incompatible with number 
              ^^^^
 
 References:
-   <BUILTINS>/core.js:526:28
-   526|     @@iterator(): Iterator<[K, V]>;
+   <BUILTINS>/core.js:529:28
+   529|     @@iterator(): Iterator<[K, V]>;
                                    ^^^^^^ [1]
    forof.js:39:12
     39|     (elem: number); // Error - tuple ~> number

--- a/tests/function/function.exp
+++ b/tests/function/function.exp
@@ -100,8 +100,8 @@ Cannot call `test.apply` because string [1] is incompatible with number [2].
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:289:28
-   289|     @@iterator(): Iterator<string>;
+   <BUILTINS>/core.js:292:28
+   292|     @@iterator(): Iterator<string>;
                                    ^^^^^^ [1]
    apply.js:1:29
      1| function test(a: string, b: number): number {
@@ -496,8 +496,8 @@ Cannot cast `x.length` to undefined because number [1] is incompatible with unde
              ^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:113:13
-   113|     length: number;
+   <BUILTINS>/core.js:116:13
+   116|     length: number;
                     ^^^^^^ [1]
    function.js:37:16
     37|     (x.length: void); // error, it's a number
@@ -513,8 +513,8 @@ Cannot cast `y.length` to undefined because number [1] is incompatible with unde
              ^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:113:13
-   113|     length: number;
+   <BUILTINS>/core.js:116:13
+   116|     length: number;
                     ^^^^^^ [1]
    function.js:38:16
     38|     (y.length: void); // error, it's a number
@@ -530,8 +530,8 @@ Cannot cast `z.length` to undefined because number [1] is incompatible with unde
              ^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:113:13
-   113|     length: number;
+   <BUILTINS>/core.js:116:13
+   116|     length: number;
                     ^^^^^^ [1]
    function.js:39:16
     39|     (z.length: void); // error, it's a number
@@ -547,8 +547,8 @@ Cannot cast `x.name` to undefined because string [1] is incompatible with undefi
              ^^^^^^
 
 References:
-   <BUILTINS>/core.js:114:11
-   114|     name: string;
+   <BUILTINS>/core.js:117:11
+   117|     name: string;
                   ^^^^^^ [1]
    function.js:41:14
     41|     (x.name: void); // error, it's a string
@@ -564,8 +564,8 @@ Cannot cast `y.name` to undefined because string [1] is incompatible with undefi
              ^^^^^^
 
 References:
-   <BUILTINS>/core.js:114:11
-   114|     name: string;
+   <BUILTINS>/core.js:117:11
+   117|     name: string;
                   ^^^^^^ [1]
    function.js:42:14
     42|     (y.name: void); // error, it's a string
@@ -581,8 +581,8 @@ Cannot cast `z.name` to undefined because string [1] is incompatible with undefi
              ^^^^^^
 
 References:
-   <BUILTINS>/core.js:114:11
-   114|     name: string;
+   <BUILTINS>/core.js:117:11
+   117|     name: string;
                   ^^^^^^ [1]
    function.js:43:14
     43|     (z.name: void); // error, it's a string
@@ -598,8 +598,8 @@ Cannot assign `'foo'` to `x.length` because string [1] is incompatible with numb
                        ^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:113:13
-   113|     length: number;
+   <BUILTINS>/core.js:116:13
+   116|     length: number;
                     ^^^^^^ [2]
 
 
@@ -612,8 +612,8 @@ Cannot assign `'foo'` to `y.length` because string [1] is incompatible with numb
                        ^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:113:13
-   113|     length: number;
+   <BUILTINS>/core.js:116:13
+   116|     length: number;
                     ^^^^^^ [2]
 
 
@@ -626,8 +626,8 @@ Cannot assign `'foo'` to `z.length` because string [1] is incompatible with numb
                        ^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:113:13
-   113|     length: number;
+   <BUILTINS>/core.js:116:13
+   116|     length: number;
                     ^^^^^^ [2]
 
 
@@ -640,8 +640,8 @@ Cannot assign `123` to `x.name` because number [1] is incompatible with string [
                      ^^^ [1]
 
 References:
-   <BUILTINS>/core.js:114:11
-   114|     name: string;
+   <BUILTINS>/core.js:117:11
+   117|     name: string;
                   ^^^^^^ [2]
 
 
@@ -654,8 +654,8 @@ Cannot assign `123` to `y.name` because number [1] is incompatible with string [
                      ^^^ [1]
 
 References:
-   <BUILTINS>/core.js:114:11
-   114|     name: string;
+   <BUILTINS>/core.js:117:11
+   117|     name: string;
                   ^^^^^^ [2]
 
 
@@ -668,8 +668,8 @@ Cannot assign `123` to `z.name` because number [1] is incompatible with string [
                      ^^^ [1]
 
 References:
-   <BUILTINS>/core.js:114:11
-   114|     name: string;
+   <BUILTINS>/core.js:117:11
+   117|     name: string;
                   ^^^^^^ [2]
 
 

--- a/tests/generators/generators.exp
+++ b/tests/generators/generators.exp
@@ -41,8 +41,8 @@ References:
    class.js:23:39
     23|   *stmt_return_err(): Generator<void, number, void> {
                                               ^^^^^^ [2]
-   <BUILTINS>/core.js:492:29
-   492| interface Generator<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:495:29
+   495| interface Generator<+Yield,+Return,-Next> {
                                     ^^^^^^ [3]
 
 
@@ -107,14 +107,14 @@ of property `@@iterator`.
                    ^^
 
 References:
-   <BUILTINS>/core.js:485:38
-   485| type Iterator<+T> = $Iterator<T,void,void>;
+   <BUILTINS>/core.js:488:38
+   488| type Iterator<+T> = $Iterator<T,void,void>;
                                              ^^^^ [1]
    class.js:125:42
    125| examples.delegate_next_iterable([]).next(""); // error: Iterator has no next value
                                                  ^^ [2]
-   <BUILTINS>/core.js:481:37
-   481| interface $Iterator<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:484:37
+   484| interface $Iterator<+Yield,+Return,-Next> {
                                             ^^^^ [3]
 
 
@@ -280,8 +280,8 @@ References:
    generators.js:22:46
     22| function *stmt_return_err(): Generator<void, number, void> {
                                                      ^^^^^^ [2]
-   <BUILTINS>/core.js:492:29
-   492| interface Generator<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:495:29
+   495| interface Generator<+Yield,+Return,-Next> {
                                     ^^^^^^ [3]
 
 
@@ -397,14 +397,14 @@ of property `@@iterator`.
                  ^^
 
 References:
-   <BUILTINS>/core.js:485:38
-   485| type Iterator<+T> = $Iterator<T,void,void>;
+   <BUILTINS>/core.js:488:38
+   488| type Iterator<+T> = $Iterator<T,void,void>;
                                              ^^^^ [1]
    generators.js:94:33
     94| delegate_next_iterable([]).next(""); // error: Iterator has no next value
                                         ^^ [2]
-   <BUILTINS>/core.js:481:37
-   481| interface $Iterator<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:484:37
+   484| interface $Iterator<+Yield,+Return,-Next> {
                                             ^^^^ [3]
 
 
@@ -514,8 +514,8 @@ Cannot cast `refuse_return_result.value` to string because:
            ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:478:28
-   478|   | { done: true, +value?: Return }
+   <BUILTINS>/core.js:481:28
+   481|   | { done: true, +value?: Return }
                                    ^^^^^^ [1]
    return.js:20:32
     20|   (refuse_return_result.value: string); // error: number | void ~> string

--- a/tests/iterable/iterable.exp
+++ b/tests/iterable/iterable.exp
@@ -14,8 +14,8 @@ References:
    array.js:7:19
      7| (["hi"]: Iterable<number>); // Error string ~> number
                           ^^^^^^ [2]
-   <BUILTINS>/core.js:481:22
-   481| interface $Iterator<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:484:22
+   484| interface $Iterator<+Yield,+Return,-Next> {
                              ^^^^^ [3]
 
 
@@ -35,8 +35,8 @@ References:
    array.js:8:22
      8| (["hi", 1]: Iterable<string>); // Error number ~> string
                              ^^^^^^ [2]
-   <BUILTINS>/core.js:481:22
-   481| interface $Iterator<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:484:22
+   484| interface $Iterator<+Yield,+Return,-Next> {
                              ^^^^^ [3]
 
 
@@ -56,8 +56,8 @@ References:
    caching_bug.js:21:62
     21| function miss_the_cache(x: Array<string | number>): Iterable<string> { return x; }
                                                                      ^^^^^^ [2]
-   <BUILTINS>/core.js:481:22
-   481| interface $Iterator<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:484:22
+   484| interface $Iterator<+Yield,+Return,-Next> {
                              ^^^^^ [3]
 
 
@@ -73,8 +73,8 @@ References:
    iterator_result.js:17:40
     17| function makeIterator(coin_flip: () => boolean ): Iterator<string> {
                                                ^^^^^^^ [1]
-   <BUILTINS>/core.js:479:13
-   479|   | { done: false, +value: Yield };
+   <BUILTINS>/core.js:482:13
+   482|   | { done: false, +value: Yield };
                     ^^^^^ [2]
 
 
@@ -90,8 +90,8 @@ References:
    iterator_result.js:17:40
     17| function makeIterator(coin_flip: () => boolean ): Iterator<string> {
                                                ^^^^^^^ [1]
-   <BUILTINS>/core.js:478:13
-   478|   | { done: true, +value?: Return }
+   <BUILTINS>/core.js:481:13
+   481|   | { done: true, +value?: Return }
                     ^^^^ [2]
 
 
@@ -105,14 +105,14 @@ value of property `@@iterator`.
                  ^^^
 
 References:
-   <BUILTINS>/core.js:526:28
-   526|     @@iterator(): Iterator<[K, V]>;
+   <BUILTINS>/core.js:529:28
+   529|     @@iterator(): Iterator<[K, V]>;
                                    ^^^^^^ [1]
    map.js:13:55
     13| function mapTest4(map: Map<number, string>): Iterable<string> {
                                                               ^^^^^^ [2]
-   <BUILTINS>/core.js:481:22
-   481| interface $Iterator<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:484:22
+   484| interface $Iterator<+Yield,+Return,-Next> {
                              ^^^^^ [3]
 
 
@@ -132,8 +132,8 @@ References:
    set.js:13:47
     13| function setTest4(set: Set<string>): Iterable<number> {
                                                       ^^^^^^ [2]
-   <BUILTINS>/core.js:481:22
-   481| interface $Iterator<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:484:22
+   484| interface $Iterator<+Yield,+Return,-Next> {
                              ^^^^^ [3]
 
 
@@ -147,14 +147,14 @@ return value of property `@@iterator`.
          ^^^^
 
 References:
-   <BUILTINS>/core.js:289:28
-   289|     @@iterator(): Iterator<string>;
+   <BUILTINS>/core.js:292:28
+   292|     @@iterator(): Iterator<string>;
                                    ^^^^^^ [1]
    string.js:5:17
      5| ("hi": Iterable<number>); // Error - string is a Iterable<string>
                         ^^^^^^ [2]
-   <BUILTINS>/core.js:481:22
-   481| interface $Iterator<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:484:22
+   484| interface $Iterator<+Yield,+Return,-Next> {
                              ^^^^^ [3]
 
 

--- a/tests/lib/lib.exp
+++ b/tests/lib/lib.exp
@@ -24,8 +24,8 @@ Cannot assign `Number.MAX_VALUE` to `y` because number [1] is incompatible with 
                        ^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:127:23
-   127|     static MAX_VALUE: number;
+   <BUILTINS>/core.js:130:23
+   130|     static MAX_VALUE: number;
                               ^^^^^^ [1]
    libtest.js:2:7
      2| var y:string = Number.MAX_VALUE;
@@ -41,8 +41,8 @@ Cannot assign `new TypeError().name` to `z` because string [1] is incompatible w
                        ^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:427:11
-   427|     name: string;
+   <BUILTINS>/core.js:430:11
+   430|     name: string;
                   ^^^^^^ [1]
    libtest.js:3:7
      3| var z:number = new TypeError().name;

--- a/tests/misc/misc.exp
+++ b/tests/misc/misc.exp
@@ -134,8 +134,8 @@ Cannot return `x.length` because number [1] is incompatible with string [2].
                  ^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:276:13
-   276|     length: number;
+   <BUILTINS>/core.js:279:13
+   279|     length: number;
                     ^^^^^^ [1]
    F.js:4:33
      4| function foo(x: Array<number>): string {
@@ -179,8 +179,8 @@ Cannot assign `"duck"` to `b.length` because string [1] is incompatible with num
                    ^^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:276:13
-   276|     length: number;
+   <BUILTINS>/core.js:279:13
+   279|     length: number;
                     ^^^^^^ [2]
 
 

--- a/tests/number_constants/number_constants.exp
+++ b/tests/number_constants/number_constants.exp
@@ -7,8 +7,8 @@ Cannot assign `Number.MAX_SAFE_INTEGER` to `b` because number [1] is incompatibl
                         ^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:126:30
-   126|     static MAX_SAFE_INTEGER: number;
+   <BUILTINS>/core.js:129:30
+   129|     static MAX_SAFE_INTEGER: number;
                                      ^^^^^^ [1]
    number_constants.js:2:8
      2| var b: string = Number.MAX_SAFE_INTEGER;
@@ -24,8 +24,8 @@ Cannot assign `Number.MIN_SAFE_INTEGER` to `d` because number [1] is incompatibl
                         ^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:128:30
-   128|     static MIN_SAFE_INTEGER: number;
+   <BUILTINS>/core.js:131:30
+   131|     static MIN_SAFE_INTEGER: number;
                                      ^^^^^^ [1]
    number_constants.js:4:8
      4| var d: string = Number.MIN_SAFE_INTEGER;
@@ -41,8 +41,8 @@ Cannot assign `Number.MAX_VALUE` to `f` because number [1] is incompatible with 
                         ^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:127:23
-   127|     static MAX_VALUE: number;
+   <BUILTINS>/core.js:130:23
+   130|     static MAX_VALUE: number;
                               ^^^^^^ [1]
    number_constants.js:6:8
      6| var f: string = Number.MAX_VALUE;
@@ -58,8 +58,8 @@ Cannot assign `Number.MIN_VALUE` to `h` because number [1] is incompatible with 
                         ^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:129:23
-   129|     static MIN_VALUE: number;
+   <BUILTINS>/core.js:132:23
+   132|     static MIN_VALUE: number;
                               ^^^^^^ [1]
    number_constants.js:8:8
      8| var h: string = Number.MIN_VALUE;
@@ -75,8 +75,8 @@ Cannot assign `Number.NaN` to `j` because number [1] is incompatible with string
                         ^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:130:17
-   130|     static NaN: number;
+   <BUILTINS>/core.js:133:17
+   133|     static NaN: number;
                         ^^^^^^ [1]
    number_constants.js:10:8
     10| var j: string = Number.NaN;
@@ -92,8 +92,8 @@ Cannot assign `Number.EPSILON` to `l` because number [1] is incompatible with st
                         ^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:125:21
-   125|     static EPSILON: number;
+   <BUILTINS>/core.js:128:21
+   128|     static EPSILON: number;
                             ^^^^^^ [1]
    number_constants.js:12:8
     12| var l: string = Number.EPSILON;

--- a/tests/object_api/object_api.exp
+++ b/tests/object_api/object_api.exp
@@ -61,6 +61,50 @@ References:
            ^ [2]
 
 
+Error -------------------------------------------------------------------------------------------- object_entries.js:5:2
+
+Cannot cast `Object.entries(...)` to array type because:
+ - string [1] is incompatible with number [2] in array element.
+ - string [3] is incompatible with number [2] in array element.
+
+   object_entries.js:5:2
+   5| (Object.entries(a): Array<[string, number]>); // error
+       ^^^^^^^^^^^^^^^^^
+
+References:
+   object_entries.js:3:20
+   3| const a = { first: 'test', second: 'thing' };
+                         ^^^^^^ [1]
+   object_entries.js:5:36
+   5| (Object.entries(a): Array<[string, number]>); // error
+                                         ^^^^^^ [2]
+   object_entries.js:3:36
+   3| const a = { first: 'test', second: 'thing' };
+                                         ^^^^^^^ [3]
+
+
+Error -------------------------------------------------------------------------------------------- object_entries.js:9:2
+
+Cannot cast `Object.entries(...)` to array type because:
+ - number [1] is incompatible with string [2] in array element.
+ - boolean [3] is incompatible with string [2] in array element.
+
+   object_entries.js:9:2
+   9| (Object.entries(b): Array<[string, string]>); // error
+       ^^^^^^^^^^^^^^^^^
+
+References:
+   object_entries.js:7:20
+   7| const b = { first: 1, second: true, third: 'test' };
+                         ^ [1]
+   object_entries.js:9:36
+   9| (Object.entries(b): Array<[string, string]>); // error
+                                         ^^^^^^ [2]
+   object_entries.js:7:31
+   7| const b = { first: 1, second: true, third: 'test' };
+                                    ^^^^ [3]
+
+
 Error ----------------------------------------------------------------------------------------------- object_keys.js:5:2
 
 Cannot cast `Object.keys(...)` to undefined because array type [1] is incompatible with undefined [2].
@@ -220,8 +264,8 @@ Cannot assign `x.toString` to `xToString` because function type [1] is incompati
                                 ^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:67:5
-   67|     toString(): string;
+   <BUILTINS>/core.js:70:5
+   70|     toString(): string;
            ^^^^^^^^^^^^^^^^^^ [1]
    object_prototype.js:38:17
    38| var xToString : number = x.toString; // error
@@ -237,8 +281,8 @@ Cannot assign `x.toString` to `xToString2` because string [1] is incompatible wi
                                        ^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:67:17
-   67|     toString(): string;
+   <BUILTINS>/core.js:70:17
+   70|     toString(): string;
                        ^^^^^^ [1]
    object_prototype.js:39:24
    39| var xToString2 : () => number = x.toString; // error
@@ -254,8 +298,8 @@ Cannot assign `y.toString` to `yToString` because function type [1] is incompati
                                 ^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:67:5
-   67|     toString(): string;
+   <BUILTINS>/core.js:70:5
+   70|     toString(): string;
            ^^^^^^^^^^^^^^^^^^ [1]
    object_prototype.js:43:17
    43| var yToString : number = y.toString; // error
@@ -285,8 +329,8 @@ Cannot call `123.toString` with `'foo'` bound to `radix` because string [1] is i
                        ^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:145:22
-   145|     toString(radix?: number): string;
+   <BUILTINS>/core.js:148:22
+   148|     toString(radix?: number): string;
                              ^^^^^^ [2]
 
 
@@ -299,8 +343,8 @@ Cannot call `123.toString` with `null` bound to `radix` because null [1] is inco
                        ^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:145:22
-   145|     toString(radix?: number): string;
+   <BUILTINS>/core.js:148:22
+   148|     toString(radix?: number): string;
                              ^^^^^^ [2]
 
 
@@ -321,8 +365,8 @@ Cannot assign `x.hasOwnProperty` to `xHasOwnProperty` because function type [1] 
                                       ^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:63:5
-   63|     hasOwnProperty(prop: any): boolean;
+   <BUILTINS>/core.js:66:5
+   66|     hasOwnProperty(prop: any): boolean;
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
    object_prototype.js:71:23
    71| var xHasOwnProperty : number = x.hasOwnProperty; // error
@@ -339,8 +383,8 @@ value.
                                                          ^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:63:32
-   63|     hasOwnProperty(prop: any): boolean;
+   <BUILTINS>/core.js:66:32
+   66|     hasOwnProperty(prop: any): boolean;
                                       ^^^^^^^ [1]
    object_prototype.js:72:42
    72| var xHasOwnProperty2 : (prop: string) => number = x.hasOwnProperty; // error
@@ -356,8 +400,8 @@ Cannot assign `y.hasOwnProperty` to `yHasOwnProperty` because function type [1] 
                                       ^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:63:5
-   63|     hasOwnProperty(prop: any): boolean;
+   <BUILTINS>/core.js:66:5
+   66|     hasOwnProperty(prop: any): boolean;
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
    object_prototype.js:76:23
    76| var yHasOwnProperty : number = y.hasOwnProperty; // error
@@ -382,8 +426,8 @@ number [2].
                                             ^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:65:5
-   65|     propertyIsEnumerable(prop: any): boolean;
+   <BUILTINS>/core.js:68:5
+   68|     propertyIsEnumerable(prop: any): boolean;
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
    object_prototype.js:96:29
    96| var xPropertyIsEnumerable : number = x.propertyIsEnumerable; // error
@@ -400,8 +444,8 @@ in the return value.
          ^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:65:38
-   65|     propertyIsEnumerable(prop: any): boolean;
+   <BUILTINS>/core.js:68:38
+   68|     propertyIsEnumerable(prop: any): boolean;
                                             ^^^^^^^ [1]
    object_prototype.js:97:48
    97| var xPropertyIsEnumerable2 : (prop: string) => number =
@@ -418,8 +462,8 @@ number [2].
                                              ^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:65:5
-    65|     propertyIsEnumerable(prop: any): boolean;
+   <BUILTINS>/core.js:68:5
+    68|     propertyIsEnumerable(prop: any): boolean;
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
    object_prototype.js:102:29
    102| var yPropertyIsEnumerable : number = y.propertyIsEnumerable; // error
@@ -443,8 +487,8 @@ Cannot assign `x.valueOf` to `xValueOf` because function type [1] is incompatibl
                                 ^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:396:5
-   396|     valueOf(): number;
+   <BUILTINS>/core.js:399:5
+   399|     valueOf(): number;
             ^^^^^^^^^^^^^^^^^ [1]
    object_prototype.js:122:16
    122| var xValueOf : number = x.valueOf; // error
@@ -460,8 +504,8 @@ Cannot assign `y.valueOf` to `yValueOf` because function type [1] is incompatibl
                                 ^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:68:5
-    68|     valueOf(): Object;
+   <BUILTINS>/core.js:71:5
+    71|     valueOf(): Object;
             ^^^^^^^^^^^^^^^^^ [1]
    object_prototype.js:126:16
    126| var yValueOf : number = y.valueOf; // error
@@ -485,8 +529,8 @@ Cannot assign `x.toLocaleString` to `xToLocaleString` because function type [1] 
                                        ^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:392:5
-   392|     toLocaleString(locales?: string | Array<string>, options?: Intl$DateTimeFormatOptions): string;
+   <BUILTINS>/core.js:395:5
+   395|     toLocaleString(locales?: string | Array<string>, options?: Intl$DateTimeFormatOptions): string;
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
    object_prototype.js:150:23
    150| var xToLocaleString : number = x.toLocaleString; // error
@@ -503,8 +547,8 @@ value.
                                               ^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:392:93
-   392|     toLocaleString(locales?: string | Array<string>, options?: Intl$DateTimeFormatOptions): string;
+   <BUILTINS>/core.js:395:93
+   395|     toLocaleString(locales?: string | Array<string>, options?: Intl$DateTimeFormatOptions): string;
                                                                                                     ^^^^^^ [1]
    object_prototype.js:151:30
    151| var xToLocaleString2 : () => number = x.toLocaleString; // error
@@ -520,12 +564,68 @@ Cannot assign `y.toLocaleString` to `yToLocaleString` because function type [1] 
                                        ^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:66:5
-    66|     toLocaleString(): string;
+   <BUILTINS>/core.js:69:5
+    69|     toLocaleString(): string;
             ^^^^^^^^^^^^^^^^^^^^^^^^ [1]
    object_prototype.js:155:23
    155| var yToLocaleString : number = y.toLocaleString; // error
                               ^^^^^^ [2]
+
+
+Error --------------------------------------------------------------------------------------------- object_values.js:9:2
+
+Cannot cast `Object.values(...)` to array type because string [1] is incompatible with number [2] in array element.
+
+   object_values.js:9:2
+   9| (Object.values(b): Array<number>); // error
+       ^^^^^^^^^^^^^^^^
+
+References:
+   object_values.js:7:40
+   7| const b = { first: 1, second: 2, last: 'different' };
+                                             ^^^^^^^^^^^ [1]
+   object_values.js:9:26
+   9| (Object.values(b): Array<number>); // error
+                               ^^^^^^ [2]
+
+
+Error -------------------------------------------------------------------------------------------- object_values.js:19:2
+
+Cannot cast `Object.values(...)` to array type because:
+ - string [1] is incompatible with number [2] in array element.
+ - string [3] is incompatible with number [2] in array element.
+
+   object_values.js:19:2
+   19| (Object.values(d): Array<number>); // error
+        ^^^^^^^^^^^^^^^^
+
+References:
+   object_values.js:15:11
+   15| d.first = 'test';
+                 ^^^^^^ [1]
+   object_values.js:19:26
+   19| (Object.values(d): Array<number>); // error
+                                ^^^^^^ [2]
+   object_values.js:16:12
+   16| d.second = 'another test';
+                  ^^^^^^^^^^^^^^ [3]
+
+
+Error -------------------------------------------------------------------------------------------- object_values.js:23:2
+
+Cannot cast `Object.values(...)` to array type because boolean [1] is incompatible with string [2] in array element.
+
+   object_values.js:23:2
+   23| (Object.values(d): Array<string>); // error
+        ^^^^^^^^^^^^^^^^
+
+References:
+   object_values.js:21:15
+   21| d.something = true;
+                     ^^^^ [1]
+   object_values.js:23:26
+   23| (Object.values(d): Array<string>); // error
+                                ^^^^^^ [2]
 
 
 Error ----------------------------------------------------------------------------------------------------- proto.js:3:2
@@ -537,8 +637,8 @@ Cannot cast `o1_proto.toString` to empty because function type [1] is incompatib
         ^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:67:5
-   67|     toString(): string;
+   <BUILTINS>/core.js:70:5
+   70|     toString(): string;
            ^^^^^^^^^^^^^^^^^^ [1]
    proto.js:3:21
     3| (o1_proto.toString: empty); // error: function ~> empty
@@ -591,4 +691,4 @@ References:
 
 
 
-Found 39 errors
+Found 47 errors

--- a/tests/object_api/object_entries.js
+++ b/tests/object_api/object_entries.js
@@ -1,0 +1,9 @@
+/* @flow */
+
+const a = { first: 'test', second: 'thing' };
+(Object.entries(a): Array<[string, string]>);
+(Object.entries(a): Array<[string, number]>); // error
+
+const b = { first: 1, second: true, third: 'test' };
+(Object.entries(b): Array<[string, mixed]>);
+(Object.entries(b): Array<[string, string]>); // error

--- a/tests/object_api/object_values.js
+++ b/tests/object_api/object_values.js
@@ -1,0 +1,24 @@
+/* @flow */
+
+// Works for known-types
+const a = { first: 1, second: 2 };
+(Object.values(a): Array<number>);
+
+const b = { first: 1, second: 2, last: 'different' };
+(Object.values(b): Array<mixed>); // mixed if the keys aren't all the same
+(Object.values(b): Array<number>); // error
+
+const c = {};
+(Object.values(c): Array<empty>);
+
+const d = {};
+d.first = 'test';
+d.second = 'another test';
+
+(Object.values(d): Array<string>);
+(Object.values(d): Array<number>); // error
+
+d.something = true;
+(Object.values(d): Array<mixed>);
+(Object.values(d): Array<string>); // error
+

--- a/tests/object_is/object_is.exp
+++ b/tests/object_is/object_is.exp
@@ -7,8 +7,8 @@ Cannot assign `Object.is(...)` to `b` because boolean [1] is incompatible with s
                        ^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:54:32
-   54|     static is(a: any, b: any): boolean;
+   <BUILTINS>/core.js:56:32
+   56|     static is(a: any, b: any): boolean;
                                       ^^^^^^^ [1]
    object_is.js:20:8
    20| var b: string = Object.is('a', 'a');
@@ -24,8 +24,8 @@ Cannot call method `is` because no more than 2 arguments are expected by functio
                         ^^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:54:5
-   54|     static is(a: any, b: any): boolean;
+   <BUILTINS>/core.js:56:5
+   56|     static is(a: any, b: any): boolean;
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 

--- a/tests/objects/objects.exp
+++ b/tests/objects/objects.exp
@@ -277,8 +277,8 @@ Cannot cast `y['hasOwnProperty']` to string because function type [1] is incompa
         ^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:63:5
-   63|     hasOwnProperty(prop: any): boolean;
+   <BUILTINS>/core.js:66:5
+   66|     hasOwnProperty(prop: any): boolean;
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
    objects.js:18:23
    18| (y['hasOwnProperty']: string); // error, prototype method is not a string

--- a/tests/overload/overload.exp
+++ b/tests/overload/overload.exp
@@ -29,8 +29,8 @@ Cannot assign `"".match(...)[0]` to `x1` because string [1] is incompatible with
                          ^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:302:44
-   302|     match(regexp: string | RegExp): ?Array<string>;
+   <BUILTINS>/core.js:305:44
+   305|     match(regexp: string | RegExp): ?Array<string>;
                                                    ^^^^^^ [1]
    overload.js:7:9
      7| var x1: number = "".match(0)[0];
@@ -46,8 +46,8 @@ Cannot get `"".match(...)[0]` because an indexer property is missing in null or 
                          ^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:302:37
-   302|     match(regexp: string | RegExp): ?Array<string>;
+   <BUILTINS>/core.js:305:37
+   305|     match(regexp: string | RegExp): ?Array<string>;
                                             ^^^^^^^^^^^^^^ [1]
 
 
@@ -60,8 +60,8 @@ Cannot call `"".match` with `0` bound to `regexp` because number [1] is incompat
                                   ^ [1]
 
 References:
-   <BUILTINS>/core.js:302:19
-   302|     match(regexp: string | RegExp): ?Array<string>;
+   <BUILTINS>/core.js:305:19
+   305|     match(regexp: string | RegExp): ?Array<string>;
                           ^^^^^^ [2]
 
 
@@ -74,8 +74,8 @@ Cannot assign `"".match(...)[0]` to `x2` because string [1] is incompatible with
                          ^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:302:44
-   302|     match(regexp: string | RegExp): ?Array<string>;
+   <BUILTINS>/core.js:305:44
+   305|     match(regexp: string | RegExp): ?Array<string>;
                                                    ^^^^^^ [1]
    overload.js:8:9
      8| var x2: number = "".match(/pattern/)[0];
@@ -91,8 +91,8 @@ Cannot get `"".match(...)[0]` because an indexer property is missing in null or 
                          ^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:302:37
-   302|     match(regexp: string | RegExp): ?Array<string>;
+   <BUILTINS>/core.js:305:37
+   305|     match(regexp: string | RegExp): ?Array<string>;
                                             ^^^^^^^^^^^^^^ [1]
 
 
@@ -105,8 +105,8 @@ Cannot assign `"".split(...)[0]` to `x4` because string [1] is incompatible with
                          ^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:310:63
-   310|     split(separator?: string | RegExp, limit?: number): Array<string>;
+   <BUILTINS>/core.js:313:63
+   313|     split(separator?: string | RegExp, limit?: number): Array<string>;
                                                                       ^^^^^^ [1]
    overload.js:10:9
     10| var x4: number = "".split(/pattern/)[0];

--- a/tests/promises/promises.exp
+++ b/tests/promises/promises.exp
@@ -84,8 +84,8 @@ Cannot call `Promise.all` because property `@@iterator` is missing in undefined 
         ^^^^^^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:601:19
-   601|     static all<T: Iterable<mixed>>(promises: T): Promise<$TupleMap<T, typeof $await>>;
+   <BUILTINS>/core.js:604:19
+   604|     static all<T: Iterable<mixed>>(promises: T): Promise<$TupleMap<T, typeof $await>>;
                           ^^^^^^^^^^^^^^^ [2]
 
 
@@ -99,8 +99,8 @@ in `$Iterable` [2].
                     ^ [1]
 
 References:
-   <BUILTINS>/core.js:601:19
-   601|     static all<T: Iterable<mixed>>(promises: T): Promise<$TupleMap<T, typeof $await>>;
+   <BUILTINS>/core.js:604:19
+   604|     static all<T: Iterable<mixed>>(promises: T): Promise<$TupleMap<T, typeof $await>>;
                           ^^^^^^^^^^^^^^^ [2]
 
 
@@ -399,8 +399,8 @@ References:
    resolve_void.js:3:29
      3| (Promise.resolve(): Promise<number>); // error
                                     ^^^^^^ [2]
-   <BUILTINS>/core.js:576:24
-   576| declare class Promise<+R> {
+   <BUILTINS>/core.js:579:24
+   579| declare class Promise<+R> {
                                ^ [3]
 
 
@@ -420,8 +420,8 @@ References:
    resolve_void.js:5:38
      5| (Promise.resolve(undefined): Promise<number>); // error
                                              ^^^^^^ [2]
-   <BUILTINS>/core.js:576:24
-   576| declare class Promise<+R> {
+   <BUILTINS>/core.js:579:24
+   579| declare class Promise<+R> {
                                ^ [3]
 
 

--- a/tests/react_hocs/react_hocs.exp
+++ b/tests/react_hocs/react_hocs.exp
@@ -31,8 +31,8 @@ References:
    Bad.js:8:8
      8|   bar: number,
                ^^^^^^ [1]
-   <BUILTINS>/core.js:145:31
-   145|     toString(radix?: number): string;
+   <BUILTINS>/core.js:148:31
+   148|     toString(radix?: number): string;
                                       ^^^^^^ [2]
 
 

--- a/tests/rec/rec.exp
+++ b/tests/rec/rec.exp
@@ -7,11 +7,11 @@ Property `@@iterator` is missing in undefined [1] but exists in `$Iterable` [2].
                         ^
 
 References:
-   <BUILTINS>/core.js:532:22
-   532|     get(key: K): V | void;
+   <BUILTINS>/core.js:535:22
+   535|     get(key: K): V | void;
                              ^^^^ [1]
-   <BUILTINS>/core.js:487:11
-   487| interface $Iterable<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:490:11
+   490| interface $Iterable<+Yield,+Return,-Next> {
                   ^^^^^^^^^ [2]
 
 
@@ -24,11 +24,11 @@ Property `@@iterator` is missing in undefined [1] but exists in `$Iterable` [2].
                         ^
 
 References:
-   <BUILTINS>/core.js:532:22
-   532|     get(key: K): V | void;
+   <BUILTINS>/core.js:535:22
+   535|     get(key: K): V | void;
                              ^^^^ [1]
-   <BUILTINS>/core.js:487:11
-   487| interface $Iterable<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:490:11
+   490| interface $Iterable<+Yield,+Return,-Next> {
                   ^^^^^^^^^ [2]
 
 
@@ -41,11 +41,11 @@ Property `@@iterator` is missing in undefined [1] but exists in `$Iterable` [2].
                         ^
 
 References:
-   <BUILTINS>/core.js:532:22
-   532|     get(key: K): V | void;
+   <BUILTINS>/core.js:535:22
+   535|     get(key: K): V | void;
                              ^^^^ [1]
-   <BUILTINS>/core.js:487:11
-   487| interface $Iterable<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:490:11
+   490| interface $Iterable<+Yield,+Return,-Next> {
                   ^^^^^^^^^ [2]
 
 
@@ -58,11 +58,11 @@ Property `@@iterator` is missing in undefined [1] but exists in `$Iterable` [2].
                         ^
 
 References:
-   <BUILTINS>/core.js:532:22
-   532|     get(key: K): V | void;
+   <BUILTINS>/core.js:535:22
+   535|     get(key: K): V | void;
                              ^^^^ [1]
-   <BUILTINS>/core.js:487:11
-   487| interface $Iterable<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:490:11
+   490| interface $Iterable<+Yield,+Return,-Next> {
                   ^^^^^^^^^ [2]
 
 

--- a/tests/refinements/refinements.exp
+++ b/tests/refinements/refinements.exp
@@ -2762,8 +2762,8 @@ Cannot get `x[0]` because an indexer property is missing in `Boolean` [1].
             ^^^^
 
 References:
-   <BUILTINS>/core.js:117:15
-   117| declare class Boolean {
+   <BUILTINS>/core.js:120:15
+   120| declare class Boolean {
                       ^^^^^^^ [1]
 
 

--- a/tests/regexp/regexp.exp
+++ b/tests/regexp/regexp.exp
@@ -7,8 +7,8 @@ Cannot assign `patt.test(...)` to `match` because boolean [1] is incompatible wi
                            ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:346:27
-   346|     test(string: string): boolean;
+   <BUILTINS>/core.js:349:27
+   349|     test(string: string): boolean;
                                   ^^^^^^^ [1]
    regexp.js:2:11
      2| var match:number = patt.test("Hello world!");

--- a/tests/return/return.exp
+++ b/tests/return/return.exp
@@ -43,8 +43,8 @@ References:
    implicit.js:7:30
      7| async function g2(): Promise<number> {}
                                      ^^^^^^ [1]
-   <BUILTINS>/core.js:576:24
-   576| declare class Promise<+R> {
+   <BUILTINS>/core.js:579:24
+   579| declare class Promise<+R> {
                                ^ [2]
 
 

--- a/tests/symbol/symbol.exp
+++ b/tests/symbol/symbol.exp
@@ -7,8 +7,8 @@ Cannot call `Symbol` because no more than 1 argument is expected by function typ
                  ^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:86:3
-   86|   static (value?:any): Symbol;
+   <BUILTINS>/core.js:89:3
+   89|   static (value?:any): Symbol;
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 

--- a/tests/union/union.exp
+++ b/tests/union/union.exp
@@ -7,8 +7,8 @@ Cannot call `str.toFixed` because property `toFixed` is missing in `String` [1].
                        ^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:142:39
-   142|     toFixed(fractionDigits?: number): string;
+   <BUILTINS>/core.js:145:39
+   145|     toFixed(fractionDigits?: number): string;
                                               ^^^^^^ [1]
 
 


### PR DESCRIPTION
I've read through a whole load of posts surrounding this topic, but can't quite get my head around exactly why `Object.keys` works in every case, but `Object.entries` and `Object.values` are unsafe.

Most importantly, why `Object.keys(object).map(k => object[k])` can correctly (and safely, apparently) pull out the values from a `{ [string]: T }`, but we can't have the same happen from `Object.values`.

So I've opened a PR, because then [Cunningham's Law](https://meta.wikimedia.org/wiki/Cunningham%27s_Law) says I'll get an answer (or maybe this is correct).

I've added tests, but I'm almost certain that these don't cover every case.

I've split this into two commits so that the updates to the test files don't get in the way of the code I've added.