### PR TITLE
fix(css): userSelect declaration added to CSS declaration

### DIFF
--- a/lib/cssom.js
+++ b/lib/cssom.js
@@ -348,6 +348,7 @@ declare class CSSStyleDeclaration {
   turn: string;
   unicodeBidi: string;
   unicodeRange: string;
+  userSelect: string;
   verticalAlign: string;
   visibility: string;
   webkitOverflowScrolling: string;


### PR DESCRIPTION
Fixes #7359 

- Adds `userSelect` to `CSSStyleDeclaration`