### PR TITLE
Add support for flow:main in package.json

### DIFF
--- a/src/parser_utils/package_json.ml
+++ b/src/parser_utils/package_json.ml
@@ -56,7 +56,8 @@ let parse ast =
           begin match key with
           | "name" -> { package with name = Some value }
           | "flow:main" -> { package with main = Some value }
-          | "main" -> { package with main = Some value }
+          (* Only use `main` if `flow:main` is not available *)
+          | "main" when package.main = None -> { package with main = Some value }
           | _ -> package
           end
       | _ -> package

--- a/src/parser_utils/package_json.ml
+++ b/src/parser_utils/package_json.ml
@@ -55,6 +55,7 @@ let parse ast =
         }) ->
           begin match key with
           | "name" -> { package with name = Some value }
+          | "flow:main" -> { package with main = Some value }
           | "main" -> { package with main = Some value }
           | _ -> package
           end

--- a/tests/declaration_files_incremental_node/declaration_files_incremental_node.exp
+++ b/tests/declaration_files_incremental_node/declaration_files_incremental_node.exp
@@ -203,6 +203,57 @@ References:
                  ^^^^^^^ [2]
 
 
+Error -------------------------------------------------------------------------------------------- test_absolute.js:44:2
+
+Cannot cast `G.fun()` to boolean because `Implementation` [1] is incompatible with boolean [2].
+
+   test_absolute.js:44:2
+   44| (G.fun(): boolean); // Error either Implementation ~> boolean or Declaration ~> boolean
+        ^^^^^^^
+
+References:
+   node_modules/package_with_full_flow_main/code.js:4:26
+    4| module.exports.fun = (): Implementation => new Implementation();
+                                ^^^^^^^^^^^^^^ [1]
+   test_absolute.js:44:11
+   44| (G.fun(): boolean); // Error either Implementation ~> boolean or Declaration ~> boolean
+                 ^^^^^^^ [2]
+
+
+Error -------------------------------------------------------------------------------------------- test_absolute.js:47:2
+
+Cannot cast `H.fun()` to boolean because `Implementation` [1] is incompatible with boolean [2].
+
+   test_absolute.js:47:2
+   47| (H.fun(): boolean); // Error either Implementation ~> boolean or Declaration ~> boolean
+        ^^^^^^^
+
+References:
+   node_modules/package_with_partial_flow_main/code.js:4:26
+    4| module.exports.fun = (): Implementation => new Implementation();
+                                ^^^^^^^^^^^^^^ [1]
+   test_absolute.js:47:11
+   47| (H.fun(): boolean); // Error either Implementation ~> boolean or Declaration ~> boolean
+                 ^^^^^^^ [2]
+
+
+Error -------------------------------------------------------------------------------------------- test_absolute.js:50:2
+
+Cannot cast `I.fun()` to boolean because `Implementation` [1] is incompatible with boolean [2].
+
+   test_absolute.js:50:2
+   50| (I.fun(): boolean); // Error either Implementation ~> boolean or Declaration ~> boolean
+        ^^^^^^^
+
+References:
+   node_modules/package_with_dir_flow_main/dir/index.js:4:26
+    4| module.exports.fun = (): Implementation => new Implementation();
+                                ^^^^^^^^^^^^^^ [1]
+   test_absolute.js:50:11
+   50| (I.fun(): boolean); // Error either Implementation ~> boolean or Declaration ~> boolean
+                 ^^^^^^^ [2]
+
+
 Error --------------------------------------------------------------------------------------------- test_relative.js:3:2
 
 Cannot cast `foo()` to boolean because `Implementation` [1] is incompatible with boolean [2].
@@ -221,7 +272,7 @@ References:
 
 
 
-Found 13 errors
+Found 16 errors
 Error --------------------------------------------------------------------------------------------- test_absolute.js:5:2
 
 Cannot cast `B1.fun()` to boolean because `Definition` [1] is incompatible with boolean [2].
@@ -423,6 +474,57 @@ References:
                                      ^^^^^^^^^^ [1]
    test_absolute.js:41:11
    41| (F.fun(): boolean); // Error either Implementation ~> boolean or Declaration ~> boolean
