### PR TITLE
Add `cursorTo` & `clearLine` to streams

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -1632,6 +1632,12 @@ declare class stream$Writable extends stream$Stream {
     encoding: string,
     callback: (error: ?Error, data?: Buffer | string) => void
   ): boolean;
+  cursorTo(
+    stream: Buffer,
+    x: number,
+    y?: number
+  ): void;
+  clearLine(stream: Buffer, dir?: -1 | 0 | 1): void
 }
 
 //According to the NodeJS docs:
@@ -1688,13 +1694,23 @@ declare class tty$ReadStream extends net$Socket {
   constructor(fd: number, options?: Object): void;
   isRaw : boolean;
   setRawMode(mode : boolean) : void;
-  isTTY : true
+  isTTY : true;
+  cursorTo(
+    x: number,
+    y?: number
+  ): void;
+  clearLine(dir?: -1 | 0 | 1): void
 }
 declare class tty$WriteStream extends net$Socket {
   constructor(fd: number) : void;
   columns : number;
   rows : number;
-  isTTY : true
+  isTTY : true;
+  cursorTo(
+    x: number,
+    y?: number
+  ): void;
+  clearLine(dir?: -1 | 0 | 1): void
 }
 
 declare module "tty" {


### PR DESCRIPTION
Using `process.stdout.cursorTo` and `process.stdout.clearLine` will error in Flow because those definitions are missing.

```bash
Error: src/db/seeds/utils/helpers.js:9
  9:   process.stdout.cursorTo(0)
                      ^^^^^^^^ property `cursorTo`. Property not found in
  9:   process.stdout.cursorTo(0)
       ^^^^^^^^^^^^^^ stream$Writable

Error: src/db/seeds/utils/helpers.js:9
  9:   process.stdout.cursorTo(0)
                      ^^^^^^^^ property `cursorTo`. Property not found in
  9:   process.stdout.cursorTo(0)
       ^^^^^^^^^^^^^^ tty$WriteStream
```
[node/lib/readline.js](https://github.com/nodejs/node/blob/4a276cc2a960b3f9a138ac3a99c9249a63b4d472/lib/readline.js#L1061-L1080)
[node/lib/tty.js](https://github.com/nodejs/node/blob/8bf48bf2cf714125fef91fd0651d3517b8953034/lib/tty.js#L131-L134)

```bash
Error: src/db/seeds/utils/helpers.js:10
 10:   process.stdout.clearLine()
                      ^^^^^^^^^ property `clearLine`. Property not found in
 10:   process.stdout.clearLine()
       ^^^^^^^^^^^^^^ stream$Writable

Error: src/db/seeds/utils/helpers.js:10
 10:   process.stdout.clearLine()
                      ^^^^^^^^^ property `clearLine`. Property not found in
 10:   process.stdout.clearLine()
       ^^^^^^^^^^^^^^ tty$WriteStream
```
[node/lib/readline.js](https://github.com/nodejs/node/blob/4a276cc2a960b3f9a138ac3a99c9249a63b4d472/lib/readline.js#L1103-L1124)
[node/lib/tty.js](https://github.com/nodejs/node/blob/8bf48bf2cf714125fef91fd0651d3517b8953034/lib/tty.js#L139-L142)

I'm not sure if I added them in the correct place, so please check and let me know.

