### PR TITLE
Custom type definition for React.cloneElement

### DIFF
--- a/lib/react.js
+++ b/lib/react.js
@@ -226,9 +226,10 @@ declare module react {
   declare export var createElement: React$CreateElement;
   declare export var cloneElement: <
     Component: React$ComponentType<any>,
-    Props: React$ElementConfig<Component>,
-    Element: React$Element<Component>
-  >(Element, Props, React$Node) => Element;
+    Props: { ref?: React$Ref<Component>} & React$ElementConfig<Component>,
+    Element: React$Element<Component>,
+    ChildrenType: $PropertyType<React$ElementConfig<Component>, 'children'>
+  >(element: Element, props: Props, children?: ChildrenType) => Element;
   declare export function createFactory<ElementType: React$ElementType>(
     type: ElementType,
   ): React$ElementFactory<ElementType>;

--- a/lib/react.js
+++ b/lib/react.js
@@ -224,7 +224,11 @@ declare module react {
     defaultValue: T,
   ): React$Context<T>;
   declare export var createElement: React$CreateElement;
-  declare export var cloneElement: React$CloneElement;
+  declare export var cloneElement: <
+    Component: React$ComponentType<any>,
+    Props: React$ElementConfig<Component>,
+    Element: React$Element<Component>
+  >(Element, Props, React$Node) => Element;
   declare export function createFactory<ElementType: React$ElementType>(
     type: ElementType,
   ): React$ElementFactory<ElementType>;


### PR DESCRIPTION
The built in type definition for React.cloneElement occasionally errors out erroneously.  This should fix that.

Should fix these issues:
 https://github.com/facebook/flow/issues/5839 
 https://github.com/facebook/flow/issues/5934
 https://github.com/facebook/flow/issues/4824
 