### PR TITLE
Update babel packages to new @babel/package 

### DIFF
--- a/website/en/docs/_install/compiler-babel.md
+++ b/website/en/docs/_install/compiler-babel.md
@@ -2,11 +2,11 @@
 support for Flow. Babel will take your Flow code and strip out any type
 annotations.
 
-First install `babel-cli` and `babel-preset-flow` with either
+First install `@babel/cli` and `@babel/preset-flow` with either
 [Yarn](https://yarnpkg.com/) or [npm](https://www.npmjs.com/).
 
 ```sh
-{{include.install_command}} babel-cli babel-preset-flow
+{{include.install_command}} @babel/cli @babel/preset-flow
 ```
 
 Next you need to create a `.babelrc` file at the root of your project with

--- a/website/en/docs/tools/babel.md
+++ b/website/en/docs/tools/babel.md
@@ -8,13 +8,13 @@ takes just a few steps to set them up together.
 If you don't have Babel setup already, you can do that by following
 [this guide](http://babeljs.io/docs/setup/).
 
-Once you have Babel setup, install `babel-preset-flow` with either
+Once you have Babel setup, install `@babel/preset-flow` with either
 [Yarn](https://yarnpkg.com/) or [npm](https://www.npmjs.com/).
 
 ```sh
-yarn add --dev babel-preset-flow
+yarn add --dev @babel/preset-flow
 # or
-npm install --save-dev babel-preset-flow
+npm install --save-dev @babel/preset-flow
 ```
 
 Then add `flow` to your Babel presets config.


### PR DESCRIPTION
I have updated the old package names to the new @babel/__ ones. 

The reason: 

If you use the old packages with @babel/core v7+ then it gives the error "plugin should return a function not an object".  

This change is important as most of the packages are now available in this format. e.g. @babel/preset-react, @babel/preset-env, etc.