### PR TITLE
Add keepAliveTimeout prop to Server

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -1268,6 +1268,7 @@ declare module "http" {
     listening: boolean;
     close(callback?: (error: ?Error) => mixed): Server;
     maxHeadersCount: number;
+    keepAliveTimeout: number;
     setTimeout(msecs: number, callback: Function): Server;
     timeout: number;
   }
@@ -1306,6 +1307,7 @@ declare module "https" {
     listen(path: string, callback?: Function): Server;
     listen(handle: Object, callback?: Function): Server;
     close(callback?: (error: ?Error) => mixed): Server;
+    keepAliveTimeout: number;
     setTimeout(msecs: number, callback: Function): Server;
     timeout: number;
   }


### PR DESCRIPTION
both the https and http servers accept an overridable `keepAliveTimeout` prop that is by default 5s.