### PR TITLE
feat: add missing properties to http server response

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -1247,18 +1247,30 @@ declare class http$ClientRequest extends stream$Writable {
 
 declare class http$ServerResponse extends stream$Writable {
   addTrailers(headers: {[key: string] : string}): void;
+  connection: net$Socket;
+  end(data: string | Buffer, encoding: string, callback?: Function);
   finished: boolean;
   getHeader(name: string): string;
+  getHeaderNames(): Array<string>;
+  getHeaders(): {[key: string] : string};
+  hasHeader(name: string): boolean;
   headersSent: boolean;
   removeHeader(name: string): void;
   sendDate: boolean;
   setHeader(name: string, value: string | Array<string>): void;
   setTimeout(msecs: number, callback?: Function): http$ServerResponse;
+  socket: net$Socket;
   statusCode: number;
   statusMessage: string;
+  write(
+    chunk?: string | Buffer,
+    encoding?: string,
+    callback?: (data: any) => void
+  ): boolean;
   writeContinue(): void;
   writeHead(status: number, statusMessage?: string, headers?: {[key: string] : string}): void;
   writeHead(status: number, headers?: {[key: string] : string}): void;
+  writeProcessing(): void;
 }
 
 declare module "http" {


### PR DESCRIPTION
hi! a month ago I asked about missing properties on this object: https://github.com/facebook/flow/issues/6860; I went ahead and updated the definition to include additional missing properties that I found.

taken straight from here: https://nodejs.org/api/http.html#http_class_http_serverresponse

let me know if there is anything else I should do.