### PR TITLE
createContextualFragment returns a DocumentFragment

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -1195,7 +1195,7 @@ declare class Range { // extension
   setStartAfter(refNode: Node): void;
   extractContents(): DocumentFragment;
   setEndAfter(refNode: Node): void;
-  createContextualFragment(fragment: string): Node;
+  createContextualFragment(fragment: string): DocumentFragment;
   static END_TO_END: number;
   static START_TO_START: number;
   static START_TO_END: number;


### PR DESCRIPTION
[Both MDN](https://developer.mozilla.org/en-US/docs/Web/API/Range/createContextualFragment) and the [DOM Parsing and Serialization Working Draft](https://w3c.github.io/DOM-Parsing/#extensions-to-the-range-interface) indicate that this method returns a `DocumentFragment`, not a `Node`.