### PR TITLE
fix(BOM): XDR

### DIFF
--- a/lib/bom.js
+++ b/lib/bom.js
@@ -561,22 +561,20 @@ declare class WorkerNavigator mixins NavigatorCommon {}
 
 declare class XDomainRequest {
     timeout: number;
-    onerror: (ev: Event) => any;
-    onload: (ev: Event) => any;
-    onprogress: (ev: Event) => any;
-    ontimeout: (ev: Event) => any;
-    responseText: string;
-    contentType: string;
-    open(method: string, url: string): void;
+    onerror(): any;
+    onload(): any;
+    onprogress(): any;
+    ontimeout(): any;
+    +responseText: string;
+    +contentType: string;
+    open(method: "GET" | "POST", url: string): void;
     abort(): void;
-    send(data?: any): void;
-    addEventListener(type: string, listener: (evt: any) => void, useCapture?: boolean): void;
+    send(data?: string): void;
 
     statics: {
         create(): XDomainRequest;
     }
 }
-
 
 declare class XMLHttpRequest extends EventTarget {
     responseBody: any;


### PR DESCRIPTION
- the callbacks don't have a parameter
- `addEventListener` wasn't supported
- 2 properties are readonly
- only two verbs were supported