### PR TITLE
Fix exact object indexer issue 7128 and 7240

### DIFF
--- a/src/typing/flow_js.ml
+++ b/src/typing/flow_js.ml
@@ -6741,7 +6741,7 @@ and flow_obj_to_obj cx trace ~use_op (lreason, l_obj) (ureason, u_obj) =
         (Field (None, lv, lpolarity), Field (None, uv, upolarity))
     | _ -> ());
 
-  if rflags.exact && rflags.sealed = Sealed && not (is_literal_object_reason ureason)
+  if udict = None && rflags.exact && rflags.sealed = Sealed && not (is_literal_object_reason ureason)
   then (
     iter_real_props cx lflds (fun ~is_sentinel s _ ->
       if not (Context.has_prop cx uflds s)

--- a/tests/exact/exact.exp
+++ b/tests/exact/exact.exp
@@ -164,6 +164,55 @@ References:
                                                            ^^^^^^^^^^ [1]
 
 
+Error --------------------------------------------------------------------------------------------- exact_indexer.js:4:2
+
+Cannot cast object literal to object type because number [1] is incompatible with string [2] in property `a`.
+
+   exact_indexer.js:4:2
+   4| ({ a: 123 }: {| ['a']: string |}); // error
+       ^^^^^^^^^^
+
+References:
+   exact_indexer.js:4:7
+   4| ({ a: 123 }: {| ['a']: string |}); // error
+            ^^^ [1]
+   exact_indexer.js:4:24
+   4| ({ a: 123 }: {| ['a']: string |}); // error
+                             ^^^^^^ [2]
+
+
+Error --------------------------------------------------------------------------------------------- exact_indexer.js:5:2
+
+Cannot cast object literal to object type because string `a` [1] is incompatible with string literal `b` [2] in the
+indexer property's key.
+
+   exact_indexer.js:5:2
+   5| ({ a: 123 }: {| ['b']: number |}); // error
+       ^^^^^^^^^^ [1]
+
+References:
+   exact_indexer.js:5:18
+   5| ({ a: 123 }: {| ['b']: number |}); // error
+                       ^^^ [2]
+
+
+Error --------------------------------------------------------------------------------------------- exact_indexer.js:7:2
+
+Cannot cast object literal to object type because number [1] is incompatible with string [2] in property `a`.
+
+   exact_indexer.js:7:2
+   7| ({ a: 123 }: {| [string]: string |}); // error
+       ^^^^^^^^^^
+
+References:
+   exact_indexer.js:7:7
+   7| ({ a: 123 }: {| [string]: string |}); // error
+            ^^^ [1]
+   exact_indexer.js:7:27
+   7| ({ a: 123 }: {| [string]: string |}); // error
+                                ^^^^^^ [2]
+
+
 Error -------------------------------------------------------------------------------------------------- objmap.js:11:32
 
 Cannot assign object literal to `doesError` because number [1] is incompatible with number literal `2` [2] in property
@@ -333,4 +382,4 @@ References:
 
 
 
-Found 20 errors
+Found 23 errors

--- a/tests/exact/exact_indexer.js
+++ b/tests/exact/exact_indexer.js
@@ -1,0 +1,7 @@
+// @flow
+
+({ a: 123 }: {| ['a']: number |}); // OK
+({ a: 123 }: {| ['a']: string |}); // error
+({ a: 123 }: {| ['b']: number |}); // error
+({ a: 123 }: {| [string]: number |}); // OK
+({ a: 123 }: {| [string]: string |}); // error


### PR DESCRIPTION
This fixes https://github.com/facebook/flow/issues/7128 and https://github.com/facebook/flow/issues/7240

Root cause for both issues were same.

In overall I think that singleton string indexer properties should be treated as a regular keys from the get go but that's probably bigger change. The change introduced in this PR is probably fine for now as nothing broke, and test harness around exact indexer properties is now slightly better.

Having debugger setup in place helps _a lot_: https://github.com/facebook/flow/issues/4181#issuecomment-447596374