+                 ^^^^^^^ [2]
+
+
+Error -------------------------------------------------------------------------------------------- test_absolute.js:44:2
+
+Cannot cast `G.fun()` to boolean because `Definition` [1] is incompatible with boolean [2].
+
+   test_absolute.js:44:2
+   44| (G.fun(): boolean); // Error either Implementation ~> boolean or Declaration ~> boolean
+        ^^^^^^^
+
+References:
+   node_modules/package_with_full_flow_main/code.js.flow:4:24
+    4| declare var fun: () => Definition;
+                              ^^^^^^^^^^ [1]
+   test_absolute.js:44:11
+   44| (G.fun(): boolean); // Error either Implementation ~> boolean or Declaration ~> boolean
+                 ^^^^^^^ [2]
+
+
+Error -------------------------------------------------------------------------------------------- test_absolute.js:47:2
+
+Cannot cast `H.fun()` to boolean because `Definition` [1] is incompatible with boolean [2].
+
+   test_absolute.js:47:2
+   47| (H.fun(): boolean); // Error either Implementation ~> boolean or Declaration ~> boolean
+        ^^^^^^^
+
+References:
+   node_modules/package_with_partial_flow_main/code.js.flow:2:32
+    2| declare export function fun(): Definition;
+                                      ^^^^^^^^^^ [1]
+   test_absolute.js:47:11
+   47| (H.fun(): boolean); // Error either Implementation ~> boolean or Declaration ~> boolean
+                 ^^^^^^^ [2]
+
+
+Error -------------------------------------------------------------------------------------------- test_absolute.js:50:2
+
+Cannot cast `I.fun()` to boolean because `Definition` [1] is incompatible with boolean [2].
+
+   test_absolute.js:50:2
+   50| (I.fun(): boolean); // Error either Implementation ~> boolean or Declaration ~> boolean
+        ^^^^^^^
+
+References:
+   node_modules/package_with_dir_flow_main/dir/index.js.flow:4:31
+    4| declare export var fun: () => Definition;
+                                     ^^^^^^^^^^ [1]
+   test_absolute.js:50:11
+   50| (I.fun(): boolean); // Error either Implementation ~> boolean or Declaration ~> boolean
                  ^^^^^^^ [2]
 
 
@@ -444,7 +546,7 @@ References:
 
 
 
-Found 13 errors
+Found 16 errors
 Error --------------------------------------------------------------------------------------------- test_absolute.js:5:2
 
 Cannot cast `B1.fun()` to boolean because `Implementation` [1] is incompatible with boolean [2].
@@ -649,6 +751,57 @@ References:
                  ^^^^^^^ [2]
 
 
+Error -------------------------------------------------------------------------------------------- test_absolute.js:44:2
+
+Cannot cast `G.fun()` to boolean because `Implementation` [1] is incompatible with boolean [2].
+
+   test_absolute.js:44:2
+   44| (G.fun(): boolean); // Error either Implementation ~> boolean or Declaration ~> boolean
+        ^^^^^^^
+
+References:
+   node_modules/package_with_full_flow_main/code.js:4:26
+    4| module.exports.fun = (): Implementation => new Implementation();
+                                ^^^^^^^^^^^^^^ [1]
+   test_absolute.js:44:11
+   44| (G.fun(): boolean); // Error either Implementation ~> boolean or Declaration ~> boolean
+                 ^^^^^^^ [2]
+
+
+Error -------------------------------------------------------------------------------------------- test_absolute.js:47:2
+
+Cannot cast `H.fun()` to boolean because `Implementation` [1] is incompatible with boolean [2].
+
+   test_absolute.js:47:2
+   47| (H.fun(): boolean); // Error either Implementation ~> boolean or Declaration ~> boolean
+        ^^^^^^^
+
+References:
+   node_modules/package_with_partial_flow_main/code.js:4:26
+    4| module.exports.fun = (): Implementation => new Implementation();
+                                ^^^^^^^^^^^^^^ [1]
+   test_absolute.js:47:11
+   47| (H.fun(): boolean); // Error either Implementation ~> boolean or Declaration ~> boolean
+                 ^^^^^^^ [2]
+
+
+Error -------------------------------------------------------------------------------------------- test_absolute.js:50:2
+
+Cannot cast `I.fun()` to boolean because `Implementation` [1] is incompatible with boolean [2].
+
+   test_absolute.js:50:2
+   50| (I.fun(): boolean); // Error either Implementation ~> boolean or Declaration ~> boolean
+        ^^^^^^^
+
+References:
+   node_modules/package_with_dir_flow_main/dir/index.js:4:26
+    4| module.exports.fun = (): Implementation => new Implementation();
+                                ^^^^^^^^^^^^^^ [1]
+   test_absolute.js:50:11
+   50| (I.fun(): boolean); // Error either Implementation ~> boolean or Declaration ~> boolean
+                 ^^^^^^^ [2]
+
+
 Error --------------------------------------------------------------------------------------------- test_relative.js:3:2
 
 Cannot cast `foo()` to boolean because `Implementation` [1] is incompatible with boolean [2].
