### PR TITLE
website: fix `declarations` header and nav

### DIFF
--- a/website/_data/guides.yml
+++ b/website/_data/guides.yml
@@ -92,6 +92,7 @@
     - path: "/docs/config/lints/"
     - path: "/docs/config/options/"
     - path: "/docs/config/version/"
+    - path: "/docs/config/declarations/"
 
 - id: libdefs
   pages:

--- a/website/_data/i18n/en.yml
+++ b/website/_data/i18n/en.yml
@@ -170,6 +170,9 @@ docs_additional_reading: "Additional Reading"
 "/docs/config/version/":
   title: ".flowconfig [version]"
   description: "How to pin your project to a specific version of Flow"
+"/docs/config/declarations/":
+  title: ".flowconfig [declarations]"
+  description: "How to include a third-party module’s types without typechecking its code"
 "/docs/errors/":
   title: "Debugging Errors"
   description: ""


### PR DESCRIPTION
Summary:
Fixes #6932.

See [“before” screenshot][before]; see [“after” screenshot][after].

[before]: https://user-images.githubusercontent.com/4317806/46028320-0de44280-c0a5-11e8-8ad9-d3ec71baafcc.png
[after]: https://user-images.githubusercontent.com/4317806/46028319-0de44280-c0a5-11e8-9d51-1d2d1a2d7724.png

Test Plan:
Run `make -C website` and visit <http://localhost:8080/en/docs/config>.
Note that “.flowconfig [declarations]” appears as a link on the right.
Click it to navigate to `declarations/`. Note that this page now has a
title, description, and navbar.

Two sibling sections are `libs` and `lints`. Run the following command
to get a list of all website files containing both of these strings…

```
$ comm -12 \
>     <(git grep --name-only lints website | sort) \
>     <(git grep --name-only libs website | sort) \
>     ;
website/_data/guides.yml
website/_data/i18n/en.yml
website/en/docs/config/index.md
```

…and then check that `declarations` is properly accounted for in each
such file.

wchargin-branch: website-fix-declarations