### PR TITLE
Fix Node.js assert.fail libdefs

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -2081,7 +2081,8 @@ declare module "assert" {
   declare module.exports: {
     (value: any, message?: string): void;
     ok(value: any, message?: string): void;
-    fail(actual: any, expected: any, message: string, operator: string): void;
+    fail(message?: string | Error): void;
+    fail(actual: any, expected: any, message?: string | Error, operator?: string, stackStartFn?: Function): void;
     equal(actual: any, expected: any, message?: string): void;
     notEqual(actual: any, expected: any, message?: string): void;
     deepEqual(actual: any, expected: any, message?: string): void;


### PR DESCRIPTION
The [non-deprecated unary/nullary form of `assert.fail`](https://nodejs.org/api/assert.html#assert_assert_fail_message) should be allowed. 

Additionally, when using the [deprecated `assert.fail` form](https://nodejs.org/api/assert.html#assert_assert_fail_actual_expected_message_operator_stackstartfn), `message` and `operator` parameters should be optional and there should be an optional fifth `stackStartFn` parameter.

Furthermore, the message parameter can be either `string` or `Error`.