@@ -667,7 +820,7 @@ References:
 
 
 
-Found 13 errors
+Found 16 errors
 
 
 ======Start off with the .js files and the .flow file======
@@ -875,6 +1028,57 @@ References:
                  ^^^^^^^ [2]
 
 
+Error -------------------------------------------------------------------------------------------- test_absolute.js:44:2
+
+Cannot cast `G.fun()` to boolean because `Definition` [1] is incompatible with boolean [2].
+
+   test_absolute.js:44:2
+   44| (G.fun(): boolean); // Error either Implementation ~> boolean or Declaration ~> boolean
+        ^^^^^^^
+
+References:
+   node_modules/package_with_full_flow_main/code.js.flow:4:24
+    4| declare var fun: () => Definition;
+                              ^^^^^^^^^^ [1]
+   test_absolute.js:44:11
+   44| (G.fun(): boolean); // Error either Implementation ~> boolean or Declaration ~> boolean
+                 ^^^^^^^ [2]
+
+
+Error -------------------------------------------------------------------------------------------- test_absolute.js:47:2
+
+Cannot cast `H.fun()` to boolean because `Definition` [1] is incompatible with boolean [2].
+
+   test_absolute.js:47:2
+   47| (H.fun(): boolean); // Error either Implementation ~> boolean or Declaration ~> boolean
+        ^^^^^^^
+
+References:
+   node_modules/package_with_partial_flow_main/code.js.flow:2:32
+    2| declare export function fun(): Definition;
+                                      ^^^^^^^^^^ [1]
+   test_absolute.js:47:11
+   47| (H.fun(): boolean); // Error either Implementation ~> boolean or Declaration ~> boolean
+                 ^^^^^^^ [2]
+
+
+Error -------------------------------------------------------------------------------------------- test_absolute.js:50:2
+
+Cannot cast `I.fun()` to boolean because `Definition` [1] is incompatible with boolean [2].
+
+   test_absolute.js:50:2
+   50| (I.fun(): boolean); // Error either Implementation ~> boolean or Declaration ~> boolean
+        ^^^^^^^
+
+References:
+   node_modules/package_with_dir_flow_main/dir/index.js.flow:4:31
+    4| declare export var fun: () => Definition;
+                                     ^^^^^^^^^^ [1]
+   test_absolute.js:50:11
+   50| (I.fun(): boolean); // Error either Implementation ~> boolean or Declaration ~> boolean
+                 ^^^^^^^ [2]
+
+
 Error --------------------------------------------------------------------------------------------- test_relative.js:3:2
 
 Cannot cast `foo()` to boolean because `Definition` [1] is incompatible with boolean [2].
@@ -893,7 +1097,7 @@ References:
 
 
 
-Found 13 errors
+Found 16 errors
 Error --------------------------------------------------------------------------------------------- test_absolute.js:5:2
 
 Cannot cast `B1.fun()` to boolean because `Implementation` [1] is incompatible with boolean [2].
