### PR TITLE
Attempt to fix AppVeyor

### DIFF
--- a/opam
+++ b/opam
@@ -20,6 +20,7 @@ depends: [
   "lwt_ppx" { >= "1.1.0" }
   "ppx_deriving" {build}
   "ppx_gen_rec" {build}
+  "ppx_tools_versioned" { = "5.2.0" }
   "visitors" {build}
   "wtf8"
 ]

--- a/opam
+++ b/opam
@@ -20,7 +20,7 @@ depends: [
   "lwt_ppx" { >= "1.1.0" }
   "ppx_deriving" {build}
   "ppx_gen_rec" {build}
-  "ppx_tools_versioned" { = "5.2.0" }
+  "ppx_tools_versioned" { = "5.2" }
   "visitors" {build}
   "wtf8"
 ]


### PR DESCRIPTION
AppVeyor started failing consistently. Main change I notice between [last success](https://ci.appveyor.com/project/Facebook/flow/build/4763) and [first failure](https://ci.appveyor.com/project/Facebook/flow/build/4764) is that ppx_tools_versioned went from 5.2 to 5.2.1. Furthermore, the error is

```
#=== ERROR while compiling sedlex.1.99.4 ======================================#
# opam-version         1.3.0~dev (9fc27413c08030d909802dcdfb6e63b75d9dd762)
# os                   win32
# command              make all
# path                 C:/cygwin64/home/appveyor/.opam/4.05.0+mingw64c/build/sedlex.1.99.4
# exit-code            2
# env-file             C:/cygwin64/home/appveyor/.opam/4.05.0+mingw64c/build/sedlex.1.99.4\sedlex-304-1a4105.env
# stdout-file          C:/cygwin64/home/appveyor/.opam/4.05.0+mingw64c/build/sedlex.1.99.4\sedlex-304-1a4105.out
# stderr-file          C:/cygwin64/home/appveyor/.opam/4.05.0+mingw64c/build/sedlex.1.99.4\sedlex-304-1a4105.err
### stdout ###
# [...]
# (cd src/lib && /usr/bin/make all doc)
# make[1]: Entering directory '/home/appveyor/.opam/4.05.0+mingw64c/build/sedlex.1.99.4/src/lib'
# ocamlfind ocamlc -package gen -w +A-4-9 -safe-string -c sedlexing.mli sedlexing.ml
# ocamlfind ocamlc -package gen -a -o sedlexing.cma sedlexing.cmo
# rm -rf ../../libdoc
# mkdir ../../libdoc
# ocamlfind ocamldoc -package gen -html sedlexing.mli -d ../../libdoc
# make[1]: Leaving directory '/home/appveyor/.opam/4.05.0+mingw64c/build/sedlex.1.99.4/src/lib'
# (cd src/syntax && /usr/bin/make all)
# make[1]: Entering directory '/home/appveyor/.opam/4.05.0+mingw64c/build/sedlex.1.99.4/src/syntax'
# ocamlfind ocamlc -package ppx_tools_versioned.metaquot_405 -package ocaml-migrate-parsetree -linkall -w +A-4-9-42 -annot -a -o sedlex.cma sedlex_cset.mli sedlex_cset.ml unicode63.mli unicode63.ml sedlex.mli sedlex.ml ppx_sedlex.ml
# make[1]: Leaving directory '/home/appveyor/.opam/4.05.0+mingw64c/build/sedlex.1.99.4/src/syntax'
### stderr ###
# File "ppx_sedlex.ml", line 11, characters 5-24:
# Error: Unbound module Ast_convenience_405
# make[1]: *** [Makefile:18: sedlex.cma] Error 2
# make: *** [Makefile:14: all] Error 2
```

That said, the patch release looks innocuous and I don't see anything obviously wrong in opam-repository or https://github.com/fdopen/opam-repository-mingw. So I'm really just seeing if this helps...