### PR TITLE
Remove misleading paragraph about other languages.

### DIFF
--- a/website/en/docs/lang/nominal-structural.md
+++ b/website/en/docs/lang/nominal-structural.md
@@ -128,10 +128,6 @@ well. Classes (or constructor functions) being the more object-oriented side
 and functions (as lambdas) and objects tend to be more on the functional side,
 developers use both simultaneously.
 
-Object oriented languages tend to be more nominally typed (C++, Java, Swift),
-while functional languages tend to be more structurally typed (OCaml, Haskell,
-Elm).
-
 When someone writes a class, they are declaring a _thing_. This thing might
 have the same structure as something else but they still serve different
 purposes. Imagine two component classes that both have `render()` methods,


### PR DESCRIPTION
OCaml and Elm are probably in equal measure nominally and structurally typed, while Haskell is firmly in the nominally typed camp.