### PR TITLE
Fix profile to not throw on windows. Fixes #6133

### DIFF
--- a/src/commands/checkCommands.ml
+++ b/src/commands/checkCommands.ml
@@ -87,11 +87,15 @@ module CheckCommand = struct
     if Options.should_profile options
     then begin
       Flow_server_profile.init ();
-      let rec sample_processor_info () =
-        Flow_server_profile.processor_sample ();
-        Timer.set_timer ~interval:1.0 ~callback:sample_processor_info |> ignore
-      in
-      sample_processor_info ()
+      if Sys.win32 then
+        Flow_server_profile.processor_sample ()
+      else begin
+        let rec sample_processor_info () =
+          Flow_server_profile.processor_sample ();
+          Timer.set_timer ~interval:1.0 ~callback:sample_processor_info |> ignore
+        in
+        sample_processor_info ();
+      end;
     end;
 
     (* initialize loggers before doing too much, especially anything that might exit *)


### PR DESCRIPTION
Timer in hack does not work in windows. 
It was added here: https://github.com/facebook/flow/commit/1147adf1e2427d2734c404c4ba4838f30e2c8c57

by @gabelevi 

and it doesn't sound that necessary to run like this on windows