### PR TITLE
Headers.get can return null

### DIFF
--- a/lib/bom.js
+++ b/lib/bom.js
@@ -916,7 +916,7 @@ declare class URLSearchParams {
     delete(name: string): void;
     entries(): Iterator<[string, string]>;
     forEach((value: string, name: string, params: URLSearchParams) => any, thisArg?: any): void;
-    get(name: string): string;
+    get(name: string): null | string;
     getAll(name: string): Array<string>;
     has(name: string): boolean;
     keys(): Iterator<string>;

--- a/lib/bom.js
+++ b/lib/bom.js
@@ -902,7 +902,7 @@ declare class Headers {
     delete(name: string): void;
     entries(): Iterator<[string, string]>;
     forEach((value: string, name: string, headers: Headers) => any, thisArg?: any): void;
-    get(name: string): string;
+    get(name: string): null | string;
     has(name: string): boolean;
     keys(): Iterator<string>;
     set(name: string, value: string): void;

--- a/tests/bom/Headers.js
+++ b/tests/bom/Headers.js
@@ -1,0 +1,8 @@
+/* @flow */
+
+// constructor
+const headers: Headers = new Headers(); // correct
+
+// get
+const a: null | string = headers.get('foo'); // correct
+const b: string = headers.get('foo'); // incorrect

--- a/tests/bom/URLSearchParams.js
+++ b/tests/bom/URLSearchParams.js
@@ -1,0 +1,8 @@
+/* @flow */
+
+// constructor
+const params: URLSearchParams = new URLSearchParams();
+
+// get
+const a: null | string = params.get('foo'); // correct
+const b: string = params.get('foo'); // incorrect

--- a/tests/bom/bom.exp
+++ b/tests/bom/bom.exp
@@ -569,6 +569,23 @@ References:
                                   ^^^^^^ [5]
 
 
+Error -------------------------------------------------------------------------------------------------- Headers.js:8:19
+
+Cannot assign `headers.get(...)` to `b` because null [1] is incompatible with string [2].
+
+   Headers.js:8:19
+     8| const b: string = headers.get('foo'); // incorrect
+                          ^^^^^^^^^^^^^^^^^^
+
+References:
+   <BUILTINS>/bom.js:905:24
+   905|     get(name: string): null | string;
+                               ^^^^ [1]
+   Headers.js:8:10
+     8| const b: string = headers.get('foo'); // incorrect
+                 ^^^^^^ [2]
+
+
 Error ----------------------------------------------------------------------------------------- MutationObserver.js:10:1
 
 Cannot call `MutationObserver` because function [1] requires another argument.
@@ -778,7 +795,7 @@ References:
 
 
 
-Found 52 errors
+Found 53 errors
 
 Only showing the most relevant union/intersection branches.
 To see all branches, re-run Flow with --show-all-branches

--- a/tests/bom/bom.exp
+++ b/tests/bom/bom.exp
@@ -794,8 +794,25 @@ References:
                               ^^^^^^^^^^^^^ [2]
 
 
+Error ------------------------------------------------------------------------------------------ URLSearchParams.js:8:19
 
-Found 53 errors
+Cannot assign `params.get(...)` to `b` because null [1] is incompatible with string [2].
+
+   URLSearchParams.js:8:19
+     8| const b: string = params.get('foo'); // incorrect
+                          ^^^^^^^^^^^^^^^^^
+
+References:
+   <BUILTINS>/bom.js:919:24
+   919|     get(name: string): null | string;
+                               ^^^^ [1]
+   URLSearchParams.js:8:10
+     8| const b: string = params.get('foo'); // incorrect
+                 ^^^^^^ [2]
+
+
+
+Found 54 errors
 
 Only showing the most relevant union/intersection branches.
 To see all branches, re-run Flow with --show-all-branches


### PR DESCRIPTION
Currently `Headers.get` is defined as returning only `string`, but it can also return `null`.

```js
const headers = new Headers();
const contentType = headers.get('Content-Type');
```

In the above example, current `master` believes `contentType` is `string`, but it should be `null | string`.

Relevant portion of the [spec]:

> The `get(name)` method, when invoked, must run these steps:
> 1. If `name` is not a name, then throw a `TypeError`.
> 2. If header list does not contain `name`, then return `null`.
> 3. Return the combined value given `name` and header list.

[spec]: https://fetch.spec.whatwg.org/#dom-headers-get

---

I'm happy to add tests if someone can give me some guidance there. I tried adding the following as `tests/bom/Headers.js`, but even without this change, I couldn't get `bash runtests.sh bin/flow bom` to fail, so I must not have been running it correctly. :confused:

```js
/* @flow */

// constructor
const headers: Headers = new Headers(); // correct

// get
const a: null | string = headers.get('foo'); // correct
const b: string = headers.get('foo'); // incorrect
```