### PR TITLE
Fix an ambiguity in the `$ReadOnlyArray` docs

### DIFF
--- a/website/en/docs/types/arrays.md
+++ b/website/en/docs/types/arrays.md
@@ -146,7 +146,7 @@ The main advantage to using `$ReadOnlyArray` instead of `Array` is that `$ReadOn
 type parameter is *covariant* while `Array`'s type parameter is *invariant*. That means that
 `$ReadOnlyArray<number>` is a subtype of `$ReadOnlyArray<number | string>` while
 `Array<number>` is NOT a subtype of `Array<number | string>`. So it's often useful to use
-`$ReadOnlyArray` as a type annotation to allow various different types of arrays.
+`$ReadOnlyArray` in type annotations for arrays of various types of elements.
 Take, for instance, the following scenario:
 
 ```js


### PR DESCRIPTION
The previous wording is confusing because “various different types of arrays” could refer either to arrays with different types in the generic parameter or to read-only and normal arrays.

This commit makes the change I suggested in https://github.com/facebook/flow/pull/6595#discussion_r212790680.