### PR TITLE
Made elementFromPoint() return type match spec

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -861,7 +861,7 @@ declare class Document extends Node {
   createEvent(eventInterface: 'CustomEvent'): CustomEvent;
   createEvent(eventInterface: string): Event;
   createRange(): Range;
-  elementFromPoint(x: number, y: number): HTMLElement;
+  elementFromPoint(x: number, y: number): HTMLElement | null;
   defaultView: any;
   compatMode: 'BackCompat' | 'CSS1Compat';
   hidden: boolean;


### PR DESCRIPTION
According to [MDN](https://developer.mozilla.org/en-US/docs/Web/API/DocumentOrShadowRoot/elementFromPoint), `document.elementFromPoint()` can return null: "if the specified point is outside the visible bounds of the document or either coordinate is negative". However, the flow type indicates it always returns `HTMLElement`. This can lead to errors where the null case is not handled.