### PR TITLE
Update types for WeakMap

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -556,12 +556,12 @@ declare class Map<K, V> extends $ReadOnlyMap<K, V> {
     [key: $SymbolToStringTag | $SymbolSpecies]: Function;
 }
 
-declare class $ReadOnlyWeakMap<K: {}, V> {
+declare class $ReadOnlyWeakMap<K: {} | $ReadOnlyArray<mixed>, V> {
     get(key: K): V | void;
     has(key: K): boolean;
 }
 
-declare class WeakMap<K: {}, V> extends $ReadOnlyWeakMap<K, V> {
+declare class WeakMap<K: {} | $ReadOnlyArray<mixed>, V> extends $ReadOnlyWeakMap<K, V> {
     constructor(iterable: ?Iterable<[K, V]>): void;
     delete(key: K): boolean;
     get(key: K): V | void;


### PR DESCRIPTION
WeakMap doesn't currently accept Arrays as keys because Arrays are not subtypes of Objects in Flow's type system. This explicitly add support for Array keys to WeakMap.