@@ -1095,6 +1299,57 @@ References:
                                 ^^^^^^^^^^^^^^ [1]
    test_absolute.js:41:11
    41| (F.fun(): boolean); // Error either Implementation ~> boolean or Declaration ~> boolean
+                 ^^^^^^^ [2]
+
+
+Error -------------------------------------------------------------------------------------------- test_absolute.js:44:2
+
+Cannot cast `G.fun()` to boolean because `Implementation` [1] is incompatible with boolean [2].
+
+   test_absolute.js:44:2
+   44| (G.fun(): boolean); // Error either Implementation ~> boolean or Declaration ~> boolean
+        ^^^^^^^
+
+References:
+   node_modules/package_with_full_flow_main/code.js:4:26
+    4| module.exports.fun = (): Implementation => new Implementation();
+                                ^^^^^^^^^^^^^^ [1]
+   test_absolute.js:44:11
+   44| (G.fun(): boolean); // Error either Implementation ~> boolean or Declaration ~> boolean
+                 ^^^^^^^ [2]
+
+
+Error -------------------------------------------------------------------------------------------- test_absolute.js:47:2
+
+Cannot cast `H.fun()` to boolean because `Implementation` [1] is incompatible with boolean [2].
+
+   test_absolute.js:47:2
+   47| (H.fun(): boolean); // Error either Implementation ~> boolean or Declaration ~> boolean
+        ^^^^^^^
+
+References:
+   node_modules/package_with_partial_flow_main/code.js:4:26
+    4| module.exports.fun = (): Implementation => new Implementation();
+                                ^^^^^^^^^^^^^^ [1]
+   test_absolute.js:47:11
+   47| (H.fun(): boolean); // Error either Implementation ~> boolean or Declaration ~> boolean
+                 ^^^^^^^ [2]
+
+
+Error -------------------------------------------------------------------------------------------- test_absolute.js:50:2
+
+Cannot cast `I.fun()` to boolean because `Implementation` [1] is incompatible with boolean [2].
+
+   test_absolute.js:50:2
+   50| (I.fun(): boolean); // Error either Implementation ~> boolean or Declaration ~> boolean
+        ^^^^^^^
+
+References:
+   node_modules/package_with_dir_flow_main/dir/index.js:4:26
+    4| module.exports.fun = (): Implementation => new Implementation();
+                                ^^^^^^^^^^^^^^ [1]
+   test_absolute.js:50:11
+   50| (I.fun(): boolean); // Error either Implementation ~> boolean or Declaration ~> boolean
                  ^^^^^^^ [2]
 
 
@@ -1116,7 +1371,7 @@ References:
 
 
 
-Found 13 errors
+Found 16 errors
 Error --------------------------------------------------------------------------------------------- test_absolute.js:5:2
 
 Cannot cast `B1.fun()` to boolean because `Definition` [1] is incompatible with boolean [2].
@@ -1321,6 +1576,57 @@ References:
                  ^^^^^^^ [2]
 
 
