### PR TITLE
Add `tooShort` to ValidityState

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -3036,6 +3036,7 @@ declare class ValidityState {
   rangeUnderflow: boolean;
   stepMismatch: boolean;
   tooLong: boolean;
+  tooShort: boolean;
   typeMismatch: boolean;
   valueMissing: boolean;
   valid: boolean;


### PR DESCRIPTION
Adds the missing `tooShort` boolean to the `ValidityState` [DOM API](https://developer.mozilla.org/en-US/docs/Web/API/ValidityState).

Is there anything else I need to update (tests etc)?

fixes #6507