### PR TITLE
Add docs on callable object types

### DIFF
--- a/website/en/docs/types/functions.md
+++ b/website/en/docs/types/functions.md
@@ -288,6 +288,27 @@ foo(5);
 foo([]);
 ```
 
+### Callable Objects <a class="toc" id="toc-callable-objects" href="#toc-callable-objects"></a>
+
+Callable objects can be typed, for example:
+
+```
+type CallableObj = {
+  (number, number): number,
+  bar: string
+};
+
+function add(x, y) {
+  return x + y; 
+}
+
+// $ExpectError
+(add: CallableObj);
+
+add.bar = "hello world";
+
+(add: CallableObj);
+```
 
 ### `Function` Type <a class="toc" id="toc-function-type" href="#toc-function-type"></a>
 


### PR DESCRIPTION
I found this functionality to be very useful, but didn't know it existed until I happened upon it in the [libdef of `React$StatelessFunctionalComponent`](https://github.com/facebook/flow/blob/a028a0fb8d1ce0ca715bd519f50916ad3cf168cc/lib/react.js#L137-L142)

This could probably belong in the object section, but I personally looked in the function section first.