### PR TITLE
Flakey appveyor LSP connection test

### DIFF
--- a/packages/flow-dev-tools/src/test/builder.js
+++ b/packages/flow-dev-tools/src/test/builder.js
@@ -981,7 +981,14 @@ export class TestBuilder {
       // server and we raced it here
       if (err && err.code !== 6) {
         throw new Error(
-          format('flow force-recheck failed!', err, stdout, stderr, files),
+          format(
+            'flow force-recheck failed! err.code=%s err=%s stdout=%s stderr=%s files=%s',
+            err.code,
+            err,
+            stdout,
+            stderr,
+            files,
+          ),
         );
       }
     }

--- a/src/commands/ideCommand.ml
+++ b/src/commands/ideCommand.ml
@@ -92,6 +92,7 @@ module HumanReadable: ClientProtocol = struct
     | Prot.AutocompleteResult (result, _ (* ignore id *)) -> handle_autocomplete result
     | Prot.DidOpenAck -> print_endline "Received file open ack"
     | Prot.DidCloseAck -> print_endline "Received file close ack"
+    | Prot.EOF -> () (* ignored here; used in lspCommand *)
 
 end
 
@@ -137,6 +138,7 @@ module VeryUnstable: ClientProtocol = struct
      * involving the buffers between the ide command and the flow server *)
     | Prot.DidOpenAck -> ()
     | Prot.DidCloseAck -> ()
