### PR TITLE
Add controlsList property on HTMLMediaElement

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -3049,6 +3049,7 @@ declare class HTMLMediaElement extends HTMLElement {
   volume: number;
   muted: boolean;
   defaultMuted: boolean;
+  controlsList?: DOMTokenList;
 
   // tracks
   audioTracks: AudioTrackList;


### PR DESCRIPTION
resolves #6859 

According to [Mozilla](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/controlsList) `controlsList` is an experimental feature, but does have full support on Chrome and Opera. I'm not sure what flow's official position is with experimental features, but it seems like having `controlsList?` as an optional property makes sense.