### PR TITLE
Docs: Add missing ending-backticks to code block

### DIFF
--- a/website/en/docs/types/utilities.md
+++ b/website/en/docs/types/utilities.md
@@ -594,6 +594,7 @@ const person2: Person = {name: 'a'}; // Error due to incorrect type of Person.
 const person3: PersonDetails = {age: 28}; // Ok
 const person4: PersonDetails = {name: 'a'}; // Ok
 const person5: PersonDetails = {age: 28, name: 'a'}; // Ok
+```
 
 ## `$Supertype<T>` <a class="toc" id="toc-supertype" href="#toc-supertype"></a>
 


### PR DESCRIPTION
Currently the sections below `Shape<T>` in the [Utility Types documentation](https://flow.org/en/docs/types/utilities/#toc-shape) are hard to read/not parsed correctly:

<img width="936" alt="screen shot 2018-08-08 at 14 57 31" src="https://user-images.githubusercontent.com/874365/43838358-656e26ec-9b1b-11e8-9d5a-a110f6753ed8.png">

Added missing backticks to the end of the code block.