### PR TITLE
Add scrollIntoView option enums

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -1309,7 +1309,7 @@ declare class Element extends Node {
   removeAttributeNS(namespaceURI: string | null, localName: string): void;
   requestFullscreen(): void;
   requestPointerLock(): void;
-  scrollIntoView(arg?: (boolean | { behavior?: ('auto' | 'instant' | 'smooth'), block?: ('start' | 'end') })): void;
+  scrollIntoView(arg?: (boolean | { behavior?: ('auto' | 'instant' | 'smooth'), block?: ('start' | 'end' | 'center' | 'nearest'), inline?: ('start' | 'end' | 'center' | 'nearest') })): void;
   setAttribute(name?: string, value?: string): void;
   setAttributeNS(namespaceURI: string | null, qualifiedName: string, value: string): void;
   setAttributeNode(newAttr: Attr): Attr | null;


### PR DESCRIPTION
Adds enums according to https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView