### PR TITLE
Re-sync with internal repository

### DIFF
--- a/hack/common/common.ml
+++ b/hack/common/common.ml
@@ -1,0 +1,84 @@
+module List = struct
+  include Core_kernel.List
+
+  let rec fold_left_env env l ~init ~f = match l with
+    | [] -> env, init
+    | x :: xs ->
+      let env, init = f env init x in
+      fold_left_env env xs ~init ~f
+
+  let rev_map_env env xs ~f =
+    let f2 env init x =
+      let env, x = f env x in
+      env, x :: init
+    in
+    fold_left_env env xs ~init:[] ~f:f2
+
+  let map_env env xs ~f =
+    let rec aux env xs counter =
+      match xs with
+      | [] -> env, []
+      | [y1] ->
+        let env, z1 = f env y1 in
+        env, [z1]
+      | [y1; y2] ->
+        let env, z1 = f env y1 in
+        let env, z2 = f env y2 in
+        env, [z1; z2]
+      | [y1; y2; y3] ->
+        let env, z1 = f env y1 in
+        let env, z2 = f env y2 in
+        let env, z3 = f env y3 in
+        env, [z1; z2; z3]
+      | [y1; y2; y3; y4] ->
+        let env, z1 = f env y1 in
+        let env, z2 = f env y2 in
+        let env, z3 = f env y3 in
+        let env, z4 = f env y4 in
+        env, [z1; z2; z3; z4]
+      | [y1; y2; y3; y4; y5] ->
+        let env, z1 = f env y1 in
+        let env, z2 = f env y2 in
+        let env, z3 = f env y3 in
+        let env, z4 = f env y4 in
+        let env, z5 = f env y5 in
+        env, [z1; z2; z3; z4; z5]
+      | y1::y2::y3::y4::y5::ys ->
+        let env, z1 = f env y1 in
+        let env, z2 = f env y2 in
+        let env, z3 = f env y3 in
+        let env, z4 = f env y4 in
+        let env, z5 = f env y5 in
+        let env, zs =
+          if counter > 1000
+          then
+            let env, zs = rev_map_env env ys ~f in
+            env, rev zs
+          else
+            aux env ys (counter + 1)
+        in
+        env, z1::z2::z3::z4::z5::zs
+    in
+    aux env xs 0
+
+  let rec map2_env env l1 l2 ~f = match l1, l2 with
+    | [], [] -> env, []
+    | [], _ | _, [] -> raise @@ Invalid_argument "map2_env"
+    | x1 :: rl1, x2 :: rl2 ->
+      let env, x = f env x1 x2 in
+      let env, rl = map2_env env rl1 rl2 ~f in
+      env, x :: rl
+
+  let filter_map_env env xs ~f =
+    let env, l = rev_map_env env xs ~f in
+    env, rev_filter_map l ~f:(fun x -> x)
+
+  let rec replicate ~num x =
+    match num with
+    | 0 -> []
+    | n when n < 0 ->
+        raise @@ Invalid_argument (
+          Printf.sprintf "List.replicate was called with %d argument" n)
+    | _ -> x :: replicate ~num:(num - 1) x
+
+end


### PR DESCRIPTION
The internal and external repositories are out of sync. This attempts to brings them back in sync by patching the GitHub repository. Please carefully review this patch. You must disable ShipIt for your project in order to merge this pull request. DO NOT IMPORT this pull request. Instead, merge it directly on GitHub using the MERGE BUTTON. Re-enable ShipIt after merging.