### PR TITLE
Add TransitionEvent.

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -138,6 +138,8 @@ type AnimationEventHandler = (event: AnimationEvent) => mixed
 type AnimationEventListener = {handleEvent: AnimationEventHandler} | AnimationEventHandler
 type ClipboardEventHandler = (event: ClipboardEvent) => mixed
 type ClipboardEventListener = {handleEvent: ClipboardEventHandler} | ClipboardEventHandler
+type TransitionEventHandler = (event: TransitionEvent) => mixed
+type TransitionEventListener = {handleEvent: TransitionEventHandler} | TransitionEventHandler
 
 type MouseEventTypes = 'contextmenu' | 'mousedown' | 'mouseenter' | 'mouseleave' | 'mousemove' | 'mouseout' | 'mouseover' | 'mouseup' | 'click' | 'dblclick';
 type FocusEventTypes = 'blur' | 'focus' | 'focusin' | 'focusout';
@@ -148,6 +150,7 @@ type ProgressEventTypes = 'abort' | 'error' | 'load' | 'loadend' | 'loadstart' |
 type DragEventTypes = 'drag' | 'dragend' | 'dragenter' | 'dragexit' | 'dragleave' | 'dragover' | 'dragstart' | 'drop';
 type AnimationEventTypes = 'animationstart' | 'animationend' | 'animationiteration';
 type ClipboardEventTypes = 'clipboardchange' | 'cut' | 'copy' | 'paste';
+type TransitionEventTypes = 'transitionrun' | 'transitionstart' | 'transitionend' | 'transitioncancel';
 
 type EventListenerOptionsOrUseCapture = boolean | {
   capture?: boolean,
@@ -165,6 +168,7 @@ declare class EventTarget {
   addEventListener(type: DragEventTypes, listener: DragEventListener, optionsOrUseCapture?: EventListenerOptionsOrUseCapture): void;
   addEventListener(type: AnimationEventTypes, listener: AnimationEventListener, optionsOrUseCapture?: EventListenerOptionsOrUseCapture): void;
   addEventListener(type: ClipboardEventTypes, listener: ClipboardEventListener, optionsOrUseCapture?: EventListenerOptionsOrUseCapture): void;
+  addEventListener(type: TransitionEventTypes, listener: TransitionEventListener, optionsOrUseCapture?: EventListenerOptionsOrUseCapture): void;
   addEventListener(type: string, listener: EventListener, optionsOrUseCapture?: EventListenerOptionsOrUseCapture): void;
 
   removeEventListener(type: MouseEventTypes, listener: MouseEventListener, optionsOrUseCapture?: EventListenerOptionsOrUseCapture): void;
@@ -176,6 +180,7 @@ declare class EventTarget {
   removeEventListener(type: DragEventTypes, listener: DragEventListener, optionsOrUseCapture?: EventListenerOptionsOrUseCapture): void;
   removeEventListener(type: AnimationEventTypes, listener: AnimationEventListener, optionsOrUseCapture?: EventListenerOptionsOrUseCapture): void;
   removeEventListener(type: ClipboardEventTypes, listener: ClipboardEventListener, optionsOrUseCapture?: EventListenerOptionsOrUseCapture): void;
+  removeEventListener(type: TransitionEventTypes, listener: TransitionEventListener, optionsOrUseCapture?: EventListenerOptionsOrUseCapture): void;
   removeEventListener(type: string, listener: EventListener, optionsOrUseCapture?: EventListenerOptionsOrUseCapture): void;
 
   attachEvent?: (type: MouseEventTypes, listener: MouseEventListener) => void;
@@ -187,6 +192,7 @@ declare class EventTarget {
   attachEvent?: (type: DragEventTypes, listener: DragEventListener) => void;
   attachEvent?: (type: AnimationEventTypes, listener: AnimationEventListener) => void;
   attachEvent?: (type: ClipboardEventTypes, listener: ClipboardEventListener) => void;
+  attachEvent?: (type: TransitionEventTypes, listener: TransitionEventListener) => void;
   attachEvent?: (type: string, listener: EventListener) => void;
 
   detachEvent?: (type: MouseEventTypes, listener: MouseEventListener) => void;
@@ -198,6 +204,7 @@ declare class EventTarget {
   detachEvent?: (type: DragEventTypes, listener: DragEventListener) => void;
   detachEvent?: (type: AnimationEventTypes, listener: AnimationEventListener) => void;
   detachEvent?: (type: ClipboardEventTypes, listener: ClipboardEventListener) => void;
+  detachEvent?: (type: TransitionEventTypes, listener: TransitionEventListener) => void;
   detachEvent?: (type: string, listener: EventListener) => void;
 
   dispatchEvent(evt: Event): boolean;
@@ -440,6 +447,21 @@ type ClipboardEvent$Init = Event$Init & {
 declare class ClipboardEvent extends Event {
   constructor(type: ClipboardEventTypes, eventInit?: ClipboardEvent$Init): void;
   +clipboardData: ?DataTransfer; // readonly
+}
+
+// https://www.w3.org/TR/2017/WD-css-transitions-1-20171130/#interface-transitionevent
+type TransitionEvent$Init = Event$Init & {
+  propertyName: string;
+  elapsedTime: number;
+  pseudoElement: string;
+};
+
+declare class TransitionEvent extends Event {
+  constructor(type: TransitionEventTypes, eventInit?: TransitionEvent$Init): void;
+
+  +propertyName: string; // readonly
+  +elapsedTime: number; // readonly
+  +pseudoElement: string; // readonly
 }
 
 // TODO: *Event


### PR DESCRIPTION
Add `TransitionEvent` as a type and accept it as a parameter to `addEventListener` and other such functions.

I think this is correct? I might have missed something. I tried following the code for the other events such as the `ClipboardEvent`.

I also followed the interface on https://www.w3.org/TR/2017/WD-css-transitions-1-20171130/#interface-transitionevent to do this.