### PR TITLE
Enforce that WeakMap keys are Object types

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -545,7 +545,7 @@ declare class Map<K, V> {
     [key: $SymbolToStringTag | $SymbolSpecies]: Function;
 }
 
-declare class WeakMap<K, V> {
+declare class WeakMap<K: Object, V> {
     constructor(iterable: ?Iterable<[K, V]>): void;
     delete(key: K): boolean;
     get(key: K): V | void;


### PR DESCRIPTION
WeakMap keys must be of Object type (primitive types such as string and number are not allowed).

Resolves https://github.com/facebook/flow/issues/4529