### PR TITLE
Website EOT Document Tweak: Explicitly Mention Vertical Bar in EOT

### DIFF
--- a/website/en/docs/types/objects.md
+++ b/website/en/docs/types/objects.md
@@ -215,7 +215,7 @@ method({
 > **Note:** This is because of ["width subtyping"](../../lang/width-subtyping/).
 
 Sometimes it is useful to disable this behavior and only allow a specific set
-of properties. For this, Flow supports "exact" object types.
+of properties. For this, Flow supports "exact" object types through enabling to add a pair of vertical bars.
 
 ```js
 {| foo: string, bar: number |}


### PR DESCRIPTION
[The "Exact Object Type" doc page](https://flow.org/en/docs/types/objects/#toc-exact-object-types) doesn't even have a SINGLE word that mentioned "pipe operator", which makes a new comer like me difficult to search what I'm looking for. (Actually it's not mentioned across the whole website:))

Also, accessibility-wise, my suggestion is we should at least mention "what the syntax looks like", rather than only about "what it does". This is the thing people are based on when they do searching and find related materials.

Open to any re-wording suggestions.