### PR TITLE
precise return types for Object.entries and Object.keys on typed objects

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -45,6 +45,7 @@ declare class Object {
     static create(o: any, properties?: PropertyDescriptorMap): any; // compiler magic
     static defineProperties(o: any, properties: PropertyDescriptorMap): any;
     static defineProperty<T>(o: any, p: any, attributes: PropertyDescriptor<T>): any;
+    static entries<K, V>(object: { [K]: V }): Array<[string, V]>;
     static entries(object: any): Array<[string, mixed]>;
     static freeze<T>(o: T): T;
     static getOwnPropertyDescriptor<T>(o: any, p: any): PropertyDescriptor<T> | void;
@@ -59,6 +60,7 @@ declare class Object {
     static preventExtensions<T>(o: T): T;
     static seal<T>(o: T): T;
     static setPrototypeOf(o: any, proto: ?Object): any;
+    static values<K, V>(object: { [K]: V }): Array<V>;
     static values(object: any): Array<mixed>;
     hasOwnProperty(prop: any): boolean;
     isPrototypeOf(o: any): boolean;

--- a/newtests/array_literal_tuple_spread/test.js
+++ b/newtests/array_literal_tuple_spread/test.js
@@ -325,8 +325,8 @@ export default suite(({addFile, addFiles, addCode}) => [
             3: const arr: Array<number> = [..."hello"];
                                           ^^^^^^^^^^^^ Cannot assign array literal to \`arr\` because string [1] is incompatible with number [2] in array element.
             References:
-            291:     @@iterator(): Iterator<string>;
-                                            ^^^^^^ [1]. See lib: [LIB] core.js:291
+            293:     @@iterator(): Iterator<string>;
+                                            ^^^^^^ [1]. See lib: [LIB] core.js:293
               3: const arr: Array<number> = [..."hello"];
                                   ^^^^^^ [2]
         `,

--- a/newtests/autocomplete/test.js
+++ b/newtests/autocomplete/test.js
@@ -49,8 +49,8 @@ export default suite(({addFile, flowCmd}) => [
                  ]
                },
                "path": "[LIB] core.js",
-               "line": 63,
-               "endline": 63,
+               "line": 65,
+               "endline": 65,
                "start": 5,
                "end": 38
              },
@@ -67,8 +67,8 @@ export default suite(({addFile, flowCmd}) => [
                  ]
                },
                "path": "[LIB] core.js",
-               "line": 64,
-               "endline": 64,
+               "line": 66,
+               "endline": 66,
                "start": 5,
                "end": 34
              },
@@ -95,8 +95,8 @@ export default suite(({addFile, flowCmd}) => [
                  ]
                },
                "path": "[LIB] core.js",
-               "line": 65,
-               "endline": 65,
+               "line": 67,
+               "endline": 67,
                "start": 5,
                "end": 44
              },
@@ -118,8 +118,8 @@ export default suite(({addFile, flowCmd}) => [
                  "params": []
                },
                "path": "[LIB] core.js",
-               "line": 66,
-               "endline": 66,
+               "line": 68,
+               "endline": 68,
                "start": 5,
                "end": 28
              },
@@ -131,8 +131,8 @@ export default suite(({addFile, flowCmd}) => [
                  "params": []
                },
                "path": "[LIB] core.js",
-               "line": 67,
-               "endline": 67,
+               "line": 69,
+               "endline": 69,
                "start": 5,
                "end": 22
              },
@@ -144,8 +144,8 @@ export default suite(({addFile, flowCmd}) => [
                  "params": []
                },
                "path": "[LIB] core.js",
-               "line": 68,
-               "endline": 68,
+               "line": 70,
+               "endline": 70,
                "start": 5,
                "end": 20
              }
@@ -205,8 +205,8 @@ export default suite(({addFile, flowCmd}) => [
                  "params": []
                },
                "path": "[LIB] core.js",
-               "line": 291,
-               "endline": 291,
+               "line": 293,
+               "endline": 293,
                "start": 5,
                "end": 34
              },
@@ -223,8 +223,8 @@ export default suite(({addFile, flowCmd}) => [
                  ]
                },
                "path": "[LIB] core.js",
-               "line": 292,
-               "endline": 292,
+               "line": 294,
+               "endline": 294,
                "start": 5,
                "end": 32
              },
@@ -241,8 +241,8 @@ export default suite(({addFile, flowCmd}) => [
                  ]
                },
                "path": "[LIB] core.js",
-               "line": 293,
-               "endline": 293,
+               "line": 295,
+               "endline": 295,
                "start": 5,
                "end": 31
              },
@@ -259,8 +259,8 @@ export default suite(({addFile, flowCmd}) => [
                  ]
                },
                "path": "[LIB] core.js",
-               "line": 294,
-               "endline": 294,
+               "line": 296,
+               "endline": 296,
                "start": 5,
                "end": 37
              },
@@ -277,8 +277,8 @@ export default suite(({addFile, flowCmd}) => [
                  ]
                },
                "path": "[LIB] core.js",
-               "line": 295,
-               "endline": 295,
+               "line": 297,
+               "endline": 297,
                "start": 5,
                "end": 38
              },
@@ -295,8 +295,8 @@ export default suite(({addFile, flowCmd}) => [
                  ]
                },
                "path": "[LIB] core.js",
-               "line": 296,
-               "endline": 296,
+               "line": 298,
+               "endline": 298,
                "start": 5,
                "end": 45
              },
@@ -317,8 +317,8 @@ export default suite(({addFile, flowCmd}) => [
                  ]
                },
                "path": "[LIB] core.js",
-               "line": 298,
-               "endline": 298,
+               "line": 300,
+               "endline": 300,
                "start": 5,
                "end": 62
              },
@@ -339,8 +339,8 @@ export default suite(({addFile, flowCmd}) => [
                  ]
                },
                "path": "[LIB] core.js",
-               "line": 299,
-               "endline": 299,
+               "line": 301,
+               "endline": 301,
                "start": 5,
                "end": 62
              },
@@ -361,8 +361,8 @@ export default suite(({addFile, flowCmd}) => [
                  ]
                },
                "path": "[LIB] core.js",
-               "line": 300,
-               "endline": 300,
+               "line": 302,
+               "endline": 302,
                "start": 5,
                "end": 60
              },
@@ -383,8 +383,8 @@ export default suite(({addFile, flowCmd}) => [
                  ]
                },
                "path": "[LIB] core.js",
-               "line": 301,
-               "endline": 301,
+               "line": 303,
+               "endline": 303,
                "start": 5,
                "end": 64
              },
@@ -393,8 +393,8 @@ export default suite(({addFile, flowCmd}) => [
                "type": "number",
                "func_details": null,
                "path": "[LIB] core.js",
-               "line": 325,
-               "endline": 325,
+               "line": 327,
+               "endline": 327,
                "start": 13,
                "end": 18
              },
@@ -411,8 +411,8 @@ export default suite(({addFile, flowCmd}) => [
                  ]
                },
                "path": "[LIB] core.js",
-               "line": 302,
-               "endline": 302,
+               "line": 304,
+               "endline": 304,
                "start": 5,
                "end": 30
              },
@@ -437,8 +437,8 @@ export default suite(({addFile, flowCmd}) => [
                  ]
                },
                "path": "[LIB] core.js",
-               "line": 303,
-               "endline": 303,
+               "line": 305,
+               "endline": 305,
                "start": 5,
                "end": 105
              },
@@ -455,8 +455,8 @@ export default suite(({addFile, flowCmd}) => [
                  ]
                },
                "path": "[LIB] core.js",
-               "line": 304,
-               "endline": 304,
+               "line": 306,
+               "endline": 306,
                "start": 5,
                "end": 61
              },
@@ -473,8 +473,8 @@ export default suite(({addFile, flowCmd}) => [
                  ]
                },
                "path": "[LIB] core.js",
-               "line": 305,
-               "endline": 305,
+               "line": 307,
+               "endline": 307,
                "start": 5,
                "end": 38
              },
@@ -495,8 +495,8 @@ export default suite(({addFile, flowCmd}) => [
                  ]
                },
                "path": "[LIB] core.js",
-               "line": 306,
-               "endline": 306,
+               "line": 308,
+               "endline": 308,
                "start": 5,
                "end": 60
              },
@@ -517,8 +517,8 @@ export default suite(({addFile, flowCmd}) => [
                  ]
                },
                "path": "[LIB] core.js",
-               "line": 307,
-               "endline": 307,
+               "line": 309,
+               "endline": 309,
                "start": 5,
                "end": 62
              },
@@ -535,8 +535,8 @@ export default suite(({addFile, flowCmd}) => [
                  ]
                },
                "path": "[LIB] core.js",
-               "line": 308,
-               "endline": 308,
+               "line": 310,
+               "endline": 310,
                "start": 5,
                "end": 33
              },
@@ -557,8 +557,8 @@ export default suite(({addFile, flowCmd}) => [
                  ]
                },
                "path": "[LIB] core.js",
-               "line": 309,
-               "endline": 309,
+               "line": 311,
+               "endline": 311,
                "start": 5,
                "end": 124
              },
@@ -575,8 +575,8 @@ export default suite(({addFile, flowCmd}) => [
                  ]
                },
                "path": "[LIB] core.js",
-               "line": 310,
-               "endline": 310,
+               "line": 312,
+               "endline": 312,
                "start": 5,
                "end": 43
              },
@@ -597,8 +597,8 @@ export default suite(({addFile, flowCmd}) => [
                  ]
                },
                "path": "[LIB] core.js",
-               "line": 311,
-               "endline": 311,
+               "line": 313,
+               "endline": 313,
                "start": 5,
                "end": 47
              },
@@ -619,8 +619,8 @@ export default suite(({addFile, flowCmd}) => [
                  ]
                },
                "path": "[LIB] core.js",
-               "line": 312,
-               "endline": 312,
+               "line": 314,
+               "endline": 314,
                "start": 5,
                "end": 69
              },
@@ -641,8 +641,8 @@ export default suite(({addFile, flowCmd}) => [
                  ]
                },
                "path": "[LIB] core.js",
-               "line": 313,
-               "endline": 313,
+               "line": 315,
+               "endline": 315,
                "start": 5,
                "end": 64
              },
@@ -663,8 +663,8 @@ export default suite(({addFile, flowCmd}) => [
                  ]
                },
                "path": "[LIB] core.js",
-               "line": 314,
-               "endline": 314,
+               "line": 316,
+               "endline": 316,
                "start": 5,
                "end": 49
              },
@@ -685,8 +685,8 @@ export default suite(({addFile, flowCmd}) => [
                  ]
                },
                "path": "[LIB] core.js",
-               "line": 315,
-               "endline": 315,
+               "line": 317,
+               "endline": 317,
                "start": 5,
                "end": 50
              },
@@ -703,8 +703,8 @@ export default suite(({addFile, flowCmd}) => [
                  ]
                },
                "path": "[LIB] core.js",
-               "line": 316,
-               "endline": 316,
+               "line": 318,
+               "endline": 318,
                "start": 5,
                "end": 62
              },
@@ -721,8 +721,8 @@ export default suite(({addFile, flowCmd}) => [
                  ]
                },
                "path": "[LIB] core.js",
-               "line": 317,
-               "endline": 317,
+               "line": 319,
+               "endline": 319,
                "start": 5,
                "end": 62
              },
@@ -734,8 +734,8 @@ export default suite(({addFile, flowCmd}) => [
                  "params": []
                },
                "path": "[LIB] core.js",
-               "line": 318,
-               "endline": 318,
+               "line": 320,
+               "endline": 320,
                "start": 5,
                "end": 25
              },
@@ -747,8 +747,8 @@ export default suite(({addFile, flowCmd}) => [
                  "params": []
                },
                "path": "[LIB] core.js",
-               "line": 324,
-               "endline": 324,
+               "line": 326,
+               "endline": 326,
                "start": 5,
                "end": 22
              },
@@ -760,8 +760,8 @@ export default suite(({addFile, flowCmd}) => [
                  "params": []
                },
                "path": "[LIB] core.js",
-               "line": 319,
-               "endline": 319,
+               "line": 321,
+               "endline": 321,
                "start": 5,
                "end": 25
              },
@@ -773,8 +773,8 @@ export default suite(({addFile, flowCmd}) => [
                  "params": []
                },
                "path": "[LIB] core.js",
-               "line": 320,
-               "endline": 320,
+               "line": 322,
+               "endline": 322,
                "start": 5,
                "end": 18
              },
@@ -786,8 +786,8 @@ export default suite(({addFile, flowCmd}) => [
                  "params": []
                },
                "path": "[LIB] core.js",
-               "line": 321,
-               "endline": 321,
+               "line": 323,
+               "endline": 323,
                "start": 5,
                "end": 22
              },
@@ -799,8 +799,8 @@ export default suite(({addFile, flowCmd}) => [
                  "params": []
                },
                "path": "[LIB] core.js",
-               "line": 322,
-               "endline": 322,
+               "line": 324,
+               "endline": 324,
                "start": 5,
                "end": 23
              },
@@ -812,8 +812,8 @@ export default suite(({addFile, flowCmd}) => [
                  "params": []
                },
                "path": "[LIB] core.js",
-               "line": 323,
-               "endline": 323,
+               "line": 325,
+               "endline": 325,
                "start": 5,
                "end": 21
              }
@@ -844,8 +844,8 @@ export default suite(({addFile, flowCmd}) => [
                  ]
                },
                "path": "[LIB] core.js",
-               "line": 140,
-               "endline": 140,
+               "line": 142,
+               "endline": 142,
                "start": 5,
                "end": 50
              },
@@ -862,8 +862,8 @@ export default suite(({addFile, flowCmd}) => [
                  ]
                },
                "path": "[LIB] core.js",
-               "line": 141,
-               "endline": 141,
+               "line": 143,
+               "endline": 143,
                "start": 5,
                "end": 44
              },
@@ -884,8 +884,8 @@ export default suite(({addFile, flowCmd}) => [
                  ]
                },
                "path": "[LIB] core.js",
-               "line": 142,
-               "endline": 142,
+               "line": 144,
+               "endline": 144,
                "start": 5,
                "end": 96
              },
@@ -902,8 +902,8 @@ export default suite(({addFile, flowCmd}) => [
                  ]
                },
                "path": "[LIB] core.js",
-               "line": 143,
-               "endline": 143,
+               "line": 145,
+               "endline": 145,
                "start": 5,
                "end": 43
              },
