### PR TITLE
Rename React hook useImperativeMethods -> useImperativeHandle

### DIFF
--- a/lib/react.js
+++ b/lib/react.js
@@ -341,7 +341,7 @@ declare module react {
     inputs: ?$ReadOnlyArray<mixed>,
   ): T;
 
-  declare export function useImperativeMethods<T>(
+  declare export function useImperativeHandle<T>(
     ref: {current: T | null} | ((inst: T | null) => mixed) | null | void,
     create: () => T,
     inputs: ?$ReadOnlyArray<mixed>,
@@ -377,7 +377,7 @@ declare module react {
     +useLayoutEffect: typeof useLayoutEffect,
     +useCallback: typeof useCallback,
     +useMemo: typeof useMemo,
-    +useImperativeMethods: typeof useImperativeMethods,
+    +useImperativeHandle: typeof useImperativeHandle,
   |};
 }
 

--- a/tests/react/react.exp
+++ b/tests/react/react.exp
@@ -3271,7 +3271,7 @@ References:
    377|     +useLayoutEffect: typeof useLayoutEffect,
    378|     +useCallback: typeof useCallback,
    379|     +useMemo: typeof useMemo,
-   380|     +useImperativeMethods: typeof useImperativeMethods,
+   380|     +useImperativeHandle: typeof useImperativeHandle,
    381|   |};
           -^ [1]
 
@@ -3395,18 +3395,18 @@ References:
                      ^^^^^^^^^^^^^^^^^^^^^ [2]
 
 
-Error --------------------------------------------------------------------------------- useImperativeMethods_hook.js:6:3
+Error --------------------------------------------------------------------------------- useImperativeHandle_hook.js:6:3
 
-Cannot call `React.useImperativeMethods` because function [1] requires another argument.
+Cannot call `React.useImperativeHandle` because function [1] requires another argument.
 
-   useImperativeMethods_hook.js:6:3
-     6|   React.useImperativeMethods(); // Error: function requires another argument.
+   useImperativeHandle_hook.js:6:3
+     6|   React.useImperativeHandle(); // Error: function requires another argument.
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
    <BUILTINS>/react.js:344:47
                                                       v---
-   344|   declare export function useImperativeMethods<T>(
+   344|   declare export function useImperativeHandle<T>(
    345|     ref: {current: T | null} | ((inst: T | null) => mixed) | null | void,
    346|     create: () => T,
    347|     inputs: ?$ReadOnlyArray<mixed>,
@@ -3414,39 +3414,39 @@ References:
           ------^ [1]
 
 
-Error ------------------------------------------------------------------------------- useImperativeMethods_hook.js:31:35
+Error ------------------------------------------------------------------------------- useImperativeHandle_hook.js:31:35
 
-Cannot call `React.useImperativeMethods` with function bound to `create` because inexact object literal [1] is
+Cannot call `React.useImperativeHandle` with function bound to `create` because inexact object literal [1] is
 incompatible with exact `Interface` [2] in the return value.
 
-   useImperativeMethods_hook.js:31:35
-   31|   React.useImperativeMethods(ref, () => ({})); // Error: inexact object literal is incompatible with exact Interface
+   useImperativeHandle_hook.js:31:35
+   31|   React.useImperativeHandle(ref, () => ({})); // Error: inexact object literal is incompatible with exact Interface
                                          ^^^^^^^^^^
 
 References:
-   useImperativeMethods_hook.js:31:42
-   31|   React.useImperativeMethods(ref, () => ({})); // Error: inexact object literal is incompatible with exact Interface
+   useImperativeHandle_hook.js:31:42
+   31|   React.useImperativeHandle(ref, () => ({})); // Error: inexact object literal is incompatible with exact Interface
                                                 ^^ [1]
-   useImperativeMethods_hook.js:30:31
+   useImperativeHandle_hook.js:30:31
    30|   const ref: {current: null | Interface } = React.createRef();
                                      ^^^^^^^^^ [2]
 
 
-Error ------------------------------------------------------------------------------- useImperativeMethods_hook.js:34:41
+Error ------------------------------------------------------------------------------- useImperativeHandle_hook.js:34:41
 
-Cannot call `React.useImperativeMethods` with function bound to `create` because inexact `Interface` [1] is incompatible
+Cannot call `React.useImperativeHandle` with function bound to `create` because inexact `Interface` [1] is incompatible
 with exact object literal [2] in the return value.
 
-   useImperativeMethods_hook.js:34:41
-   34|   React.useImperativeMethods(refSetter, () => ({})); // Error: inexact object literal is incompatible with exact Interface
+   useImperativeHandle_hook.js:34:41
+   34|   React.useImperativeHandle(refSetter, () => ({})); // Error: inexact object literal is incompatible with exact Interface
                                                ^^^^^^^^^^
 
 References:
-   useImperativeMethods_hook.js:33:39
+   useImperativeHandle_hook.js:33:39
    33|   const refSetter = (instance: null | Interface) => {};
                                              ^^^^^^^^^ [1]
-   useImperativeMethods_hook.js:34:48
-   34|   React.useImperativeMethods(refSetter, () => ({})); // Error: inexact object literal is incompatible with exact Interface
+   useImperativeHandle_hook.js:34:48
+   34|   React.useImperativeHandle(refSetter, () => ({})); // Error: inexact object literal is incompatible with exact Interface
                                                       ^^ [2]
 
 
@@ -3573,7 +3573,7 @@ References:
    377|     +useLayoutEffect: typeof useLayoutEffect,
    378|     +useCallback: typeof useCallback,
    379|     +useMemo: typeof useMemo,
-   380|     +useImperativeMethods: typeof useImperativeMethods,
+   380|     +useImperativeHandle: typeof useImperativeHandle,
    381|   |};
           -^ [1]
 
@@ -3618,7 +3618,7 @@ References:
    377|     +useLayoutEffect: typeof useLayoutEffect,
    378|     +useCallback: typeof useCallback,
    379|     +useMemo: typeof useMemo,
-   380|     +useImperativeMethods: typeof useImperativeMethods,
+   380|     +useImperativeHandle: typeof useImperativeHandle,
    381|   |};
           -^ [1]
 
