### PR TITLE
Fix iframe srcdoc typo

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -2879,7 +2879,7 @@ declare class HTMLIFrameElement extends HTMLElement {
   scrolling: string;
   sandbox: DOMTokenList;
   src: string;
-  srcDoc: string;
+  srcdoc: string;
   width: string;
 }
 


### PR DESCRIPTION
Per [the DOM spec][1], the HTMLIFrameElement interface has a `srcdoc` property - not a `srcDoc` property.

[1]: https://html.spec.whatwg.org/multipage/iframe-embed-object.html#htmliframeelement