+Error -------------------------------------------------------------------------------------------- test_absolute.js:44:2
+
+Cannot cast `G.fun()` to boolean because `Definition` [1] is incompatible with boolean [2].
+
+   test_absolute.js:44:2
+   44| (G.fun(): boolean); // Error either Implementation ~> boolean or Declaration ~> boolean
+        ^^^^^^^
+
+References:
+   node_modules/package_with_full_flow_main/code.js.flow:4:24
+    4| declare var fun: () => Definition;
+                              ^^^^^^^^^^ [1]
+   test_absolute.js:44:11
+   44| (G.fun(): boolean); // Error either Implementation ~> boolean or Declaration ~> boolean
+                 ^^^^^^^ [2]
+
+
+Error -------------------------------------------------------------------------------------------- test_absolute.js:47:2
+
+Cannot cast `H.fun()` to boolean because `Definition` [1] is incompatible with boolean [2].
+
+   test_absolute.js:47:2
+   47| (H.fun(): boolean); // Error either Implementation ~> boolean or Declaration ~> boolean
+        ^^^^^^^
+
+References:
+   node_modules/package_with_partial_flow_main/code.js.flow:2:32
+    2| declare export function fun(): Definition;
+                                      ^^^^^^^^^^ [1]
+   test_absolute.js:47:11
+   47| (H.fun(): boolean); // Error either Implementation ~> boolean or Declaration ~> boolean
+                 ^^^^^^^ [2]
+
+
+Error -------------------------------------------------------------------------------------------- test_absolute.js:50:2
+
+Cannot cast `I.fun()` to boolean because `Definition` [1] is incompatible with boolean [2].
+
+   test_absolute.js:50:2
+   50| (I.fun(): boolean); // Error either Implementation ~> boolean or Declaration ~> boolean
+        ^^^^^^^
+
+References:
+   node_modules/package_with_dir_flow_main/dir/index.js.flow:4:31
+    4| declare export var fun: () => Definition;
+                                     ^^^^^^^^^^ [1]
+   test_absolute.js:50:11
+   50| (I.fun(): boolean); // Error either Implementation ~> boolean or Declaration ~> boolean
+                 ^^^^^^^ [2]
+
+
 Error --------------------------------------------------------------------------------------------- test_relative.js:3:2
 
 Cannot cast `foo()` to boolean because `Definition` [1] is incompatible with boolean [2].
@@ -1339,7 +1645,7 @@ References:
 
 
 
-Found 13 errors
+Found 16 errors
 
 
 ======Start off without the .js files and with the .flow file======
@@ -1547,6 +1853,57 @@ References:
                  ^^^^^^^ [2]
 
 
+Error -------------------------------------------------------------------------------------------- test_absolute.js:44:2
+
+Cannot cast `G.fun()` to boolean because `Definition` [1] is incompatible with boolean [2].
+
+   test_absolute.js:44:2
+   44| (G.fun(): boolean); // Error either Implementation ~> boolean or Declaration ~> boolean
+        ^^^^^^^
+
+References:
+   node_modules/package_with_full_flow_main/code.js.flow:4:24
+    4| declare var fun: () => Definition;
+                              ^^^^^^^^^^ [1]
+   test_absolute.js:44:11
+   44| (G.fun(): boolean); // Error either Implementation ~> boolean or Declaration ~> boolean
+                 ^^^^^^^ [2]
+
+
+Error -------------------------------------------------------------------------------------------- test_absolute.js:47:2
+
+Cannot cast `H.fun()` to boolean because `Definition` [1] is incompatible with boolean [2].
+
+   test_absolute.js:47:2
+   47| (H.fun(): boolean); // Error either Implementation ~> boolean or Declaration ~> boolean
+        ^^^^^^^
+
+References:
+   node_modules/package_with_partial_flow_main/code.js.flow:2:32
+    2| declare export function fun(): Definition;
+                                      ^^^^^^^^^^ [1]
+   test_absolute.js:47:11
+   47| (H.fun(): boolean); // Error either Implementation ~> boolean or Declaration ~> boolean
+                 ^^^^^^^ [2]
+
+
+Error -------------------------------------------------------------------------------------------- test_absolute.js:50:2
+
+Cannot cast `I.fun()` to boolean because `Definition` [1] is incompatible with boolean [2].
+
+   test_absolute.js:50:2
+   50| (I.fun(): boolean); // Error either Implementation ~> boolean or Declaration ~> boolean
+        ^^^^^^^
+
+References:
+   node_modules/package_with_dir_flow_main/dir/index.js.flow:4:31
+    4| declare export var fun: () => Definition;
+                                     ^^^^^^^^^^ [1]
+   test_absolute.js:50:11
+   50| (I.fun(): boolean); // Error either Implementation ~> boolean or Declaration ~> boolean
+                 ^^^^^^^ [2]
+
+
 Error --------------------------------------------------------------------------------------------- test_relative.js:3:2
 
 Cannot cast `foo()` to boolean because `Definition` [1] is incompatible with boolean [2].
@@ -1565,7 +1922,7 @@ References:
 
 
 
