### PR TITLE
Introduce gitignore matching and exclusion logic 

### DIFF
--- a/src/commands/commandUtils.ml
+++ b/src/commands/commandUtils.ml
@@ -461,6 +461,11 @@ let collect_flowconfig_flags main ignores_str untyped_str declarations_str inclu
   let raw_lint_severities = list_of_string_arg lints_str in
   main { ignores; includes; libs; raw_lint_severities; untyped; declarations; }
 
+let remove_exclusion pattern =
+  if Base.String.is_prefix pattern "!" then (
+    String.sub pattern 1 ((String.length pattern) - 1)
+  ) else pattern
+
 let file_options =
   let default_lib_dir ~no_flowlib tmp_dir =
     let root = Path.make (Tmp.temp_dir tmp_dir "flowlib") in
@@ -477,6 +482,7 @@ let file_options =
      let root = Path.to_string root
        |> Sys_utils.normalize_filename_dir_sep in
      let reg = s
+	   |> remove_exclusion
        |> Str.split_delim Files.project_root_token
        |> String.concat root
        |> Str.regexp in

--- a/src/common/files.ml
+++ b/src/common/files.ml
@@ -316,32 +316,39 @@ let absolute_path_regexp = Str.regexp "^\\(/\\|[A-Za-z]:[/\\\\]\\)"
 
 let project_root_token = Str.regexp_string "<PROJECT_ROOT>"
 
+let is_matching path pattern_list =
+  List.fold_left (
+    fun current (pattern, rx) ->
+      if Base.String.is_prefix pattern "!" then (
+        current && not (Str.string_match rx path 0)
+      ) else (
+        current || (Str.string_match rx path 0)
+      )
+    ) false pattern_list;;
+
 (* true if a file path matches an [ignore] entry in config *)
 let is_ignored (options: options) =
-  let list = Core_list.map ~f:snd options.ignores in
   fun path ->
     (* On Windows, the path may use \ instead of /, but let's standardize the
      * ignore regex to use / *)
     let path = Sys_utils.normalize_filename_dir_sep path in
-    List.exists (fun rx -> Str.string_match rx path 0) list
+    is_matching path options.ignores
 
 (* true if a file path matches an [untyped] entry in config *)
 let is_untyped (options: options) =
-  let list = Core_list.map ~f:snd options.untyped in
   fun path ->
     (* On Windows, the path may use \ instead of /, but let's standardize the
      * ignore regex to use / *)
     let path = Sys_utils.normalize_filename_dir_sep path in
-    List.exists (fun rx -> Str.string_match rx path 0) list
+    is_matching path options.untyped
 
 (* true if a file path matches a [declarations] entry in config *)
 let is_declaration (options: options) =
-  let list = Core_list.map ~f:snd options.declarations in
   fun path ->
     (* On Windows, the path may use \ instead of /, but let's standardize the
      * ignore regex to use / *)
     let path = Sys_utils.normalize_filename_dir_sep path in
-    List.exists (fun rx -> Str.string_match rx path 0) list
+    is_matching path options.declarations
 
 (* true if a file path matches an [include] path in config *)
 let is_included options f =


### PR DESCRIPTION
Introduce .gitignore matching and exclusion logic for patterns in ignore, untyped and declarations sections.

An optional prefix "!" which negates the pattern; any matching file excluded by a previous pattern will become included again. 

example: Excludes all files in `node_modules` except `not-excluded-package`
```
[ignore]
<PROJECT_ROOT>/node_modules/.*
!<PROJECT_ROOT>/node_modules/not-excluded-package/.*

[options]
all=true
```