### PR TITLE
Fix docs for `$Shape`

### DIFF
--- a/website/en/docs/types/utilities.md
+++ b/website/en/docs/types/utilities.md
@@ -18,6 +18,7 @@ Table of contents:
 - [`$TupleMap<T, F>`](#toc-tuplemap)
 - [`$Call<F>`](#toc-call)
 - [`Class<T>`](#toc-class)
+- [`$Shape<T>`](#toc-shape)
 - [`$Supertype<T>`](#toc-supertype)
 - [`$Subtype<T>`](#toc-subtype)
 - [`Existential Type (*)`](#toc-existential-type)
@@ -578,22 +579,24 @@ function makeParamStore<T>(storeClass: Class<ParamStore<T>>, data: T): ParamStor
 (makeParamStore(ParamStore, 1): ParamStore<boolean>); // failed because of the second parameter
 ```
 
-## `Shape<T>` <a class="toc" id="toc-shape" href="#toc-shape"></a>
+## `$Shape<T>` <a class="toc" id="toc-shape" href="#toc-shape"></a>
 
 Copies the shape of the type supplied, but marks every field optional.
 
 ```js
+// @flow
 type Person = {
   age: number,
   name: string,
 }
 type PersonDetails = $Shape<Person>;
 
-const person1: Person = {age: 28}; // Error due to incorrect type of Person.
-const person2: Person = {name: 'a'}; // Error due to incorrect type of Person.
-const person3: PersonDetails = {age: 28}; // Ok
-const person4: PersonDetails = {name: 'a'}; // Ok
-const person5: PersonDetails = {age: 28, name: 'a'}; // Ok
+const person1: Person = {age: 28};  // Error: missing `name`
+const person2: Person = {name: 'a'};  // Error: missing `age`
+const person3: PersonDetails = {age: 28};  // OK
+const person4: PersonDetails = {name: 'a'};  // OK
+const person5: PersonDetails = {age: 28, name: 'a'};  // OK
+```
 
 ## `$Supertype<T>` <a class="toc" id="toc-supertype" href="#toc-supertype"></a>
 


### PR DESCRIPTION
Summary:
Docs for `$Shape` were introduced in #6694, but that PR had four major
errors:

  - the section was not linked from the table of contents;
  - the type `$Shape<T>` was misspelled as `Shape<T>` in the header;
  - the code block did not have `// @flow`, so lacked error annotations;
  - the code block was not terminated, so the entirety of the rest of
    the page was marked as code, [like this][1]—clearly no one previewed
    the page before deploying!

[1]: https://archive.fo/CqH7D#87%

This patch fixes those errors. While in the area, we clean up the
comments reading "Error" and "OK" to (a) eliminate the horizontal
scrollbar and (b) match the style elsewhere on the page.

Closes #6692.

Test Plan:
After much effort, managed to get the website to build locally. Visited
<http://localhost:8080/en/docs/types/utilities/#toc-shape> and checked
that the four issues mentioned above are all fixed.

(For posterity, steps taken to get the build working are listed here:
<https://github.com/facebook/flow/pull/6708#issuecomment-411308129>.)

wchargin-branch: fix-shape-docs

