### PR TITLE
Upgrade to bootstrap 4.0.0

### DIFF
--- a/website/_assets/css/_article.scss
+++ b/website/_assets/css/_article.scss
@@ -25,8 +25,8 @@
     }
 
     em code {
-      background: $code-bg;
-      color: $code-color;
+      background: $gray-200;
+      color: #bd4147;
     }
   }
 
@@ -35,11 +35,11 @@
   blockquote {
     margin-bottom: 1.2rem;
     padding: (1.2rem + $fix-margin-collapse) 1.2rem $fix-margin-collapse;
-    background: $gray-lightest;
-    border-left: $border-radius solid $gray-light;
+    background: $gray-100;
+    border-left: $border-radius solid $gray-600;
 
     p code {
-      background-color: $gray-lighter;
+      background-color: $gray-200;
     }
   }
 

--- a/website/_assets/css/_editor.scss
+++ b/website/_assets/css/_editor.scss
@@ -2,7 +2,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 .language-sh pre {
-  background: $gray-dark;
+  background: $gray-900;
   color: white !important;
   -webkit-font-smoothing: antialiased;
   border-left: 4px solid $editor-accent-alt;
@@ -12,7 +12,7 @@
   }
 
   span.c {
-    color: lighten($gray-light, 15%) !important;
+    color: lighten($gray-600, 15%) !important;
   }
 }
 

--- a/website/_assets/css/_feature.scss
+++ b/website/_assets/css/_feature.scss
@@ -332,13 +332,13 @@ $feature-hero-text-shadow: '';
 }
 
 .featurette-heading {
-  color: $gray;
+  color: $gray-700;
   font-weight: 900;
   text-transform: uppercase;
 }
 
 .featurette-text {
-  color: $gray;
+  color: $gray-700;
   font-size: 1.1rem;
 }
 

--- a/website/_assets/css/_search.scss
+++ b/website/_assets/css/_search.scss
@@ -15,7 +15,7 @@
   height: 0.9rem;
   top: 0.75rem;
   left: 0.6rem;
