### PR TITLE
Fix nullable methods on HTMLCollection

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -536,9 +536,9 @@ declare class Attr extends Node {
 declare class HTMLCollection<Elem: HTMLElement> {
   @@iterator(): Iterator<Elem>;
   length: number;
-  item(nameOrIndex?: any, optionalIndex?: any): Elem;
-  namedItem(name: string): Elem;
-  [index: number]: Elem;
+  item(nameOrIndex?: any, optionalIndex?: any): Elem | null;
+  namedItem(name: string): Elem | null;
+  [index: number | string]: ?Elem;
 }
 
 // from https://www.w3.org/TR/custom-elements/#extensions-to-document-interface-to-register

--- a/tests/dom/HTMLCollection.js
+++ b/tests/dom/HTMLCollection.js
@@ -1,0 +1,28 @@
+// @flow
+
+var collection = document.children
+
+// properties
+var length: number = collection.length // valid
+
+// methods
+var el = collection.item(0)
+el.className // invalid
+if (el) el.className // valid
+
+el = collection.namedItem('name')
+el.className // invalid
+if (el) el.className // valid
+
+// accessing items
+el = collection[0]
+el.className // invalid
+if (el) el.className // valid
+
+el = collection['query']
+el.className // invalid
+if (el) el.className // valid
+
+for (var field of collection) {
+  field.className // valid
+}

--- a/tests/dom/dom.exp
+++ b/tests/dom/dom.exp
@@ -144,6 +144,62 @@ References:
                                  ^^^^^^^ [2]
 
 
+Error ------------------------------------------------------------------------------------------- HTMLCollection.js:10:1
+
+Cannot get `el.className` because property `className` is missing in null [1].
+
+   HTMLCollection.js:10:1
+    10| el.className // invalid
+        ^^^^^^^^^^^^
+
+References:
+   <BUILTINS>/dom.js:539:56
+   539|   item(nameOrIndex?: any, optionalIndex?: any): Elem | null;
+                                                               ^^^^ [1]
+
+
+Error ------------------------------------------------------------------------------------------- HTMLCollection.js:14:1
+
+Cannot get `el.className` because property `className` is missing in null [1].
+
+   HTMLCollection.js:14:1
+    14| el.className // invalid
+        ^^^^^^^^^^^^
+
+References:
+   <BUILTINS>/dom.js:540:35
+   540|   namedItem(name: string): Elem | null;
+                                          ^^^^ [1]
+
+
+Error ------------------------------------------------------------------------------------------- HTMLCollection.js:19:1
+
+Cannot get `el.className` because property `className` is missing in null or undefined [1].
+
+   HTMLCollection.js:19:1
+    19| el.className // invalid
+        ^^^^^^^^^^^^
+
+References:
+   <BUILTINS>/dom.js:541:29
+   541|   [index: number | string]: ?Elem;
+                                    ^^^^^ [1]
+
+
+Error ------------------------------------------------------------------------------------------- HTMLCollection.js:23:1
+
+Cannot get `el.className` because property `className` is missing in null or undefined [1].
+
+   HTMLCollection.js:23:1
+    23| el.className // invalid
+        ^^^^^^^^^^^^
+
+References:
+   <BUILTINS>/dom.js:541:29
+   541|   [index: number | string]: ?Elem;
+                                    ^^^^^ [1]
+
+
 Error --------------------------------------------------------------------------------------------- HTMLElement.js:14:28
 
 Cannot call `element.scrollIntoView` with object literal bound to `arg` because string [1] is incompatible with enum [2]
@@ -916,7 +972,7 @@ References:
 
 
 
-Found 33 errors
+Found 37 errors
 
 Only showing the most relevant union/intersection branches.
 To see all branches, re-run Flow with --show-all-branches


### PR DESCRIPTION
[`namedItem()`](https://dom.spec.whatwg.org/#dom-htmlcollection-nameditem-key) and [`item()`](https://dom.spec.whatwg.org/#dom-htmlcollection-item) can be `null`, and `[]` can be `undefined`.