### PR TITLE
Fix createContextualFragment declaration

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -1195,7 +1195,7 @@ declare class Range { // extension
   setStartAfter(refNode: Node): void;
   extractContents(): DocumentFragment;
   setEndAfter(refNode: Node): void;
-  createContextualFragment(fragment: string): Node;
+  createContextualFragment(fragment: string): DocumentFragment;
   static END_TO_END: number;
   static START_TO_START: number;
   static START_TO_END: number;


### PR DESCRIPTION
Per the [DOM parsing spec][1], `Range#createContextualFragment` returns a `DocumentFragment`, and can't return other `Node`s.

[1]: https://w3c.github.io/DOM-Parsing/#extensions-to-the-range-interface