### PR TITLE
Change wording on the landing page - ‘Coworkers’

### DIFF
--- a/website/_data/i18n/en.yml
+++ b/website/_data/i18n/en.yml
@@ -37,7 +37,7 @@ homepage_code_bigger_img_alt: ""
 homepage_code_bigger_description: >
   Working in a codebase with lots of developers can make it difficult to keep
   your master branch working. Flow can help prevent bad rebases. Flow can help
-  protect your carefully designed library from your coworkers. And Flow can help
+  protect your carefully designed library from errors. And Flow can help
   you understand the code you wrote six months ago.
 
 homepage_featurettes:

--- a/website/_data/i18n/en.yml
+++ b/website/_data/i18n/en.yml
@@ -37,8 +37,8 @@ homepage_code_bigger_img_alt: ""
 homepage_code_bigger_description: >
   Working in a codebase with lots of developers can make it difficult to keep
   your master branch working. Flow can help prevent bad rebases. Flow can help
-  protect your carefully designed library from errors. And Flow can help
-  you understand the code you wrote six months ago.
+  protect your carefully designed library from misuse and misinterpretation.
+  And Flow can help you understand the code you wrote six months ago.
 
 homepage_featurettes:
   - title: "Type Inference"


### PR DESCRIPTION
Currently, on the landing page it reads:
‘Flow can help prevent bad rebases. Flow can help **protect** your carefully designed library **from your coworkers**.’ (Emphasis mine)

I do not want to protect my library from coworkers. I want them to be able to quickly and safely contribute.

In this PR I suggest ‘protect […] from errors’. However, I'd be happy with other changes.