### PR TITLE
fix broken link to FB Open Source Code of Conduct

### DIFF
--- a/website/_includes/footer.html
+++ b/website/_includes/footer.html
@@ -6,7 +6,7 @@
       <div class="footer-left">
         <span class="footer-item">&copy; 2014&ndash;{{ site.time | date: '%Y' }} Facebook Inc.</span>
         <span class="footer-item"><a href="https://github.com/facebook/flow/blob/master/LICENSE">{{i18n.site_license}}</a></span>
-        <span class="footer-item"><a href="https://code.facebook.com/pages/876921332402685/open-source-code-of-conduct">{{i18n.site_code_of_conduct}}</a></span>
+        <span class="footer-item"><a href="https://code.fb.com/codeofconduct/">{{i18n.site_code_of_conduct}}</a></span>
         {% if lang.tag == "en" %}
           <span class="footer-item"><a href="https://github.com/{{site.repository}}/edit/master/website/{{page.path}}">{{i18n.site_edit_this_page}}</a></span>
         {% else %}


### PR DESCRIPTION
currently goes to https://code.fb.com/redirect which doesn't redirect