### PR TITLE
lib/node.js: stream: Allow Uint8Array in a few places.

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -1417,7 +1417,7 @@ declare class net$Socket extends stream$Duplex {
   destroy(exception?: Error): void;
   destroyed: boolean;
   end(
-    chunk?: string | Buffer,
+    chunkOrEncodingOrCallback?: Buffer | Uint8Array | string | (data: any) => void,
     encodingOrCallback?: string | (data: any) => void,
     callback?: (data: any) => void
   ): void;
@@ -1435,7 +1435,7 @@ declare class net$Socket extends stream$Duplex {
   setTimeout(timeout: number, callback?: Function): net$Socket;
   unref(): net$Socket;
   write(
-    chunk?: string | Buffer,
+    chunk: Buffer | Uint8Array | string,
     encodingOrCallback?: string | (data: any) => void,
     callback?: (data: any) => void
   ): boolean;
@@ -1670,8 +1670,8 @@ declare class stream$Readable extends stream$Stream {
   read(size?: number): ?(string | Buffer);
   resume(): stream$Readable;
   unpipe(dest?: (stream$Writable | stream$Duplex)): void;
-  unshift(chunk: Buffer | string): void;
-  push(chunk: ?(Buffer | string), encoding? : string): boolean;
+  unshift(chunk: Buffer | Uint8Array | string): void;
+  push(chunk: ?(Buffer | Uint8Array | string), encoding? : string): boolean;
   wrap(oldReadable: any): stream$Readable;
 }
 
@@ -1680,14 +1680,14 @@ declare class stream$Writable extends stream$Stream {
   constructor(options?: writableStreamOptions): void;
   cork(): void;
   end(
-    chunkOrEncodingOrCallback?: Buffer | string | Function,
+    chunkOrEncodingOrCallback?: Buffer | Uint8Array | string | Function,
     encodingOrCallback?: string | Function,
     callback?: Function
   ): void;
   setDefaultEncoding(encoding: string): boolean;
   uncork() : void;
   write(
-    chunk: Buffer | string,
+    chunk: Buffer | Uint8Array | string,
     encodingOrCallback?: string | Function,
     callback?: Function
   ): boolean;
@@ -1711,14 +1711,14 @@ declare class stream$Duplex extends stream$Readable mixins stream$Writable {
   constructor(options?: duplexStreamOptions): void;
   cork(): void;
   end(
-    chunkOrEncodingOrCallback?: Buffer | string | Function,
+    chunkOrEncodingOrCallback?: Buffer | Uint8Array | string | Function,
     encodingOrCallback?: string | Function,
     callback?: Function
   ): void;
   setDefaultEncoding(encoding: string): boolean;
   uncork() : void;
   write(
-    chunk: Buffer | string,
+    chunk: Buffer | Uint8Array | string,
     encodingOrCallback?: string | Function,
     callback?: Function
   ): boolean;

--- a/tests/node_tests/node_tests.exp
+++ b/tests/node_tests/node_tests.exp
@@ -67,9 +67,9 @@ Cannot call `hmac.write` with `123` bound to `chunk` because number [1] is incom
                         ^^^ [1]
 
 References:
-   <BUILTINS>/node.js:1721:21
-   1721|     chunk: Buffer | string,
-                             ^^^^^^ [2]
+   <BUILTINS>/node.js:1721:34
+   1721|     chunk: Buffer | Uint8Array | string,
+                                          ^^^^^^ [2]
 
 
 Error ------------------------------------------------------------------------------------------- crypto/crypto.js:26:24


### PR DESCRIPTION
Support for Uint8Array was added in Node 8.