### PR TITLE
Make Geolocation PositionOptions properties optional

### DIFF
--- a/lib/bom.js
+++ b/lib/bom.js
@@ -677,9 +677,9 @@ declare class PositionError {
 }
 
 type PositionOptions = {
-    enableHighAccuracy: boolean;
-    timeout: number;
-    maximumAge: number;
+    enableHighAccuracy?: boolean;
+    timeout?: number;
+    maximumAge?: number;
 }
 
 declare class AudioContext {


### PR DESCRIPTION
This should be allowed:
```js
navigator.geolocation.getCurrentPosition(onSuccess, onError, {timeout: 2000});
```