### PR TITLE
Fix bad markup in the Utility Types documentation

### DIFF
--- a/website/en/docs/types/utilities.md
+++ b/website/en/docs/types/utilities.md
@@ -578,7 +578,7 @@ function makeParamStore<T>(storeClass: Class<ParamStore<T>>, data: T): ParamStor
 (makeParamStore(ParamStore, 1): ParamStore<boolean>); // failed because of the second parameter
 ```
 
-## `Shape<T>` <a class="toc" id="toc-shape" href="#toc-shape"></a>
+## `$Shape<T>` <a class="toc" id="toc-shape" href="#toc-shape"></a>
 
 Copies the shape of the type supplied, but marks every field optional.
 
@@ -591,9 +591,10 @@ type PersonDetails = $Shape<Person>;
 
 const person1: Person = {age: 28}; // Error due to incorrect type of Person.
 const person2: Person = {name: 'a'}; // Error due to incorrect type of Person.
-const person3: PersonDetails = {age: 28}; // Ok
-const person4: PersonDetails = {name: 'a'}; // Ok
-const person5: PersonDetails = {age: 28, name: 'a'}; // Ok
+const person3: PersonDetails = {age: 28}; // OK
+const person4: PersonDetails = {name: 'a'}; // OK
+const person5: PersonDetails = {age: 28, name: 'a'}; // OK
+```
 
 ## `$Supertype<T>` <a class="toc" id="toc-supertype" href="#toc-supertype"></a>
 


### PR DESCRIPTION
Also:

- fix the name of the `$Shape` utility type
- fix grammar within the `$Shape` code example

You can see that currently the page is messed up after the `Shape` section because of the unclosed code block: https://flow.org/en/docs/types/utilities/#toc-shape