### PR TITLE
Fix MouseEvent type definitions

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -296,7 +296,7 @@ type MouseEvent$MouseEventInit = {
   button?: number,
   buttons?: number,
   region?: string | null,
-  relatedTarget?: string | null,
+  relatedTarget?: EventTarget | null,
 };
 
 declare class MouseEvent extends UIEvent {
@@ -317,11 +317,13 @@ declare class MouseEvent extends UIEvent {
   offsetY: number;
   pageX: number;
   pageY: number;
-  region: ?string;
+  region: string | null;
+  relatedTarget: EventTarget | null;
   screenX: number;
   screenY: number;
   shiftKey: boolean;
-  relatedTarget: ?EventTarget;
+  x: number;
+  y: number;
   getModifierState(keyArg: string): boolean;
 }
 


### PR DESCRIPTION
Fixes a few inaccuracies in the `MouseEvent` typedefs:

- Correct `relatedTarget` in constructor ([docs](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/MouseEvent#Values))
- Replace unnecessary Maybe type with `| null` ([docs](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/region))
- Add missing `x` and `y` properties ([docs](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/x))

Fixes #7354 