### PR TITLE
Fix typo `,` -> `;` in libdef docs

### DIFF
--- a/website/en/docs/libdefs/creation.md
+++ b/website/en/docs/libdefs/creation.md
@@ -133,7 +133,7 @@ declare module "some-es-module" {
 
   // Declares a named "concatPath" export which returns an instance of the
   // `Path` class (defined above)
-  declare export function concatPath(dirA: string, dirB: string): Path,
+  declare export function concatPath(dirA: string, dirB: string): Path;
 }
 ```
 


### PR DESCRIPTION
Pretty sure this should be a `;`