### PR TITLE
use package that works with 7.x in babel doc

### DIFF
--- a/website/en/docs/tools/babel.md
+++ b/website/en/docs/tools/babel.md
@@ -8,19 +8,19 @@ takes just a few steps to set them up together.
 If you don't have Babel setup already, you can do that by following
 [this guide](http://babeljs.io/docs/setup/).
 
-Once you have Babel setup, install `babel-preset-flow` with either
+Once you have Babel setup, install `@babel/preset-flow` with either
 [Yarn](https://yarnpkg.com/) or [npm](https://www.npmjs.com/).
 
 ```sh
-yarn add --dev babel-preset-flow
+yarn add --dev @babel/preset-flow
 # or
-npm install --save-dev babel-preset-flow
+npm install --save-dev @babel/preset-flow
 ```
 
 Then add `flow` to your Babel presets config.
 
 ```json
 {
-  "presets": ["flow"]
+  "presets": ["@babel/preset-flow"]
 }
 ```


### PR DESCRIPTION
packages listed in the doc were 2 years old; only supported babel 6.x which is going to become the exception vs the normal use-case for projects soon.  Should resolve #7046