-Found 13 errors
+Found 16 errors
 Error --------------------------------------------------------------------------------------------- test_absolute.js:5:2
 
 Cannot cast `B1.fun()` to boolean because `Definition` [1] is incompatible with boolean [2].
@@ -1770,6 +2127,57 @@ References:
                  ^^^^^^^ [2]
 
 
+Error -------------------------------------------------------------------------------------------- test_absolute.js:44:2
+
+Cannot cast `G.fun()` to boolean because `Definition` [1] is incompatible with boolean [2].
+
+   test_absolute.js:44:2
+   44| (G.fun(): boolean); // Error either Implementation ~> boolean or Declaration ~> boolean
+        ^^^^^^^
+
+References:
+   node_modules/package_with_full_flow_main/code.js.flow:4:24
+    4| declare var fun: () => Definition;
+                              ^^^^^^^^^^ [1]
+   test_absolute.js:44:11
+   44| (G.fun(): boolean); // Error either Implementation ~> boolean or Declaration ~> boolean
+                 ^^^^^^^ [2]
+
+
+Error -------------------------------------------------------------------------------------------- test_absolute.js:47:2
+
+Cannot cast `H.fun()` to boolean because `Definition` [1] is incompatible with boolean [2].
+
+   test_absolute.js:47:2
+   47| (H.fun(): boolean); // Error either Implementation ~> boolean or Declaration ~> boolean
+        ^^^^^^^
+
+References:
+   node_modules/package_with_partial_flow_main/code.js.flow:2:32
+    2| declare export function fun(): Definition;
+                                      ^^^^^^^^^^ [1]
+   test_absolute.js:47:11
+   47| (H.fun(): boolean); // Error either Implementation ~> boolean or Declaration ~> boolean
+                 ^^^^^^^ [2]
+
+
+Error -------------------------------------------------------------------------------------------- test_absolute.js:50:2
+
+Cannot cast `I.fun()` to boolean because `Definition` [1] is incompatible with boolean [2].
+
+   test_absolute.js:50:2
+   50| (I.fun(): boolean); // Error either Implementation ~> boolean or Declaration ~> boolean
+        ^^^^^^^
+
+References:
+   node_modules/package_with_dir_flow_main/dir/index.js.flow:4:31
+    4| declare export var fun: () => Definition;
+                                     ^^^^^^^^^^ [1]
+   test_absolute.js:50:11
+   50| (I.fun(): boolean); // Error either Implementation ~> boolean or Declaration ~> boolean
+                 ^^^^^^^ [2]
+
+
 Error --------------------------------------------------------------------------------------------- test_relative.js:3:2
 
 Cannot cast `foo()` to boolean because `Definition` [1] is incompatible with boolean [2].
@@ -1788,7 +2196,7 @@ References:
 
 
 
-Found 13 errors
+Found 16 errors
 Error --------------------------------------------------------------------------------------------- test_absolute.js:5:2
 
 Cannot cast `B1.fun()` to boolean because `Definition` [1] is incompatible with boolean [2].
@@ -1993,6 +2401,57 @@ References:
                  ^^^^^^^ [2]
 
 
