### PR TITLE
Add definition for HTMLFormControlsCollection

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -546,6 +546,10 @@ declare class NodeList<T> {
   values(): Iterator<T>;
 }
 
+declare class RadioNodeList<T> extends NodeList<T> {
+  value: string;
+}
+
 declare class NamedNodeMap {
   @@iterator(): Iterator<Attr>;
   length: number;
@@ -576,6 +580,20 @@ declare class HTMLCollection<Elem: HTMLElement> {
   item(nameOrIndex?: any, optionalIndex?: any): Elem | null;
   namedItem(name: string): Elem | null;
   [index: number | string]: Elem;
+}
+
+// https://html.spec.whatwg.org/multipage/forms.html#category-listed
+type FormListedElement =
+  HTMLButtonElement |
+  HTMLFieldSetElement |
+  HTMLInputElement |
+  HTMLObjectElement |
+  HTMLOutputElement |
+  HTMLSelectElement |
+  HTMLTextAreaElement;
+
+declare class HTMLFormControlsCollection<Elem: FormListedElement> extends HTMLCollection<Elem> {
+  namedItem(name: string): RadioNodeList<Elem> | Elem | null;
 }
 
 // from https://www.w3.org/TR/custom-elements/#extensions-to-document-interface-to-register
@@ -2824,7 +2842,7 @@ declare class HTMLFormElement extends HTMLElement {
   [index: number | string]: HTMLElement | null;
   acceptCharset: string;
   action: string;
-  elements: HTMLCollection<HTMLElement>;
+  elements: HTMLFormControlsCollection<FormListedElement>;
   encoding: string;
   enctype: string;
   length: number;
@@ -2841,7 +2859,7 @@ declare class HTMLFormElement extends HTMLElement {
 // https://www.w3.org/TR/html5/forms.html#the-fieldset-element
 declare class HTMLFieldSetElement extends HTMLElement {
   disabled: boolean;
-  elements: HTMLCollection<HTMLElement>; // readonly
+  elements: HTMLCollection<FormListedElement>; // readonly
   form: HTMLFormElement | null; // readonly
   name: string;
   type: string; // readonly


### PR DESCRIPTION
Returned by `HTMLFormElement#elements.`<sup>[1]</sup> `HTMLFormControlsCollection`—in addition from containing a subset of possible elements<sup>[2]</sup>—has a slightly different behavior for `.namedItem` then `HTMLCollection`.<sup>[3]</sup> According to the spec `HTMLFieldSetElement` should return the same subset of listed elements but in a normal `HTMLCollection`.<sup>[4]</sup>

[1]: https://html.spec.whatwg.org/multipage/forms.html#dom-form-elements
[2]: https://html.spec.whatwg.org/multipage/forms.html#category-listed
[3]: https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#htmlformcontrolscollection
[4]: https://html.spec.whatwg.org/multipage/form-elements.html#dom-fieldset-elements

Closes #6612