### PR TITLE
 Fix nested spread prop variance, issue 7242

### DIFF
--- a/src/typing/flow_js.ml
+++ b/src/typing/flow_js.ml
@@ -10929,12 +10929,9 @@ and flow_opt_p cx ?trace ~use_op ~report_polarity lreason ureason propref =
   | Field (_, lt, Neutral),
     Field (_, ut, Neutral) ->
     unify_opt cx ?trace ~use_op lt ut
-  | Field (_, DefT (lreason, lt), Positive),
-    Field (_, DefT (ureason, ut), Neutral) ->
-    flow_opt cx ?trace (DefT (lreason, lt), UseT (use_op, DefT (ureason, ut)))
-  | Field (_, ExactT (lreason, lt), Positive),
-    Field (_, DefT (ureason, ut), Neutral) ->
-    flow_opt cx ?trace (ExactT (lreason, lt), UseT (use_op, DefT (ureason, ut)))
+  | Field (_, (DefT (_, _) | ExactT (_, _) as lt), Positive),
+    Field (_, (DefT (_, _) as ut), Neutral) ->
+    flow_opt cx ?trace (lt, UseT (use_op, ut))
   (* directional cases *)
   | lp, up ->
     let x = match propref with Named (_, x) -> Some x | Computed _ -> None in

--- a/src/typing/flow_js.ml
+++ b/src/typing/flow_js.ml
@@ -10929,6 +10929,9 @@ and flow_opt_p cx ?trace ~use_op ~report_polarity lreason ureason propref =
   | Field (_, lt, Neutral),
     Field (_, ut, Neutral) ->
     unify_opt cx ?trace ~use_op lt ut
+  | Field (_, DefT (lreason, lt), Positive),
+    Field (_, DefT (ureason, ut), Neutral) ->
+    flow_opt cx ?trace (DefT (lreason, lt), UseT (use_op, DefT (ureason, ut)))
   (* directional cases *)
   | lp, up ->
     let x = match propref with Named (_, x) -> Some x | Computed _ -> None in

--- a/src/typing/flow_js.ml
+++ b/src/typing/flow_js.ml
@@ -10932,6 +10932,9 @@ and flow_opt_p cx ?trace ~use_op ~report_polarity lreason ureason propref =
   | Field (_, DefT (lreason, lt), Positive),
     Field (_, DefT (ureason, ut), Neutral) ->
     flow_opt cx ?trace (DefT (lreason, lt), UseT (use_op, DefT (ureason, ut)))
+  | Field (_, ExactT (lreason, lt), Positive),
+    Field (_, DefT (ureason, ut), Neutral) ->
+    flow_opt cx ?trace (ExactT (lreason, lt), UseT (use_op, DefT (ureason, ut)))
   (* directional cases *)
   | lp, up ->
     let x = match propref with Named (_, x) -> Some x | Computed _ -> None in

--- a/tests/friendly_errors/prop-variance.js
+++ b/tests/friendly_errors/prop-variance.js
@@ -18,5 +18,8 @@ declare opaque type T;
 
 type Ob = {|+foo: {| +bar: string |}|};
 declare var update: Ob;
-
 ({ foo: { bar: 'valid' }, ...update }: Ob); // Ok
+
+type NestedOb = {|+foo: {| +bar: {| +foo: number |} |}|};
+declare var update2: NestedOb;
+({ foo: { bar: { foo: 123 } }, ...update2 }: NestedOb); // Ok

--- a/tests/friendly_errors/prop-variance.js
+++ b/tests/friendly_errors/prop-variance.js
@@ -15,3 +15,8 @@ declare opaque type T;
 ((any: {-p: T}): {p: T}); // Error: write-only ~> readable
 ((any: {-p: T}): {+p: T}); // Error: write-only ~> read-only
 ((any: {-p: T}): {-p: T}); // Ok
+
+type Ob = {|+foo: {| +bar: string |}|};
+declare var update: Ob;
+
+({ foo: { bar: 'valid' }, ...update }: Ob); // Ok


### PR DESCRIPTION
Fixes https://github.com/facebook/flow/issues/7242

Currently broken examples which this PR fixes:
[first test case](https://flow.org/try/#0PTAEAEDMBsHsHcBQAXAngBwKagPICNQBeUAbwB8BqSWWALlLNArwEMAnegZ2TYEsA7AOagyAXzEBuRABNMAY2jtsAN3agArumktkmevikAKEqGp1SoVh1AByVdF7SboUQBpQAOi+btul-rwASglQEFwAayA)
[second test case](https://flow.org/try/#0PTAEAEDMBsHsHcBQAXAngBwKagHKYM7KYAmA8gEagC8oA3gD4DUkssAXHfaI+QIYBOHBtxbtQAOwCuAW3KZ+oegF9FS5QG5ExTAGNoA7ADcBoSemK8iAJg55CJCpoAUtUKKGg+gum9YcAjFYAzKAqSgA0oAB0MWYW1qG2BERk5ACU6kA)

I'm not entirely sure wether test cases are in right file or should I have separate file for them, but that file has probably the closest test cases to ones I made.

I'm also not sure wether `flow_opt cx ?trace (DefT (lreason, lt), UseT (use_op, DefT (ureason, ut)))` is proper call in matches, or should I have there something else instead.