@@ -920,8 +920,8 @@ export default suite(({addFile, flowCmd}) => [
                  ]
                },
                "path": "[LIB] core.js",
-               "line": 144,
-               "endline": 144,
+               "line": 146,
+               "endline": 146,
                "start": 5,
                "end": 36
              },
@@ -933,8 +933,8 @@ export default suite(({addFile, flowCmd}) => [
                  "params": []
                },
                "path": "[LIB] core.js",
-               "line": 145,
-               "endline": 145,
+               "line": 147,
+               "endline": 147,
                "start": 5,
                "end": 21
              }
@@ -960,8 +960,8 @@ export default suite(({addFile, flowCmd}) => [
                  "params": []
                },
                "path": "[LIB] core.js",
-               "line": 120,
-               "endline": 120,
+               "line": 122,
+               "endline": 122,
                "start": 5,
                "end": 22
              },
@@ -973,8 +973,8 @@ export default suite(({addFile, flowCmd}) => [
                  "params": []
                },
                "path": "[LIB] core.js",
-               "line": 119,
-               "endline": 119,
+               "line": 121,
+               "endline": 121,
                "start": 5,
                "end": 22
              }
@@ -1015,8 +1015,8 @@ export default suite(({addFile, flowCmd}) => [
                  ]
                },
                "path": "[LIB] core.js",
-               "line": 63,
-               "endline": 63,
+               "line": 65,
+               "endline": 65,
                "start": 5,
                "end": 38
              },
@@ -1033,8 +1033,8 @@ export default suite(({addFile, flowCmd}) => [
                  ]
                },
                "path": "[LIB] core.js",
-               "line": 64,
-               "endline": 64,
+               "line": 66,
+               "endline": 66,
                "start": 5,
                "end": 34
              },
@@ -1051,8 +1051,8 @@ export default suite(({addFile, flowCmd}) => [
                  ]
                },
                "path": "[LIB] core.js",
-               "line": 65,
-               "endline": 65,
+               "line": 67,
+               "endline": 67,
                "start": 5,
                "end": 44
              },
@@ -1064,8 +1064,8 @@ export default suite(({addFile, flowCmd}) => [
                  "params": []
                },
                "path": "[LIB] core.js",
-               "line": 66,
-               "endline": 66,
+               "line": 68,
+               "endline": 68,
                "start": 5,
                "end": 28
              },
@@ -1077,8 +1077,8 @@ export default suite(({addFile, flowCmd}) => [
                  "params": []
                },
                "path": "[LIB] core.js",
-               "line": 67,
-               "endline": 67,
+               "line": 69,
+               "endline": 69,
                "start": 5,
                "end": 22
              },
@@ -1090,8 +1090,8 @@ export default suite(({addFile, flowCmd}) => [
                  "params": []
                },
                "path": "[LIB] core.js",
-               "line": 68,
-               "endline": 68,
+               "line": 70,
+               "endline": 70,
                "start": 5,
                "end": 20
              }
@@ -1213,8 +1213,8 @@ export default suite(({addFile, flowCmd}) => [
                  ]
                },
                "path": "[LIB] core.js",
-               "line": 140,
-               "endline": 140,
+               "line": 142,
+               "endline": 142,
                "start": 5,
                "end": 50
              },
@@ -1231,8 +1231,8 @@ export default suite(({addFile, flowCmd}) => [
                  ]
                },
                "path": "[LIB] core.js",
-               "line": 141,
-               "endline": 141,
+               "line": 143,
+               "endline": 143,
                "start": 5,
                "end": 44
              },
@@ -1253,8 +1253,8 @@ export default suite(({addFile, flowCmd}) => [
                  ]
                },
                "path": "[LIB] core.js",
-               "line": 142,
-               "endline": 142,
+               "line": 144,
+               "endline": 144,
                "start": 5,
                "end": 96
              },
@@ -1271,8 +1271,8 @@ export default suite(({addFile, flowCmd}) => [
                  ]
                },
                "path": "[LIB] core.js",
-               "line": 143,
-               "endline": 143,
+               "line": 145,
+               "endline": 145,
                "start": 5,
                "end": 43
              },
@@ -1289,8 +1289,8 @@ export default suite(({addFile, flowCmd}) => [
                  ]
                },
                "path": "[LIB] core.js",
-               "line": 144,
-               "endline": 144,
+               "line": 146,
+               "endline": 146,
                "start": 5,
                "end": 36
              },
@@ -1302,8 +1302,8 @@ export default suite(({addFile, flowCmd}) => [
                  "params": []
                },
                "path": "[LIB] core.js",
-               "line": 145,
-               "endline": 145,
+               "line": 147,
+               "endline": 147,
                "start": 5,
                "end": 21
              }
@@ -1344,8 +1344,8 @@ export default suite(({addFile, flowCmd}) => [
                  ]
                },
                "path": "[LIB] core.js",
-               "line": 63,
-               "endline": 63,
+               "line": 65,
+               "endline": 65,
                "start": 5,
                "end": 38
              },
@@ -1362,8 +1362,8 @@ export default suite(({addFile, flowCmd}) => [
                  ]
                },
                "path": "[LIB] core.js",
-               "line": 64,
-               "endline": 64,
+               "line": 66,
+               "endline": 66,
                "start": 5,
                "end": 34
              },
@@ -1380,8 +1380,8 @@ export default suite(({addFile, flowCmd}) => [
                  ]
                },
                "path": "[LIB] core.js",
-               "line": 65,
-               "endline": 65,
+               "line": 67,
+               "endline": 67,
                "start": 5,
                "end": 44
              },
@@ -1393,8 +1393,8 @@ export default suite(({addFile, flowCmd}) => [
                  "params": []
                },
                "path": "[LIB] core.js",
-               "line": 66,
-               "endline": 66,
+               "line": 68,
+               "endline": 68,
                "start": 5,
                "end": 28
              },
@@ -1406,8 +1406,8 @@ export default suite(({addFile, flowCmd}) => [
                  "params": []
                },
                "path": "[LIB] core.js",
-               "line": 67,
-               "endline": 67,
+               "line": 69,
+               "endline": 69,
                "start": 5,
                "end": 22
              },
@@ -1419,8 +1419,8 @@ export default suite(({addFile, flowCmd}) => [
                  "params": []
                },
                "path": "[LIB] core.js",
-               "line": 68,
-               "endline": 68,
+               "line": 70,
+               "endline": 70,
                "start": 5,
                "end": 20
              }
@@ -1469,8 +1469,8 @@ export default suite(({addFile, flowCmd}) => [
                  ]
                },
                "path": "[LIB] core.js",
-               "line": 63,
-               "endline": 63,
+               "line": 65,
+               "endline": 65,
                "start": 5,
                "end": 38
              },
@@ -1487,8 +1487,8 @@ export default suite(({addFile, flowCmd}) => [
                  ]
                },
                "path": "[LIB] core.js",
-               "line": 64,
-               "endline": 64,
+               "line": 66,
+               "endline": 66,
                "start": 5,
                "end": 34
              },
@@ -1515,8 +1515,8 @@ export default suite(({addFile, flowCmd}) => [
                  ]
                },
                "path": "[LIB] core.js",
-               "line": 65,
-               "endline": 65,
+               "line": 67,
+               "endline": 67,
                "start": 5,
                "end": 44
              },
@@ -1528,8 +1528,8 @@ export default suite(({addFile, flowCmd}) => [
                  "params": []
                },
                "path": "[LIB] core.js",
-               "line": 66,
-               "endline": 66,
+               "line": 68,
+               "endline": 68,
                "start": 5,
                "end": 28
              },
@@ -1541,8 +1541,8 @@ export default suite(({addFile, flowCmd}) => [
                  "params": []
                },
                "path": "[LIB] core.js",
-               "line": 67,
-               "endline": 67,
+               "line": 69,
+               "endline": 69,
                "start": 5,
                "end": 22
              },
@@ -1554,8 +1554,8 @@ export default suite(({addFile, flowCmd}) => [
                  "params": []
                },
                "path": "[LIB] core.js",
-               "line": 68,
-               "endline": 68,
+               "line": 70,
+               "endline": 70,
                "start": 5,
                "end": 20
              },
@@ -1784,8 +1784,8 @@ export default suite(({addFile, flowCmd}) => [
                ]
              },
              "path": "[LIB] core.js",
-             "line": 63,
-             "endline": 63,
+             "line": 65,
+             "endline": 65,
              "start": 5,
              "end": 38
            },
@@ -1802,8 +1802,8 @@ export default suite(({addFile, flowCmd}) => [
                ]
              },
              "path": "[LIB] core.js",
-             "line": 64,
-             "endline": 64,
+             "line": 66,
+             "endline": 66,
              "start": 5,
              "end": 34
            },
@@ -1830,8 +1830,8 @@ export default suite(({addFile, flowCmd}) => [
                ]
              },
              "path": "[LIB] core.js",
-             "line": 65,
-             "endline": 65,
+             "line": 67,
+             "endline": 67,
              "start": 5,
              "end": 44
            },
@@ -1853,8 +1853,8 @@ export default suite(({addFile, flowCmd}) => [
                "params": []
              },
              "path": "[LIB] core.js",
-             "line": 66,
-             "endline": 66,
+             "line": 68,
+             "endline": 68,
              "start": 5,
              "end": 28
            },
@@ -1866,8 +1866,8 @@ export default suite(({addFile, flowCmd}) => [
                "params": []
              },
              "path": "[LIB] core.js",
-             "line": 67,
-             "endline": 67,
+             "line": 69,
+             "endline": 69,
              "start": 5,
              "end": 22
            },
@@ -1879,8 +1879,8 @@ export default suite(({addFile, flowCmd}) => [
                "params": []
              },
              "path": "[LIB] core.js",
-             "line": 68,
-             "endline": 68,
+             "line": 70,
+             "endline": 70,
              "start": 5,
              "end": 20
            }