+Error -------------------------------------------------------------------------------------------- test_absolute.js:44:2
+
+Cannot cast `G.fun()` to boolean because `Definition` [1] is incompatible with boolean [2].
+
+   test_absolute.js:44:2
+   44| (G.fun(): boolean); // Error either Implementation ~> boolean or Declaration ~> boolean
+        ^^^^^^^
+
+References:
+   node_modules/package_with_full_flow_main/code.js.flow:4:24
+    4| declare var fun: () => Definition;
+                              ^^^^^^^^^^ [1]
+   test_absolute.js:44:11
+   44| (G.fun(): boolean); // Error either Implementation ~> boolean or Declaration ~> boolean
+                 ^^^^^^^ [2]
+
+
+Error -------------------------------------------------------------------------------------------- test_absolute.js:47:2
+
+Cannot cast `H.fun()` to boolean because `Definition` [1] is incompatible with boolean [2].
+
+   test_absolute.js:47:2
+   47| (H.fun(): boolean); // Error either Implementation ~> boolean or Declaration ~> boolean
+        ^^^^^^^
+
+References:
+   node_modules/package_with_partial_flow_main/code.js.flow:2:32
+    2| declare export function fun(): Definition;
+                                      ^^^^^^^^^^ [1]
+   test_absolute.js:47:11
+   47| (H.fun(): boolean); // Error either Implementation ~> boolean or Declaration ~> boolean
+                 ^^^^^^^ [2]
+
+
+Error -------------------------------------------------------------------------------------------- test_absolute.js:50:2
+
+Cannot cast `I.fun()` to boolean because `Definition` [1] is incompatible with boolean [2].
+
+   test_absolute.js:50:2
+   50| (I.fun(): boolean); // Error either Implementation ~> boolean or Declaration ~> boolean
+        ^^^^^^^
+
+References:
+   node_modules/package_with_dir_flow_main/dir/index.js.flow:4:31
+    4| declare export var fun: () => Definition;
+                                     ^^^^^^^^^^ [1]
+   test_absolute.js:50:11
+   50| (I.fun(): boolean); // Error either Implementation ~> boolean or Declaration ~> boolean
+                 ^^^^^^^ [2]
+
+
 Error --------------------------------------------------------------------------------------------- test_relative.js:3:2
 
 Cannot cast `foo()` to boolean because `Definition` [1] is incompatible with boolean [2].
@@ -2011,4 +2470,4 @@ References:
 
 
 
-Found 13 errors
+Found 16 errors

--- a/tests/declaration_files_incremental_node/node_modules/package_with_dir_flow_main/dir/index.js
+++ b/tests/declaration_files_incremental_node/node_modules/package_with_dir_flow_main/dir/index.js
@@ -1,0 +1,4 @@
+/* @flow */
+
+class Implementation {}
+module.exports.fun = (): Implementation => new Implementation();

--- a/tests/declaration_files_incremental_node/node_modules/package_with_dir_flow_main/dir/index.js.flow.ignored
+++ b/tests/declaration_files_incremental_node/node_modules/package_with_dir_flow_main/dir/index.js.flow.ignored
@@ -1,0 +1,4 @@
+/* @flow */
+
+declare class Definition {}
+declare export var fun: () => Definition;

--- a/tests/declaration_files_incremental_node/node_modules/package_with_dir_flow_main/package.json
+++ b/tests/declaration_files_incremental_node/node_modules/package_with_dir_flow_main/package.json
@@ -1,0 +1,3 @@
+{ "name": "package_with_full_main",
+  "main": "dir-non-existent",
+  "flow:main": "dir" }

--- a/tests/declaration_files_incremental_node/node_modules/package_with_full_flow_main/code.js
+++ b/tests/declaration_files_incremental_node/node_modules/package_with_full_flow_main/code.js
@@ -1,0 +1,4 @@
+/* @flow */
+
+class Implementation {}
+module.exports.fun = (): Implementation => new Implementation();

--- a/tests/declaration_files_incremental_node/node_modules/package_with_full_flow_main/code.js.flow.ignored
+++ b/tests/declaration_files_incremental_node/node_modules/package_with_full_flow_main/code.js.flow.ignored
@@ -1,0 +1,5 @@
+/* @flow */
+
+declare class Definition {}
+declare var fun: () => Definition;
+declare export { fun };

--- a/tests/declaration_files_incremental_node/node_modules/package_with_full_flow_main/package.json
+++ b/tests/declaration_files_incremental_node/node_modules/package_with_full_flow_main/package.json
@@ -1,0 +1,3 @@
+{ "name": "package_with_full_main",
+  "flow:main": "./code.js",
+  "main": "./code-non-existent.js" }

--- a/tests/declaration_files_incremental_node/node_modules/package_with_partial_flow_main/code.js
+++ b/tests/declaration_files_incremental_node/node_modules/package_with_partial_flow_main/code.js
@@ -1,0 +1,4 @@
+/* @flow */
+
+class Implementation {}
+module.exports.fun = (): Implementation => new Implementation();

