### PR TITLE
Changed instructions to use @babel/preset-flow

### DIFF
--- a/website/en/docs/tools/babel.md
+++ b/website/en/docs/tools/babel.md
@@ -12,15 +12,15 @@ Once you have Babel setup, install `babel-preset-flow` with either
 [Yarn](https://yarnpkg.com/) or [npm](https://www.npmjs.com/).
 
 ```sh
-yarn add --dev babel-preset-flow
+yarn add --dev @babel/preset-flow
 # or
-npm install --save-dev babel-preset-flow
+npm install --save-dev @babel/preset-flow
 ```
 
 Then add `flow` to your Babel presets config.
 
 ```json
 {
-  "presets": ["flow"]
+  "presets": ["@babel/flow"]
 }
 ```


### PR DESCRIPTION
Past instructions caused babel to throw an error:

```
Error: Plugin/Preset files are not allowed to export objects, only functions.
```

I don't know why this happens, I only know that this fixes it. Took the tip from this other issue: https://github.com/babel/babel-loader/issues/540.

I hope this is useful.