### PR TITLE
Minor grammar fix

### DIFF
--- a/website/en/docs/lang/refinements.md
+++ b/website/en/docs/lang/refinements.md
@@ -139,8 +139,8 @@ function method(value: { prop?: string }) {
 method(obj);
 ```
 
-Inside of `otherMethod()` we are sometimes removing `prop`. Flow doesn't know
-if the `if (value.prop)` check is still true, so it invalidates the refinement.
+Inside of `otherMethod()` we sometimes remove `prop`. Flow doesn't know if the
+`if (value.prop)` check is still true, so it invalidates the refinement.
 
 There's a straightforward way to get around this. Store the value before
 calling another method and use the stored value instead. This way you can


### PR DESCRIPTION
To the best of my knowledge (native English speaker, but not grammar expert) the "are sometimes removing" is not grammatically correct. Instead it is correct to say "we sometimes remove".