### PR TITLE
Docs: fix subtype example indention

### DIFF
--- a/website/en/docs/lang/subtypes.md
+++ b/website/en/docs/lang/subtypes.md
@@ -38,7 +38,7 @@ each have some unique items.
 
 ```js
 type TypeA = 1 | 2 | 3;
-type TypeB =         3 | 4 | 5;
+type TypeB = 3 | 4 | 5;
 ```
 
 ## When are subtypes used? <a class="toc" id="toc-when-are-subtypes-used" href="#toc-when-are-subtypes-used"></a>


### PR DESCRIPTION
Fixes a misaligned code example on the subtypes page: https://flow.org/en/docs/lang/subtypes/