--- a/tests/declaration_files_incremental_node/node_modules/package_with_partial_flow_main/code.js.flow.ignored
+++ b/tests/declaration_files_incremental_node/node_modules/package_with_partial_flow_main/code.js.flow.ignored
@@ -1,0 +1,2 @@
+declare class Definition {}
+declare export function fun(): Definition;

--- a/tests/declaration_files_incremental_node/node_modules/package_with_partial_flow_main/package.json
+++ b/tests/declaration_files_incremental_node/node_modules/package_with_partial_flow_main/package.json
@@ -1,0 +1,2 @@
+{ "name": "package_with_partial_main",
+  "flow:main": "./code" }

--- a/tests/declaration_files_incremental_node/test.sh
+++ b/tests/declaration_files_incremental_node/test.sh
@@ -9,6 +9,9 @@ IMPL_FILES="
   node_modules/package_with_full_main/code.js
   node_modules/package_with_no_package_json/index.js
   node_modules/package_with_partial_main/code.js
+  node_modules/package_with_dir_flow_main/dir/index.js
+  node_modules/package_with_full_flow_main/code.js
+  node_modules/package_with_partial_flow_main/code.js
 "
 DECL_FILES=$(echo "$IMPL_FILES" | sed -e "s/\.js/.js.flow/g")
 

--- a/tests/declaration_files_incremental_node/test_absolute.js
+++ b/tests/declaration_files_incremental_node/test_absolute.js
@@ -39,3 +39,12 @@ var E = require('package_with_no_package_json');
 
 var F = require('package_with_dir_main');
 (F.fun(): boolean); // Error either Implementation ~> boolean or Declaration ~> boolean
+
+var G = require('package_with_full_flow_main');
+(G.fun(): boolean); // Error either Implementation ~> boolean or Declaration ~> boolean
+
+var H = require('package_with_partial_flow_main');
+(H.fun(): boolean); // Error either Implementation ~> boolean or Declaration ~> boolean
+
+var I = require('package_with_dir_flow_main');
+(I.fun(): boolean); // Error either Implementation ~> boolean or Declaration ~> boolean


### PR DESCRIPTION
This PR is a resurrection of https://github.com/facebook/flow/pull/1459

## Situation

Flow syntax is not natively supported by JS Engines so flow users use tools like [`babel`](https://babeljs.io/) to strip types from flow to ship it in [`npm`](https://www.npmjs.com/). This means that people that import those packages into their projects don't have typing support and have to in turn again use [`flow-typed`](https://github.com/flowtype/flow-typed) to add support for packages that were originally written in flow.

There are of course workarounds for this, the most popular one being to mirror sources of files in the same folder as dist as `[file].js.flow`. It has it's own sets of quirks and limitations.

As things are, it's nearly impossible to use Flowtype in a monorepo setup without having to rely on third party tooling.

## Why current alternatives aren't enough

The flow community has had this problem for a while and as such demand has given birth to a supply of "fixes" for this including but not limited to

- https://github.com/AgentME/flow-copy-source
- https://github.com/steelbrain/babel-cli-flow
- https://github.com/ImmoweltGroup/flow-mono-cli

All of them are unreliable and easily break as they all use `.js.flow` way of working this issue around

## Proposed solution

The path this PR tries to take is to add a new field to `package.json` called `flow:main`. When available, it'll be used instead of `main`. It's resolution and handling is no different than that of a `main` field.

This change is non API breaking and no existing packages running flow would break with this. Furthermore those packages that already are using `lib/index.js.flow` or similar ways would also be unaffected by this. This change would only affect the packages that explicitly specify the new key.

This PR enables package authors to allow package authors to specify `main` to `lib/index.js` (example value) and `flow:main` to `src/index.js` (example value). This change when combined with un-ignoring `src` directory in `.npmignore` would give flow typings for modules out of the box.

Furthermore, with this change, no special changes have to be done to make typings in mono repo modules work. They should work OOB.

## Why flow:main

It's just a proposed solution. Typescript [uses `types`/`typings`](https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html). We could do something similar. I'm open to suggestion for names but I think `flow:main` is simple, straight forward and gets the job done :)