### PR TITLE
Create an explicit type for Contexts 

### DIFF
--- a/lib/react.js
+++ b/lib/react.js
@@ -192,6 +192,15 @@ declare type React$Ref<ElementType: React$ElementType> =
   | string;
 
 /**
+ * The type of a React Context.  React Contexts are created by calling
+ * createContext() with a default value.
+ */
+declare type React$Context<T> = {
+  Provider: React$ComponentType<{ value: T }>,
+  Consumer: React$ComponentType<{ children: (value: T) => React$Node }>,
+}
+
+/**
  * A React portal node. The implementation of the portal node is hidden to React
  * users so we use an opaque type.
  */
@@ -213,10 +222,7 @@ declare module react {
   declare export var createClass: React$CreateClass;
   declare export function createContext<T>(
     defaultValue: T,
-  ): {
-    Provider: React$ComponentType<{value: T}>,
-    Consumer: React$ComponentType<{children: (value: T) => React$Node}>,
-  };
+  ): React$Context<T>;
   declare export var createElement: React$CreateElement;
   declare export var cloneElement: React$CloneElement;
   declare export function createFactory<ElementType: React$ElementType>(
@@ -238,6 +244,7 @@ declare module react {
   declare export type Key = React$Key;
   declare export type Ref<C> = React$Ref<C>;
   declare export type Node = React$Node;
+  declare export type Context<T> = React$Context<T>;
   declare export type Portal = React$Portal;
 
   declare export type ElementProps<C> = React$ElementProps<C>;


### PR DESCRIPTION
Sometimes you want to interact with a React Context in an abstract way, such as an implementation for a higher order component that spreads a context consumer into a component.  The way that `createContext` is currently typed makes this a little more difficult than it probably needs to be, so I created a type called `React$Context<T>` and exported the type from the react package as well which seems to be the standard approach for types like this.