### PR TITLE
Fix function signature for String.prototype.codePointAt method

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -290,7 +290,7 @@ declare class String {
     anchor(name: string): string;
     charAt(pos: number): string;
     charCodeAt(index: number): number;
-    codePointAt(index: number): ?number;
+    codePointAt(index: number): number | void;
     concat(...strings: Array<string>): string;
     constructor(value?: mixed): void;
     endsWith(searchString: string, position?: number): boolean;

--- a/lib/core.js
+++ b/lib/core.js
@@ -290,7 +290,7 @@ declare class String {
     anchor(name: string): string;
     charAt(pos: number): string;
     charCodeAt(index: number): number;
-    codePointAt(index: number): number;
+    codePointAt(index: number): ?number;
     concat(...strings: Array<string>): string;
     constructor(value?: mixed): void;
     endsWith(searchString: string, position?: number): boolean;

--- a/newtests/autocomplete/test.js
+++ b/newtests/autocomplete/test.js
@@ -266,7 +266,7 @@ export default suite(({addFile, flowCmd}) => [
              },
              {
                "name": "codePointAt",
-               "type": "(index: number) => number | void",
+               "type": "(index: number) => (number | void)",
                "func_details": {
                  "return_type": "number | void",
                  "params": [
@@ -280,7 +280,7 @@ export default suite(({addFile, flowCmd}) => [
                "line": 293,
                "endline": 293,
                "start": 5,
-               "end": 46
+               "end": 45
              },
              {
                "name": "concat",

--- a/newtests/autocomplete/test.js
+++ b/newtests/autocomplete/test.js
@@ -266,9 +266,9 @@ export default suite(({addFile, flowCmd}) => [
              },
              {
                "name": "codePointAt",
-               "type": "(index: number) => ?number",
+               "type": "(index: number) => number | void",
                "func_details": {
-                 "return_type": "?number",
+                 "return_type": "number | void",
                  "params": [
                    {
                      "name": "index",
@@ -280,7 +280,7 @@ export default suite(({addFile, flowCmd}) => [
                "line": 293,
                "endline": 293,
                "start": 5,
-               "end": 39
+               "end": 46
              },
              {
                "name": "concat",

--- a/newtests/autocomplete/test.js
+++ b/newtests/autocomplete/test.js
@@ -266,9 +266,9 @@ export default suite(({addFile, flowCmd}) => [
              },
              {
                "name": "codePointAt",
-               "type": "(index: number) => number",
+               "type": "(index: number) => ?number",
                "func_details": {
-                 "return_type": "number",
+                 "return_type": "?number",
                  "params": [
                    {
                      "name": "index",
@@ -280,7 +280,7 @@ export default suite(({addFile, flowCmd}) => [
                "line": 293,
                "endline": 293,
                "start": 5,
-               "end": 38
+               "end": 39
              },
              {
                "name": "concat",

--- a/tests/autocomplete/autocomplete.exp
+++ b/tests/autocomplete/autocomplete.exp
@@ -149,13 +149,13 @@ str.js = {
     },
     {
       "name":"codePointAt",
-      "type":"(index: number) => ?number",
-      "func_details":{"return_type":"?number","params":[{"name":"index","type":"number"}]},
+      "type":"(index: number) => (number | void)",
+      "func_details":{"return_type":"number | void","params":[{"name":"index","type":"number"}]},
       "path":"[LIB] core.js",
       "line":293,
       "endline":293,
       "start":5,
-      "end":39
+      "end":45
     },
     {
       "name":"concat",
@@ -1586,13 +1586,13 @@ if.js = {
     },
     {
       "name":"codePointAt",
-      "type":"(index: number) => ?number",
-      "func_details":{"return_type":"?number","params":[{"name":"index","type":"number"}]},
+      "type":"(index: number) => (number | void)",
+      "func_details":{"return_type":"number | void","params":[{"name":"index","type":"number"}]},
       "path":"[LIB] core.js",
       "line":293,
       "endline":293,
       "start":5,
-      "end":39
+      "end":45
     },
     {
       "name":"concat",

--- a/tests/autocomplete/autocomplete.exp
+++ b/tests/autocomplete/autocomplete.exp
@@ -149,13 +149,13 @@ str.js = {
     },
     {
       "name":"codePointAt",
-      "type":"(index: number) => number",
-      "func_details":{"return_type":"number","params":[{"name":"index","type":"number"}]},
+      "type":"(index: number) => ?number",
+      "func_details":{"return_type":"?number","params":[{"name":"index","type":"number"}]},
       "path":"[LIB] core.js",
       "line":293,
       "endline":293,
       "start":5,
-      "end":38
+      "end":39
     },
     {
       "name":"concat",
@@ -1586,13 +1586,13 @@ if.js = {
     },
     {
       "name":"codePointAt",
-      "type":"(index: number) => number",
-      "func_details":{"return_type":"number","params":[{"name":"index","type":"number"}]},
+      "type":"(index: number) => ?number",
+      "func_details":{"return_type":"?number","params":[{"name":"index","type":"number"}]},
       "path":"[LIB] core.js",
       "line":293,
       "endline":293,
       "start":5,
-      "end":38
+      "end":39
     },
     {
       "name":"concat",

--- a/tests/lib/lib.exp
+++ b/tests/lib/lib.exp
@@ -68,16 +68,16 @@ References:
 
 Error ------------------------------------------------------------------------------------------------- libtest.js:14:10
 
-Cannot return `s.codePointAt(...)` because null or undefined [1] is incompatible with number [2].
+Cannot return `s.codePointAt(...)` because undefined [1] is incompatible with number [2].
 
    libtest.js:14:10
     14|   return s.codePointAt(0);
                  ^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:293:33
-   293|     codePointAt(index: number): ?number;
-                                        ^^^^^^^ [1]
+   <BUILTINS>/core.js:293:42
+   293|     codePointAt(index: number): number | void;
+                                                 ^^^^ [1]
    libtest.js:13:25
     13| function f(s: string) : number {
                                 ^^^^^^ [2]

--- a/tests/lib/lib.exp
+++ b/tests/lib/lib.exp
@@ -66,5 +66,22 @@ References:
              ^^^^^^ [2]
 
 
+Error ------------------------------------------------------------------------------------------------- libtest.js:14:10
 
-Found 4 errors
+Cannot return `s.codePointAt(...)` because null or undefined [1] is incompatible with number [2].
+
+   libtest.js:14:10
+    14|   return s.codePointAt(0);
+                 ^^^^^^^^^^^^^^^^
+
+References:
+   <BUILTINS>/core.js:293:33
+   293|     codePointAt(index: number): ?number;
+                                        ^^^^^^^ [1]
+   libtest.js:13:25
+    13| function f(s: string) : number {
+                                ^^^^^^ [2]
+
+
+
+Found 5 errors

--- a/tests/lib/libtest.js
+++ b/tests/lib/libtest.js
@@ -9,3 +9,7 @@ a.delete('foobar');
 var b = undefined;
 if (undefined) {
 }
+
+function f(s: string) : number {
+  return s.codePointAt(0);
+}


### PR DESCRIPTION
The ECMAScript spec defines that the String.prototype.codePointAt
function should return undefined if there is no element at the provided
index. This means that the function signature should be:

(index: number) => (number | void)

instead of currently:

(index: number) => number

The following code should produce an 'undefined is
incompatible with number' type error but currently does not:

```
function f(s: string) : number {
  return s.codePointAt(0);
}
```