### PR TITLE
Fix issue #7284 (fs.promises.readFile not overloaded correctly)

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -1164,7 +1164,7 @@ declare module "fs" {
   }
 
   declare type FSPromisePath = string | Buffer | URL;
-  declare type FSPromise = {
+  declare class FSPromise {
     access(path: FSPromisePath, mode?: number): Promise<void>,
     appendFile(path: FSPromisePath | FileHandle, data: string | Buffer, options: WriteOptions | string): Promise<void>,
     chmod(path: FSPromisePath, mode: number): Promise<void>,
@@ -1216,7 +1216,7 @@ declare module "fs" {
       data: string | Buffer | Uint8Array,
       options?: string | WriteOptions
     ): Promise<void>,
-  };
+  }
 
   declare var promises: FSPromise;
 }


### PR DESCRIPTION
This fixes issue #7284.

Types can't have overloaded methods (like readFile here). Classes can. (Maybe Flow should error when a type or object has duplicate keys? This has been a common issue in my experience.)