+    | Prot.EOF -> ()
 
   let handle_autocomplete id = Hh_json.(function
     | [JSON_String file; JSON_Number line_str; JSON_Number column_str; JSON_String contents] ->
@@ -244,7 +246,8 @@ end = struct
       | LspFromServer _, _
       | Please_hold _, _
       | StartRecheck, _
-      | EndRecheck _, _ ->
+      | EndRecheck _, _
+      | EOF, _ ->
           t
       | AutocompleteResult (_, response_id), Some (Autocomplete (_, request_id)) ->
           if response_id <> request_id then begin

--- a/src/monitor/socketAcceptor.ml
+++ b/src/monitor/socketAcceptor.ml
@@ -117,6 +117,7 @@ let create_persistent_connection ~client_fd ~close ~logging_context ~lsp =
   (* On exit, do our best to send all pending messages to the waiting client *)
   let close_on_exit =
     let%lwt _ = Lwt_condition.wait ExitSignal.signal in
+    PersistentConnection.write Persistent_connection_prot.EOF conn;
     PersistentConnection.flush_and_close conn
   in
 

--- a/src/server/protocol/persistent_connection_prot.ml
+++ b/src/server/protocol/persistent_connection_prot.ml
@@ -40,6 +40,7 @@ type response =
   | ServerExit of FlowExitStatus.t (* only used for the subset of exists which client handles *)
   | LspFromServer of Lsp.lsp_message (* requests, notifications, responses to client *)
   | Please_hold of (ServerStatus.status * FileWatcherStatus.status)
+  | EOF (* monitor is about to close the connection *)
 
 let string_of_response = function
 | Errors _ -> "errors"
@@ -53,3 +54,4 @@ let string_of_response = function
 | Please_hold (server_status, watcher_status) -> Printf.sprintf "pleaseHold_server=%s_watcher=%s"
     (ServerStatus.string_of_status server_status)
     (FileWatcherStatus.string_of_status watcher_status)
+| EOF -> "EOF"


### PR DESCRIPTION
Summary:
Appveyor (windows) has been seeing failures in the lsp\connection test 'Restarts a lost server in response to flowconfig benign change', although it's been working fine on unix machines. Here's the anatomy of the windows failure:

1. Flow server is launched with no watchman
2. Test modifies the file .flowconfig by altering a comment. Nothing happens because no watchman.
3. Test calls `flow force-recheck .flowconfig`. This causes the server to exit.
4. Monitor receives the exit signal from the server and handles the WEXITED case in `FlowServerMonitorServer.wait_for_server_to_die`.
5. Wait_for_server_to_die sends `Persistent_connection_prot.ServerExit` to all persistent clients so they know the exit code reason for their forthcoming discovery that the connection has closed.
6. Wait_for_server_to_die calls `FlowServerMonitorServer.exit`. (Note that Wait_for_server_to_die never terminates, and so `killall_persistent_connections` never gets called).
7. The exit procedure broadcasts the `ExitSignal.signal` signal to all listeners, then waits one second while the signal handlers fire, then does `Pervasives.exit`.
8. The signal handler of interest to us is in `SocketAcceptor.create_persistent_connection.close_on_exit`. It handles the signal by calling `PersistentConnection.flush_and_close`.
9. Flush_and_close calls `conn.close`, which calls into the "close" callback that was created when we created the connection, which calls into "close_without_autostop" callback that was created at the same time, which calls into `SocketAcceptor.close` which is a belt-and-braces way to close a connection, which calls `Lwt_unix.shutdown SHUTDOWN_ALL`.
10. ??? the client's call to `select [server_fd; client_fd] 1.0` should be tickled to look at server_fd after this (i.e. claiming that server_fd can be read from), and a subsequent read on server_fd will return 0 bytes available, which is interpreted as an EOF.

What's happening in the failure scenarios on Appveyor is that step 10 doesn't happen! IN other words, the server closes the connection, and the server then exits, but this by itself isn't enough for the client (on appveyor) to have its server_fd tickled.

This diff fixes the issue by changing step 8 so that before calling `flush_and_close`, it first sends an explicit `Persistent_connection_prot.EOF` message over the wire with the intended meaning that "the connection is about to be closed, and the client should act as if it's closed immediately, because we're not sure whether the underlying transport mechanism will be able to deliver a subsequent 'real' EOF via normal connection-closure mechanisms".

Here's background research which suggests that relying on the existing behavior (that client will get a 'real' EOF due to the server closing) isn't in general reliable across platforms. The consensus is that if you want participants in a protocol to detect that the other side has closed the connection, then you should do it within that protocol built on top of TCP, rather than relying on any properties in TCP itself.

On Unix, we creates the client<->monitor connection with `Unix.open_connection (Unix.ADDR_UNIX sock_name)`. But on Windows we do `Unix.connect (Unix.ADDR_INET loopback port)`. So the connections have very different natures.

A general property of INET connections is that you have no way of knowing whether the other party has closed their connection. TCP was designed this way to be robust e.g. in case of a connection that temporarily goes down. The only way to know whether a connection has gone down is by trying to send data and observing that the send has failed.

I'm sure that in real-world situations the client would discover in short order that the server is down, when it next attempts to send a request. But this particular lsp/connection test doesn't exercise that route; it tests that the client is informed immediately.

I'm not convinced that cygwin does the intended handling of Unix.shutdown. It relies upon underlying win32 winsock APIs. The docs for shutdown says this "disables reading and writing on the socket" with no guarantee about what a future "select" will do. The docs for recv says that if shutdown has been called then it will get a WSAESHUTDOWN error, which to me looks different from an EOF. In all, I'm dubious.

shutdown: https://msdn.microsoft.com/en-us/library/windows/desktop/ms740481(v=vs.85).aspx?f=255&MSPPError=-2147217396
recv: https://msdn.microsoft.com/en-us/library/windows/desktop/ms740121(v=vs.85).aspx?f=255&MSPPError=-2147217396

There are other sources which suggest that `select` after `shutdown` isn't a reliable way to do things:
https://github.com/open62541/open62541/pull/1013
https://stackoverflow.com/questions/18352039/why-shutdown-a-socket-cant-let-the-select-return

Across different platforms, it varies according to whether a closed socket produces `POLLIN` (old MacOS) or `POLLHUP` (cygwin and old linux) or `POLLIN|POLLHUP` (modern linux and MacOS). There's a specific note that "On Cygwin, reading from a socket that you’ve shutdown with SHUT_RD produces ESHUTDOWN rather than EOF, and POLLERR if you poll it."
https://www.greenend.org.uk/rjk/tech/poll.html

Differential Revision: D8347551