--- a/newtests/tuples/test.js
+++ b/newtests/tuples/test.js
@@ -78,8 +78,8 @@ export default suite(({addFile, addFiles, addCode}) => [
            3: function foo(x: [1,2]): string { return x.length; }
                                                       ^^^^^^^^ Cannot return \`x.length\` because number [1] is incompatible with string [2].
            References:
-           235:     +length: number;
-                             ^^^^^^ [1]. See lib: [LIB] core.js:235
+           237:     +length: number;
+                             ^^^^^^ [1]. See lib: [LIB] core.js:237
              3: function foo(x: [1,2]): string { return x.length; }
                                         ^^^^^^ [2]
        `,
@@ -103,8 +103,8 @@ export default suite(({addFile, addFiles, addCode}) => [
             6:           readOnlyRef.push(123);
                                      ^^^^ Cannot call \`readOnlyRef.push\` because property \`push\` is missing in \`$ReadOnlyArray\` [1].
             References:
-            207:     forEach(callbackfn: (value: T, index: number, array: $ReadOnlyArray<T>) => any, thisArg?: any): void;
-                                                                          ^^^^^^^^^^^^^^^^^ [1]. See lib: [LIB] core.js:207
+            209:     forEach(callbackfn: (value: T, index: number, array: $ReadOnlyArray<T>) => any, thisArg?: any): void;
+                                                                          ^^^^^^^^^^^^^^^^^ [1]. See lib: [LIB] core.js:209
 
           test.js:7
             7:           (readOnlyRef[0]: 1);

--- a/tests/arrows/arrows.exp
+++ b/tests/arrows/arrows.exp
@@ -45,8 +45,8 @@ References:
    arrows.js:7:36
      7|     images = images.sort((a, b) => (a.width - b.width) + "");
                                            ^^^^^^^^^^^^^^^^^^^^^^^^ [1]
-   <BUILTINS>/core.js:269:38
-   269|     sort(compareFn?: (a: T, b: T) => number): Array<T>;
+   <BUILTINS>/core.js:271:38
+   271|     sort(compareFn?: (a: T, b: T) => number): Array<T>;
                                              ^^^^^^ [2]
 
 

--- a/tests/async/async.exp
+++ b/tests/async/async.exp
@@ -10,8 +10,8 @@ References:
    async.js:11:30
     11| async function f1(): Promise<bool> {
                                      ^^^^ [2]
-   <BUILTINS>/core.js:612:24
-   612| declare class Promise<+R> {
+   <BUILTINS>/core.js:614:24
+   614| declare class Promise<+R> {
                                ^ [3]
 
 
@@ -30,8 +30,8 @@ References:
    async.js:30:48
     30| async function f4(p: Promise<number>): Promise<bool> {
                                                        ^^^^ [2]
-   <BUILTINS>/core.js:612:24
-   612| declare class Promise<+R> {
+   <BUILTINS>/core.js:614:24
+   614| declare class Promise<+R> {
                                ^ [3]
 
 
@@ -100,8 +100,8 @@ References:
    async2.js:57:13
     57|   : Promise<number> { // error, number != void
                     ^^^^^^ [1]
-   <BUILTINS>/core.js:612:24
-   612| declare class Promise<+R> {
+   <BUILTINS>/core.js:614:24
+   614| declare class Promise<+R> {
                                ^ [2]
 
 
@@ -134,8 +134,8 @@ References:
    async_return_void.js:3:32
      3| async function foo1(): Promise<string> {
                                        ^^^^^^ [2]
-   <BUILTINS>/core.js:612:24
-   612| declare class Promise<+R> {
+   <BUILTINS>/core.js:614:24
+   614| declare class Promise<+R> {
                                ^ [3]
 
 
@@ -151,8 +151,8 @@ References:
    async_return_void.js:7:32
      7| async function foo2(): Promise<string> {
                                        ^^^^^^ [2]
-   <BUILTINS>/core.js:612:24
-   612| declare class Promise<+R> {
+   <BUILTINS>/core.js:614:24
+   614| declare class Promise<+R> {
                                ^ [3]
 
 
@@ -171,8 +171,8 @@ References:
    async_return_void.js:11:32
     11| async function foo3(): Promise<string> {
                                        ^^^^^^ [2]
-   <BUILTINS>/core.js:612:24
-   612| declare class Promise<+R> {
+   <BUILTINS>/core.js:614:24
+   614| declare class Promise<+R> {
                                ^ [3]
 
 

--- a/tests/async_iteration/async_iteration.exp
+++ b/tests/async_iteration/async_iteration.exp
@@ -99,8 +99,8 @@ Cannot cast `result.value` to string because:
              ^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:484:28
-   484|   | { done: true, +value?: Return }
+   <BUILTINS>/core.js:486:28
+   486|   | { done: true, +value?: Return }
                                    ^^^^^^ [1]
    return.js:20:20
     20|     (result.value: string); // error: number | void ~> string

--- a/tests/autocomplete/autocomplete.exp
+++ b/tests/autocomplete/autocomplete.exp
@@ -13,8 +13,8 @@ foo.js = {
       "type":"(prop: any) => boolean",
       "func_details":{"return_type":"boolean","params":[{"name":"prop","type":"any"}]},
       "path":"[LIB] core.js",
-      "line":63,
-      "endline":63,
+      "line":65,
+      "endline":65,
       "start":5,
       "end":38
     },
@@ -23,8 +23,8 @@ foo.js = {
       "type":"(o: any) => boolean",
       "func_details":{"return_type":"boolean","params":[{"name":"o","type":"any"}]},
       "path":"[LIB] core.js",
-      "line":64,
-      "endline":64,
+      "line":66,
+      "endline":66,
       "start":5,
       "end":34
     },
@@ -43,8 +43,8 @@ foo.js = {
       "type":"(prop: any) => boolean",
       "func_details":{"return_type":"boolean","params":[{"name":"prop","type":"any"}]},
       "path":"[LIB] core.js",
-      "line":65,
-      "endline":65,
+      "line":67,
+      "endline":67,
       "start":5,
       "end":44
     },
@@ -63,8 +63,8 @@ foo.js = {
       "type":"() => string",
       "func_details":{"return_type":"string","params":[]},
       "path":"[LIB] core.js",
-      "line":66,
-      "endline":66,
+      "line":68,
+      "endline":68,
       "start":5,
       "end":28
     },
@@ -73,8 +73,8 @@ foo.js = {
       "type":"() => string",
       "func_details":{"return_type":"string","params":[]},
       "path":"[LIB] core.js",
-      "line":67,
-      "endline":67,
+      "line":69,
+      "endline":69,
       "start":5,
       "end":22
     },
@@ -83,8 +83,8 @@ foo.js = {
       "type":"() => mixed",
       "func_details":{"return_type":"mixed","params":[]},
       "path":"[LIB] core.js",
-      "line":68,
-      "endline":68,
+      "line":70,
+      "endline":70,
       "start":5,
       "end":20
     }
@@ -112,8 +112,8 @@ str.js = {
       "type":"() => Iterator<string>",
       "func_details":{"return_type":"Iterator<string>","params":[]},
       "path":"[LIB] core.js",
-      "line":291,
-      "endline":291,
+      "line":293,
+      "endline":293,
       "start":5,
       "end":34
     },
@@ -122,8 +122,8 @@ str.js = {
       "type":"(name: string) => string",
       "func_details":{"return_type":"string","params":[{"name":"name","type":"string"}]},
       "path":"[LIB] core.js",
-      "line":292,
-      "endline":292,
+      "line":294,
+      "endline":294,
       "start":5,
       "end":32
     },
@@ -132,8 +132,8 @@ str.js = {
       "type":"(pos: number) => string",
       "func_details":{"return_type":"string","params":[{"name":"pos","type":"number"}]},
       "path":"[LIB] core.js",
-      "line":293,
-      "endline":293,
+      "line":295,
+      "endline":295,
       "start":5,
       "end":31
     },
@@ -142,8 +142,8 @@ str.js = {
       "type":"(index: number) => number",
       "func_details":{"return_type":"number","params":[{"name":"index","type":"number"}]},
       "path":"[LIB] core.js",
-      "line":294,
-      "endline":294,
+      "line":296,
+      "endline":296,
       "start":5,
       "end":37
     },
@@ -152,8 +152,8 @@ str.js = {
       "type":"(index: number) => number",
       "func_details":{"return_type":"number","params":[{"name":"index","type":"number"}]},
       "path":"[LIB] core.js",
-      "line":295,
-      "endline":295,
+      "line":297,
+      "endline":297,
       "start":5,
       "end":38
     },
@@ -165,8 +165,8 @@ str.js = {
         "params":[{"name":"...strings","type":"Array<string>"}]
       },
       "path":"[LIB] core.js",
-      "line":296,
-      "endline":296,
+      "line":298,
+      "endline":298,
       "start":5,
       "end":45
     },
@@ -178,8 +178,8 @@ str.js = {
         "params":[{"name":"searchString","type":"string"},{"name":"position?","type":"number"}]
       },
       "path":"[LIB] core.js",
-      "line":298,
-      "endline":298,
+      "line":300,
+      "endline":300,
       "start":5,
       "end":62
     },
@@ -191,8 +191,8 @@ str.js = {
         "params":[{"name":"searchString","type":"string"},{"name":"position?","type":"number"}]
       },
       "path":"[LIB] core.js",
-      "line":299,
-      "endline":299,
+      "line":301,
+      "endline":301,
       "start":5,
       "end":62
     },
@@ -204,8 +204,8 @@ str.js = {
         "params":[{"name":"searchString","type":"string"},{"name":"position?","type":"number"}]
       },
       "path":"[LIB] core.js",
-      "line":300,
-      "endline":300,
+      "line":302,
+      "endline":302,
       "start":5,
       "end":60
     },
@@ -217,8 +217,8 @@ str.js = {
         "params":[{"name":"searchString","type":"string"},{"name":"position?","type":"number"}]
       },
       "path":"[LIB] core.js",
-      "line":301,
-      "endline":301,
+      "line":303,
+      "endline":303,
       "start":5,
       "end":64
     },
@@ -227,8 +227,8 @@ str.js = {
       "type":"number",
       "func_details":null,
       "path":"[LIB] core.js",
-      "line":325,
-      "endline":325,
+      "line":327,
+      "endline":327,
       "start":13,
       "end":18
     },
@@ -237,8 +237,8 @@ str.js = {
       "type":"(href: string) => string",
       "func_details":{"return_type":"string","params":[{"name":"href","type":"string"}]},
       "path":"[LIB] core.js",
-      "line":302,
-      "endline":302,
+      "line":304,
+      "endline":304,
       "start":5,
       "end":30
     },
@@ -254,8 +254,8 @@ str.js = {
         ]
       },
       "path":"[LIB] core.js",
-      "line":303,
-      "endline":303,
+      "line":305,
+      "endline":305,
       "start":5,
       "end":105
     },
@@ -267,8 +267,8 @@ str.js = {
         "params":[{"name":"regexp","type":"string | RegExp"}]
       },
       "path":"[LIB] core.js",
-      "line":304,
-      "endline":304,
+      "line":306,
+      "endline":306,
       "start":5,
       "end":61
     },
@@ -277,8 +277,8 @@ str.js = {
       "type":"(format?: string) => string",
       "func_details":{"return_type":"string","params":[{"name":"format?","type":"string"}]},
       "path":"[LIB] core.js",
-      "line":305,
-      "endline":305,
+      "line":307,
+      "endline":307,
       "start":5,
       "end":38
     },
@@ -290,8 +290,8 @@ str.js = {
         "params":[{"name":"targetLength","type":"number"},{"name":"padString?","type":"string"}]
       },
       "path":"[LIB] core.js",
-      "line":306,
-      "endline":306,
+      "line":308,
+      "endline":308,
       "start":5,
       "end":60
     },
@@ -303,8 +303,8 @@ str.js = {
         "params":[{"name":"targetLength","type":"number"},{"name":"padString?","type":"string"}]
       },
       "path":"[LIB] core.js",
-      "line":307,
-      "endline":307,
+      "line":309,
+      "endline":309,
       "start":5,
       "end":62
     },
@@ -313,8 +313,8 @@ str.js = {
       "type":"(count: number) => string",
       "func_details":{"return_type":"string","params":[{"name":"count","type":"number"}]},
       "path":"[LIB] core.js",
-      "line":308,
-      "endline":308,
+      "line":310,
+      "endline":310,
       "start":5,
       "end":33
     },
@@ -332,8 +332,8 @@ str.js = {
         ]
       },
       "path":"[LIB] core.js",
-      "line":309,
-      "endline":309,
+      "line":311,
+      "endline":311,
       "start":5,
       "end":124
     },
@@ -342,8 +342,8 @@ str.js = {
       "type":"(regexp: (string | RegExp)) => number",
       "func_details":{"return_type":"number","params":[{"name":"regexp","type":"string | RegExp"}]},
       "path":"[LIB] core.js",
-      "line":310,
-      "endline":310,
+      "line":312,
+      "endline":312,
       "start":5,
       "end":43
     },
@@ -355,8 +355,8 @@ str.js = {
         "params":[{"name":"start?","type":"number"},{"name":"end?","type":"number"}]
       },
       "path":"[LIB] core.js",
-      "line":311,
-      "endline":311,
+      "line":313,
+      "endline":313,
       "start":5,
       "end":47
     },
@@ -371,8 +371,8 @@ str.js = {
         ]
       },
       "path":"[LIB] core.js",
-      "line":312,
-      "endline":312,
+      "line":314,
+      "endline":314,
       "start":5,
       "end":69
     },
@@ -384,8 +384,8 @@ str.js = {
         "params":[{"name":"searchString","type":"string"},{"name":"position?","type":"number"}]
       },
       "path":"[LIB] core.js",
-      "line":313,
-      "endline":313,
+      "line":315,
+      "endline":315,
       "start":5,
       "end":64
     },
@@ -397,8 +397,8 @@ str.js = {
         "params":[{"name":"from","type":"number"},{"name":"length?","type":"number"}]
       },
       "path":"[LIB] core.js",
-      "line":314,
-      "endline":314,
+      "line":316,
+      "endline":316,
       "start":5,
       "end":49
     },
@@ -410,8 +410,8 @@ str.js = {
         "params":[{"name":"start","type":"number"},{"name":"end?","type":"number"}]
       },
       "path":"[LIB] core.js",
-      "line":315,
-      "endline":315,
+      "line":317,
+      "endline":317,
       "start":5,
       "end":50
     },
@@ -423,8 +423,8 @@ str.js = {
         "params":[{"name":"locale?","type":"string | Array<string>"}]
       },
       "path":"[LIB] core.js",
-      "line":316,
-      "endline":316,
+      "line":318,
+      "endline":318,
       "start":5,
       "end":62
     },
@@ -436,8 +436,8 @@ str.js = {
         "params":[{"name":"locale?","type":"string | Array<string>"}]
       },
       "path":"[LIB] core.js",
-      "line":317,
-      "endline":317,
+      "line":319,
+      "endline":319,
       "start":5,
       "end":62
     },
@@ -446,8 +446,8 @@ str.js = {
       "type":"() => string",
       "func_details":{"return_type":"string","params":[]},
       "path":"[LIB] core.js",
-      "line":318,
-      "endline":318,
+      "line":320,
+      "endline":320,
       "start":5,
       "end":25
     },
@@ -456,8 +456,8 @@ str.js = {
       "type":"() => string",
       "func_details":{"return_type":"string","params":[]},
       "path":"[LIB] core.js",
-      "line":324,
-      "endline":324,
+      "line":326,
+      "endline":326,
       "start":5,
       "end":22
     },
@@ -466,8 +466,8 @@ str.js = {
       "type":"() => string",
       "func_details":{"return_type":"string","params":[]},
       "path":"[LIB] core.js",
-      "line":319,
-      "endline":319,
+      "line":321,
+      "endline":321,
       "start":5,
       "end":25
     },
@@ -476,8 +476,8 @@ str.js = {
       "type":"() => string",
       "func_details":{"return_type":"string","params":[]},
       "path":"[LIB] core.js",
-      "line":320,
-      "endline":320,
+      "line":322,
+      "endline":322,
       "start":5,
       "end":18
     },
@@ -486,8 +486,8 @@ str.js = {
       "type":"() => string",
       "func_details":{"return_type":"string","params":[]},
       "path":"[LIB] core.js",
-      "line":321,
-      "endline":321,
+      "line":323,
+      "endline":323,
       "start":5,
       "end":22
     },
@@ -496,8 +496,8 @@ str.js = {
       "type":"() => string",
       "func_details":{"return_type":"string","params":[]},
       "path":"[LIB] core.js",
-      "line":322,
-      "endline":322,
+      "line":324,
+      "endline":324,
       "start":5,
       "end":23
     },
@@ -506,8 +506,8 @@ str.js = {
       "type":"() => string",
       "func_details":{"return_type":"string","params":[]},
       "path":"[LIB] core.js",
-      "line":323,
-      "endline":323,
+      "line":325,
+      "endline":325,
       "start":5,
       "end":21
     }
@@ -520,8 +520,8 @@ num.js = {
       "type":"(fractionDigits?: number) => string",
       "func_details":{"return_type":"string","params":[{"name":"fractionDigits?","type":"number"}]},
       "path":"[LIB] core.js",
-      "line":140,
-      "endline":140,
+      "line":142,
+      "endline":142,
       "start":5,
       "end":50
     },
@@ -530,8 +530,8 @@ num.js = {
       "type":"(fractionDigits?: number) => string",
       "func_details":{"return_type":"string","params":[{"name":"fractionDigits?","type":"number"}]},
       "path":"[LIB] core.js",
-      "line":141,
-      "endline":141,
+      "line":143,
+      "endline":143,
       "start":5,
       "end":44
     },
@@ -546,8 +546,8 @@ num.js = {
         ]
       },
       "path":"[LIB] core.js",
-      "line":142,
-      "endline":142,
+      "line":144,
+      "endline":144,
       "start":5,
       "end":96
     },
@@ -556,8 +556,8 @@ num.js = {
       "type":"(precision?: number) => string",
       "func_details":{"return_type":"string","params":[{"name":"precision?","type":"number"}]},
       "path":"[LIB] core.js",
-      "line":143,
-      "endline":143,
+      "line":145,
+      "endline":145,
       "start":5,
       "end":43
     },
@@ -566,8 +566,8 @@ num.js = {
       "type":"(radix?: number) => string",
       "func_details":{"return_type":"string","params":[{"name":"radix?","type":"number"}]},
       "path":"[LIB] core.js",
-      "line":144,
-      "endline":144,
+      "line":146,
+      "endline":146,
       "start":5,
       "end":36
     },
@@ -576,8 +576,8 @@ num.js = {
       "type":"() => number",
       "func_details":{"return_type":"number","params":[]},
       "path":"[LIB] core.js",
-      "line":145,
-      "endline":145,
+      "line":147,
+      "endline":147,
       "start":5,
       "end":21
     }
@@ -590,8 +590,8 @@ bool.js = {
       "type":"() => string",
       "func_details":{"return_type":"string","params":[]},
       "path":"[LIB] core.js",
-      "line":120,
-      "endline":120,
+      "line":122,
+      "endline":122,
       "start":5,
       "end":22
     },
@@ -600,8 +600,8 @@ bool.js = {
       "type":"() => boolean",
       "func_details":{"return_type":"boolean","params":[]},
       "path":"[LIB] core.js",
-      "line":119,
-      "endline":119,
+      "line":121,
+      "endline":121,
       "start":5,
       "end":22
     }
@@ -624,8 +624,8 @@ union.js = {
       "type":"(prop: any) => boolean",
       "func_details":{"return_type":"boolean","params":[{"name":"prop","type":"any"}]},
       "path":"[LIB] core.js",
-      "line":63,
-      "endline":63,
+      "line":65,
+      "endline":65,
       "start":5,
       "end":38
     },
@@ -634,8 +634,8 @@ union.js = {
       "type":"(o: any) => boolean",
       "func_details":{"return_type":"boolean","params":[{"name":"o","type":"any"}]},
       "path":"[LIB] core.js",
-      "line":64,
-      "endline":64,
+      "line":66,
+      "endline":66,
       "start":5,
       "end":34
     },
@@ -644,8 +644,8 @@ union.js = {
       "type":"(prop: any) => boolean",
       "func_details":{"return_type":"boolean","params":[{"name":"prop","type":"any"}]},
       "path":"[LIB] core.js",
-      "line":65,
-      "endline":65,
+      "line":67,
+      "endline":67,
       "start":5,
       "end":44
     },
@@ -654,8 +654,8 @@ union.js = {
       "type":"() => string",
       "func_details":{"return_type":"string","params":[]},
       "path":"[LIB] core.js",
-      "line":66,
-      "endline":66,
+      "line":68,
+      "endline":68,
       "start":5,
       "end":28
     },
@@ -664,8 +664,8 @@ union.js = {
       "type":"() => string",
       "func_details":{"return_type":"string","params":[]},
       "path":"[LIB] core.js",
-      "line":67,
-      "endline":67,
+      "line":69,
+      "endline":69,
       "start":5,
       "end":22
     },
@@ -674,8 +674,8 @@ union.js = {
       "type":"() => mixed",
       "func_details":{"return_type":"mixed","params":[]},
       "path":"[LIB] core.js",
-      "line":68,
-      "endline":68,
+      "line":70,
+      "endline":70,
       "start":5,
       "end":20
     }
@@ -725,8 +725,8 @@ typeparams.js = {
       "type":"(fractionDigits?: number) => string",
       "func_details":{"return_type":"string","params":[{"name":"fractionDigits?","type":"number"}]},
       "path":"[LIB] core.js",
-      "line":140,
-      "endline":140,
+      "line":142,
+      "endline":142,
       "start":5,
       "end":50
     },
@@ -735,8 +735,8 @@ typeparams.js = {
       "type":"(fractionDigits?: number) => string",
       "func_details":{"return_type":"string","params":[{"name":"fractionDigits?","type":"number"}]},
       "path":"[LIB] core.js",
-      "line":141,
-      "endline":141,
+      "line":143,
+      "endline":143,
       "start":5,
       "end":44
     },
@@ -751,8 +751,8 @@ typeparams.js = {
         ]
       },
       "path":"[LIB] core.js",
-      "line":142,
-      "endline":142,
+      "line":144,
+      "endline":144,
       "start":5,
       "end":96
     },
@@ -761,8 +761,8 @@ typeparams.js = {
       "type":"(precision?: number) => string",
       "func_details":{"return_type":"string","params":[{"name":"precision?","type":"number"}]},
       "path":"[LIB] core.js",
-      "line":143,
-      "endline":143,
+      "line":145,
+      "endline":145,
       "start":5,
       "end":43
     },
@@ -771,8 +771,8 @@ typeparams.js = {
       "type":"(radix?: number) => string",
       "func_details":{"return_type":"string","params":[{"name":"radix?","type":"number"}]},
       "path":"[LIB] core.js",
-      "line":144,
-      "endline":144,
+      "line":146,
+      "endline":146,
       "start":5,
       "end":36
     },
@@ -781,8 +781,8 @@ typeparams.js = {
       "type":"() => number",
       "func_details":{"return_type":"number","params":[]},
       "path":"[LIB] core.js",
-      "line":145,
-      "endline":145,
+      "line":147,
+      "endline":147,
       "start":5,
       "end":21
     }
@@ -805,8 +805,8 @@ generics.js = {
       "type":"(prop: any) => boolean",
       "func_details":{"return_type":"boolean","params":[{"name":"prop","type":"any"}]},
       "path":"[LIB] core.js",
-      "line":63,
-      "endline":63,
+      "line":65,
+      "endline":65,
       "start":5,
       "end":38
     },
@@ -815,8 +815,8 @@ generics.js = {
       "type":"(o: any) => boolean",
       "func_details":{"return_type":"boolean","params":[{"name":"o","type":"any"}]},
       "path":"[LIB] core.js",
-      "line":64,
-      "endline":64,
+      "line":66,
+      "endline":66,
       "start":5,
       "end":34
     },
@@ -825,8 +825,8 @@ generics.js = {
       "type":"(prop: any) => boolean",
       "func_details":{"return_type":"boolean","params":[{"name":"prop","type":"any"}]},
       "path":"[LIB] core.js",
-      "line":65,
-      "endline":65,
+      "line":67,
+      "endline":67,
       "start":5,
       "end":44
     },
@@ -835,8 +835,8 @@ generics.js = {
       "type":"() => string",
       "func_details":{"return_type":"string","params":[]},
       "path":"[LIB] core.js",
-      "line":66,
-      "endline":66,
+      "line":68,
+      "endline":68,
       "start":5,
       "end":28
     },
@@ -845,8 +845,8 @@ generics.js = {
       "type":"() => string",
       "func_details":{"return_type":"string","params":[]},
       "path":"[LIB] core.js",
-      "line":67,
-      "endline":67,
+      "line":69,
+      "endline":69,
       "start":5,
       "end":22
     },
@@ -855,8 +855,8 @@ generics.js = {
       "type":"() => mixed",
       "func_details":{"return_type":"mixed","params":[]},
       "path":"[LIB] core.js",
-      "line":68,
-      "endline":68,
+      "line":70,
+      "endline":70,
       "start":5,
       "end":20
     }
@@ -879,8 +879,8 @@ optional.js = {
       "type":"(prop: any) => boolean",
       "func_details":{"return_type":"boolean","params":[{"name":"prop","type":"any"}]},
       "path":"[LIB] core.js",
-      "line":63,
-      "endline":63,
+      "line":65,
+      "endline":65,
       "start":5,
       "end":38
     },
@@ -889,8 +889,8 @@ optional.js = {
       "type":"(o: any) => boolean",
       "func_details":{"return_type":"boolean","params":[{"name":"o","type":"any"}]},
       "path":"[LIB] core.js",
-      "line":64,
-      "endline":64,
+      "line":66,
+      "endline":66,
       "start":5,
       "end":34
     },
@@ -909,8 +909,8 @@ optional.js = {
       "type":"(prop: any) => boolean",
       "func_details":{"return_type":"boolean","params":[{"name":"prop","type":"any"}]},
       "path":"[LIB] core.js",
-      "line":65,
-      "endline":65,
+      "line":67,
+      "endline":67,
       "start":5,
       "end":44
     },
@@ -919,8 +919,8 @@ optional.js = {
       "type":"() => string",
       "func_details":{"return_type":"string","params":[]},
       "path":"[LIB] core.js",
-      "line":66,
-      "endline":66,
+      "line":68,
+      "endline":68,
       "start":5,
       "end":28
     },
@@ -929,8 +929,8 @@ optional.js = {
       "type":"() => string",
       "func_details":{"return_type":"string","params":[]},
       "path":"[LIB] core.js",
-      "line":67,
-      "endline":67,
+      "line":69,
+      "endline":69,
       "start":5,
       "end":22
     },
@@ -939,8 +939,8 @@ optional.js = {
       "type":"() => mixed",
       "func_details":{"return_type":"mixed","params":[]},
       "path":"[LIB] core.js",
-      "line":68,
-      "endline":68,
+      "line":70,
+      "endline":70,
       "start":5,
       "end":20
     },
@@ -1088,8 +1088,8 @@ if.js = {
       "type":"() => Iterator<string>",
       "func_details":{"return_type":"Iterator<string>","params":[]},
       "path":"[LIB] core.js",
-      "line":291,
-      "endline":291,
+      "line":293,
+      "endline":293,
       "start":5,
       "end":34
     },
@@ -1098,8 +1098,8 @@ if.js = {
       "type":"(name: string) => string",
       "func_details":{"return_type":"string","params":[{"name":"name","type":"string"}]},
       "path":"[LIB] core.js",
-      "line":292,
-      "endline":292,
+      "line":294,
+      "endline":294,
       "start":5,
       "end":32
     },
@@ -1108,8 +1108,8 @@ if.js = {
       "type":"(pos: number) => string",
       "func_details":{"return_type":"string","params":[{"name":"pos","type":"number"}]},
       "path":"[LIB] core.js",
-      "line":293,
-      "endline":293,
+      "line":295,
+      "endline":295,
       "start":5,
       "end":31
     },
@@ -1118,8 +1118,8 @@ if.js = {
       "type":"(index: number) => number",
       "func_details":{"return_type":"number","params":[{"name":"index","type":"number"}]},
       "path":"[LIB] core.js",
-      "line":294,
-      "endline":294,
+      "line":296,
+      "endline":296,
       "start":5,
       "end":37
     },
@@ -1128,8 +1128,8 @@ if.js = {
       "type":"(index: number) => number",
       "func_details":{"return_type":"number","params":[{"name":"index","type":"number"}]},
       "path":"[LIB] core.js",
-      "line":295,
-      "endline":295,
+      "line":297,
+      "endline":297,
       "start":5,
       "end":38
     },
@@ -1141,8 +1141,8 @@ if.js = {
         "params":[{"name":"...strings","type":"Array<string>"}]
       },
       "path":"[LIB] core.js",
-      "line":296,
-      "endline":296,
+      "line":298,
+      "endline":298,
       "start":5,
       "end":45
     },
@@ -1154,8 +1154,8 @@ if.js = {
         "params":[{"name":"searchString","type":"string"},{"name":"position?","type":"number"}]
       },
       "path":"[LIB] core.js",
-      "line":298,
-      "endline":298,
+      "line":300,
+      "endline":300,
       "start":5,
       "end":62
     },
@@ -1167,8 +1167,8 @@ if.js = {
         "params":[{"name":"searchString","type":"string"},{"name":"position?","type":"number"}]
       },
       "path":"[LIB] core.js",
-      "line":299,
-      "endline":299,
+      "line":301,
+      "endline":301,
       "start":5,
       "end":62
     },
@@ -1180,8 +1180,8 @@ if.js = {
         "params":[{"name":"searchString","type":"string"},{"name":"position?","type":"number"}]
       },
       "path":"[LIB] core.js",
-      "line":300,
-      "endline":300,
+      "line":302,
+      "endline":302,
       "start":5,
       "end":60
     },
@@ -1193,8 +1193,8 @@ if.js = {
         "params":[{"name":"searchString","type":"string"},{"name":"position?","type":"number"}]
       },
       "path":"[LIB] core.js",
-      "line":301,
-      "endline":301,
+      "line":303,
+      "endline":303,
       "start":5,
       "end":64
     },
@@ -1203,8 +1203,8 @@ if.js = {
       "type":"number",
       "func_details":null,
       "path":"[LIB] core.js",
-      "line":325,
-      "endline":325,
+      "line":327,
+      "endline":327,
       "start":13,
       "end":18
     },
@@ -1213,8 +1213,8 @@ if.js = {
       "type":"(href: string) => string",
       "func_details":{"return_type":"string","params":[{"name":"href","type":"string"}]},
       "path":"[LIB] core.js",
-      "line":302,
-      "endline":302,
+      "line":304,
+      "endline":304,
       "start":5,
       "end":30
     },
@@ -1230,8 +1230,8 @@ if.js = {
         ]
       },
       "path":"[LIB] core.js",
-      "line":303,
-      "endline":303,
+      "line":305,
+      "endline":305,
       "start":5,
       "end":105
     },
@@ -1243,8 +1243,8 @@ if.js = {
         "params":[{"name":"regexp","type":"string | RegExp"}]
       },
       "path":"[LIB] core.js",
-      "line":304,
-      "endline":304,
+      "line":306,
+      "endline":306,
       "start":5,
       "end":61
     },
@@ -1253,8 +1253,8 @@ if.js = {
       "type":"(format?: string) => string",
       "func_details":{"return_type":"string","params":[{"name":"format?","type":"string"}]},
       "path":"[LIB] core.js",
-      "line":305,
-      "endline":305,
+      "line":307,
+      "endline":307,
       "start":5,
       "end":38
     },
@@ -1266,8 +1266,8 @@ if.js = {
         "params":[{"name":"targetLength","type":"number"},{"name":"padString?","type":"string"}]
       },
       "path":"[LIB] core.js",
-      "line":306,
-      "endline":306,
+      "line":308,
+      "endline":308,
       "start":5,
       "end":60
     },
@@ -1279,8 +1279,8 @@ if.js = {
         "params":[{"name":"targetLength","type":"number"},{"name":"padString?","type":"string"}]
       },
       "path":"[LIB] core.js",
-      "line":307,
-      "endline":307,
+      "line":309,
+      "endline":309,
       "start":5,
       "end":62
     },
@@ -1289,8 +1289,8 @@ if.js = {
       "type":"(count: number) => string",
       "func_details":{"return_type":"string","params":[{"name":"count","type":"number"}]},
       "path":"[LIB] core.js",
-      "line":308,
-      "endline":308,
+      "line":310,
+      "endline":310,
       "start":5,
       "end":33
     },
@@ -1308,8 +1308,8 @@ if.js = {
         ]
       },
       "path":"[LIB] core.js",
-      "line":309,
-      "endline":309,
+      "line":311,
+      "endline":311,
       "start":5,
       "end":124
     },
@@ -1318,8 +1318,8 @@ if.js = {
       "type":"(regexp: (string | RegExp)) => number",
       "func_details":{"return_type":"number","params":[{"name":"regexp","type":"string | RegExp"}]},
       "path":"[LIB] core.js",
-      "line":310,
-      "endline":310,
+      "line":312,
+      "endline":312,
       "start":5,
       "end":43
     },
@@ -1331,8 +1331,8 @@ if.js = {
         "params":[{"name":"start?","type":"number"},{"name":"end?","type":"number"}]
       },
       "path":"[LIB] core.js",
-      "line":311,
-      "endline":311,
+      "line":313,
+      "endline":313,
       "start":5,
       "end":47
     },
@@ -1347,8 +1347,8 @@ if.js = {
         ]
       },
       "path":"[LIB] core.js",
-      "line":312,
-      "endline":312,
+      "line":314,
+      "endline":314,
       "start":5,
       "end":69
     },
@@ -1360,8 +1360,8 @@ if.js = {
         "params":[{"name":"searchString","type":"string"},{"name":"position?","type":"number"}]
       },
       "path":"[LIB] core.js",
-      "line":313,
-      "endline":313,
+      "line":315,
+      "endline":315,
       "start":5,
       "end":64
     },
@@ -1373,8 +1373,8 @@ if.js = {
         "params":[{"name":"from","type":"number"},{"name":"length?","type":"number"}]
       },
       "path":"[LIB] core.js",
-      "line":314,
-      "endline":314,
+      "line":316,
+      "endline":316,
       "start":5,
       "end":49
     },
@@ -1386,8 +1386,8 @@ if.js = {
         "params":[{"name":"start","type":"number"},{"name":"end?","type":"number"}]
       },
       "path":"[LIB] core.js",
-      "line":315,
-      "endline":315,
+      "line":317,
+      "endline":317,
       "start":5,
       "end":50
     },
@@ -1399,8 +1399,8 @@ if.js = {
         "params":[{"name":"locale?","type":"string | Array<string>"}]
       },
       "path":"[LIB] core.js",
-      "line":316,
-      "endline":316,
+      "line":318,
+      "endline":318,
       "start":5,
       "end":62
     },
@@ -1412,8 +1412,8 @@ if.js = {
         "params":[{"name":"locale?","type":"string | Array<string>"}]
       },
       "path":"[LIB] core.js",
-      "line":317,
-      "endline":317,
+      "line":319,
+      "endline":319,
       "start":5,
       "end":62
     },
@@ -1422,8 +1422,8 @@ if.js = {
       "type":"() => string",
       "func_details":{"return_type":"string","params":[]},
       "path":"[LIB] core.js",
-      "line":318,
-      "endline":318,
+      "line":320,
+      "endline":320,
       "start":5,
       "end":25
     },
@@ -1432,8 +1432,8 @@ if.js = {
       "type":"() => string",
       "func_details":{"return_type":"string","params":[]},
       "path":"[LIB] core.js",
-      "line":324,
-      "endline":324,
+      "line":326,
+      "endline":326,
       "start":5,
       "end":22
     },
@@ -1442,8 +1442,8 @@ if.js = {
       "type":"() => string",
       "func_details":{"return_type":"string","params":[]},
       "path":"[LIB] core.js",
-      "line":319,
-      "endline":319,
+      "line":321,
+      "endline":321,
       "start":5,
       "end":25
     },
@@ -1452,8 +1452,8 @@ if.js = {
       "type":"() => string",
       "func_details":{"return_type":"string","params":[]},
       "path":"[LIB] core.js",
-      "line":320,
-      "endline":320,
+      "line":322,
+      "endline":322,
       "start":5,
       "end":18
     },
@@ -1462,8 +1462,8 @@ if.js = {
       "type":"() => string",
       "func_details":{"return_type":"string","params":[]},
       "path":"[LIB] core.js",
-      "line":321,
-      "endline":321,
+      "line":323,
+      "endline":323,
       "start":5,
       "end":22
     },
@@ -1472,8 +1472,8 @@ if.js = {
       "type":"() => string",
       "func_details":{"return_type":"string","params":[]},
       "path":"[LIB] core.js",
-      "line":322,
-      "endline":322,
+      "line":324,
+      "endline":324,
       "start":5,
       "end":23
     },
@@ -1482,8 +1482,8 @@ if.js = {
       "type":"() => string",
       "func_details":{"return_type":"string","params":[]},
       "path":"[LIB] core.js",
-      "line":323,
-      "endline":323,
+      "line":325,
+      "endline":325,
       "start":5,
       "end":21
     }
@@ -1540,8 +1540,8 @@ class.js = {
       "type":"(prop: any) => boolean",
       "func_details":{"return_type":"boolean","params":[{"name":"prop","type":"any"}]},
       "path":"[LIB] core.js",
-      "line":63,
-      "endline":63,
+      "line":65,
+      "endline":65,
       "start":5,
       "end":38
     },
@@ -1550,8 +1550,8 @@ class.js = {
       "type":"(o: any) => boolean",
       "func_details":{"return_type":"boolean","params":[{"name":"o","type":"any"}]},
       "path":"[LIB] core.js",
-      "line":64,
-      "endline":64,
+      "line":66,
+      "endline":66,
       "start":5,
       "end":34
     },
@@ -1570,8 +1570,8 @@ class.js = {
       "type":"(prop: any) => boolean",
       "func_details":{"return_type":"boolean","params":[{"name":"prop","type":"any"}]},
       "path":"[LIB] core.js",
-      "line":65,
-      "endline":65,
+      "line":67,
+      "endline":67,
       "start":5,
       "end":44
     },
@@ -1580,8 +1580,8 @@ class.js = {
       "type":"() => string",
       "func_details":{"return_type":"string","params":[]},
       "path":"[LIB] core.js",
-      "line":66,
-      "endline":66,
+      "line":68,
+      "endline":68,
       "start":5,
       "end":28
     },
@@ -1590,8 +1590,8 @@ class.js = {
       "type":"() => string",
       "func_details":{"return_type":"string","params":[]},
       "path":"[LIB] core.js",
-      "line":67,
-      "endline":67,
+      "line":69,
+      "endline":69,
       "start":5,
       "end":22
     },
@@ -1600,8 +1600,8 @@ class.js = {
       "type":"() => mixed",
       "func_details":{"return_type":"mixed","params":[]},
       "path":"[LIB] core.js",
-      "line":68,
-      "endline":68,
+      "line":70,
+      "endline":70,
       "start":5,
       "end":20
     }
@@ -1652,8 +1652,8 @@ idx.js = {
       "type":"(prop: any) => boolean",
       "func_details":{"return_type":"boolean","params":[{"name":"prop","type":"any"}]},
       "path":"[LIB] core.js",
-      "line":63,
-      "endline":63,
+      "line":65,
+      "endline":65,
       "start":5,
       "end":38
     },
@@ -1662,8 +1662,8 @@ idx.js = {
       "type":"(o: any) => boolean",
       "func_details":{"return_type":"boolean","params":[{"name":"o","type":"any"}]},
       "path":"[LIB] core.js",
-      "line":64,
-      "endline":64,
+      "line":66,
+      "endline":66,
       "start":5,
       "end":34
     },
@@ -1672,8 +1672,8 @@ idx.js = {
       "type":"(prop: any) => boolean",
       "func_details":{"return_type":"boolean","params":[{"name":"prop","type":"any"}]},
       "path":"[LIB] core.js",
-      "line":65,
-      "endline":65,
+      "line":67,
+      "endline":67,
       "start":5,
       "end":44
     },
@@ -1682,8 +1682,8 @@ idx.js = {
       "type":"() => string",
       "func_details":{"return_type":"string","params":[]},
       "path":"[LIB] core.js",
-      "line":66,
-      "endline":66,
+      "line":68,
+      "endline":68,
       "start":5,
       "end":28
     },
@@ -1692,8 +1692,8 @@ idx.js = {
       "type":"() => string",
       "func_details":{"return_type":"string","params":[]},
       "path":"[LIB] core.js",
-      "line":67,
-      "endline":67,
+      "line":69,
+      "endline":69,
       "start":5,
       "end":22
     },
@@ -1702,8 +1702,8 @@ idx.js = {
       "type":"() => mixed",
       "func_details":{"return_type":"mixed","params":[]},
       "path":"[LIB] core.js",
-      "line":68,
-      "endline":68,
+      "line":70,
+      "endline":70,
       "start":5,
       "end":20
     }

--- a/tests/compose/compose.exp
+++ b/tests/compose/compose.exp
@@ -7,8 +7,8 @@ Cannot cast `compose(...)(...)` to empty because string [1] is incompatible with
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:144:31
-   144|     toString(radix?: number): string;
+   <BUILTINS>/core.js:146:31
+   146|     toString(radix?: number): string;
                                       ^^^^^^ [1]
    basic.js:6:34
      6| (compose(n => n.toString())(42): empty); // Error: string ~> empty
@@ -24,8 +24,8 @@ Cannot cast `composeReverse(...)(...)` to empty because string [1] is incompatib
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:144:31
-   144|     toString(radix?: number): string;
+   <BUILTINS>/core.js:146:31
+   146|     toString(radix?: number): string;
                                       ^^^^^^ [1]
    basic.js:8:41
      8| (composeReverse(n => n.toString())(42): empty); // Error: string ~> empty
@@ -62,8 +62,8 @@ Cannot perform arithmetic operation because string [1] is not a number.
                ^
 
 References:
-   <BUILTINS>/core.js:144:31
-   144|     toString(radix?: number): string;
+   <BUILTINS>/core.js:146:31
+   146|     toString(radix?: number): string;
                                       ^^^^^^ [1]
 
 
@@ -80,8 +80,8 @@ Cannot cast `composeReverse(...)(...)` to empty because string [1] is incompatib
         ----^
 
 References:
-   <BUILTINS>/core.js:144:31
-   144|     toString(radix?: number): string;
+   <BUILTINS>/core.js:146:31
+   146|     toString(radix?: number): string;
                                       ^^^^^^ [1]
    basic.js:18:8
     18| )(42): empty); // Error: string ~> empty
@@ -100,8 +100,8 @@ References:
    recompose.js:20:8
     20|     p: `${props.p * 3}`,
                ^^^^^^^^^^^^^^^^ [1]
-   <BUILTINS>/core.js:184:14
-   184|     round(x: number): number;
+   <BUILTINS>/core.js:186:14
+   186|     round(x: number): number;
                      ^^^^^^ [2]
 
 

--- a/tests/computed_props/computed_props.exp
+++ b/tests/computed_props/computed_props.exp
@@ -114,8 +114,8 @@ Cannot assign `arr[0]()` to `y` because number [1] is incompatible with string [
                         ^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:275:13
-   275|     length: number;
+   <BUILTINS>/core.js:277:13
+   277|     length: number;
                     ^^^^^^ [1]
    test7.js:5:8
      5| var y: string = arr[0](); // error: number ~> string

--- a/tests/core_tests/core_tests.exp
+++ b/tests/core_tests/core_tests.exp
@@ -14,11 +14,11 @@ References:
    map.js:23:22
     23|     let x = new Map(['foo', 123]); // error
                              ^^^^^ [1]
-   <BUILTINS>/core.js:544:37
-   544|     constructor(iterable: ?Iterable<[K, V]>): void;
+   <BUILTINS>/core.js:546:37
+   546|     constructor(iterable: ?Iterable<[K, V]>): void;
                                             ^^^^^^ [2]
-   <BUILTINS>/core.js:487:22
-   487| interface $Iterator<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:489:22
+   489| interface $Iterator<+Yield,+Return,-Next> {
                              ^^^^^ [3]
    map.js:23:29
     23|     let x = new Map(['foo', 123]); // error
@@ -42,8 +42,8 @@ References:
    map.js:24:16
     24|     let y: Map<number, string> = new Map([['foo', 123]]); // error
                        ^^^^^^ [2]
-   <BUILTINS>/core.js:542:19
-   542| declare class Map<K, V> extends $ReadOnlyMap<K, V> {
+   <BUILTINS>/core.js:544:19
+   544| declare class Map<K, V> extends $ReadOnlyMap<K, V> {
                           ^ [3]
    map.js:24:51
     24|     let y: Map<number, string> = new Map([['foo', 123]]); // error
@@ -51,8 +51,8 @@ References:
    map.js:24:24
     24|     let y: Map<number, string> = new Map([['foo', 123]]); // error
                                ^^^^^^ [5]
-   <BUILTINS>/core.js:542:22
-   542| declare class Map<K, V> extends $ReadOnlyMap<K, V> {
+   <BUILTINS>/core.js:544:22
+   544| declare class Map<K, V> extends $ReadOnlyMap<K, V> {
                              ^ [6]
 
 
@@ -67,8 +67,8 @@ Cannot cast `x.get(...)` to boolean because:
              ^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:549:22
-   549|     get(key: K): V | void;
+   <BUILTINS>/core.js:551:22
+   551|     get(key: K): V | void;
                              ^^^^ [1]
    map.js:29:20
     29|     (x.get('foo'): boolean); // error, string | void
@@ -102,8 +102,8 @@ since `z` is not a member of the set.
                           ^^^ [1]
 
 References:
-   <BUILTINS>/core.js:287:21
-   287| type RegExp$flags = $CharSet<"gimsuy">;
+   <BUILTINS>/core.js:289:21
+   289| type RegExp$flags = $CharSet<"gimsuy">;
                             ^^^^^^^^^^^^^^^^^^ [2]
 
 
@@ -117,8 +117,8 @@ since `z` is not a member of the set.
                               ^^^ [1]
 
 References:
-   <BUILTINS>/core.js:287:21
-   287| type RegExp$flags = $CharSet<"gimsuy">;
+   <BUILTINS>/core.js:289:21
+   289| type RegExp$flags = $CharSet<"gimsuy">;
                             ^^^^^^^^^^^^^^^^^^ [2]
 
 

--- a/tests/date/date.exp
+++ b/tests/date/date.exp
@@ -7,8 +7,8 @@ Cannot assign `d.getTime()` to `x` because number [1] is incompatible with strin
                        ^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:363:16
-   363|     getTime(): number;
+   <BUILTINS>/core.js:365:16
+   365|     getTime(): number;
                        ^^^^^^ [1]
    date.js:2:7
      2| var x:string = d.getTime();
@@ -30,14 +30,14 @@ References:
    date.js:18:10
     18| new Date({});
                  ^^ [1]
-   <BUILTINS>/core.js:352:28
-   352|     constructor(timestamp: number): void;
+   <BUILTINS>/core.js:354:28
+   354|     constructor(timestamp: number): void;
                                    ^^^^^^ [2]
-   <BUILTINS>/core.js:353:29
-   353|     constructor(dateString: string): void;
+   <BUILTINS>/core.js:355:29
+   355|     constructor(dateString: string): void;
                                     ^^^^^^ [3]
-   <BUILTINS>/core.js:354:23
-   354|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
+   <BUILTINS>/core.js:356:23
+   356|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
                               ^^^^^^ [4]
 
 
@@ -53,8 +53,8 @@ References:
    date.js:19:16
     19| new Date(2015, '6');
                        ^^^ [1]
-   <BUILTINS>/core.js:354:38
-   354|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
+   <BUILTINS>/core.js:356:38
+   356|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
                                              ^^^^^^ [2]
 
 
@@ -70,8 +70,8 @@ References:
    date.js:20:19
     20| new Date(2015, 6, '18');
                           ^^^^ [1]
-   <BUILTINS>/core.js:354:52
-   354|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
+   <BUILTINS>/core.js:356:52
+   356|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
                                                            ^^^^^^ [2]
 
 
@@ -87,8 +87,8 @@ References:
    date.js:21:23
     21| new Date(2015, 6, 18, '11');
                               ^^^^ [1]
-   <BUILTINS>/core.js:354:67
-   354|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
+   <BUILTINS>/core.js:356:67
+   356|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
                                                                           ^^^^^^ [2]
 
 
@@ -104,8 +104,8 @@ References:
    date.js:22:27
     22| new Date(2015, 6, 18, 11, '55');
                                   ^^^^ [1]
-   <BUILTINS>/core.js:354:84
-   354|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
+   <BUILTINS>/core.js:356:84
+   356|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
                                                                                            ^^^^^^ [2]
 
 
@@ -121,8 +121,8 @@ References:
    date.js:23:31
     23| new Date(2015, 6, 18, 11, 55, '42');
                                       ^^^^ [1]
-   <BUILTINS>/core.js:354:101
-   354|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
+   <BUILTINS>/core.js:356:101
+   356|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
                                                                                                             ^^^^^^ [2]
 
 
@@ -138,8 +138,8 @@ References:
    date.js:24:35
     24| new Date(2015, 6, 18, 11, 55, 42, '999');
                                           ^^^^^ [1]
-   <BUILTINS>/core.js:354:123
-   354|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
+   <BUILTINS>/core.js:356:123
+   356|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
                                                                                                                                   ^^^^^^ [2]
 
 
@@ -156,17 +156,17 @@ Cannot call `Date` because:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:351:5
-   351|     constructor(): void;
-            ^^^^^^^^^^^^^^^^^^^ [1]
-   <BUILTINS>/core.js:352:5
-   352|     constructor(timestamp: number): void;
-            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [2]
    <BUILTINS>/core.js:353:5
-   353|     constructor(dateString: string): void;
-            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [3]
+   353|     constructor(): void;
+            ^^^^^^^^^^^^^^^^^^^ [1]
    <BUILTINS>/core.js:354:5
-   354|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
+   354|     constructor(timestamp: number): void;
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [2]
+   <BUILTINS>/core.js:355:5
+   355|     constructor(dateString: string): void;
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [3]
+   <BUILTINS>/core.js:356:5
+   356|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [4]
 
 
@@ -182,8 +182,8 @@ References:
    date.js:26:10
     26| new Date('2015', 6);
                  ^^^^^^ [1]
-   <BUILTINS>/core.js:354:23
-   354|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
+   <BUILTINS>/core.js:356:23
+   356|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
                               ^^^^^^ [2]
 
 

--- a/tests/dictionary/dictionary.exp
+++ b/tests/dictionary/dictionary.exp
@@ -69,8 +69,8 @@ Cannot cast `o.toString()` to boolean because string [1] is incompatible with bo
           ^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:67:17
-   67|     toString(): string;
+   <BUILTINS>/core.js:69:17
+   69|     toString(): string;
                        ^^^^^^ [1]
    dictionary.js:94:18
    94|   (o.toString(): boolean); // error: string ~> boolean

--- a/tests/fetch/fetch.exp
+++ b/tests/fetch/fetch.exp
@@ -13,8 +13,8 @@ References:
    fetch.js:12:18
      12| const b: Promise<string> = fetch(myRequest); // incorrect
                           ^^^^^^ [2]
-   <BUILTINS>/core.js:612:24
-    612| declare class Promise<+R> {
+   <BUILTINS>/core.js:614:24
+    614| declare class Promise<+R> {
                                 ^ [3]
 
 
@@ -33,8 +33,8 @@ References:
    <BUILTINS>/bom.js:1059:76
    1059| declare function fetch(input: RequestInfo, init?: RequestOptions): Promise<Response>;
                                                                                     ^^^^^^^^ [2]
-   <BUILTINS>/core.js:612:24
-    612| declare class Promise<+R> {
+   <BUILTINS>/core.js:614:24
+    614| declare class Promise<+R> {
                                 ^ [3]
 
 
@@ -523,11 +523,11 @@ References:
    <BUILTINS>/bom.js:969:62
    969| type BodyInit = string | URLSearchParams | FormData | Blob | ArrayBuffer | $ArrayBufferView | ReadableStream;
                                                                      ^^^^^^^^^^^ [5]
-   <BUILTINS>/core.js:657:25
-   657| type $ArrayBufferView = $TypedArray | DataView;
+   <BUILTINS>/core.js:659:25
+   659| type $ArrayBufferView = $TypedArray | DataView;
                                 ^^^^^^^^^^^ [6]
-   <BUILTINS>/core.js:657:39
-   657| type $ArrayBufferView = $TypedArray | DataView;
+   <BUILTINS>/core.js:659:39
+   659| type $ArrayBufferView = $TypedArray | DataView;
                                               ^^^^^^^^ [7]
    <BUILTINS>/bom.js:969:95
    969| type BodyInit = string | URLSearchParams | FormData | Blob | ArrayBuffer | $ArrayBufferView | ReadableStream;

--- a/tests/forof/forof.exp
+++ b/tests/forof/forof.exp
@@ -41,8 +41,8 @@ Cannot cast `x` to number because string [1] is incompatible with number [2].
              ^
 
 References:
-   <BUILTINS>/core.js:291:28
-   291|     @@iterator(): Iterator<string>;
+   <BUILTINS>/core.js:293:28
+   293|     @@iterator(): Iterator<string>;
                                    ^^^^^^ [1]
    forof.js:25:9
     25|     (x: number); // Error - string ~> number
@@ -58,8 +58,8 @@ Cannot cast `elem` to number because tuple type [1] is incompatible with number 
              ^^^^
 
 References:
-   <BUILTINS>/core.js:543:28
-   543|     @@iterator(): Iterator<[K, V]>;
+   <BUILTINS>/core.js:545:28
+   545|     @@iterator(): Iterator<[K, V]>;
                                    ^^^^^^ [1]
    forof.js:32:12
     32|     (elem: number); // Error - tuple ~> number
@@ -75,8 +75,8 @@ Cannot cast `elem` to number because tuple type [1] is incompatible with number 
              ^^^^
 
 References:
-   <BUILTINS>/core.js:543:28
-   543|     @@iterator(): Iterator<[K, V]>;
+   <BUILTINS>/core.js:545:28
+   545|     @@iterator(): Iterator<[K, V]>;
                                    ^^^^^^ [1]
    forof.js:39:12
     39|     (elem: number); // Error - tuple ~> number

--- a/tests/function/function.exp
+++ b/tests/function/function.exp
@@ -100,8 +100,8 @@ Cannot call `test.apply` because string [1] is incompatible with number [2].
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:291:28
-   291|     @@iterator(): Iterator<string>;
+   <BUILTINS>/core.js:293:28
+   293|     @@iterator(): Iterator<string>;
                                    ^^^^^^ [1]
    apply.js:1:29
      1| function test(a: string, b: number): number {
@@ -431,8 +431,8 @@ Cannot cast `x.length` to undefined because number [1] is incompatible with unde
              ^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:112:13
-   112|     length: number;
+   <BUILTINS>/core.js:114:13
+   114|     length: number;
                     ^^^^^^ [1]
    function.js:37:16
     37|     (x.length: void); // error, it's a number
@@ -448,8 +448,8 @@ Cannot cast `x.name` to undefined because string [1] is incompatible with undefi
              ^^^^^^
 
 References:
-   <BUILTINS>/core.js:113:11
-   113|     name: string;
+   <BUILTINS>/core.js:115:11
+   115|     name: string;
                   ^^^^^^ [1]
    function.js:41:14
     41|     (x.name: void); // error, it's a string
@@ -465,8 +465,8 @@ Cannot assign `'foo'` to `x.length` because string [1] is incompatible with numb
                        ^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:112:13
-   112|     length: number;
+   <BUILTINS>/core.js:114:13
+   114|     length: number;
                     ^^^^^^ [2]
 
 
@@ -479,8 +479,8 @@ Cannot assign `123` to `x.name` because number [1] is incompatible with string [
                      ^^^ [1]
 
 References:
-   <BUILTINS>/core.js:113:11
-   113|     name: string;
+   <BUILTINS>/core.js:115:11
+   115|     name: string;
                   ^^^^^^ [2]
 
 

--- a/tests/generators/generators.exp
+++ b/tests/generators/generators.exp
@@ -41,8 +41,8 @@ References:
    class.js:23:39
     23|   *stmt_return_err(): Generator<void, number, void> {
                                               ^^^^^^ [2]
-   <BUILTINS>/core.js:498:29
-   498| interface Generator<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:500:29
+   500| interface Generator<+Yield,+Return,-Next> {
                                     ^^^^^^ [3]
 
 
@@ -107,14 +107,14 @@ of property `@@iterator`.
                    ^^
 
 References:
-   <BUILTINS>/core.js:491:38
-   491| type Iterator<+T> = $Iterator<T,void,void>;
+   <BUILTINS>/core.js:493:38
+   493| type Iterator<+T> = $Iterator<T,void,void>;
                                              ^^^^ [1]
    class.js:125:42
    125| examples.delegate_next_iterable([]).next(""); // error: Iterator has no next value
                                                  ^^ [2]
-   <BUILTINS>/core.js:487:37
-   487| interface $Iterator<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:489:37
+   489| interface $Iterator<+Yield,+Return,-Next> {
                                             ^^^^ [3]
 
 
@@ -280,8 +280,8 @@ References:
    generators.js:22:46
     22| function *stmt_return_err(): Generator<void, number, void> {
                                                      ^^^^^^ [2]
-   <BUILTINS>/core.js:498:29
-   498| interface Generator<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:500:29
+   500| interface Generator<+Yield,+Return,-Next> {
                                     ^^^^^^ [3]
 
 
@@ -397,14 +397,14 @@ of property `@@iterator`.
                  ^^
 
 References:
-   <BUILTINS>/core.js:491:38
-   491| type Iterator<+T> = $Iterator<T,void,void>;
+   <BUILTINS>/core.js:493:38
+   493| type Iterator<+T> = $Iterator<T,void,void>;
                                              ^^^^ [1]
    generators.js:94:33
     94| delegate_next_iterable([]).next(""); // error: Iterator has no next value
                                         ^^ [2]
-   <BUILTINS>/core.js:487:37
-   487| interface $Iterator<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:489:37
+   489| interface $Iterator<+Yield,+Return,-Next> {
                                             ^^^^ [3]
 
 
@@ -514,8 +514,8 @@ Cannot cast `refuse_return_result.value` to string because:
            ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:484:28
-   484|   | { done: true, +value?: Return }
+   <BUILTINS>/core.js:486:28
+   486|   | { done: true, +value?: Return }
                                    ^^^^^^ [1]
    return.js:20:32
     20|   (refuse_return_result.value: string); // error: number | void ~> string

--- a/tests/iterable/iterable.exp
+++ b/tests/iterable/iterable.exp
@@ -14,8 +14,8 @@ References:
    array.js:7:19
      7| (["hi"]: Iterable<number>); // Error string ~> number
                           ^^^^^^ [2]
-   <BUILTINS>/core.js:487:22
-   487| interface $Iterator<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:489:22
+   489| interface $Iterator<+Yield,+Return,-Next> {
                              ^^^^^ [3]
 
 
@@ -35,8 +35,8 @@ References:
    array.js:8:22
      8| (["hi", 1]: Iterable<string>); // Error number ~> string
                              ^^^^^^ [2]
-   <BUILTINS>/core.js:487:22
-   487| interface $Iterator<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:489:22
+   489| interface $Iterator<+Yield,+Return,-Next> {
                              ^^^^^ [3]
 
 
@@ -56,8 +56,8 @@ References:
    caching_bug.js:21:62
     21| function miss_the_cache(x: Array<string | number>): Iterable<string> { return x; }
                                                                      ^^^^^^ [2]
-   <BUILTINS>/core.js:487:22
-   487| interface $Iterator<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:489:22
+   489| interface $Iterator<+Yield,+Return,-Next> {
                              ^^^^^ [3]
 
 
@@ -73,8 +73,8 @@ References:
    iterator_result.js:17:40
     17| function makeIterator(coin_flip: () => boolean ): Iterator<string> {
                                                ^^^^^^^ [1]
-   <BUILTINS>/core.js:485:13
-   485|   | { done: false, +value: Yield };
+   <BUILTINS>/core.js:487:13
+   487|   | { done: false, +value: Yield };
                     ^^^^^ [2]
 
 
@@ -90,8 +90,8 @@ References:
    iterator_result.js:17:40
     17| function makeIterator(coin_flip: () => boolean ): Iterator<string> {
                                                ^^^^^^^ [1]
-   <BUILTINS>/core.js:484:13
-   484|   | { done: true, +value?: Return }
+   <BUILTINS>/core.js:486:13
+   486|   | { done: true, +value?: Return }
                     ^^^^ [2]
 
 
@@ -105,14 +105,14 @@ value of property `@@iterator`.
                  ^^^
 
 References:
-   <BUILTINS>/core.js:543:28
-   543|     @@iterator(): Iterator<[K, V]>;
+   <BUILTINS>/core.js:545:28
+   545|     @@iterator(): Iterator<[K, V]>;
                                    ^^^^^^ [1]
    map.js:13:55
     13| function mapTest4(map: Map<number, string>): Iterable<string> {
                                                               ^^^^^^ [2]
-   <BUILTINS>/core.js:487:22
-   487| interface $Iterator<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:489:22
+   489| interface $Iterator<+Yield,+Return,-Next> {
                              ^^^^^ [3]
 
 
@@ -132,8 +132,8 @@ References:
    set.js:13:47
     13| function setTest4(set: Set<string>): Iterable<number> {
                                                       ^^^^^^ [2]
-   <BUILTINS>/core.js:487:22
-   487| interface $Iterator<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:489:22
+   489| interface $Iterator<+Yield,+Return,-Next> {
                              ^^^^^ [3]
 
 
@@ -147,14 +147,14 @@ return value of property `@@iterator`.
          ^^^^
 
 References:
-   <BUILTINS>/core.js:291:28
-   291|     @@iterator(): Iterator<string>;
+   <BUILTINS>/core.js:293:28
+   293|     @@iterator(): Iterator<string>;
                                    ^^^^^^ [1]
    string.js:5:17
      5| ("hi": Iterable<number>); // Error - string is a Iterable<string>
                         ^^^^^^ [2]
-   <BUILTINS>/core.js:487:22
-   487| interface $Iterator<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:489:22
+   489| interface $Iterator<+Yield,+Return,-Next> {
                              ^^^^^ [3]
 
 

--- a/tests/lib/lib.exp
+++ b/tests/lib/lib.exp
@@ -24,8 +24,8 @@ Cannot assign `Number.MAX_VALUE` to `y` because number [1] is incompatible with 
                        ^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:126:23
-   126|     static MAX_VALUE: number;
+   <BUILTINS>/core.js:128:23
+   128|     static MAX_VALUE: number;
                               ^^^^^^ [1]
    libtest.js:2:7
      2| var y:string = Number.MAX_VALUE;
@@ -41,8 +41,8 @@ Cannot assign `new TypeError().name` to `z` because string [1] is incompatible w
                        ^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:427:11
-   427|     name: string;
+   <BUILTINS>/core.js:429:11
+   429|     name: string;
                   ^^^^^^ [1]
    libtest.js:3:7
      3| var z:number = new TypeError().name;

--- a/tests/misc/misc.exp
+++ b/tests/misc/misc.exp
@@ -134,8 +134,8 @@ Cannot return `x.length` because number [1] is incompatible with string [2].
                  ^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:275:13
-   275|     length: number;
+   <BUILTINS>/core.js:277:13
+   277|     length: number;
                     ^^^^^^ [1]
    F.js:4:33
      4| function foo(x: Array<number>): string {
@@ -179,8 +179,8 @@ Cannot assign `"duck"` to `b.length` because string [1] is incompatible with num
                    ^^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:275:13
-   275|     length: number;
+   <BUILTINS>/core.js:277:13
+   277|     length: number;
                     ^^^^^^ [2]
 
 

--- a/tests/number_constants/number_constants.exp
+++ b/tests/number_constants/number_constants.exp
@@ -7,8 +7,8 @@ Cannot assign `Number.MAX_SAFE_INTEGER` to `b` because number [1] is incompatibl
                         ^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:125:30
-   125|     static MAX_SAFE_INTEGER: number;
+   <BUILTINS>/core.js:127:30
+   127|     static MAX_SAFE_INTEGER: number;
                                      ^^^^^^ [1]
    number_constants.js:2:8
      2| var b: string = Number.MAX_SAFE_INTEGER;
@@ -24,8 +24,8 @@ Cannot assign `Number.MIN_SAFE_INTEGER` to `d` because number [1] is incompatibl
                         ^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:127:30
-   127|     static MIN_SAFE_INTEGER: number;
+   <BUILTINS>/core.js:129:30
+   129|     static MIN_SAFE_INTEGER: number;
                                      ^^^^^^ [1]
    number_constants.js:4:8
      4| var d: string = Number.MIN_SAFE_INTEGER;
@@ -41,8 +41,8 @@ Cannot assign `Number.MAX_VALUE` to `f` because number [1] is incompatible with 
                         ^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:126:23
-   126|     static MAX_VALUE: number;
+   <BUILTINS>/core.js:128:23
+   128|     static MAX_VALUE: number;
                               ^^^^^^ [1]
    number_constants.js:6:8
      6| var f: string = Number.MAX_VALUE;
@@ -58,8 +58,8 @@ Cannot assign `Number.MIN_VALUE` to `h` because number [1] is incompatible with 
                         ^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:128:23
-   128|     static MIN_VALUE: number;
+   <BUILTINS>/core.js:130:23
+   130|     static MIN_VALUE: number;
                               ^^^^^^ [1]
    number_constants.js:8:8
      8| var h: string = Number.MIN_VALUE;
@@ -75,8 +75,8 @@ Cannot assign `Number.NaN` to `j` because number [1] is incompatible with string
                         ^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:129:17
-   129|     static NaN: number;
+   <BUILTINS>/core.js:131:17
+   131|     static NaN: number;
                         ^^^^^^ [1]
    number_constants.js:10:8
     10| var j: string = Number.NaN;
@@ -92,8 +92,8 @@ Cannot assign `Number.EPSILON` to `l` because number [1] is incompatible with st
                         ^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:124:21
-   124|     static EPSILON: number;
+   <BUILTINS>/core.js:126:21
+   126|     static EPSILON: number;
                             ^^^^^^ [1]
    number_constants.js:12:8
     12| var l: string = Number.EPSILON;

--- a/tests/object_api/object_api.exp
+++ b/tests/object_api/object_api.exp
@@ -43,6 +43,23 @@ References:
            ^ [2]
 
 
+Error ------------------------------------------------------------------------------------------- object_entries.js:23:6
+
+Cannot cast `val` to string because number [1] is incompatible with string [2].
+
+   object_entries.js:23:6
+   23|     (val: string) // error: number ~> string
+            ^^^
+
+References:
+   object_entries.js:13:28
+   13| const strToNum: {[string]: number} = {};
+                                  ^^^^^^ [1]
+   object_entries.js:23:11
+   23|     (val: string) // error: number ~> string
+                 ^^^^^^ [2]
+
+
 Error ----------------------------------------------------------------------------------------------- object_keys.js:5:2
 
 Cannot cast `Object.keys(...)` to undefined because array type [1] is incompatible with undefined [2].
@@ -199,8 +216,8 @@ Cannot assign `x.toString` to `xToString` because function type [1] is incompati
                                 ^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:67:5
-   67|     toString(): string;
+   <BUILTINS>/core.js:69:5
+   69|     toString(): string;
            ^^^^^^^^^^^^^^^^^^ [1]
    object_prototype.js:38:17
    38| var xToString : number = x.toString; // error
@@ -216,8 +233,8 @@ Cannot assign `x.toString` to `xToString2` because string [1] is incompatible wi
                                        ^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:67:17
-   67|     toString(): string;
+   <BUILTINS>/core.js:69:17
+   69|     toString(): string;
                        ^^^^^^ [1]
    object_prototype.js:39:24
    39| var xToString2 : () => number = x.toString; // error
@@ -233,8 +250,8 @@ Cannot assign `y.toString` to `yToString` because function type [1] is incompati
                                 ^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:67:5
-   67|     toString(): string;
+   <BUILTINS>/core.js:69:5
+   69|     toString(): string;
            ^^^^^^^^^^^^^^^^^^ [1]
    object_prototype.js:43:17
    43| var yToString : number = y.toString; // error
@@ -264,8 +281,8 @@ Cannot call `123.toString` with `'foo'` bound to `radix` because string [1] is i
                        ^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:144:22
-   144|     toString(radix?: number): string;
+   <BUILTINS>/core.js:146:22
+   146|     toString(radix?: number): string;
                              ^^^^^^ [2]
 
 
@@ -278,8 +295,8 @@ Cannot call `123.toString` with `null` bound to `radix` because null [1] is inco
                        ^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:144:22
-   144|     toString(radix?: number): string;
+   <BUILTINS>/core.js:146:22
+   146|     toString(radix?: number): string;
                              ^^^^^^ [2]
 
 
@@ -300,8 +317,8 @@ Cannot assign `x.hasOwnProperty` to `xHasOwnProperty` because function type [1] 
                                       ^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:63:5
-   63|     hasOwnProperty(prop: any): boolean;
+   <BUILTINS>/core.js:65:5
+   65|     hasOwnProperty(prop: any): boolean;
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
    object_prototype.js:71:23
    71| var xHasOwnProperty : number = x.hasOwnProperty; // error
@@ -318,8 +335,8 @@ value.
                                                          ^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:63:32
-   63|     hasOwnProperty(prop: any): boolean;
+   <BUILTINS>/core.js:65:32
+   65|     hasOwnProperty(prop: any): boolean;
                                       ^^^^^^^ [1]
    object_prototype.js:72:42
    72| var xHasOwnProperty2 : (prop: string) => number = x.hasOwnProperty; // error
@@ -335,8 +352,8 @@ Cannot assign `y.hasOwnProperty` to `yHasOwnProperty` because function type [1] 
                                       ^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:63:5
-   63|     hasOwnProperty(prop: any): boolean;
+   <BUILTINS>/core.js:65:5
+   65|     hasOwnProperty(prop: any): boolean;
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
    object_prototype.js:76:23
    76| var yHasOwnProperty : number = y.hasOwnProperty; // error
@@ -361,8 +378,8 @@ number [2].
                                             ^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:65:5
-   65|     propertyIsEnumerable(prop: any): boolean;
+   <BUILTINS>/core.js:67:5
+   67|     propertyIsEnumerable(prop: any): boolean;
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
    object_prototype.js:96:29
    96| var xPropertyIsEnumerable : number = x.propertyIsEnumerable; // error
@@ -379,8 +396,8 @@ in the return value.
          ^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:65:38
-   65|     propertyIsEnumerable(prop: any): boolean;
+   <BUILTINS>/core.js:67:38
+   67|     propertyIsEnumerable(prop: any): boolean;
                                             ^^^^^^^ [1]
    object_prototype.js:97:48
    97| var xPropertyIsEnumerable2 : (prop: string) => number =
@@ -397,8 +414,8 @@ number [2].
                                              ^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:65:5
-    65|     propertyIsEnumerable(prop: any): boolean;
+   <BUILTINS>/core.js:67:5
+    67|     propertyIsEnumerable(prop: any): boolean;
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
    object_prototype.js:102:29
    102| var yPropertyIsEnumerable : number = y.propertyIsEnumerable; // error
@@ -422,8 +439,8 @@ Cannot assign `x.valueOf` to `xValueOf` because function type [1] is incompatibl
                                 ^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:396:5
-   396|     valueOf(): number;
+   <BUILTINS>/core.js:398:5
+   398|     valueOf(): number;
             ^^^^^^^^^^^^^^^^^ [1]
    object_prototype.js:122:16
    122| var xValueOf : number = x.valueOf; // error
@@ -439,8 +456,8 @@ Cannot assign `y.valueOf` to `yValueOf` because function type [1] is incompatibl
                                 ^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:68:5
-    68|     valueOf(): mixed;
+   <BUILTINS>/core.js:70:5
+    70|     valueOf(): mixed;
             ^^^^^^^^^^^^^^^^ [1]
    object_prototype.js:126:16
    126| var yValueOf : number = y.valueOf; // error
@@ -464,8 +481,8 @@ Cannot assign `x.toLocaleString` to `xToLocaleString` because function type [1] 
                                        ^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:392:5
-   392|     toLocaleString(locales?: string | Array<string>, options?: Intl$DateTimeFormatOptions): string;
+   <BUILTINS>/core.js:394:5
+   394|     toLocaleString(locales?: string | Array<string>, options?: Intl$DateTimeFormatOptions): string;
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
    object_prototype.js:150:23
    150| var xToLocaleString : number = x.toLocaleString; // error
@@ -482,8 +499,8 @@ value.
                                               ^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:392:93
-   392|     toLocaleString(locales?: string | Array<string>, options?: Intl$DateTimeFormatOptions): string;
+   <BUILTINS>/core.js:394:93
+   394|     toLocaleString(locales?: string | Array<string>, options?: Intl$DateTimeFormatOptions): string;
                                                                                                     ^^^^^^ [1]
    object_prototype.js:151:30
    151| var xToLocaleString2 : () => number = x.toLocaleString; // error
@@ -499,12 +516,29 @@ Cannot assign `y.toLocaleString` to `yToLocaleString` because function type [1] 
                                        ^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:66:5
-    66|     toLocaleString(): string;
+   <BUILTINS>/core.js:68:5
+    68|     toLocaleString(): string;
             ^^^^^^^^^^^^^^^^^^^^^^^^ [1]
    object_prototype.js:155:23
    155| var yToLocaleString : number = y.toLocaleString; // error
                               ^^^^^^ [2]
+
+
+Error -------------------------------------------------------------------------------------------- object_values.js:23:6
+
+Cannot cast `val` to string because number [1] is incompatible with string [2].
+
+   object_values.js:23:6
+   23|     (val: string) // error: number ~> string
+            ^^^
+
+References:
+   object_values.js:13:28
+   13| const strToNum: {[string]: number} = {};
+                                  ^^^^^^ [1]
+   object_values.js:23:11
+   23|     (val: string) // error: number ~> string
+                 ^^^^^^ [2]
 
 
 Error ----------------------------------------------------------------------------------------------------- proto.js:3:2
@@ -516,8 +550,8 @@ Cannot cast `o1_proto.toString` to empty because function type [1] is incompatib
         ^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:67:5
-   67|     toString(): string;
+   <BUILTINS>/core.js:69:5
+   69|     toString(): string;
            ^^^^^^^^^^^^^^^^^^ [1]
    proto.js:3:21
     3| (o1_proto.toString: empty); // error: function ~> empty
@@ -570,4 +604,4 @@ References:
 
 
 
-Found 38 errors
+Found 40 errors

--- a/tests/object_api/object_entries.js
+++ b/tests/object_api/object_entries.js
@@ -1,0 +1,24 @@
+/* @flow */
+
+// argument doesn't have to be an object
+(Object.entries(1): Array<[string, mixed]>);
+(Object.entries(false): Array<[string, mixed]>);
+(Object.entries("blah"): Array<[string, mixed]>);
+
+// sealed objects have more specific types
+const sealed = { foo: 'foo', bar: 2 };
+(Object.entries(sealed): Array<[string, string|number]>);
+
+// objects-as-maps have more specific types
+const strToNum: {[string]: number} = {};
+(Object.entries(strToNum): Array<[string, number]>);
+
+const strToStr: {[string]: string} = {};
+(Object.entries(strToStr): Array<[string, string]>);
+
+const numToNum: {[number]: number} = {};
+(Object.entries(numToNum): Array<[string, number]>);
+
+Object.entries(strToNum).forEach(([key, val]) => {
+    (val: string) // error: number ~> string
+});

--- a/tests/object_api/object_values.js
+++ b/tests/object_api/object_values.js
@@ -1,0 +1,24 @@
+/* @flow */
+
+// argument doesn't have to be an object
+(Object.values(1): Array<mixed>);
+(Object.values(false): Array<mixed>);
+(Object.values("blah"): Array<mixed>);
+
+// sealed objects have more specific types
+const sealed = { foo: 'foo', bar: 2 };
+(Object.values(sealed): Array<string|number>);
+
+// objects-as-maps have more specific types
+const strToNum: {[string]: number} = {};
+(Object.values(strToNum): Array<number>);
+
+const strToStr: {[string]: string} = {};
+(Object.values(strToStr): Array<string>);
+
+const numToNum: {[number]: number} = {};
+(Object.values(numToNum): Array<number>);
+
+Object.values(strToNum).forEach(val => {
+    (val: string) // error: number ~> string
+});

--- a/tests/object_is/object_is.exp
+++ b/tests/object_is/object_is.exp
@@ -7,8 +7,8 @@ Cannot assign `Object.is(...)` to `b` because boolean [1] is incompatible with s
                        ^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:54:32
-   54|     static is(a: any, b: any): boolean;
+   <BUILTINS>/core.js:55:32
+   55|     static is(a: any, b: any): boolean;
                                       ^^^^^^^ [1]
    object_is.js:20:8
    20| var b: string = Object.is('a', 'a');
@@ -24,8 +24,8 @@ Cannot call method `is` because no more than 2 arguments are expected by functio
                         ^^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:54:5
-   54|     static is(a: any, b: any): boolean;
+   <BUILTINS>/core.js:55:5
+   55|     static is(a: any, b: any): boolean;
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 

--- a/tests/objects/objects.exp
+++ b/tests/objects/objects.exp
@@ -277,8 +277,8 @@ Cannot cast `y['hasOwnProperty']` to string because function type [1] is incompa
         ^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:63:5
-   63|     hasOwnProperty(prop: any): boolean;
+   <BUILTINS>/core.js:65:5
+   65|     hasOwnProperty(prop: any): boolean;
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
    objects.js:18:23
    18| (y['hasOwnProperty']: string); // error, prototype method is not a string

--- a/tests/overload/overload.exp
+++ b/tests/overload/overload.exp
@@ -29,8 +29,8 @@ Cannot assign `"".match(...)[0]` to `x1` because string [1] is incompatible with
                          ^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:288:33
-   288| type RegExp$matchResult = Array<string> & {index: number, input: string, groups: ?{[name: string]: string}};
+   <BUILTINS>/core.js:290:33
+   290| type RegExp$matchResult = Array<string> & {index: number, input: string, groups: ?{[name: string]: string}};
                                         ^^^^^^ [1]
    overload.js:7:9
      7| var x1: number = "".match(0)[0];
@@ -46,8 +46,8 @@ Cannot get `"".match(...)[0]` because an indexer property is missing in null [1]
                          ^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:304:58
-   304|     match(regexp: string | RegExp): RegExp$matchResult | null;
+   <BUILTINS>/core.js:306:58
+   306|     match(regexp: string | RegExp): RegExp$matchResult | null;
                                                                  ^^^^ [1]
 
 
@@ -60,8 +60,8 @@ Cannot call `"".match` with `0` bound to `regexp` because number [1] is incompat
                                   ^ [1]
 
 References:
-   <BUILTINS>/core.js:304:19
-   304|     match(regexp: string | RegExp): RegExp$matchResult | null;
+   <BUILTINS>/core.js:306:19
+   306|     match(regexp: string | RegExp): RegExp$matchResult | null;
                           ^^^^^^ [2]
 
 
@@ -74,8 +74,8 @@ Cannot assign `"".match(...)[0]` to `x2` because string [1] is incompatible with
                          ^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:288:33
-   288| type RegExp$matchResult = Array<string> & {index: number, input: string, groups: ?{[name: string]: string}};
+   <BUILTINS>/core.js:290:33
+   290| type RegExp$matchResult = Array<string> & {index: number, input: string, groups: ?{[name: string]: string}};
                                         ^^^^^^ [1]
    overload.js:8:9
      8| var x2: number = "".match(/pattern/)[0];
@@ -91,8 +91,8 @@ Cannot get `"".match(...)[0]` because an indexer property is missing in null [1]
                          ^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:304:58
-   304|     match(regexp: string | RegExp): RegExp$matchResult | null;
+   <BUILTINS>/core.js:306:58
+   306|     match(regexp: string | RegExp): RegExp$matchResult | null;
                                                                  ^^^^ [1]
 
 
@@ -105,8 +105,8 @@ Cannot assign `"".split(...)[0]` to `x4` because string [1] is incompatible with
                          ^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:312:63
-   312|     split(separator?: string | RegExp, limit?: number): Array<string>;
+   <BUILTINS>/core.js:314:63
+   314|     split(separator?: string | RegExp, limit?: number): Array<string>;
                                                                       ^^^^^^ [1]
    overload.js:10:9
     10| var x4: number = "".split(/pattern/)[0];

--- a/tests/promises/promises.exp
+++ b/tests/promises/promises.exp
@@ -84,8 +84,8 @@ Cannot call `Promise.all` because property `@@iterator` is missing in undefined 
         ^^^^^^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:637:19
-   637|     static all<T: Iterable<mixed>>(promises: T): Promise<$TupleMap<T, typeof $await>>;
+   <BUILTINS>/core.js:639:19
+   639|     static all<T: Iterable<mixed>>(promises: T): Promise<$TupleMap<T, typeof $await>>;
                           ^^^^^^^^^^^^^^^ [2]
 
 
@@ -99,8 +99,8 @@ in `$Iterable` [2].
                     ^ [1]
 
 References:
-   <BUILTINS>/core.js:637:19
-   637|     static all<T: Iterable<mixed>>(promises: T): Promise<$TupleMap<T, typeof $await>>;
+   <BUILTINS>/core.js:639:19
+   639|     static all<T: Iterable<mixed>>(promises: T): Promise<$TupleMap<T, typeof $await>>;
                           ^^^^^^^^^^^^^^^ [2]
 
 
@@ -405,8 +405,8 @@ References:
    resolve_void.js:3:29
      3| (Promise.resolve(): Promise<number>); // error
                                     ^^^^^^ [2]
-   <BUILTINS>/core.js:612:24
-   612| declare class Promise<+R> {
+   <BUILTINS>/core.js:614:24
+   614| declare class Promise<+R> {
                                ^ [3]
 
 
@@ -426,8 +426,8 @@ References:
    resolve_void.js:5:38
      5| (Promise.resolve(undefined): Promise<number>); // error
                                              ^^^^^^ [2]
-   <BUILTINS>/core.js:612:24
-   612| declare class Promise<+R> {
+   <BUILTINS>/core.js:614:24
+   614| declare class Promise<+R> {
                                ^ [3]
 
 

--- a/tests/react_16_6/react_16_6.exp
+++ b/tests/react_16_6/react_16_6.exp
@@ -93,8 +93,8 @@ References:
    <BUILTINS>/react.js:302:30
    302|     component: () => Promise<{ default: React$ComponentType<P> }>,
                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [2]
-   <BUILTINS>/core.js:612:24
-   612| declare class Promise<+R> {
+   <BUILTINS>/core.js:614:24
+   614| declare class Promise<+R> {
                                ^ [3]
 
 
@@ -114,8 +114,8 @@ References:
    <BUILTINS>/react.js:302:30
    302|     component: () => Promise<{ default: React$ComponentType<P> }>,
                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [2]
-   <BUILTINS>/core.js:612:24
-   612| declare class Promise<+R> {
+   <BUILTINS>/core.js:614:24
+   614| declare class Promise<+R> {
                                ^ [3]
 
 

--- a/tests/react_hocs/react_hocs.exp
+++ b/tests/react_hocs/react_hocs.exp
@@ -105,8 +105,8 @@ string [1] is incompatible with number [2] in property `bar`.
         -^
 
 References:
-   <BUILTINS>/core.js:144:31
-   144|     toString(radix?: number): string;
+   <BUILTINS>/core.js:146:31
+   146|     toString(radix?: number): string;
                                       ^^^^^^ [1]
    Bad.js:8:8
      8|   bar: number,

--- a/tests/rec/rec.exp
+++ b/tests/rec/rec.exp
@@ -7,11 +7,11 @@ Property `@@iterator` is missing in undefined [1] but exists in `$Iterable` [2].
                         ^
 
 References:
-   <BUILTINS>/core.js:549:22
-   549|     get(key: K): V | void;
+   <BUILTINS>/core.js:551:22
+   551|     get(key: K): V | void;
                              ^^^^ [1]
-   <BUILTINS>/core.js:493:11
-   493| interface $Iterable<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:495:11
+   495| interface $Iterable<+Yield,+Return,-Next> {
                   ^^^^^^^^^ [2]
 
 
@@ -24,11 +24,11 @@ Property `@@iterator` is missing in undefined [1] but exists in `$Iterable` [2].
                         ^
 
 References:
-   <BUILTINS>/core.js:549:22
-   549|     get(key: K): V | void;
+   <BUILTINS>/core.js:551:22
+   551|     get(key: K): V | void;
                              ^^^^ [1]
-   <BUILTINS>/core.js:493:11
-   493| interface $Iterable<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:495:11
+   495| interface $Iterable<+Yield,+Return,-Next> {
                   ^^^^^^^^^ [2]
 
 
@@ -41,11 +41,11 @@ Property `@@iterator` is missing in undefined [1] but exists in `$Iterable` [2].
                         ^
 
 References:
-   <BUILTINS>/core.js:549:22
-   549|     get(key: K): V | void;
+   <BUILTINS>/core.js:551:22
+   551|     get(key: K): V | void;
                              ^^^^ [1]
-   <BUILTINS>/core.js:493:11
-   493| interface $Iterable<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:495:11
+   495| interface $Iterable<+Yield,+Return,-Next> {
                   ^^^^^^^^^ [2]
 
 
@@ -58,11 +58,11 @@ Property `@@iterator` is missing in undefined [1] but exists in `$Iterable` [2].
                         ^
 
 References:
-   <BUILTINS>/core.js:549:22
-   549|     get(key: K): V | void;
+   <BUILTINS>/core.js:551:22
+   551|     get(key: K): V | void;
                              ^^^^ [1]
-   <BUILTINS>/core.js:493:11
-   493| interface $Iterable<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:495:11
+   495| interface $Iterable<+Yield,+Return,-Next> {
                   ^^^^^^^^^ [2]
 
 

--- a/tests/refinements/refinements.exp
+++ b/tests/refinements/refinements.exp
@@ -2060,8 +2060,8 @@ number [1] is incompatible with function type [2].
                                ^ [1]
 
 References:
-   <BUILTINS>/core.js:144:5
-   144|     toString(radix?: number): string;
+   <BUILTINS>/core.js:146:5
+   146|     toString(radix?: number): string;
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [2]
 
 
@@ -2110,8 +2110,8 @@ number [1] is incompatible with function type [2].
                               ^ [1]
 
 References:
-   <BUILTINS>/core.js:119:5
-   119|     valueOf(): boolean;
+   <BUILTINS>/core.js:121:5
+   121|     valueOf(): boolean;
             ^^^^^^^^^^^^^^^^^^ [2]
 
 
@@ -2944,8 +2944,8 @@ Cannot get `x[0]` because an indexer property is missing in `Boolean` [1].
             ^^^^
 
 References:
-   <BUILTINS>/core.js:116:15
-   116| declare class Boolean {
+   <BUILTINS>/core.js:118:15
+   118| declare class Boolean {
                       ^^^^^^^ [1]
 
 

--- a/tests/regexp/regexp.exp
+++ b/tests/regexp/regexp.exp
@@ -7,8 +7,8 @@ Cannot assign `patt.test(...)` to `match` because boolean [1] is incompatible wi
                            ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:346:27
-   346|     test(string: string): boolean;
+   <BUILTINS>/core.js:348:27
+   348|     test(string: string): boolean;
                                   ^^^^^^^ [1]
    regexp.js:2:11
      2| var match:number = patt.test("Hello world!");

--- a/tests/return/return.exp
+++ b/tests/return/return.exp
@@ -43,8 +43,8 @@ References:
    implicit.js:7:30
      7| async function g2(): Promise<number> {}
                                      ^^^^^^ [1]
-   <BUILTINS>/core.js:612:24
-   612| declare class Promise<+R> {
+   <BUILTINS>/core.js:614:24
+   614| declare class Promise<+R> {
                                ^ [2]
 
 

--- a/tests/symbol/symbol.exp
+++ b/tests/symbol/symbol.exp
@@ -7,8 +7,8 @@ Cannot call `Symbol` because no more than 1 argument is expected by function typ
                  ^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:85:3
-   85|   static (value?:any): Symbol;
+   <BUILTINS>/core.js:87:3
+   87|   static (value?:any): Symbol;
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 

--- a/tests/union/union.exp
+++ b/tests/union/union.exp
@@ -7,8 +7,8 @@ Cannot call `str.toFixed` because property `toFixed` is missing in `String` [1].
                        ^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:141:39
-   141|     toFixed(fractionDigits?: number): string;
+   <BUILTINS>/core.js:143:39
+   143|     toFixed(fractionDigits?: number): string;
                                               ^^^^^^ [1]
 
 


### PR DESCRIPTION
Fixes #5838.

Our codebase makes extensive use of [objects as maps](https://flow.org/en/docs/types/objects/#toc-objects-as-maps), and we currently lose that type information when passing into `Object.entries` or `Object.values`, since they return `Array<string, mixed>` and `Array<mixed>` respectively. I've added some additional annotations for these functions when the object passed in has an exact type – this lets us do things like this:

```js
const obj: {
  	[string]: number
} = {
	a: 1,
  	b: 2,
  	c: 3
};
for (const [char, num] of Object.entries(obj)) {
	const copy: number = num;
}
```