@@ -3663,7 +3663,7 @@ References:
    377|     +useLayoutEffect: typeof useLayoutEffect,
    378|     +useCallback: typeof useCallback,
    379|     +useMemo: typeof useMemo,
-   380|     +useImperativeMethods: typeof useImperativeMethods,
+   380|     +useImperativeHandle: typeof useImperativeHandle,
    381|   |};
           -^ [1]
 
@@ -3708,7 +3708,7 @@ References:
    377|     +useLayoutEffect: typeof useLayoutEffect,
    378|     +useCallback: typeof useCallback,
    379|     +useMemo: typeof useMemo,
-   380|     +useImperativeMethods: typeof useImperativeMethods,
+   380|     +useImperativeHandle: typeof useImperativeHandle,
    381|   |};
           -^ [1]
 
@@ -3753,7 +3753,7 @@ References:
    377|     +useLayoutEffect: typeof useLayoutEffect,
    378|     +useCallback: typeof useCallback,
    379|     +useMemo: typeof useMemo,
-   380|     +useImperativeMethods: typeof useImperativeMethods,
+   380|     +useImperativeHandle: typeof useImperativeHandle,
    381|   |};
           -^ [1]
 
@@ -3798,7 +3798,7 @@ References:
    377|     +useLayoutEffect: typeof useLayoutEffect,
    378|     +useCallback: typeof useCallback,
    379|     +useMemo: typeof useMemo,
-   380|     +useImperativeMethods: typeof useImperativeMethods,
+   380|     +useImperativeHandle: typeof useImperativeHandle,
    381|   |};
           -^ [1]
 
@@ -3843,7 +3843,7 @@ References:
    377|     +useLayoutEffect: typeof useLayoutEffect,
    378|     +useCallback: typeof useCallback,
    379|     +useMemo: typeof useMemo,
-   380|     +useImperativeMethods: typeof useImperativeMethods,
+   380|     +useImperativeHandle: typeof useImperativeHandle,
    381|   |};
           -^ [1]
 
@@ -3888,7 +3888,7 @@ References:
    377|     +useLayoutEffect: typeof useLayoutEffect,
    378|     +useCallback: typeof useCallback,
    379|     +useMemo: typeof useMemo,
-   380|     +useImperativeMethods: typeof useImperativeMethods,
+   380|     +useImperativeHandle: typeof useImperativeHandle,
    381|   |};
           -^ [1]
 
@@ -3933,7 +3933,7 @@ References:
    377|     +useLayoutEffect: typeof useLayoutEffect,
    378|     +useCallback: typeof useCallback,
    379|     +useMemo: typeof useMemo,
-   380|     +useImperativeMethods: typeof useImperativeMethods,
+   380|     +useImperativeHandle: typeof useImperativeHandle,
    381|   |};
           -^ [1]
 

--- a/tests/react/useImperativeHandle_hook.js
+++ b/tests/react/useImperativeHandle_hook.js
@@ -3,7 +3,7 @@
 import React from 'react';
 
 {
-  React.useImperativeMethods(); // Error: function requires another argument.
+  React.useImperativeHandle(); // Error: function requires another argument.
 }
 
 type Interface = {|
@@ -16,10 +16,10 @@ type Interface = {|
   };
 
   const ref: {current: null | Interface } = React.createRef();
-  React.useImperativeMethods(ref, () => api); // Ok
+  React.useImperativeHandle(ref, () => api); // Ok
 
   const refSetter = (instance: null | Interface) => {};
-  React.useImperativeMethods(refSetter, () => api); // Ok
+  React.useImperativeHandle(refSetter, () => api); // Ok
 }
 
 {
@@ -28,8 +28,9 @@ type Interface = {|
   };
 
   const ref: {current: null | Interface } = React.createRef();
-  React.useImperativeMethods(ref, () => ({})); // Error: inexact object literal is incompatible with exact Interface
+  React.useImperativeHandle(ref, () => ({})); // Error: inexact object literal is incompatible with exact Interface
 
   const refSetter = (instance: null | Interface) => {};
-  React.useImperativeMethods(refSetter, () => ({})); // Error: inexact object literal is incompatible with exact Interface
+  React.useImperativeHandle(refSetter, () => ({})); // Error: inexact object literal is incompatible with exact Interface
 }
+  

--- a/tests/react_imports/react_imports.exp
+++ b/tests/react_imports/react_imports.exp
@@ -217,7 +217,7 @@ References:
    377|     +useLayoutEffect: typeof useLayoutEffect,
    378|     +useCallback: typeof useCallback,
    379|     +useMemo: typeof useMemo,
-   380|     +useImperativeMethods: typeof useImperativeMethods,
+   380|     +useImperativeHandle: typeof useImperativeHandle,
    381|   |};
           -^ [1]
 
@@ -262,7 +262,7 @@ References:
    377|     +useLayoutEffect: typeof useLayoutEffect,
    378|     +useCallback: typeof useCallback,
    379|     +useMemo: typeof useMemo,
-   380|     +useImperativeMethods: typeof useImperativeMethods,
+   380|     +useImperativeHandle: typeof useImperativeHandle,
    381|   |};
           -^ [1]
 
@@ -307,7 +307,7 @@ References:
    377|     +useLayoutEffect: typeof useLayoutEffect,
    378|     +useCallback: typeof useCallback,
    379|     +useMemo: typeof useMemo,
-   380|     +useImperativeMethods: typeof useImperativeMethods,
+   380|     +useImperativeHandle: typeof useImperativeHandle,
    381|   |};
           -^ [1]
 


### PR DESCRIPTION
To stay in sync with the change made in https://github.com/facebook/react/pull/14565

Disclaimer: These changes were manual and I'm going to let CI verify them. I'm having trouble actually building Flow locally and running tests. `make` fails with
> hh_shared.c:1524:16: error: conflicting types for 'hh_collect'
CAMLprim value hh_collect(void) {
                ^
> .../flow/_build/hack/heap/hh_shared.h:56:16: note: previous declaration is here
CAMLprim value hh_collect(value aggressive_val);
               ^
hh_shared.c:2670:16: error: conflicting types for 'hh_save_dep_table_sqlite'
CAMLprim value hh_save_dep_table_sqlite(
               ^
.../flow/_build/hack/heap/hh_shared.h:106:16: note: previous declaration is here
CAMLprim value hh_save_dep_table_sqlite(