### PR TITLE
Allow use of string and array parameters in toLocaleLowerCase, toLocaleUpperCase

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -311,8 +311,8 @@ declare class String {
     startsWith(searchString: string, position?: number): boolean;
     substr(from: number, length?: number): string;
     substring(start: number, end?: number): string;
-    toLocaleLowerCase(): string;
-    toLocaleUpperCase(): string;
+    toLocaleLowerCase(locale?: string | Array<string>): string;
+    toLocaleUpperCase(locale?: string | Array<string>): string;
     toLowerCase(): string;
     toUpperCase(): string;
     trim(): string;

--- a/newtests/autocomplete/test.js
+++ b/newtests/autocomplete/test.js
@@ -692,7 +692,7 @@ export default suite(({addFile, flowCmd}) => [
              },
              {
                "name": "toLocaleLowerCase",
-               "type": "() => string",
+               "type": "(locale?: string | Array<string>) => string",
                "func_details": {
                  "return_type": "string",
                  "params": []
@@ -705,7 +705,7 @@ export default suite(({addFile, flowCmd}) => [
              },
              {
                "name": "toLocaleUpperCase",
-               "type": "() => string",
+               "type": "(locale?: string | Array<string>) => string",
                "func_details": {
                  "return_type": "string",
                  "params": []

--- a/tests/autocomplete/autocomplete.exp
+++ b/tests/autocomplete/autocomplete.exp
@@ -417,7 +417,7 @@ str.js = {
     },
     {
       "name":"toLocaleLowerCase",
-      "type":"() => string",
+      "type":"(locale?: string | Array<string>) => string",
       "func_details":{"return_type":"string","params":[]},
       "path":"[LIB] core.js",
       "line":314,
@@ -427,7 +427,7 @@ str.js = {
     },
     {
       "name":"toLocaleUpperCase",
-      "type":"() => string",
+      "type":"(locale?: string | Array<string>) => string",
       "func_details":{"return_type":"string","params":[]},
       "path":"[LIB] core.js",
       "line":315,


### PR DESCRIPTION
String.toLocaleLowerCase and String.toLocaleUpperCase methods allow parameters to specify locale to be used to convert. 

Here is the details for toLocaleLowerCase: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/toLocaleLowerCase
And toLocaleUpperCase: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/toLocaleUpperCase