### PR TITLE
Fix CircleCI macos build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,6 +133,10 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/flow
+      # https://github.com/Homebrew/brew/issues/5513
+      - run:
+          name: Fix homebrew python
+          command: brew update
       # https://github.com/Homebrew/homebrew-core/issues/26358
       - run:
           name: Fix homebrew python


### PR DESCRIPTION
Per Homebrew/brew#5513, this will hopefully work around a bug in the
homebrew auto-updater until a fix is merged and released.