### PR TITLE
Cipher.prototype.setAAD returns Cipher for method chaining

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -355,7 +355,7 @@ declare class crypto$Cipher extends stream$Duplex {
   final(output_encoding: 'latin1' | 'binary' | 'base64' | 'hex'): string;
   final(output_encoding: void): Buffer;
   getAuthTag(): Buffer;
-  setAAD(buffer: Buffer): void;
+  setAAD(buffer: Buffer): crypto$Cipher;
   setAuthTag(buffer: Buffer): void;
   setAutoPadding(auto_padding?: boolean): crypto$Cipher;
   update(


### PR DESCRIPTION
Solves #6804.

Reference: https://nodejs.org/api/crypto.html#crypto_cipher_setaad_buffer_options