### PR TITLE
add formatToParts to DateTimeFormat

### DIFF
--- a/lib/intl.js
+++ b/lib/intl.js
@@ -52,6 +52,9 @@ declare type Intl$CollatorOptions = {
   caseFirst?: 'upper' | 'lower' | 'false'
 }
 
+type FormatToPartsType = | 'day' | 'dayPeriod' | 'era' | 'hour' | 'literal'
+  | 'minute' | 'month' | 'second' | 'timeZoneName' | 'weekday' | 'year';
+
 declare class Intl$DateTimeFormat {
   constructor (
     locales?: Intl$Locales,
@@ -64,6 +67,11 @@ declare class Intl$DateTimeFormat {
   ): Intl$DateTimeFormat;
 
   format (value?: Date | number): string;
+
+  formatToParts (value?: Date | number): Array<{
+    type: FormatToPartsType,
+    value: string,
+  }>;
 
   resolvedOptions (): {
     locale: Intl$Locale,

--- a/tests/intl/date_time_format.js
+++ b/tests/intl/date_time_format.js
@@ -41,6 +41,10 @@ new DateTimeFormat().format() // correct
 new DateTimeFormat().format(1) // correct
 new DateTimeFormat().format(new Date(2018, 3, 17)) // correct
 
+new DateTimeFormat().formatToParts();
+new DateTimeFormat().formatToParts(1) // correct
+new DateTimeFormat().formatToParts(new Date(2018, 3, 17)) // correct
+
 new DateTimeFormat().resolvedOptions() // correct
 
 DateTimeFormat.getCanonicalLocales() // incorrect

--- a/tests/intl/intl.exp
+++ b/tests/intl/intl.exp
@@ -164,80 +164,80 @@ References:
    date_time_format.js:7:18
      7|   localeMatcher: 'look',
                          ^^^^^^ [1]
-   <BUILTINS>/intl.js:89:19
-    89|   localeMatcher?: 'lookup' | 'best fit',
+   <BUILTINS>/intl.js:97:19
+    97|   localeMatcher?: 'lookup' | 'best fit',
                           ^^^^^^^^^^^^^^^^^^^^^ [2]
    date_time_format.js:8:13
      8|   timeZone: 1,
                     ^ [3]
-   <BUILTINS>/intl.js:90:14
-    90|   timeZone?: string,
+   <BUILTINS>/intl.js:98:14
+    98|   timeZone?: string,
                      ^^^^^^ [4]
    date_time_format.js:9:11
      9|   hour12: '',
                   ^^ [5]
-   <BUILTINS>/intl.js:91:12
-    91|   hour12?: boolean,
+   <BUILTINS>/intl.js:99:12
+    99|   hour12?: boolean,
                    ^^^^^^^ [6]
    date_time_format.js:10:18
     10|   formatMatcher: 'basic fit',
                          ^^^^^^^^^^^ [7]
-   <BUILTINS>/intl.js:92:19
-    92|   formatMatcher?: 'basic' | 'best fit',
+   <BUILTINS>/intl.js:100:19
+   100|   formatMatcher?: 'basic' | 'best fit',
                           ^^^^^^^^^^^^^^^^^^^^ [8]
    date_time_format.js:11:12
     11|   weekday: '2-digit',
                    ^^^^^^^^^ [9]
-   <BUILTINS>/intl.js:93:13
-    93|   weekday?: 'narrow' | 'short' | 'long',
+   <BUILTINS>/intl.js:101:13
+   101|   weekday?: 'narrow' | 'short' | 'long',
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ [10]
    date_time_format.js:12:8
     12|   era: '',
                ^^ [11]
-   <BUILTINS>/intl.js:94:9
-    94|   era?: 'narrow' | 'short' | 'long',
+   <BUILTINS>/intl.js:102:9
+   102|   era?: 'narrow' | 'short' | 'long',
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^ [12]
    date_time_format.js:13:9
     13|   year: '',
                 ^^ [13]
-   <BUILTINS>/intl.js:95:10
-    95|   year?: 'numeric' | '2-digit',
+   <BUILTINS>/intl.js:103:10
+   103|   year?: 'numeric' | '2-digit',
                  ^^^^^^^^^^^^^^^^^^^^^ [14]
    date_time_format.js:14:10
     14|   month: '',
                  ^^ [15]
-   <BUILTINS>/intl.js:96:11
-    96|   month?: 'numeric' | '2-digit' | 'narrow' | 'short' | 'long',
+   <BUILTINS>/intl.js:104:11
+   104|   month?: 'numeric' | '2-digit' | 'narrow' | 'short' | 'long',
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [16]
    date_time_format.js:15:8
     15|   day: '',
                ^^ [17]
-   <BUILTINS>/intl.js:97:9
-    97|   day?: 'numeric' | '2-digit',
+   <BUILTINS>/intl.js:105:9
+   105|   day?: 'numeric' | '2-digit',
                 ^^^^^^^^^^^^^^^^^^^^^ [18]
    date_time_format.js:16:9
     16|   hour: '',
                 ^^ [19]
-   <BUILTINS>/intl.js:98:10
-    98|   hour?: 'numeric' | '2-digit',
+   <BUILTINS>/intl.js:106:10
+   106|   hour?: 'numeric' | '2-digit',
                  ^^^^^^^^^^^^^^^^^^^^^ [20]
    date_time_format.js:17:11
     17|   minute: 'long',
                   ^^^^^^ [21]
-   <BUILTINS>/intl.js:99:12
-    99|   minute?: 'numeric' | '2-digit',
+   <BUILTINS>/intl.js:107:12
+   107|   minute?: 'numeric' | '2-digit',
                    ^^^^^^^^^^^^^^^^^^^^^ [22]
    date_time_format.js:18:11
     18|   second: 'short',
                   ^^^^^^^ [23]
-   <BUILTINS>/intl.js:100:12
-   100|   second?: 'numeric' | '2-digit',
+   <BUILTINS>/intl.js:108:12
+   108|   second?: 'numeric' | '2-digit',
                    ^^^^^^^^^^^^^^^^^^^^^ [24]
    date_time_format.js:19:17
     19|   timeZoneName: 'narrow'
                         ^^^^^^^^ [25]
-   <BUILTINS>/intl.js:101:18
-   101|   timeZoneName?: 'short' | 'long'
+   <BUILTINS>/intl.js:109:18
+   109|   timeZoneName?: 'short' | 'long'
                          ^^^^^^^^^^^^^^^^ [26]
 
 
@@ -423,62 +423,62 @@ References:
    number_format.js:7:18
      7|   localeMatcher: 'best',
                          ^^^^^^ [1]
-   <BUILTINS>/intl.js:135:19
-   135|   localeMatcher?: 'lookup' | 'best fit',
+   <BUILTINS>/intl.js:143:19
+   143|   localeMatcher?: 'lookup' | 'best fit',
                           ^^^^^^^^^^^^^^^^^^^^^ [2]
    number_format.js:8:10
      8|   style: 'octal',
                  ^^^^^^^ [3]
-   <BUILTINS>/intl.js:136:11
-   136|   style?: 'decimal' | 'currency' | 'percent',
+   <BUILTINS>/intl.js:144:11
+   144|   style?: 'decimal' | 'currency' | 'percent',
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [4]
    number_format.js:9:13
      9|   currency: 123,
                     ^^^ [5]
-   <BUILTINS>/intl.js:137:14
-   137|   currency?: string,
+   <BUILTINS>/intl.js:145:14
+   145|   currency?: string,
                      ^^^^^^ [6]
    number_format.js:10:20
     10|   currencyDisplay: 'sym',
                            ^^^^^ [7]
-   <BUILTINS>/intl.js:138:21
-   138|   currencyDisplay?: 'symbol' | 'code' | 'name',
+   <BUILTINS>/intl.js:146:21
+   146|   currencyDisplay?: 'symbol' | 'code' | 'name',
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^ [8]
    number_format.js:11:16
     11|   useGrouping: 5,
                        ^ [9]
-   <BUILTINS>/intl.js:139:17
-   139|   useGrouping?: boolean,
+   <BUILTINS>/intl.js:147:17
+   147|   useGrouping?: boolean,
                         ^^^^^^^ [10]
    number_format.js:12:25
     12|   minimumIntegerDigits: {},
                                 ^^ [11]
-   <BUILTINS>/intl.js:140:26
-   140|   minimumIntegerDigits?: number,
+   <BUILTINS>/intl.js:148:26
+   148|   minimumIntegerDigits?: number,
                                  ^^^^^^ [12]
    number_format.js:13:26
     13|   minimumFractionDigits: '',
                                  ^^ [13]
-   <BUILTINS>/intl.js:141:27
-   141|   minimumFractionDigits?: number,
+   <BUILTINS>/intl.js:149:27
+   149|   minimumFractionDigits?: number,
                                   ^^^^^^ [14]
    number_format.js:14:26
     14|   maximumFractionDigits: null,
                                  ^^^^ [15]
-   <BUILTINS>/intl.js:142:27
-   142|   maximumFractionDigits?: number,
+   <BUILTINS>/intl.js:150:27
+   150|   maximumFractionDigits?: number,
                                   ^^^^^^ [16]
    number_format.js:15:29
     15|   minimumSignificantDigits: '',
                                     ^^ [17]
-   <BUILTINS>/intl.js:143:30
-   143|   minimumSignificantDigits?: number,
+   <BUILTINS>/intl.js:151:30
+   151|   minimumSignificantDigits?: number,
                                      ^^^^^^ [18]
    number_format.js:16:29
     16|   maximumSignificantDigits: null
                                     ^^^^ [19]
-   <BUILTINS>/intl.js:144:30
-   144|   maximumSignificantDigits?: number
+   <BUILTINS>/intl.js:152:30
+   152|   maximumSignificantDigits?: number
                                      ^^^^^^ [20]
 
 
@@ -504,8 +504,8 @@ References:
    <BUILTINS>/intl.js:12:16
     12|   PluralRules: ?Class<Intl$PluralRules>,
                        ^^^^^^^^^^^^^^^^^^^^^^^^ [1]
-   <BUILTINS>/intl.js:147:15
-   147| declare class Intl$PluralRules {
+   <BUILTINS>/intl.js:155:15
+   155| declare class Intl$PluralRules {
                       ^^^^^^^^^^^^^^^^ [2]
 
 
@@ -518,8 +518,8 @@ Cannot call `PluralRules` because a callable signature is missing in statics of 
                     ^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/intl.js:147:15
-   147| declare class Intl$PluralRules {
+   <BUILTINS>/intl.js:155:15
+   155| declare class Intl$PluralRules {
                       ^^^^^^^^^^^^^^^^ [1]
 
 
@@ -563,32 +563,32 @@ References:
    plural_rules.js:12:20
     12|     localeMatcher: 'best one',
                            ^^^^^^^^^^ [1]
-   <BUILTINS>/intl.js:172:19
-   172|   localeMatcher?: 'lookup' | 'best fit',
+   <BUILTINS>/intl.js:180:19
+   180|   localeMatcher?: 'lookup' | 'best fit',
                           ^^^^^^^^^^^^^^^^^^^^^ [2]
    plural_rules.js:13:11
     13|     type: 'count',
                   ^^^^^^^ [3]
-   <BUILTINS>/intl.js:173:10
-   173|   type?: 'cardinal' | 'ordinal',
+   <BUILTINS>/intl.js:181:10
+   181|   type?: 'cardinal' | 'ordinal',
                  ^^^^^^^^^^^^^^^^^^^^^^ [4]
    plural_rules.js:14:27
     14|     minimumIntegerDigits: '',
                                   ^^ [5]
-   <BUILTINS>/intl.js:174:26
-   174|   minimumIntegerDigits?: number,
+   <BUILTINS>/intl.js:182:26
+   182|   minimumIntegerDigits?: number,
                                  ^^^^^^ [6]
    plural_rules.js:7:13
      7|   const c = new PluralRules(); // correct
                     ^^^^^^^^^^^^^^^^^ [7]
-   <BUILTINS>/intl.js:177:30
-   177|   minimumSignificantDigits?: number,
+   <BUILTINS>/intl.js:185:30
+   185|   minimumSignificantDigits?: number,
                                      ^^^^^^ [8]
    plural_rules.js:18:31
     18|     maximumSignificantDigits: ''
                                       ^^ [9]
-   <BUILTINS>/intl.js:178:30
-   178|   maximumSignificantDigits?: number
+   <BUILTINS>/intl.js:186:30
+   186|   maximumSignificantDigits?: number
                                      ^^^^^^ [10]
 
 
@@ -615,8 +615,8 @@ Cannot call `new PluralRules().select` because function [1] requires another arg
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/intl.js:153:3
-   153|   select (number): Intl$PluralRule;
+   <BUILTINS>/intl.js:161:3
+   161|   select (number): Intl$PluralRule;
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 
@@ -630,8 +630,8 @@ Cannot call `PluralRules.getCanonicalLocales` because property `getCanonicalLoca
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/intl.js:147:15
-   147| declare class Intl$PluralRules {
+   <BUILTINS>/intl.js:155:15
+   155| declare class Intl$PluralRules {
                       ^^^^^^^^^^^^^^^^ [1]
 
 


### PR DESCRIPTION
Small update to `lib` to add [`formatToParts`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat/formatToParts) to `DateTimeFormat`.