### PR TITLE
[circle] use actual opam version in cache key

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,12 @@ aliases:
       - image: circleci/node:8
     working_directory: ~/flow
 
+  # Saves the currently-installed opam version to a file, which we include
+  # in cache keys.
+  - &opam_version
+    name: Calculate opam version
+    command: opam --version > .circleci/opamversion
+
   - &opam_deps
     name: Install deps from opam
     command: |
@@ -25,12 +31,12 @@ aliases:
 
   - &restore_opam_cache
     keys:
-      - opam-cache-{{ arch }}-opam_1_2_2-ocaml_4_05_0-{{ checksum "opam" }}
-      - opam-cache-{{ arch }}-opam_1_2_2-ocaml_4_05_0
-      - opam-cache-{{ arch }}-opam_1_2_2
+      - opam-cache-{{ arch }}-opam_{{ checksum ".circleci/opamversion" }}-ocaml_4_05_0-{{ checksum "opam" }}
+      - opam-cache-{{ arch }}-opam_{{ checksum ".circleci/opamversion" }}-ocaml_4_05_0
+      - opam-cache-{{ arch }}-opam_{{ checksum ".circleci/opamversion" }}
 
   - &save_opam_cache
-    key: opam-cache-{{ arch }}-opam_1_2_2-ocaml_4_05_0-{{ checksum "opam" }}
+    key: opam-cache-{{ arch }}-opam_{{ checksum ".circleci/opamversion" }}-ocaml_4_05_0-{{ checksum "opam" }}
     paths:
       - ~/.opam
 
@@ -64,6 +70,7 @@ jobs:
           # TODO: move this to a custom docker image
           name: Install deps
           command: sudo apt-get update && sudo apt-get install zip
+      - run: *opam_version
       - restore_cache: *restore_opam_cache
       - run:
           name: Update opam repo
@@ -126,9 +133,6 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/flow
-      - restore_cache:
-          keys:
-            - brew-cache-{{ arch }}-v2
       # https://github.com/Homebrew/homebrew-core/issues/26358
       - run:
           name: Fix homebrew python
@@ -136,17 +140,13 @@ jobs:
       - run:
           name: Install opam
           command: command -v opam || brew install opam aspcud
-      - save_cache:
-          key: brew-cache-{{ arch }}-v2
-          paths:
-            - /usr/local/bin/opam
-            - /usr/local/bin/aspcud
+      - run: *opam_version
       - restore_cache: *restore_opam_cache
       - run:
           name: Install ocaml
           command: opam init --comp 4.05.0 -yn | cat
       - save_cache:
-          key: opam-cache-{{ arch }}-opam_1_2_2-ocaml_4_05_0
+          key: opam-cache-{{ arch }}-opam_{{ checksum ".circleci/opamversion" }}-ocaml_4_05_0
           paths:
             - ~/.opam
       - run:


### PR DESCRIPTION
writes `opam --version` to a file and includes it in the circleci cache key, so it invalidates when homebrew upgrades opam.