### PR TITLE
Get your sqlite3 chocolate out of my NO_SQLITE3 peanut butter

### DIFF
--- a/hack/heap/hh_shared.c
+++ b/hack/heap/hh_shared.c
@@ -1955,6 +1955,7 @@ CAMLprim value hh_get_and_deserialize(value key) {
   CAMLreturn(result);
 }
 
+#ifndef NO_SQLITE3
 CAMLprim value hh_get_and_deserialize_sqlite(
     value ml_use_fileinfo_sqlite,
     value ml_key
@@ -1979,6 +1980,7 @@ CAMLprim value hh_get_and_deserialize_sqlite(
   }
   return 0; // impossible
 }
+#endif
 
 /*****************************************************************************/
 /* Returns the size of the value associated to a given key. */
@@ -2037,6 +2039,8 @@ void hh_remove(value key) {
   removed_count += 1;
 }
 
+#ifndef NO_SQLITE3
+
 /*****************************************************************************/
 /* Saved State with SQLite */
 /*****************************************************************************/
@@ -2070,9 +2074,6 @@ value Val_some(value v)
 
 #define Some_val(v) Field(v,0)
 
-#ifndef NO_SQLITE3
-
-// ------------------------ START OF SQLITE3 SECTION --------------------------
 CAMLprim value hh_removed_count(value ml_unit) {
     CAMLparam1(ml_unit);
     UNUSED(ml_unit);
@@ -2852,123 +2853,4 @@ CAMLprim value hh_get_sqlite(value ocaml_key) {
   CAMLreturn(result);
 }
 
-// --------------------------END OF SQLITE3 SECTION ---------------------------
-#else
-
-// ----------------------- START OF NO_SQLITE3 SECTION ------------------------
-
-CAMLprim value hh_get_loaded_dep_table_filename() {
-  CAMLparam0();
-  CAMLreturn(caml_copy_string(""));
-}
-
-CAMLprim value hh_save_dep_table_sqlite(
-    value out_filename,
-    value build_revision
-) {
-  CAMLparam0();
-  CAMLreturn(Val_long(0));
-}
-
-CAMLprim value hh_update_dep_table_sqlite(
-    value out_filename,
-    value build_revision
-) {
-  CAMLparam0();
-  CAMLreturn(Val_long(0));
-}
-
-CAMLprim value hh_save_file_info_sqlite(
-    value out_filename,
-    value ml_name,
-    value ml_kind,
-    value ml_filespec
-) {
-  CAMLparam0();
-  CAMLreturn(Val_long(0));
-}
-
-CAMLprim value hh_load_dep_table_sqlite(
-    value in_filename,
-    value ignore_hh_version) {
-  CAMLparam0();
-  CAMLreturn(Val_long(0));
-}
-
-CAMLprim value hh_get_dep_sqlite(value ocaml_key) {
-  // Empty list
-  CAMLparam0();
-  CAMLreturn(Val_int(0));
-}
-
-CAMLprim value hh_save_table_sqlite(value out_filename) {
-  CAMLparam0();
-  CAMLreturn(Val_long(0));
-}
-
-CAMLprim value hh_save_table_keys_sqlite(value out_filename, value keys) {
-  CAMLparam0();
-  CAMLreturn(Val_long(0));
-}
-
-CAMLprim value hh_load_table_sqlite(value in_filename, value verify) {
-  CAMLparam0();
-  CAMLreturn(Val_long(0));
-}
-
-CAMLprim value hh_get_sqlite(value ocaml_key) {
-  CAMLparam0();
-  CAMLreturn(Val_none);
-}
-
-CAMLprim value set_file_info_on_disk(value ml_str) {
-  CAMLparam1(ml_str);
-  UNUSED(ml_str);
-  CAMLreturn(Val_long(0));
-}
-
-CAMLprim value get_file_info_on_disk(value ml_str) {
-  CAMLparam1(ml_str);
-  UNUSED(ml_str);
-  CAMLreturn(Val_long(0));
-}
-
-CAMLprim value get_file_info_on_disk_path(value ml_str) {
-  CAMLparam1(ml_str);
-  UNUSED(ml_str);
-  CAMLreturn(caml_copy_string(""));
-}
-
-CAMLprim value set_file_info_on_disk_path(value ml_str) {
-  CAMLparam1(ml_str);
-  UNUSED(ml_str);
-  CAMLreturn(Val_unit);
-}
-
-CAMLprim value open_file_info_db(
-    value ml_unit
-) {
-  UNUSED(ml_unit);
-  return Val_unit;
-}
-
-CAMLprim value hh_save_file_info_init(
-        value ml_path
-) {
-    UNUSED(ml_path);
-    return Val_unit;
-}
-
-CAMLprim value hh_save_file_info_free(
-        value ml_unit
-) {
-    UNUSED(ml_unit);
-    return Val_unit;
-}
-
-CAMLprim value hh_removed_count(value ml_unit) {
-    CAMLparam1(ml_unit);
-    UNUSED(ml_unit);
-    return Val_long(removed_count);
-}
-#endif
+#endif /* NO_SQLITE3 */

--- a/hack/heap/hh_shared.c
+++ b/hack/heap/hh_shared.c
@@ -1955,33 +1955,6 @@ CAMLprim value hh_get_and_deserialize(value key) {
   CAMLreturn(result);
 }
 
-#ifndef NO_SQLITE3
-CAMLprim value hh_get_and_deserialize_sqlite(
-    value ml_use_fileinfo_sqlite,
-    value ml_key
-) {
-  CAMLparam2(ml_use_fileinfo_sqlite, ml_key);
-  CAMLlocal1(ml_out);
-  int64_t hash = (int64_t) get_hash(ml_key);
-  int use_sqlite_fallback = Bool_val(ml_use_fileinfo_sqlite);
-  check_should_exit();
-  if (use_sqlite_fallback) {
-      // TODO: almost certainly wrong,
-      // we're getting back a stringified Relative_path.t
-      char *fs = hhfi_get_filespec(hhfi_get_db(), hash);
-      assert(fs);
-      ml_out = caml_copy_string(fs);
-      free(fs);
-      CAMLreturn(ml_out);
-  } else {
-      CAMLlocal1(ml_res);
-      ml_res = hh_get_and_deserialize(ml_key);
-      CAMLreturn(ml_res);
-  }
-  return 0; // impossible
-}
-#endif
-
 /*****************************************************************************/
 /* Returns the size of the value associated to a given key. */
 /* The key MUST be present. */
@@ -2039,8 +2012,6 @@ void hh_remove(value key) {
   removed_count += 1;
 }
 
-#ifndef NO_SQLITE3
-
 /*****************************************************************************/
 /* Saved State with SQLite */
 /*****************************************************************************/
@@ -2074,6 +2045,9 @@ value Val_some(value v)
 
 #define Some_val(v) Field(v,0)
 
+#ifndef NO_SQLITE3
+
+// ------------------------ START OF SQLITE3 SECTION --------------------------
 CAMLprim value hh_removed_count(value ml_unit) {
     CAMLparam1(ml_unit);
     UNUSED(ml_unit);
@@ -2853,4 +2827,123 @@ CAMLprim value hh_get_sqlite(value ocaml_key) {
   CAMLreturn(result);
 }
 
-#endif /* NO_SQLITE3 */
+// --------------------------END OF SQLITE3 SECTION ---------------------------
+#else
+
+// ----------------------- START OF NO_SQLITE3 SECTION ------------------------
+
+CAMLprim value hh_get_loaded_dep_table_filename() {
+  CAMLparam0();
+  CAMLreturn(caml_copy_string(""));
+}
+
+CAMLprim value hh_save_dep_table_sqlite(
+    value out_filename,
+    value build_revision
+) {
+  CAMLparam0();
+  CAMLreturn(Val_long(0));
+}
+
+CAMLprim value hh_update_dep_table_sqlite(
+    value out_filename,
+    value build_revision
+) {
+  CAMLparam0();
+  CAMLreturn(Val_long(0));
+}
+
+CAMLprim value hh_save_file_info_sqlite(
+    value out_filename,
+    value ml_name,
+    value ml_kind,
+    value ml_filespec
+) {
+  CAMLparam0();
+  CAMLreturn(Val_long(0));
+}
+
+CAMLprim value hh_load_dep_table_sqlite(
+    value in_filename,
+    value ignore_hh_version) {
+  CAMLparam0();
+  CAMLreturn(Val_long(0));
+}
+
+CAMLprim value hh_get_dep_sqlite(value ocaml_key) {
+  // Empty list
+  CAMLparam0();
+  CAMLreturn(Val_int(0));
+}
+
+CAMLprim value hh_save_table_sqlite(value out_filename) {
+  CAMLparam0();
+  CAMLreturn(Val_long(0));
+}
+
+CAMLprim value hh_save_table_keys_sqlite(value out_filename, value keys) {
+  CAMLparam0();
+  CAMLreturn(Val_long(0));
+}
+
+CAMLprim value hh_load_table_sqlite(value in_filename, value verify) {
+  CAMLparam0();
+  CAMLreturn(Val_long(0));
+}
+
+CAMLprim value hh_get_sqlite(value ocaml_key) {
+  CAMLparam0();
+  CAMLreturn(Val_none);
+}
+
+CAMLprim value set_file_info_on_disk(value ml_str) {
+  CAMLparam1(ml_str);
+  UNUSED(ml_str);
+  CAMLreturn(Val_long(0));
+}
+
+CAMLprim value get_file_info_on_disk(value ml_str) {
+  CAMLparam1(ml_str);
+  UNUSED(ml_str);
+  CAMLreturn(Val_long(0));
+}
+
+CAMLprim value get_file_info_on_disk_path(value ml_str) {
+  CAMLparam1(ml_str);
+  UNUSED(ml_str);
+  CAMLreturn(caml_copy_string(""));
+}
+
+CAMLprim value set_file_info_on_disk_path(value ml_str) {
+  CAMLparam1(ml_str);
+  UNUSED(ml_str);
+  CAMLreturn(Val_unit);
+}
+
+CAMLprim value open_file_info_db(
+    value ml_unit
+) {
+  UNUSED(ml_unit);
+  return Val_unit;
+}
+
+CAMLprim value hh_save_file_info_init(
+        value ml_path
+) {
+    UNUSED(ml_path);
+    return Val_unit;
+}
+
+CAMLprim value hh_save_file_info_free(
+        value ml_unit
+) {
+    UNUSED(ml_unit);
+    return Val_unit;
+}
+
+CAMLprim value hh_removed_count(value ml_unit) {
+    CAMLparam1(ml_unit);
+    UNUSED(ml_unit);
+    return Val_long(removed_count);
+}
+#endif

--- a/hack/heap/hh_shared.h
+++ b/hack/heap/hh_shared.h
@@ -64,13 +64,6 @@ CAMLprim value hh_deserialize(char *src);
 /* The key MUST be present. */
 CAMLprim value hh_get_and_deserialize(value key);
 
-#ifndef NO_SQLITE3
-CAMLprim value hh_get_and_deserialize_sqlite(
-        value ml_use_fileinfo_sqlite,
-        value ml_key
-);
-#endif
-
 /*****************************************************************************/
 /* Dependency table operations. */
 /*****************************************************************************/
@@ -105,8 +98,6 @@ CAMLprim value hh_mem_status(value key);
 void hh_move(value key1, value key2);
 /* Removes a key from the hash table. */
 void hh_remove(value key);
-
-#ifndef NO_SQLITE3
 
 /*****************************************************************************/
 /* Saved State with SQLite */
@@ -143,5 +134,4 @@ CAMLprim value hh_save_file_info_sqlite(
         value ml_filespec
 );
 
-#endif /* NO_SQLITE3 */
-#endif /* HH_SHARED_H */
+#endif

--- a/hack/heap/hh_shared.h
+++ b/hack/heap/hh_shared.h
@@ -63,10 +63,13 @@ CAMLprim value hh_deserialize(char *src);
 /* Returns the value associated to a given key, and deserialize it. */
 /* The key MUST be present. */
 CAMLprim value hh_get_and_deserialize(value key);
+
+#ifndef NO_SQLITE3
 CAMLprim value hh_get_and_deserialize_sqlite(
         value ml_use_fileinfo_sqlite,
         value ml_key
 );
+#endif
 
 /*****************************************************************************/
 /* Dependency table operations. */
@@ -103,6 +106,8 @@ void hh_move(value key1, value key2);
 /* Removes a key from the hash table. */
 void hh_remove(value key);
 
+#ifndef NO_SQLITE3
+
 /*****************************************************************************/
 /* Saved State with SQLite */
 /*****************************************************************************/
@@ -138,4 +143,5 @@ CAMLprim value hh_save_file_info_sqlite(
         value ml_filespec
 );
 
-#endif
+#endif /* NO_SQLITE3 */
+#endif /* HH_SHARED_H */

--- a/hack/heap/hh_shared_sqlite.c
+++ b/hack/heap/hh_shared_sqlite.c
@@ -6,6 +6,8 @@
  * LICENSE file in the "hack" directory of this source tree.
  *
  */
+#ifndef NO_SQLITE3
+
 #include "hh_shared_sqlite.h"
 
 #define CAML_NAME_SPACE
@@ -13,18 +15,12 @@
 #include <caml/callback.h>
 #include <caml/fail.h>
 
-#ifndef NO_SQLITE3
 #include <sqlite3.h>
-#endif
 
-#ifdef _WIN32
-#include <windows.h>
-#else
 #include <stdio.h>
 #include <stdint.h>
 #include <string.h>
 #include <sys/types.h>
-#endif
 
 #include "hh_assert.h"
 
@@ -38,7 +34,6 @@
     (UNUSED(a), UNUSED(b))
 
 
-#ifndef NO_SQLITE3
 const char *create_tables_sql[] = {
   "CREATE TABLE IF NOT EXISTS HEADER(" \
   "    MAGIC_CONSTANT INTEGER PRIMARY KEY NOT NULL," \
@@ -165,25 +160,4 @@ sqlite3_ptr hhfi_get_db(void) {
     return hhfi_db;
 }
 
-#else
-char *hhfi_get_filespec(
-        sqlite3_ptr db,
-        int64_t hash
-) {
-    UNUSED2(db, hash);
-    return NULL;
-}
-
-void hhfi_init_db(const char *path) {
-    UNUSED(path);
-    return;
-}
-
-void hhfi_free_db(void) {
-    return;
-}
-
-sqlite3_ptr hhfi_get_db(void) {
-    return NULL;
-}
-#endif
+#endif /* NO_SQLITE3 */

--- a/hack/heap/hh_shared_sqlite.h
+++ b/hack/heap/hh_shared_sqlite.h
@@ -10,34 +10,21 @@
 #ifndef HH_SHARED_SQLITE_H
 #define HH_SHARED_SQLITE_H
 
-#ifdef _WIN32
-#include <windows.h>
-#else
-#include <stdint.h>
-#endif
-
 #ifndef NO_SQLITE3
+
 #include <sqlite3.h>
-#endif
 
+#include <stdint.h>
 
-#ifndef NO_SQLITE3
 typedef sqlite3 *sqlite3_ptr;
-#else
-typedef void *sqlite3_ptr;
-#endif
 
-#ifndef NO_SQLITE3
 #define assert_sql(x, y) (assert_sql_with_line((x), (y), __LINE__))
-#endif
-
 
 void assert_sql_with_line(
   int result,
   int correct_result,
   int line_number);
 
-#ifndef NO_SQLITE3
 void make_all_tables(sqlite3 *db);
 
 void hhfi_insert_row(
@@ -47,7 +34,6 @@ void hhfi_insert_row(
   int64_t kind,
   const char *filespec
 );
-#endif
 
 char *hhfi_get_filespec(
   sqlite3_ptr db,
@@ -57,4 +43,6 @@ char *hhfi_get_filespec(
 void hhfi_init_db(const char *path);
 void hhfi_free_db(void);
 sqlite3_ptr hhfi_get_db(void);
-#endif
+
+#endif /* NO_SQLITE3 */
+#endif /* HH_SHARED_SQLITE_H */


### PR DESCRIPTION
The Hack project uses some sqlite3 integration which Flow does not use.
We introduced NO_SQLITE3 to conditionally compile that stuff for Hack,
but the define is granular and Hack changes break Flow builds pretty
regularly. This is especially complicated because Flow builds on Windows
and Hack doesn't.

Now that sqlite3 code is (mostly) untangled from the sharedmem code,
it's easier to ignore the entire thing with a big #ifndef block around
the sqlite3 code.