-  fill: $gray;
+  fill: $gray-700;
 }
 
 .search-input {

--- a/website/_assets/css/main.scss
+++ b/website/_assets/css/main.scss
@@ -8,7 +8,8 @@ $flow-green: #9CD732;
 // $flow-blue: #287093;
 // $flow-purple: #6A2C9C;
 
-$brand-primary: $flow-red;
+$primary: $flow-red;
+$secondary: #dee2e6; // $gray-300
 
 $flow-gray: slategray;
 $flow-gray-dark: darken($flow-gray, 20%);

--- a/website/_includes/additional-reading.html
+++ b/website/_includes/additional-reading.html
@@ -1,7 +1,7 @@
 {% include vars.html %}
 
 <div class="list-group mt-1">
-  <strong class="list-group-item bg-faded">
+  <strong class="list-group-item bg-light">
     {{i18n.docs_additional_reading}}
   </strong>
 

--- a/website/_includes/guide-controls.html
+++ b/website/_includes/guide-controls.html
@@ -3,14 +3,14 @@
 
   <div class="clearfix">
     {% if guide_prev %}
-      <a class="btn btn-outline-primary float-xs-left" href="{{url_base}}{{guide_prev.path}}">
+      <a class="btn btn-outline-primary float-left" href="{{url_base}}{{guide_prev.path}}">
         &larr;
         {{i18n[guide_prev.path].title}}
       </a>
     {% endif %}
 
     {% if guide_next %}
-      <a class="btn btn-primary float-xs-right" href="{{url_base}}{{guide_next.path}}">
+      <a class="btn btn-primary float-right" href="{{url_base}}{{guide_next.path}}">
         {{i18n[guide_next.path].title}}
         &rarr;
       </a>

--- a/website/_includes/nav-guide.html
+++ b/website/_includes/nav-guide.html
@@ -1,6 +1,6 @@
 {% include vars.html %}
 
-<ul class="nav nav-stacked guide-nav">
+<ul class="nav flex-column guide-nav">
   {% for guide_page in guide.pages %}
     <li class="nav-item">
       {% if guide_page.path == url_relative %}
@@ -9,7 +9,7 @@
           <span class="sr-only">(current)</span>
         </strong>
       {% else %}
-        <a class="nav-link" href="{{url_base}}{{guide_page.path}}">
+        <a href="{{url_base}}{{guide_page.path}}">
           {{i18n[guide_page.path].title}}
         </a>
       {% endif %}

--- a/website/_includes/nav-posts.html
+++ b/website/_includes/nav-posts.html
@@ -1,4 +1,4 @@
-<ul class="nav nav-stacked guide-nav">
+<ul class="nav flex-column guide-nav">
   {% for post in site.posts %}
     <li class="nav-item">
       {% if post.url == url_relative %}
@@ -7,11 +7,11 @@
           <span class="sr-only">(current)</span>
         </strong>
       {% elsif post.medium-link %}
-        <a class="nav-link" href="{{post.medium-link}}">
+        <a href="{{post.medium-link}}">
           {{post.short-title | default: post.title}}
         </a>
       {% else %}
-        <a class="nav-link" href="{{site.baseurl}}{{post.url}}">
+        <a href="{{site.baseurl}}{{post.url}}">
           {{post.short-title | default: post.title}}
         </a>
       {% endif %}

--- a/website/_includes/navbar.html
+++ b/website/_includes/navbar.html
@@ -1,22 +1,22 @@
 {% include vars.html %}
 
-<nav class="navbar navbar-full navbar-fixed-top navbar-dark">
+<nav class="navbar navbar-full navbar-expand-lg fixed-top navbar-dark">
   <div class="container">
     <a class="navbar-brand" href="{{url_base}}/">
       {% include svg/logo-flow-nav.svg %}
       <span class="sr-only">Flow</span>
     </a>
 
-    <div class="clearfix hidden-lg-up">
-      <button class="navbar-toggler float-xs-right" type="button"
+    <div class="clearfix d-lg-none">
+      <button class="navbar-toggler float-right" type="button"
         data-toggle="collapse" data-target="#navbar"
-        aria-controls="exCollapsingNavbar2" aria-expanded="false" aria-label="Toggle navigation">
-        <!-- &#9776; -->
+        aria-controls="navbar" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
       </button>
     </div>
 
-    <div class="collapse navbar-toggleable-md" id="navbar">
-      <ul class="nav navbar-nav">
+    <div class="collapse navbar-collapse" id="navbar">
+      <ul class="navbar-nav mr-auto">
         <li class="nav-item">
           <a class="nav-link" href="{{url_base}}/docs/getting-started/">{{i18n.navbar_getting_started}}</a>
         </li>
@@ -31,7 +31,7 @@
         </li>
       </ul>
 
-      <ul class="nav navbar-nav float-lg-right">
+      <ul class="navbar-nav">
         {% assign path = page.url | split: '/' %}
         {% unless true || path[1] == 'blog' %}
           <li class="nav-item dropdown">

--- a/website/_includes/search-docs.html
+++ b/website/_includes/search-docs.html
@@ -1,4 +1,4 @@
-<div class="col-md-3{% unless page.mobile_search or layout.mobile_search %} hidden-sm-down{% endunless %}">
+<div class="col-md-3{% unless page.mobile_search or layout.mobile_search %} d-none d-lg-block{% endunless %}">
   <div class="search">
     <label class="search-label sr-only" for="algolia-doc-search">
       Search docs

--- a/website/_layouts/default.html
+++ b/website/_layouts/default.html
@@ -33,15 +33,14 @@
         baseUrl: '/assets',
         waitSeconds: 30,
         shim: {
-          'bootstrap': { 'deps': ['jquery', 'tether'] }
+          'bootstrap': { 'deps': ['jquery'] }
         },
         paths: {
           {% for script in page.scripts %}
           '{% asset_name {{script}} %}': '{{ script | asset_path | strip_extension }}',
           {% endfor %}
-          'jquery': 'https://cdnjs.cloudflare.com/ajax/libs/jquery/3.2.0/jquery.min',
-          'tether-min': 'https://cdnjs.cloudflare.com/ajax/libs/tether/1.3.7/js/tether.min',
-          'bootstrap': 'https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.0.0-alpha.5/js/bootstrap.min',
+          'jquery': 'https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min',
+          'bootstrap': 'https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.0.0/js/bootstrap.bundle.min',
           'docsearch': 'https://cdnjs.cloudflare.com/ajax/libs/docsearch.js/2.1.8/docsearch.min',
           'codemirror/lib/codemirror': 'https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.20.2/codemirror.min',
           'codemirror/addon/lint/lint': 'https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.20.2/addon/lint/lint.min',

--- a/website/_layouts/page.html
+++ b/website/_layouts/page.html
@@ -6,7 +6,7 @@ editor: true
 
 {% include vars.html %}
 
-<div class="py-3 mb-2 bg-faded">
+<div class="py-5 mb-3 bg-light">
   <div class="container">
     <div class="row">
       <div class="col-md-9">
@@ -48,7 +48,7 @@ editor: true
       </div>
 
       <div class="col-md-3">
-        <hr class="hidden-md-up">
+        <hr class="d-md-none">
         {% include nav-posts.html %}
       </div>
     </div>
@@ -64,7 +64,7 @@ editor: true
       </div>
 
       <div class="col-md-3">
-        <hr class="hidden-md-up"/>
+        <hr class="d-md-none"/>
         {% include nav-guide.html %}
       </div>
     </div>

--- a/website/_layouts/pages/guides.html
+++ b/website/_layouts/pages/guides.html
@@ -20,12 +20,12 @@ mobile_search: true
     {% endif %}
 
     <div class="col-lg-4">
-      <a class="card guide-card" href="{{url_base}}{{guide.pages[0].path}}">
-        <div class="card-block">
+      <a class="card mb-3 guide-card" href="{{url_base}}{{guide.pages[0].path}}">
+        <div class="card-body">
           <h4 class="card-title">{{i18n.guides[guide.id].title}}</h4>
           <p class="card-text text-muted">
             {{i18n.guides[guide.id].description}}
-            <span class="float-xs-right text-primary">
+            <span class="float-right text-primary">
               {{i18n.docs_read_more}}
             </span>
           </p>

--- a/website/_layouts/pages/homepage.html
+++ b/website/_layouts/pages/homepage.html
@@ -7,11 +7,11 @@ layout: default
 <div class="feature feature-hero">
   <div class="container">
     <h1 class="feature-heading">
-      {{i18n.homepage_hero_title | replace: '|', '<br class="hidden-lg-up">' | replace: '[', '<span>' | replace: ']', '</span>'}}
+      {{i18n.homepage_hero_title | replace: '|', '<br class="d-lg-none">' | replace: '[', '<span>' | replace: ']', '</span>'}}
     </h1>
 
-    <a class="feature-btn hidden-sm-down" href="{{url_base}}/docs/getting-started/"><span>{{i18n.homepage_get_started}}</span></a>
-    <a class="feature-btn hidden-sm-down" href="{{url_base}}/docs/install/"><span>{{i18n.homepage_install_flow}}</span></a>
+    <a class="feature-btn d-none d-md-inline-block" href="{{url_base}}/docs/getting-started/"><span>{{i18n.homepage_get_started}}</span></a>
+    <a class="feature-btn d-none d-md-inline-block" href="{{url_base}}/docs/install/"><span>{{i18n.homepage_install_flow}}</span></a>
 
     <iframe class="gh-btn"
       src="https://ghbtns.com/github-btn.html?user=facebook&repo=flow&type=star&count=true&size=large"
@@ -133,13 +133,13 @@ layout: default
   <div class="feature-decoration feature-decoration-rise"></div>
   <div class="feature-decoration feature-decoration-drop"></div>
 
-  <div class="container text-xs-center">
+  <div class="container text-sm-center">
     <h2 class="feature-heading">
       {{i18n.homepage_ready_to_get_going}}
     </h2>
     <div class="mt-2">
       <a class="feature-btn" href="{{url_base}}/docs/getting-started/"><span>{{i18n.homepage_get_started}}</span></a>
-      <a class="feature-btn mr-0 hidden-sm-down" href="{{url_base}}/docs/install/"><span>{{i18n.homepage_install_flow}}</span></a>
+      <a class="feature-btn mr-0 d-none d-md-inline-block" href="{{url_base}}/docs/install/"><span>{{i18n.homepage_install_flow}}</span></a>
     </div>
   </div>
 </div>

--- a/website/blog/index.html
+++ b/website/blog/index.html
@@ -40,7 +40,7 @@ include_nav_posts: true
     </div>
 
     {% unless forloop.last %}
-      <hr class="my-2"/>
+      <hr class="my-4"/>
     {% endunless %}
   </div>
 {% endfor %}

--- a/website/en/docs/install.html
+++ b/website/en/docs/install.html
@@ -7,7 +7,7 @@ scripts:
 <div class="row">
   <div class="col-lg-6">
     <label><strong>Package Managers</strong></label>
-    <div class="btn-group install-toggle" data-toggle="buttons" style="width: 100%">
+    <div class="btn-group btn-group-toggle install-toggle" data-toggle="buttons" style="width: 100%">
       <label class="btn btn-secondary active" style="width: 50%">
         <input type="radio" name="packagemanager" value="yarn" autocomplete="off" checked>
         Yarn
@@ -21,7 +21,7 @@ scripts:
   </div>
   <div class="col-lg-6">
     <label><strong>Compilers</strong></label>
-    <div class="btn-group install-toggle" data-toggle="buttons" style="width: 100%">
+    <div class="btn-group btn-group-toggle install-toggle" data-toggle="buttons" style="width: 100%">
       <label class="btn btn-secondary active" style="width: 50%">
         <input type="radio" name="compiler" value="babel" autocomplete="off" checked>
         Babel
@@ -35,10 +35,10 @@ scripts:
   </div>
 
   <div class="col-lg-12">
-    <p class="text-muted my-1 text-xs-center">
+    <p class="text-muted my-1 text-sm-center">
       There are a few ways to setup Flow depending on what tools
       you're already using.
-      <br class="hidden-md-down">
+      <br class="d-none d-lg-inline">
       You can customize this guide from the tools above.
     </p>
   </div>

--- a/website/package.json
+++ b/website/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "license": "CC-BY-4.0",
   "dependencies": {
-    "bootstrap": "4.0.0-alpha.5",
+    "bootstrap": "~4.0.0",
     "jquery": "3.2.0"
   }
 }

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -2,17 +2,11 @@
 # yarn lockfile v1
 
 
-bootstrap@4.0.0-alpha.5:
-  version "4.0.0-alpha.5"
-  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-4.0.0-alpha.5.tgz#a126b648c3bd2f52b8fad4bbc5e2d0ad2abf7064"
-  dependencies:
-    jquery "1.9.1 - 3"
-    tether "^1.3.7"
+bootstrap@~4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-4.0.0.tgz#ceb03842c145fcc1b9b4e15da2a05656ba68469a"
+  integrity sha512-gulJE5dGFo6Q61V/whS6VM4WIyrlydXfCgkE+Gxe5hjrJ8rXLLZlALq7zq2RPhOc45PSwQpJkrTnc2KgD6cvmA==
 
-"jquery@1.9.1 - 3", jquery@3.2.0:
+jquery@3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.2.0.tgz#3bdbba66e1eee0785532dddadb0e0d2521ca584b"
-
-tether@^1.3.7:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/tether/-/tether-1.4.0.tgz#0f9fa171f75bf58485d8149e94799d7ae74d1c1a"


### PR DESCRIPTION
Pretty significant changes from 4.0.0.alpha.5 to the 4.0.0.beta's to 4.0.0 final, and then even more to get up to latest 4.1.

I had a hard time figuring out what changed since it was using undocumented alpha features, so had to dig through bootstrap commits. This PR goes from alpha5 to 4.0.0, taking it in small steps so if something breaks we can bisect more easily.