### PR TITLE
Add AbortController and AbortSignal typing

### DIFF
--- a/lib/bom.js
+++ b/lib/bom.js
@@ -952,6 +952,7 @@ type RequestOptions = {
     redirect?: RedirectType;
     referrer?: string;
     referrerPolicy?: ReferrerPolicyType;
+    signal?: ?AbortSignal;
     window?: any;
 }
 
@@ -1011,6 +1012,17 @@ declare class Request {
     formData(): Promise<FormData>;
     json(): Promise<any>;
     text(): Promise<string>;
+}
+
+declare class AbortController {
+    constructor(): void;
+    +signal: AbortSignal;
+    abort(): void;
+}
+
+declare class AbortSignal extends EventTarget {
+    +aborted: boolean;
+    onabort: (event: AbortProgressEventTypes) => mixed;
 }
 
 declare function fetch(input: RequestInfo, init?: RequestOptions): Promise<Response>;

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -129,6 +129,8 @@ type TouchEventHandler = (event: TouchEvent) => mixed
 type TouchEventListener = {handleEvent: TouchEventHandler} | TouchEventHandler
 type WheelEventHandler = (event: WheelEvent) => mixed
 type WheelEventListener = {handleEvent: WheelEventHandler} | WheelEventHandler
+type AbortProgressEventHandler = (event: ProgressEvent) => mixed
+type AbortProgressEventListener = {handleEvent: AbortProgressEventHandler} | AbortProgressEventHandler
 type ProgressEventHandler = (event: ProgressEvent) => mixed
 type ProgressEventListener = {handleEvent: ProgressEventHandler} | ProgressEventHandler
 type DragEventHandler = (event: DragEvent) => mixed
@@ -143,6 +145,7 @@ type FocusEventTypes = 'blur' | 'focus' | 'focusin' | 'focusout';
 type KeyboardEventTypes = 'keydown' | 'keyup' | 'keypress';
 type TouchEventTypes = 'touchstart' | 'touchmove' | 'touchend' | 'touchcancel';
 type WheelEventTypes = 'wheel';
+type AbortProgressEventTypes = 'abort';
 type ProgressEventTypes = 'abort' | 'error' | 'load' | 'loadend' | 'loadstart' | 'progress' | 'timeout';
 type DragEventTypes = 'drag' | 'dragend' | 'dragenter' | 'dragexit' | 'dragleave' | 'dragover' | 'dragstart' | 'drop';
 type AnimationEventTypes = 'animationstart' | 'animationend' | 'animationiteration';
@@ -160,6 +163,7 @@ declare class EventTarget {
   addEventListener(type: KeyboardEventTypes, listener: KeyboardEventListener, optionsOrUseCapture?: EventListenerOptionsOrUseCapture): void;
   addEventListener(type: TouchEventTypes, listener: TouchEventListener, optionsOrUseCapture?: EventListenerOptionsOrUseCapture): void;
   addEventListener(type: WheelEventTypes, listener: WheelEventListener, optionsOrUseCapture?: EventListenerOptionsOrUseCapture): void;
+  addEventListener(type: AbortProgressEventTypes, listener: AbortProgressEventListener, optionsOrUseCapture?: EventListenerOptionsOrUseCapture): void;
   addEventListener(type: ProgressEventTypes, listener: ProgressEventListener, optionsOrUseCapture?: EventListenerOptionsOrUseCapture): void;
   addEventListener(type: DragEventTypes, listener: DragEventListener, optionsOrUseCapture?: EventListenerOptionsOrUseCapture): void;
   addEventListener(type: AnimationEventTypes, listener: AnimationEventListener, optionsOrUseCapture?: EventListenerOptionsOrUseCapture): void;
@@ -171,6 +175,7 @@ declare class EventTarget {
   removeEventListener(type: KeyboardEventTypes, listener: KeyboardEventListener, optionsOrUseCapture?: EventListenerOptionsOrUseCapture): void;
   removeEventListener(type: TouchEventTypes, listener: TouchEventListener, optionsOrUseCapture?: EventListenerOptionsOrUseCapture): void;
   removeEventListener(type: WheelEventTypes, listener: WheelEventListener, optionsOrUseCapture?: EventListenerOptionsOrUseCapture): void;
+  removeEventListener(type: AbortProgressEventTypes, listener: AbortProgressEventListener, optionsOrUseCapture?: EventListenerOptionsOrUseCapture): void;
   removeEventListener(type: ProgressEventTypes, listener: ProgressEventListener, optionsOrUseCapture?: EventListenerOptionsOrUseCapture): void;
   removeEventListener(type: DragEventTypes, listener: DragEventListener, optionsOrUseCapture?: EventListenerOptionsOrUseCapture): void;
   removeEventListener(type: AnimationEventTypes, listener: AnimationEventListener, optionsOrUseCapture?: EventListenerOptionsOrUseCapture): void;
@@ -182,6 +187,7 @@ declare class EventTarget {
   attachEvent?: (type: KeyboardEventTypes, listener: KeyboardEventListener) => void;
   attachEvent?: (type: TouchEventTypes, listener: TouchEventListener) => void;
   attachEvent?: (type: WheelEventTypes, listener: WheelEventListener) => void;
+  attachEvent?: (type: AbortProgressEventTypes, listener: AbortProgressEventListener) => void;
   attachEvent?: (type: ProgressEventTypes, listener: ProgressEventListener) => void;
   attachEvent?: (type: DragEventTypes, listener: DragEventListener) => void;
   attachEvent?: (type: AnimationEventTypes, listener: AnimationEventListener) => void;
@@ -193,6 +199,7 @@ declare class EventTarget {
   detachEvent?: (type: KeyboardEventTypes, listener: KeyboardEventListener) => void;
   detachEvent?: (type: TouchEventTypes, listener: TouchEventListener) => void;
   detachEvent?: (type: WheelEventTypes, listener: WheelEventListener) => void;
+  detachEvent?: (type: AbortProgressEventTypes, listener: AbortProgressEventListener) => void;
   detachEvent?: (type: ProgressEventTypes, listener: ProgressEventListener) => void;
   detachEvent?: (type: DragEventTypes, listener: DragEventListener) => void;
   detachEvent?: (type: AnimationEventTypes, listener: AnimationEventListener) => void;


### PR DESCRIPTION
Add `AbortController` and `AbortSignal` typings.

According to the DOM spec:
https://developer.mozilla.org/en-US/docs/Web/API/AbortController
https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal