### PR TITLE
Added optional 'displayName' property to React$Context

### DIFF
--- a/lib/react.js
+++ b/lib/react.js
@@ -202,6 +202,9 @@ declare type React$Ref<ElementType: React$ElementType> =
 declare type React$Context<T> = {
   Provider: React$ComponentType<{ value: T, children?: ?React$Node }>,
   Consumer: React$ComponentType<{ children: (value: T) => ?React$Node }>,
+
+  // Optional, user-specified value for custom display label in React DevTools.
+  displayName?: string,
 }
 
 /**

--- a/tests/getters_and_setters/getters_and_setters.diff
+++ b/tests/getters_and_setters/getters_and_setters.diff
@@ -1,0 +1,24 @@
+--- getters_and_setters.exp
++++ getters_and_setters.out
+@@ -465,8 +465,8 @@
+    react.js:17:13
+     17| (<Example a="bad" />); // error: number ~> string
+                     ^^^^^ [1]
+-   <BUILTINS>/react.js:422:36
+-   422|   number: React$PropType$Primitive<number>;
++   <BUILTINS>/react.js:425:36
++   425|   number: React$PropType$Primitive<number>;
+                                            ^^^^^^ [2]
+ 
+ 
+@@ -482,8 +482,8 @@
+    react.js:18:20
+     18| (<Example a={0} c={0} />); // error: number ~> string
+                            ^ [1]
+-   <BUILTINS>/react.js:424:36
+-   424|   string: React$PropType$Primitive<string>;
++   <BUILTINS>/react.js:427:36
++   427|   string: React$PropType$Primitive<string>;
+                                            ^^^^^^ [2]
+ 
+ 

--- a/tests/more_react/more_react.diff
+++ b/tests/more_react/more_react.diff
@@ -1,0 +1,61 @@
+--- more_react.exp
++++ more_react.out
+@@ -58,15 +58,15 @@
+         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ 
+ References:
+-   <BUILTINS>/react.js:218:41
++   <BUILTINS>/react.js:221:41
+                                                 v---
+-   218|   declare export function checkPropTypes<V>(
+-   219|     propTypes : any,
+-   220|     values: V,
+-   221|     location: string,
+-   222|     componentName: string,
+-   223|     getStack: ?(() => ?string)
+-   224|   ) : void;
++   221|   declare export function checkPropTypes<V>(
++   222|     propTypes : any,
++   223|     values: V,
++   224|     location: string,
++   225|     componentName: string,
++   226|     getStack: ?(() => ?string)
++   227|   ) : void;
+           -------^ [1]
+ 
+ 
+@@ -79,15 +79,15 @@
+         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ 
+ References:
+-   <BUILTINS>/react.js:218:41
++   <BUILTINS>/react.js:221:41
+                                                 v---
+-   218|   declare export function checkPropTypes<V>(
+-   219|     propTypes : any,
+-   220|     values: V,
+-   221|     location: string,
+-   222|     componentName: string,
+-   223|     getStack: ?(() => ?string)
+-   224|   ) : void;
++   221|   declare export function checkPropTypes<V>(
++   222|     propTypes : any,
++   223|     values: V,
++   224|     location: string,
++   225|     componentName: string,
++   226|     getStack: ?(() => ?string)
++   227|   ) : void;
+           -------^ [1]
+ 
+ 
+@@ -104,8 +104,8 @@
+    checkPropTypes.js:12:91
+     12| checkPropTypes({ foo: PropTypes.string }, { foo: 'foo' }, 'value', 'TestComponent', () => 123); // error: number ~> string
+                                                                                                   ^^^ [1]
+-   <BUILTINS>/react.js:223:24
+-   223|     getStack: ?(() => ?string)
++   <BUILTINS>/react.js:226:24
++   226|     getStack: ?(() => ?string)
+                                ^^^^^^ [2]
+ 
+ 

--- a/tests/new_react/new_react.diff
+++ b/tests/new_react/new_react.diff
@@ -1,0 +1,127 @@
+--- new_react.exp
++++ new_react.out
+@@ -193,8 +193,8 @@
+                             ^^^^^^^^^^^^
+ 
+ References:
+-   <BUILTINS>/react.js:422:36
+-   422|   number: React$PropType$Primitive<number>;
++   <BUILTINS>/react.js:425:36
++   425|   number: React$PropType$Primitive<number>;
+                                            ^^^^^^ [1]
+    classes.js:57:12
+     57|     var _: string = this.props.x;
+@@ -420,8 +420,8 @@
+                                   ^^^^^^^^^^^^
+ 
+ References:
+-   <BUILTINS>/react.js:422:36
+-   422|   number: React$PropType$Primitive<number>;
++   <BUILTINS>/react.js:425:36
++   425|   number: React$PropType$Primitive<number>;
+                                            ^^^^^^ [1]
+    new_react.js:19:18
+     19|         var qux: string = this.props.z;
+@@ -437,8 +437,8 @@
+                                ^^^^^^^^^^^^
+ 
+ References:
+-   <BUILTINS>/react.js:424:36
+-   424|   string: React$PropType$Primitive<string>;
++   <BUILTINS>/react.js:427:36
++   427|   string: React$PropType$Primitive<string>;
+                                            ^^^^^^ [1]
+    new_react.js:20:15
+     20|         var w:number = this.props.x;
+@@ -471,8 +471,8 @@
+    new_react.js:29:23
+     29| var element = <C x = {0}/>;
+                               ^ [1]
+-   <BUILTINS>/react.js:424:36
+-   424|   string: React$PropType$Primitive<string>;
++   <BUILTINS>/react.js:427:36
++   427|   string: React$PropType$Primitive<string>;
+                                            ^^^^^^ [2]
+ 
+ 
+@@ -529,8 +529,8 @@
+                                 ^^^^^^^^^^^^
+ 
+ References:
+-   <BUILTINS>/react.js:424:36
+-   424|   string: React$PropType$Primitive<string>;
++   <BUILTINS>/react.js:427:36
++   427|   string: React$PropType$Primitive<string>;
+                                            ^^^^^^ [1]
+    props.js:14:16
+     14|         var a: number = this.props.x; // error
+@@ -566,8 +566,8 @@
+                                 ^^^^^^^^^^^^
+ 
+ References:
+-   <BUILTINS>/react.js:422:36
+-   422|   number: React$PropType$Primitive<number>;
++   <BUILTINS>/react.js:425:36
++   425|   number: React$PropType$Primitive<number>;
+                                            ^^^^^^ [1]
+    props.js:16:16
+     16|         var c: string = this.props.z; // error
+@@ -588,14 +588,14 @@
+    props.js:20:29
+     20| var element = <TestProps x={false} y={false} z={false} />; // 3 errors
+                                     ^^^^^ [1]
+-   <BUILTINS>/react.js:424:36
+-   424|   string: React$PropType$Primitive<string>;
++   <BUILTINS>/react.js:427:36
++   427|   string: React$PropType$Primitive<string>;
+                                            ^^^^^^ [2]
+    props.js:20:49
+     20| var element = <TestProps x={false} y={false} z={false} />; // 3 errors
+                                                         ^^^^^ [3]
+-   <BUILTINS>/react.js:422:36
+-   422|   number: React$PropType$Primitive<number>;
++   <BUILTINS>/react.js:425:36
++   425|   number: React$PropType$Primitive<number>;
+                                            ^^^^^^ [4]
+ 
+ 
+@@ -652,8 +652,8 @@
+    props2.js:9:41
+      9|     getInitialState: function(): { bar: number } {
+                                                 ^^^^^^ [1]
+-   <BUILTINS>/react.js:424:36
+-   424|   string: React$PropType$Primitive<string>;
++   <BUILTINS>/react.js:427:36
++   427|   string: React$PropType$Primitive<string>;
+                                            ^^^^^^ [2]
+    props2.js:15:42
+     15|         return <C {...this.state} foo = {0} />;
+@@ -669,8 +669,8 @@
+                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ 
+ References:
+-   <BUILTINS>/react.js:215:33
+-   215|   declare export var PropTypes: ReactPropTypes;
++   <BUILTINS>/react.js:218:33
++   218|   declare export var PropTypes: ReactPropTypes;
+                                         ^^^^^^^^^^^^^^ [1]
+ 
+ 
+@@ -684,12 +684,12 @@
+                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ 
+ References:
+-   <BUILTINS>/react.js:398:39
++   <BUILTINS>/react.js:401:39
+                                               v
+-   398| type ReactPropsChainableTypeChecker = {
+-   399|   isRequired: ReactPropsCheckType;
+-   400|   (props: any, propName: string, componentName: string, href?: string): ?Error;
+-   401| };
++   401| type ReactPropsChainableTypeChecker = {
++   402|   isRequired: ReactPropsCheckType;
++   403|   (props: any, propName: string, componentName: string, href?: string): ?Error;
++   404| };
+         ^ [1]
+ 
+ 

--- a/tests/react/createContext.js
+++ b/tests/react/createContext.js
@@ -50,3 +50,8 @@ import React from 'react';
     },
   );
 }
+
+{
+  const ThemeContext = createContext("light");
+  ThemeContext.displayName = "ThemeContext";
+}

--- a/tests/react/react.diff
+++ b/tests/react/react.diff
@@ -1,0 +1,1398 @@
+--- react.exp
++++ react.out
+@@ -57,6 +57,14 @@
+                                ^^^^^^^^^^^^^^^^ [2]
+ 
+ 
++Error ------------------------------------------------------------------------------------------- createContext.js:55:24
++
++Cannot resolve name `createContext`.
++
++   55|   const ThemeContext = createContext("light");
++                              ^^^^^^^^^^^^^
++
++
+ Error ------------------------------------------------------------------------ createElementRequiredProp_string.js:17:13
+ 
+ Cannot create `Cmp` element because property `test` is missing in props [1] but exists in object type [2].
+@@ -80,8 +88,8 @@
+              ^^^^^^^^^^^^^^
+ 
+ References:
+-   <BUILTINS>/react.js:424:36
+-   424|   string: React$PropType$Primitive<string>;
++   <BUILTINS>/react.js:427:36
++   427|   string: React$PropType$Primitive<string>;
+                                            ^^^^^^ [1]
+    create_class.js:7:22
+      7|     (this.props.foo: empty); // error: string ~> empty
+@@ -97,8 +105,8 @@
+              ^^^^^^^^^^^^^^
+ 
+ References:
+-   <BUILTINS>/react.js:422:36
+-   422|   number: React$PropType$Primitive<number>;
++   <BUILTINS>/react.js:425:36
++   425|   number: React$PropType$Primitive<number>;
+                                            ^^^^^^ [1]
+    create_class.js:8:22
+      8|     (this.props.bar: empty); // error: number ~> empty
+@@ -251,8 +259,8 @@
+              ^^^^^^^^^^^^^^
+ 
+ References:
+-   <BUILTINS>/react.js:424:36
+-   424|   string: React$PropType$Primitive<string>;
++   <BUILTINS>/react.js:427:36
++   427|   string: React$PropType$Primitive<string>;
+                                            ^^^^^^ [1]
+    create_class.js:117:22
+    117|     (this.props.foo: empty); // string ~> empty
+@@ -268,8 +276,8 @@
+              ^^^^^^^^^^^^^^
+ 
+ References:
+-   <BUILTINS>/react.js:424:36
+-   424|   string: React$PropType$Primitive<string>;
++   <BUILTINS>/react.js:427:36
++   427|   string: React$PropType$Primitive<string>;
+                                            ^^^^^^ [1]
+    create_class.js:118:22
+    118|     (this.state.foo: empty); // string ~> empty
+@@ -285,8 +293,8 @@
+              ^^^^^^^^^^^^^^
+ 
+ References:
+-   <BUILTINS>/react.js:424:36
+-   424|   string: React$PropType$Primitive<string>;
++   <BUILTINS>/react.js:427:36
++   427|   string: React$PropType$Primitive<string>;
+                                            ^^^^^^ [1]
+    create_class.js:133:22
+    133|     (this.props.foo: empty); // string ~> empty
+@@ -302,8 +310,8 @@
+              ^^^^^^^^^^^^^^
+ 
+ References:
+-   <BUILTINS>/react.js:424:36
+-   424|   string: React$PropType$Primitive<string>;
++   <BUILTINS>/react.js:427:36
++   427|   string: React$PropType$Primitive<string>;
+                                            ^^^^^^ [1]
+    create_class.js:137:22
+    137|     (this.props.foo: empty); // string ~> empty
+@@ -319,8 +327,8 @@
+              ^^^^^^^^^^^^^^
+ 
+ References:
+-   <BUILTINS>/react.js:424:36
+-   424|   string: React$PropType$Primitive<string>;
++   <BUILTINS>/react.js:427:36
++   427|   string: React$PropType$Primitive<string>;
+                                            ^^^^^^ [1]
+    create_class.js:141:22
+    141|     (this.props.foo: empty); // string ~> empty
+@@ -336,8 +344,8 @@
+              ^^^^^^^^^^^^^
+ 
+ References:
+-   <BUILTINS>/react.js:424:36
+-   424|   string: React$PropType$Primitive<string>;
++   <BUILTINS>/react.js:427:36
++   427|   string: React$PropType$Primitive<string>;
+                                            ^^^^^^ [1]
+    create_class.js:142:21
+    142|     (nextProps.foo: empty); // string ~> empty
+@@ -353,8 +361,8 @@
+              ^^^^^^^^^^^^^^
+ 
+ References:
+-   <BUILTINS>/react.js:424:36
+-   424|   string: React$PropType$Primitive<string>;
++   <BUILTINS>/react.js:427:36
++   427|   string: React$PropType$Primitive<string>;
+                                            ^^^^^^ [1]
+    create_class.js:146:22
+    146|     (this.props.foo: empty); // string ~> empty
+@@ -387,8 +395,8 @@
+              ^^^^^^^^^^^^^
+ 
+ References:
+-   <BUILTINS>/react.js:424:36
+-   424|   string: React$PropType$Primitive<string>;
++   <BUILTINS>/react.js:427:36
++   427|   string: React$PropType$Primitive<string>;
+                                            ^^^^^^ [1]
+    create_class.js:148:21
+    148|     (nextProps.foo: empty); // string ~> empty
+@@ -435,8 +443,8 @@
+              ^^^^^^^^^^^^^^
+ 
+ References:
+-   <BUILTINS>/react.js:424:36
+-   424|   string: React$PropType$Primitive<string>;
++   <BUILTINS>/react.js:427:36
++   427|   string: React$PropType$Primitive<string>;
+                                            ^^^^^^ [1]
+    create_class.js:153:22
+    153|     (this.props.foo: empty); // string ~> empty
+@@ -469,8 +477,8 @@
+              ^^^^^^^^^^^^^
+ 
+ References:
+-   <BUILTINS>/react.js:424:36
+-   424|   string: React$PropType$Primitive<string>;
++   <BUILTINS>/react.js:427:36
++   427|   string: React$PropType$Primitive<string>;
+                                            ^^^^^^ [1]
+    create_class.js:155:21
+    155|     (nextProps.foo: empty); // string ~> empty
+@@ -503,8 +511,8 @@
+              ^^^^^^^^^^^^^^
+ 
+ References:
+-   <BUILTINS>/react.js:424:36
+-   424|   string: React$PropType$Primitive<string>;
++   <BUILTINS>/react.js:427:36
++   427|   string: React$PropType$Primitive<string>;
+                                            ^^^^^^ [1]
+    create_class.js:160:22
+    160|     (this.props.foo: empty); // string ~> empty
+@@ -537,8 +545,8 @@
+              ^^^^^^^^^^^^^
+ 
+ References:
+-   <BUILTINS>/react.js:424:36
+-   424|   string: React$PropType$Primitive<string>;
++   <BUILTINS>/react.js:427:36
++   427|   string: React$PropType$Primitive<string>;
+                                            ^^^^^^ [1]
+    create_class.js:162:21
+    162|     (nextProps.foo: empty); // string ~> empty
+@@ -571,8 +579,8 @@
+              ^^^^^^^^^^^^^^
+ 
+ References:
+-   <BUILTINS>/react.js:424:36
+-   424|   string: React$PropType$Primitive<string>;
++   <BUILTINS>/react.js:427:36
++   427|   string: React$PropType$Primitive<string>;
+                                            ^^^^^^ [1]
+    create_class.js:167:22
+    167|     (this.props.foo: empty); // string ~> empty
+@@ -1840,8 +1848,8 @@
+    jsx_spread.js:10:19
+     10| var props = {bar: 42};
+                           ^^ [1]
+-   <BUILTINS>/react.js:424:36
+-   424|   string: React$PropType$Primitive<string>;
++   <BUILTINS>/react.js:427:36
++   427|   string: React$PropType$Primitive<string>;
+                                            ^^^^^^ [2]
+ 
+ 
+@@ -1954,8 +1962,8 @@
+    proptype_arrayOf.js:15:45
+     15| var fail_mistyped_elems = <Example arr={[1, "foo"]} />
+                                                     ^^^^^ [1]
+-   <BUILTINS>/react.js:422:36
+-   422|   number: React$PropType$Primitive<number>;
++   <BUILTINS>/react.js:425:36
++   425|   number: React$PropType$Primitive<number>;
+                                            ^^^^^^ [2]
+ 
+ 
+@@ -1971,8 +1979,8 @@
+    proptype_arrayOf.js:20:36
+     20| var todo_required = <Example arr={[null]} />
+                                            ^^^^ [1]
+-   <BUILTINS>/react.js:422:36
+-   422|   number: React$PropType$Primitive<number>;
++   <BUILTINS>/react.js:425:36
++   425|   number: React$PropType$Primitive<number>;
+                                            ^^^^^^ [2]
+ 
+ 
+@@ -1989,8 +1997,8 @@
+    proptype_arrayOf.js:30:25
+     30| (<OptionalExample arr={[""]} />); // error: string ~> number
+                                 ^^ [1]
+-   <BUILTINS>/react.js:422:36
+-   422|   number: React$PropType$Primitive<number>;
++   <BUILTINS>/react.js:425:36
++   425|   number: React$PropType$Primitive<number>;
+                                            ^^^^^^ [2]
+ 
+ 
+@@ -2028,8 +2036,8 @@
+                ^^^^^^^^
+ 
+ References:
+-   <BUILTINS>/react.js:394:13
+-   394|   propName: string,
++   <BUILTINS>/react.js:397:13
++   397|   propName: string,
+                     ^^^^^^ [1]
+    proptype_custom_validator.js:8:18
+      8|       (propName: empty); // error: propName is a string
+@@ -2045,8 +2053,8 @@
+                ^^^^^^^^^^^^^
+ 
+ References:
+-   <BUILTINS>/react.js:395:18
+-   395|   componentName: string,
++   <BUILTINS>/react.js:398:18
++   398|   componentName: string,
+                          ^^^^^^ [1]
+    proptype_custom_validator.js:9:23
+      9|       (componentName: empty); // error: componentName is a string
+@@ -2064,8 +2072,8 @@
+                ^^^^
+ 
+ References:
+-   <BUILTINS>/react.js:396:10
+-   396|   href?: string) => ?Error;
++   <BUILTINS>/react.js:399:10
++   399|   href?: string) => ?Error;
+                  ^^^^^^ [1]
+    proptype_custom_validator.js:10:14
+     10|       (href: empty); // error: href is an optional string
+@@ -2084,8 +2092,8 @@
+    proptype_custom_validator.js:11:18
+     11|       return (0: mixed); // error: should return ?Error
+                          ^^^^^ [1]
+-   <BUILTINS>/react.js:396:22
+-   396|   href?: string) => ?Error;
++   <BUILTINS>/react.js:399:22
++   399|   href?: string) => ?Error;
+                              ^^^^^ [2]
+ 
+ 
+@@ -2178,8 +2186,8 @@
+    proptype_objectOf.js:15:47
+     15| var fail_mistyped_props = <Example obj={{foo: "foo"}} />
+                                                       ^^^^^ [1]
+-   <BUILTINS>/react.js:422:36
+-   422|   number: React$PropType$Primitive<number>;
++   <BUILTINS>/react.js:425:36
++   425|   number: React$PropType$Primitive<number>;
+                                            ^^^^^^ [2]
+ 
+ 
+@@ -2195,8 +2203,8 @@
+    proptype_objectOf.js:20:38
+     20| var todo_required = <Example obj={{p:null}} />
+                                              ^^^^ [1]
+-   <BUILTINS>/react.js:422:36
+-   422|   number: React$PropType$Primitive<number>;
++   <BUILTINS>/react.js:425:36
++   425|   number: React$PropType$Primitive<number>;
+                                            ^^^^^^ [2]
+ 
+ 
+@@ -2212,8 +2220,8 @@
+    proptype_objectOf.js:30:27
+     30| (<OptionalExample obj={{p:""}} />); // error: string ~> number
+                                   ^^ [1]
+-   <BUILTINS>/react.js:422:36
+-   422|   number: React$PropType$Primitive<number>;
++   <BUILTINS>/react.js:425:36
++   425|   number: React$PropType$Primitive<number>;
+                                            ^^^^^^ [2]
+ 
+ 
+@@ -2388,11 +2396,11 @@
+    proptype_oneOfType.js:24:32
+     24| var fail_bool = <Example prop={true} />;
+                                        ^^^^ [1]
+-   <BUILTINS>/react.js:424:36
+-   424|   string: React$PropType$Primitive<string>;
++   <BUILTINS>/react.js:427:36
++   427|   string: React$PropType$Primitive<string>;
+                                            ^^^^^^ [2]
+-   <BUILTINS>/react.js:422:36
+-   422|   number: React$PropType$Primitive<number>;
++   <BUILTINS>/react.js:425:36
++   425|   number: React$PropType$Primitive<number>;
+                                            ^^^^^^ [3]
+ 
+ 
+@@ -2410,11 +2418,11 @@
+    proptype_oneOfType.js:29:36
+     29| var todo_required = <Example prop={null} />;
+                                            ^^^^ [1]
+-   <BUILTINS>/react.js:424:36
+-   424|   string: React$PropType$Primitive<string>;
++   <BUILTINS>/react.js:427:36
++   427|   string: React$PropType$Primitive<string>;
+                                            ^^^^^^ [2]
+-   <BUILTINS>/react.js:422:36
+-   422|   number: React$PropType$Primitive<number>;
++   <BUILTINS>/react.js:425:36
++   425|   number: React$PropType$Primitive<number>;
+                                            ^^^^^^ [3]
+ 
+ 
+@@ -2430,8 +2438,8 @@
+    proptype_oneOfType.js:41:22
+     41| (<OptionalExample p={0} />); // error: number ~> string
+                              ^ [1]
+-   <BUILTINS>/react.js:424:36
+-   424|   string: React$PropType$Primitive<string>;
++   <BUILTINS>/react.js:427:36
++   427|   string: React$PropType$Primitive<string>;
+                                            ^^^^^^ [2]
+ 
+ 
+@@ -2513,14 +2521,14 @@
+          ^^^^^^^^^^^^^^^^^^^^^^^
+ 
+ References:
+-   <BUILTINS>/react.js:404:17
+-   404|   (typeChecker: ReactPropsCheckType) => ReactPropsChainableTypeChecker;
++   <BUILTINS>/react.js:407:17
++   407|   (typeChecker: ReactPropsCheckType) => ReactPropsChainableTypeChecker;
+                         ^^^^^^^^^^^^^^^^^^^ [1]
+    proptypes_builtins.js:3:14
+      3| type NoFun = mixed => empty;
+                      ^^^^^ [2]
+-   <BUILTINS>/react.js:404:41
+-   404|   (typeChecker: ReactPropsCheckType) => ReactPropsChainableTypeChecker;
++   <BUILTINS>/react.js:407:41
++   407|   (typeChecker: ReactPropsCheckType) => ReactPropsChainableTypeChecker;
+                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [3]
+    proptypes_builtins.js:3:23
+      3| type NoFun = mixed => empty;
+@@ -2537,8 +2545,8 @@
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^
+ 
+ References:
+-   <BUILTINS>/react.js:406:27
+-   406|   (expectedClass: any) => ReactPropsChainableTypeChecker;
++   <BUILTINS>/react.js:409:27
++   409|   (expectedClass: any) => ReactPropsChainableTypeChecker;
+                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
+    proptypes_builtins.js:3:23
+      3| type NoFun = mixed => empty;
+@@ -2556,14 +2564,14 @@
+          ^^^^^^^^^^^^^^^^^^^^^^^^
+ 
+ References:
+-   <BUILTINS>/react.js:408:17
+-   408|   (typeChecker: ReactPropsCheckType) => ReactPropsChainableTypeChecker;
++   <BUILTINS>/react.js:411:17
++   411|   (typeChecker: ReactPropsCheckType) => ReactPropsChainableTypeChecker;
+                         ^^^^^^^^^^^^^^^^^^^ [1]
+    proptypes_builtins.js:3:14
+      3| type NoFun = mixed => empty;
+                      ^^^^^ [2]
+-   <BUILTINS>/react.js:408:41
+-   408|   (typeChecker: ReactPropsCheckType) => ReactPropsChainableTypeChecker;
++   <BUILTINS>/react.js:411:41
++   411|   (typeChecker: ReactPropsCheckType) => ReactPropsChainableTypeChecker;
+                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [3]
+    proptypes_builtins.js:3:23
+      3| type NoFun = mixed => empty;
+@@ -2581,14 +2589,14 @@
+          ^^^^^^^^^^^^^^^^^^^^^
+ 
+ References:
+-   <BUILTINS>/react.js:410:20
+-   410|   (expectedValues: Array<any>) => ReactPropsChainableTypeChecker;
++   <BUILTINS>/react.js:413:20
++   413|   (expectedValues: Array<any>) => ReactPropsChainableTypeChecker;
+                            ^^^^^^^^^^ [1]
+    proptypes_builtins.js:3:14
+      3| type NoFun = mixed => empty;
+                      ^^^^^ [2]
+-   <BUILTINS>/react.js:410:35
+-   410|   (expectedValues: Array<any>) => ReactPropsChainableTypeChecker;
++   <BUILTINS>/react.js:413:35
++   413|   (expectedValues: Array<any>) => ReactPropsChainableTypeChecker;
+                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [3]
+    proptypes_builtins.js:3:23
+      3| type NoFun = mixed => empty;
+@@ -2606,14 +2614,14 @@
+          ^^^^^^^^^^^^^^^^^^^^^^^^^
+ 
+ References:
+-   <BUILTINS>/react.js:412:25
+-   412|   (arrayOfTypeCheckers: Array<ReactPropsCheckType>) =>
++   <BUILTINS>/react.js:415:25
++   415|   (arrayOfTypeCheckers: Array<ReactPropsCheckType>) =>
+                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
+    proptypes_builtins.js:3:14
+      3| type NoFun = mixed => empty;
+                      ^^^^^ [2]
+-   <BUILTINS>/react.js:413:5
+-   413|     ReactPropsChainableTypeChecker;
++   <BUILTINS>/react.js:416:5
++   416|     ReactPropsChainableTypeChecker;
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [3]
+    proptypes_builtins.js:3:23
+      3| type NoFun = mixed => empty;
+@@ -2631,14 +2639,14 @@
+          ^^^^^^^^^^^^^^^^^^^^^
+ 
+ References:
+-   <BUILTINS>/react.js:415:16
+-   415|   (shapeTypes: { [key: string]: ReactPropsCheckType }) =>
++   <BUILTINS>/react.js:418:16
++   418|   (shapeTypes: { [key: string]: ReactPropsCheckType }) =>
+                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
+    proptypes_builtins.js:3:14
+      3| type NoFun = mixed => empty;
+                      ^^^^^ [2]
+-   <BUILTINS>/react.js:416:5
+-   416|     ReactPropsChainableTypeChecker;
++   <BUILTINS>/react.js:419:5
++   419|     ReactPropsChainableTypeChecker;
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [3]
+    proptypes_builtins.js:3:23
+      3| type NoFun = mixed => empty;
+@@ -3116,12 +3124,12 @@
+           ^^^^^^^^^^^^^^^^^^^
+ 
+ References:
+-   <BUILTINS>/react.js:336:38
++   <BUILTINS>/react.js:339:38
+                                              v----------------------------------------------
+-   336|   declare export function useCallback<T: (...args: $ReadOnlyArray<empty>) => mixed>(
+-   337|     callback: T,
+-   338|     inputs: ?$ReadOnlyArray<mixed>,
+-   339|   ): T;
++   339|   declare export function useCallback<T: (...args: $ReadOnlyArray<empty>) => mixed>(
++   340|     callback: T,
++   341|     inputs: ?$ReadOnlyArray<mixed>,
++   342|   ): T;
+           ---^ [1]
+ 
+ 
+@@ -3197,39 +3205,39 @@
+           ^^^^^^^^^^^^^^^^^^^^^^^^^
+ 
+ References:
+-   <BUILTINS>/react.js:352:26
++   <BUILTINS>/react.js:355:26
+                                  v-
+-   352|   declare export default {|
+-   353|     +DOM: typeof DOM,
+-   354|     +PropTypes: typeof PropTypes,
+-   355|     +version: typeof version,
+-   356|     +checkPropTypes: typeof checkPropTypes,
+-   357|     +memo: typeof memo,
+-   358|     +lazy: typeof lazy,
+-   359|     +createClass: typeof createClass,
+-   360|     +createContext: typeof createContext,
+-   361|     +createElement: typeof createElement,
+-   362|     +cloneElement: typeof cloneElement,
+-   363|     +createFactory: typeof createFactory,
+-   364|     +createRef: typeof createRef,
+-   365|     +forwardRef: typeof forwardRef,
+-   366|     +isValidElement: typeof isValidElement,
++   355|   declare export default {|
++   356|     +DOM: typeof DOM,
++   357|     +PropTypes: typeof PropTypes,
++   358|     +version: typeof version,
++   359|     +checkPropTypes: typeof checkPropTypes,
++   360|     +memo: typeof memo,
++   361|     +lazy: typeof lazy,
++   362|     +createClass: typeof createClass,
++   363|     +createContext: typeof createContext,
++   364|     +createElement: typeof createElement,
++   365|     +cloneElement: typeof cloneElement,
++   366|     +createFactory: typeof createFactory,
++   367|     +createRef: typeof createRef,
++   368|     +forwardRef: typeof forwardRef,
++   369|     +isValidElement: typeof isValidElement,
+       :
+-   369|     +Fragment: typeof Fragment,
+-   370|     +Children: typeof Children,
+-   371|     +ConcurrentMode: typeof ConcurrentMode,
+-   372|     +StrictMode: typeof StrictMode,
+-   373|     +Suspense: typeof Suspense,
+-   374|     +useContext: typeof useContext,
+-   375|     +useState: typeof useState,
+-   376|     +useReducer: typeof useReducer,
+-   377|     +useRef: typeof useRef,
+-   378|     +useEffect: typeof useEffect,
+-   379|     +useLayoutEffect: typeof useLayoutEffect,
+-   380|     +useCallback: typeof useCallback,
+-   381|     +useMemo: typeof useMemo,
+-   382|     +useImperativeHandle: typeof useImperativeHandle,
+-   383|   |};
++   372|     +Fragment: typeof Fragment,
++   373|     +Children: typeof Children,
++   374|     +ConcurrentMode: typeof ConcurrentMode,
++   375|     +StrictMode: typeof StrictMode,
++   376|     +Suspense: typeof Suspense,
++   377|     +useContext: typeof useContext,
++   378|     +useState: typeof useState,
++   379|     +useReducer: typeof useReducer,
++   380|     +useRef: typeof useRef,
++   381|     +useEffect: typeof useEffect,
++   382|     +useLayoutEffect: typeof useLayoutEffect,
++   383|     +useCallback: typeof useCallback,
++   384|     +useMemo: typeof useMemo,
++   385|     +useImperativeHandle: typeof useImperativeHandle,
++   386|   |};
+           -^ [1]
+ 
+ 
+@@ -3314,39 +3322,39 @@
+                                ^^^^^^^^^^^^^^^^^^^^^^^^
+ 
+ References:
+-   <BUILTINS>/react.js:352:26
++   <BUILTINS>/react.js:355:26
+                                  v-
+-   352|   declare export default {|
+-   353|     +DOM: typeof DOM,
+-   354|     +PropTypes: typeof PropTypes,
+-   355|     +version: typeof version,
+-   356|     +checkPropTypes: typeof checkPropTypes,
+-   357|     +memo: typeof memo,
+-   358|     +lazy: typeof lazy,
+-   359|     +createClass: typeof createClass,
+-   360|     +createContext: typeof createContext,
+-   361|     +createElement: typeof createElement,
+-   362|     +cloneElement: typeof cloneElement,
+-   363|     +createFactory: typeof createFactory,
+-   364|     +createRef: typeof createRef,
+-   365|     +forwardRef: typeof forwardRef,
+-   366|     +isValidElement: typeof isValidElement,
++   355|   declare export default {|
++   356|     +DOM: typeof DOM,
++   357|     +PropTypes: typeof PropTypes,
++   358|     +version: typeof version,
++   359|     +checkPropTypes: typeof checkPropTypes,
++   360|     +memo: typeof memo,
++   361|     +lazy: typeof lazy,
++   362|     +createClass: typeof createClass,
++   363|     +createContext: typeof createContext,
++   364|     +createElement: typeof createElement,
++   365|     +cloneElement: typeof cloneElement,
++   366|     +createFactory: typeof createFactory,
++   367|     +createRef: typeof createRef,
++   368|     +forwardRef: typeof forwardRef,
++   369|     +isValidElement: typeof isValidElement,
+       :
+-   369|     +Fragment: typeof Fragment,
+-   370|     +Children: typeof Children,
+-   371|     +ConcurrentMode: typeof ConcurrentMode,
+-   372|     +StrictMode: typeof StrictMode,
+-   373|     +Suspense: typeof Suspense,
+-   374|     +useContext: typeof useContext,
+-   375|     +useState: typeof useState,
+-   376|     +useReducer: typeof useReducer,
+-   377|     +useRef: typeof useRef,
+-   378|     +useEffect: typeof useEffect,
+-   379|     +useLayoutEffect: typeof useLayoutEffect,
+-   380|     +useCallback: typeof useCallback,
+-   381|     +useMemo: typeof useMemo,
+-   382|     +useImperativeHandle: typeof useImperativeHandle,
+-   383|   |};
++   372|     +Fragment: typeof Fragment,
++   373|     +Children: typeof Children,
++   374|     +ConcurrentMode: typeof ConcurrentMode,
++   375|     +StrictMode: typeof StrictMode,
++   376|     +Suspense: typeof Suspense,
++   377|     +useContext: typeof useContext,
++   378|     +useState: typeof useState,
++   379|     +useReducer: typeof useReducer,
++   380|     +useRef: typeof useRef,
++   381|     +useEffect: typeof useEffect,
++   382|     +useLayoutEffect: typeof useLayoutEffect,
++   383|     +useCallback: typeof useCallback,
++   384|     +useMemo: typeof useMemo,
++   385|     +useImperativeHandle: typeof useImperativeHandle,
++   386|   |};
+           -^ [1]
+ 
+ 
+@@ -3359,12 +3367,12 @@
+           ^^^^^^^^^^^^^^^^^
+ 
+ References:
+-   <BUILTINS>/react.js:326:36
++   <BUILTINS>/react.js:329:36
+                                            v
+-   326|   declare export function useEffect(
+-   327|     create: () => MaybeCleanUpFn,
+-   328|     inputs: ?$ReadOnlyArray<mixed>,
+-   329|   ): void;
++   329|   declare export function useEffect(
++   330|     create: () => MaybeCleanUpFn,
++   331|     inputs: ?$ReadOnlyArray<mixed>,
++   332|   ): void;
+           ------^ [1]
+ 
+ 
+@@ -3377,8 +3385,8 @@
+                           ^ [1]
+ 
+ References:
+-   <BUILTINS>/react.js:327:13
+-   327|     create: () => MaybeCleanUpFn,
++   <BUILTINS>/react.js:330:13
++   330|     create: () => MaybeCleanUpFn,
+                     ^^^^^^^^^^^^^^^^^^^^ [2]
+ 
+ 
+@@ -3392,8 +3400,8 @@
+                                     ^ [1]
+ 
+ References:
+-   <BUILTINS>/react.js:328:14
+-   328|     inputs: ?$ReadOnlyArray<mixed>,
++   <BUILTINS>/react.js:331:14
++   331|     inputs: ?$ReadOnlyArray<mixed>,
+                      ^^^^^^^^^^^^^^^^^^^^^ [2]
+ 
+ 
+@@ -3406,13 +3414,13 @@
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ 
+ References:
+-   <BUILTINS>/react.js:346:46
++   <BUILTINS>/react.js:349:46
+                                                      v---
+-   346|   declare export function useImperativeHandle<T>(
+-   347|     ref: {current: T | null} | ((inst: T | null) => mixed) | null | void,
+-   348|     create: () => T,
+-   349|     inputs: ?$ReadOnlyArray<mixed>,
+-   350|   ): void;
++   349|   declare export function useImperativeHandle<T>(
++   350|     ref: {current: T | null} | ((inst: T | null) => mixed) | null | void,
++   351|     create: () => T,
++   352|     inputs: ?$ReadOnlyArray<mixed>,
++   353|   ): void;
+           ------^ [1]
+ 
+ 
+@@ -3461,12 +3469,12 @@
+           ^^^^^^^^^^^^^^^^^^^^^^^
+ 
+ References:
+-   <BUILTINS>/react.js:331:42
++   <BUILTINS>/react.js:334:42
+                                                  v
+-   331|   declare export function useLayoutEffect(
+-   332|     create: () => MaybeCleanUpFn,
+-   333|     inputs: ?$ReadOnlyArray<mixed>,
+-   334|   ): void;
++   334|   declare export function useLayoutEffect(
++   335|     create: () => MaybeCleanUpFn,
++   336|     inputs: ?$ReadOnlyArray<mixed>,
++   337|   ): void;
+           ------^ [1]
+ 
+ 
+@@ -3480,8 +3488,8 @@
+                                 ^ [1]
+ 
+ References:
+-   <BUILTINS>/react.js:332:13
+-   332|     create: () => MaybeCleanUpFn,
++   <BUILTINS>/react.js:335:13
++   335|     create: () => MaybeCleanUpFn,
+                     ^^^^^^^^^^^^^^^^^^^^ [2]
+ 
+ 
+@@ -3495,8 +3503,8 @@
+                                           ^ [1]
+ 
+ References:
+-   <BUILTINS>/react.js:333:14
+-   333|     inputs: ?$ReadOnlyArray<mixed>,
++   <BUILTINS>/react.js:336:14
++   336|     inputs: ?$ReadOnlyArray<mixed>,
+                      ^^^^^^^^^^^^^^^^^^^^^ [2]
+ 
+ 
+@@ -3509,12 +3517,12 @@
+           ^^^^^^^^^^^^^^^
+ 
+ References:
+-   <BUILTINS>/react.js:341:34
++   <BUILTINS>/react.js:344:34
+                                          v---
+-   341|   declare export function useMemo<T>(
+-   342|     create: () => T,
+-   343|     inputs: ?$ReadOnlyArray<mixed>,
+-   344|   ): T;
++   344|   declare export function useMemo<T>(
++   345|     create: () => T,
++   346|     inputs: ?$ReadOnlyArray<mixed>,
++   347|   ): T;
+           ---^ [1]
+ 
+ 
+@@ -3544,39 +3552,39 @@
+           ^^^^^^^^^^^^^^^^^^^^^^^^^
+ 
+ References:
+-   <BUILTINS>/react.js:352:26
++   <BUILTINS>/react.js:355:26
+                                  v-
+-   352|   declare export default {|
+-   353|     +DOM: typeof DOM,
+-   354|     +PropTypes: typeof PropTypes,
+-   355|     +version: typeof version,
+-   356|     +checkPropTypes: typeof checkPropTypes,
+-   357|     +memo: typeof memo,
+-   358|     +lazy: typeof lazy,
+-   359|     +createClass: typeof createClass,
+-   360|     +createContext: typeof createContext,
+-   361|     +createElement: typeof createElement,
+-   362|     +cloneElement: typeof cloneElement,
+-   363|     +createFactory: typeof createFactory,
+-   364|     +createRef: typeof createRef,
+-   365|     +forwardRef: typeof forwardRef,
+-   366|     +isValidElement: typeof isValidElement,
++   355|   declare export default {|
++   356|     +DOM: typeof DOM,
++   357|     +PropTypes: typeof PropTypes,
++   358|     +version: typeof version,
++   359|     +checkPropTypes: typeof checkPropTypes,
++   360|     +memo: typeof memo,
++   361|     +lazy: typeof lazy,
++   362|     +createClass: typeof createClass,
++   363|     +createContext: typeof createContext,
++   364|     +createElement: typeof createElement,
++   365|     +cloneElement: typeof cloneElement,
++   366|     +createFactory: typeof createFactory,
++   367|     +createRef: typeof createRef,
++   368|     +forwardRef: typeof forwardRef,
++   369|     +isValidElement: typeof isValidElement,
+       :
+-   369|     +Fragment: typeof Fragment,
+-   370|     +Children: typeof Children,
+-   371|     +ConcurrentMode: typeof ConcurrentMode,
+-   372|     +StrictMode: typeof StrictMode,
+-   373|     +Suspense: typeof Suspense,
+-   374|     +useContext: typeof useContext,
+-   375|     +useState: typeof useState,
+-   376|     +useReducer: typeof useReducer,
+-   377|     +useRef: typeof useRef,
+-   378|     +useEffect: typeof useEffect,
+-   379|     +useLayoutEffect: typeof useLayoutEffect,
+-   380|     +useCallback: typeof useCallback,
+-   381|     +useMemo: typeof useMemo,
+-   382|     +useImperativeHandle: typeof useImperativeHandle,
+-   383|   |};
++   372|     +Fragment: typeof Fragment,
++   373|     +Children: typeof Children,
++   374|     +ConcurrentMode: typeof ConcurrentMode,
++   375|     +StrictMode: typeof StrictMode,
++   376|     +Suspense: typeof Suspense,
++   377|     +useContext: typeof useContext,
++   378|     +useState: typeof useState,
++   379|     +useReducer: typeof useReducer,
++   380|     +useRef: typeof useRef,
++   381|     +useEffect: typeof useEffect,
++   382|     +useLayoutEffect: typeof useLayoutEffect,
++   383|     +useCallback: typeof useCallback,
++   384|     +useMemo: typeof useMemo,
++   385|     +useImperativeHandle: typeof useImperativeHandle,
++   386|   |};
+           -^ [1]
+ 
+ 
+@@ -3589,39 +3597,39 @@
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ 
+ References:
+-   <BUILTINS>/react.js:352:26
++   <BUILTINS>/react.js:355:26
+                                  v-
+-   352|   declare export default {|
+-   353|     +DOM: typeof DOM,
+-   354|     +PropTypes: typeof PropTypes,
+-   355|     +version: typeof version,
+-   356|     +checkPropTypes: typeof checkPropTypes,
+-   357|     +memo: typeof memo,
+-   358|     +lazy: typeof lazy,
+-   359|     +createClass: typeof createClass,
+-   360|     +createContext: typeof createContext,
+-   361|     +createElement: typeof createElement,
+-   362|     +cloneElement: typeof cloneElement,
+-   363|     +createFactory: typeof createFactory,
+-   364|     +createRef: typeof createRef,
+-   365|     +forwardRef: typeof forwardRef,
+-   366|     +isValidElement: typeof isValidElement,
++   355|   declare export default {|
++   356|     +DOM: typeof DOM,
++   357|     +PropTypes: typeof PropTypes,
++   358|     +version: typeof version,
++   359|     +checkPropTypes: typeof checkPropTypes,
++   360|     +memo: typeof memo,
++   361|     +lazy: typeof lazy,
++   362|     +createClass: typeof createClass,
++   363|     +createContext: typeof createContext,
++   364|     +createElement: typeof createElement,
++   365|     +cloneElement: typeof cloneElement,
++   366|     +createFactory: typeof createFactory,
++   367|     +createRef: typeof createRef,
++   368|     +forwardRef: typeof forwardRef,
++   369|     +isValidElement: typeof isValidElement,
+       :
+-   369|     +Fragment: typeof Fragment,
+-   370|     +Children: typeof Children,
+-   371|     +ConcurrentMode: typeof ConcurrentMode,
+-   372|     +StrictMode: typeof StrictMode,
+-   373|     +Suspense: typeof Suspense,
+-   374|     +useContext: typeof useContext,
+-   375|     +useState: typeof useState,
+-   376|     +useReducer: typeof useReducer,
+-   377|     +useRef: typeof useRef,
+-   378|     +useEffect: typeof useEffect,
+-   379|     +useLayoutEffect: typeof useLayoutEffect,
+-   380|     +useCallback: typeof useCallback,
+-   381|     +useMemo: typeof useMemo,
+-   382|     +useImperativeHandle: typeof useImperativeHandle,
+-   383|   |};
++   372|     +Fragment: typeof Fragment,
++   373|     +Children: typeof Children,
++   374|     +ConcurrentMode: typeof ConcurrentMode,
++   375|     +StrictMode: typeof StrictMode,
++   376|     +Suspense: typeof Suspense,
++   377|     +useContext: typeof useContext,
++   378|     +useState: typeof useState,
++   379|     +useReducer: typeof useReducer,
++   380|     +useRef: typeof useRef,
++   381|     +useEffect: typeof useEffect,
++   382|     +useLayoutEffect: typeof useLayoutEffect,
++   383|     +useCallback: typeof useCallback,
++   384|     +useMemo: typeof useMemo,
++   385|     +useImperativeHandle: typeof useImperativeHandle,
++   386|   |};
+           -^ [1]
+ 
+ 
+@@ -3634,39 +3642,39 @@
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ 
+ References:
+-   <BUILTINS>/react.js:352:26
++   <BUILTINS>/react.js:355:26
+                                  v-
+-   352|   declare export default {|
+-   353|     +DOM: typeof DOM,
+-   354|     +PropTypes: typeof PropTypes,
+-   355|     +version: typeof version,
+-   356|     +checkPropTypes: typeof checkPropTypes,
+-   357|     +memo: typeof memo,
+-   358|     +lazy: typeof lazy,
+-   359|     +createClass: typeof createClass,
+-   360|     +createContext: typeof createContext,
+-   361|     +createElement: typeof createElement,
+-   362|     +cloneElement: typeof cloneElement,
+-   363|     +createFactory: typeof createFactory,
+-   364|     +createRef: typeof createRef,
+-   365|     +forwardRef: typeof forwardRef,
+-   366|     +isValidElement: typeof isValidElement,
++   355|   declare export default {|
++   356|     +DOM: typeof DOM,
++   357|     +PropTypes: typeof PropTypes,
++   358|     +version: typeof version,
++   359|     +checkPropTypes: typeof checkPropTypes,
++   360|     +memo: typeof memo,
++   361|     +lazy: typeof lazy,
++   362|     +createClass: typeof createClass,
++   363|     +createContext: typeof createContext,
++   364|     +createElement: typeof createElement,
++   365|     +cloneElement: typeof cloneElement,
++   366|     +createFactory: typeof createFactory,
++   367|     +createRef: typeof createRef,
++   368|     +forwardRef: typeof forwardRef,
++   369|     +isValidElement: typeof isValidElement,
+       :
+-   369|     +Fragment: typeof Fragment,
+-   370|     +Children: typeof Children,
+-   371|     +ConcurrentMode: typeof ConcurrentMode,
+-   372|     +StrictMode: typeof StrictMode,
+-   373|     +Suspense: typeof Suspense,
+-   374|     +useContext: typeof useContext,
+-   375|     +useState: typeof useState,
+-   376|     +useReducer: typeof useReducer,
+-   377|     +useRef: typeof useRef,
+-   378|     +useEffect: typeof useEffect,
+-   379|     +useLayoutEffect: typeof useLayoutEffect,
+-   380|     +useCallback: typeof useCallback,
+-   381|     +useMemo: typeof useMemo,
+-   382|     +useImperativeHandle: typeof useImperativeHandle,
+-   383|   |};
++   372|     +Fragment: typeof Fragment,
++   373|     +Children: typeof Children,
++   374|     +ConcurrentMode: typeof ConcurrentMode,
++   375|     +StrictMode: typeof StrictMode,
++   376|     +Suspense: typeof Suspense,
++   377|     +useContext: typeof useContext,
++   378|     +useState: typeof useState,
++   379|     +useReducer: typeof useReducer,
++   380|     +useRef: typeof useRef,
++   381|     +useEffect: typeof useEffect,
++   382|     +useLayoutEffect: typeof useLayoutEffect,
++   383|     +useCallback: typeof useCallback,
++   384|     +useMemo: typeof useMemo,
++   385|     +useImperativeHandle: typeof useImperativeHandle,
++   386|   |};
+           -^ [1]
+ 
+ 
+@@ -3679,39 +3687,39 @@
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ 
+ References:
+-   <BUILTINS>/react.js:352:26
++   <BUILTINS>/react.js:355:26
+                                  v-
+-   352|   declare export default {|
+-   353|     +DOM: typeof DOM,
+-   354|     +PropTypes: typeof PropTypes,
+-   355|     +version: typeof version,
+-   356|     +checkPropTypes: typeof checkPropTypes,
+-   357|     +memo: typeof memo,
+-   358|     +lazy: typeof lazy,
+-   359|     +createClass: typeof createClass,
+-   360|     +createContext: typeof createContext,
+-   361|     +createElement: typeof createElement,
+-   362|     +cloneElement: typeof cloneElement,
+-   363|     +createFactory: typeof createFactory,
+-   364|     +createRef: typeof createRef,
+-   365|     +forwardRef: typeof forwardRef,
+-   366|     +isValidElement: typeof isValidElement,
++   355|   declare export default {|
++   356|     +DOM: typeof DOM,
++   357|     +PropTypes: typeof PropTypes,
++   358|     +version: typeof version,
++   359|     +checkPropTypes: typeof checkPropTypes,
++   360|     +memo: typeof memo,
++   361|     +lazy: typeof lazy,
++   362|     +createClass: typeof createClass,
++   363|     +createContext: typeof createContext,
++   364|     +createElement: typeof createElement,
++   365|     +cloneElement: typeof cloneElement,
++   366|     +createFactory: typeof createFactory,
++   367|     +createRef: typeof createRef,
++   368|     +forwardRef: typeof forwardRef,
++   369|     +isValidElement: typeof isValidElement,
+       :
+-   369|     +Fragment: typeof Fragment,
+-   370|     +Children: typeof Children,
+-   371|     +ConcurrentMode: typeof ConcurrentMode,
+-   372|     +StrictMode: typeof StrictMode,
+-   373|     +Suspense: typeof Suspense,
+-   374|     +useContext: typeof useContext,
+-   375|     +useState: typeof useState,
+-   376|     +useReducer: typeof useReducer,
+-   377|     +useRef: typeof useRef,
+-   378|     +useEffect: typeof useEffect,
+-   379|     +useLayoutEffect: typeof useLayoutEffect,
+-   380|     +useCallback: typeof useCallback,
+-   381|     +useMemo: typeof useMemo,
+-   382|     +useImperativeHandle: typeof useImperativeHandle,
+-   383|   |};
++   372|     +Fragment: typeof Fragment,
++   373|     +Children: typeof Children,
++   374|     +ConcurrentMode: typeof ConcurrentMode,
++   375|     +StrictMode: typeof StrictMode,
++   376|     +Suspense: typeof Suspense,
++   377|     +useContext: typeof useContext,
++   378|     +useState: typeof useState,
++   379|     +useReducer: typeof useReducer,
++   380|     +useRef: typeof useRef,
++   381|     +useEffect: typeof useEffect,
++   382|     +useLayoutEffect: typeof useLayoutEffect,
++   383|     +useCallback: typeof useCallback,
++   384|     +useMemo: typeof useMemo,
++   385|     +useImperativeHandle: typeof useImperativeHandle,
++   386|   |};
+           -^ [1]
+ 
+ 
+@@ -3724,39 +3732,39 @@
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ 
+ References:
+-   <BUILTINS>/react.js:352:26
++   <BUILTINS>/react.js:355:26
+                                  v-
+-   352|   declare export default {|
+-   353|     +DOM: typeof DOM,
+-   354|     +PropTypes: typeof PropTypes,
+-   355|     +version: typeof version,
+-   356|     +checkPropTypes: typeof checkPropTypes,
+-   357|     +memo: typeof memo,
+-   358|     +lazy: typeof lazy,
+-   359|     +createClass: typeof createClass,
+-   360|     +createContext: typeof createContext,
+-   361|     +createElement: typeof createElement,
+-   362|     +cloneElement: typeof cloneElement,
+-   363|     +createFactory: typeof createFactory,
+-   364|     +createRef: typeof createRef,
+-   365|     +forwardRef: typeof forwardRef,
+-   366|     +isValidElement: typeof isValidElement,
++   355|   declare export default {|
++   356|     +DOM: typeof DOM,
++   357|     +PropTypes: typeof PropTypes,
++   358|     +version: typeof version,
++   359|     +checkPropTypes: typeof checkPropTypes,
++   360|     +memo: typeof memo,
++   361|     +lazy: typeof lazy,
++   362|     +createClass: typeof createClass,
++   363|     +createContext: typeof createContext,
++   364|     +createElement: typeof createElement,
++   365|     +cloneElement: typeof cloneElement,
++   366|     +createFactory: typeof createFactory,
++   367|     +createRef: typeof createRef,
++   368|     +forwardRef: typeof forwardRef,
++   369|     +isValidElement: typeof isValidElement,
+       :
+-   369|     +Fragment: typeof Fragment,
+-   370|     +Children: typeof Children,
+-   371|     +ConcurrentMode: typeof ConcurrentMode,
+-   372|     +StrictMode: typeof StrictMode,
+-   373|     +Suspense: typeof Suspense,
+-   374|     +useContext: typeof useContext,
+-   375|     +useState: typeof useState,
+-   376|     +useReducer: typeof useReducer,
+-   377|     +useRef: typeof useRef,
+-   378|     +useEffect: typeof useEffect,
+-   379|     +useLayoutEffect: typeof useLayoutEffect,
+-   380|     +useCallback: typeof useCallback,
+-   381|     +useMemo: typeof useMemo,
+-   382|     +useImperativeHandle: typeof useImperativeHandle,
+-   383|   |};
++   372|     +Fragment: typeof Fragment,
++   373|     +Children: typeof Children,
++   374|     +ConcurrentMode: typeof ConcurrentMode,
++   375|     +StrictMode: typeof StrictMode,
++   376|     +Suspense: typeof Suspense,
++   377|     +useContext: typeof useContext,
++   378|     +useState: typeof useState,
++   379|     +useReducer: typeof useReducer,
++   380|     +useRef: typeof useRef,
++   381|     +useEffect: typeof useEffect,
++   382|     +useLayoutEffect: typeof useLayoutEffect,
++   383|     +useCallback: typeof useCallback,
++   384|     +useMemo: typeof useMemo,
++   385|     +useImperativeHandle: typeof useImperativeHandle,
++   386|   |};
+           -^ [1]
+ 
+ 
+@@ -3769,39 +3777,39 @@
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ 
+ References:
+-   <BUILTINS>/react.js:352:26
++   <BUILTINS>/react.js:355:26
+                                  v-
+-   352|   declare export default {|
+-   353|     +DOM: typeof DOM,
+-   354|     +PropTypes: typeof PropTypes,
+-   355|     +version: typeof version,
+-   356|     +checkPropTypes: typeof checkPropTypes,
+-   357|     +memo: typeof memo,
+-   358|     +lazy: typeof lazy,
+-   359|     +createClass: typeof createClass,
+-   360|     +createContext: typeof createContext,
+-   361|     +createElement: typeof createElement,
+-   362|     +cloneElement: typeof cloneElement,
+-   363|     +createFactory: typeof createFactory,
+-   364|     +createRef: typeof createRef,
+-   365|     +forwardRef: typeof forwardRef,
+-   366|     +isValidElement: typeof isValidElement,
++   355|   declare export default {|
++   356|     +DOM: typeof DOM,
++   357|     +PropTypes: typeof PropTypes,
++   358|     +version: typeof version,
++   359|     +checkPropTypes: typeof checkPropTypes,
++   360|     +memo: typeof memo,
++   361|     +lazy: typeof lazy,
++   362|     +createClass: typeof createClass,
++   363|     +createContext: typeof createContext,
++   364|     +createElement: typeof createElement,
++   365|     +cloneElement: typeof cloneElement,
++   366|     +createFactory: typeof createFactory,
++   367|     +createRef: typeof createRef,
++   368|     +forwardRef: typeof forwardRef,
++   369|     +isValidElement: typeof isValidElement,
+       :
+-   369|     +Fragment: typeof Fragment,
+-   370|     +Children: typeof Children,
+-   371|     +ConcurrentMode: typeof ConcurrentMode,
+-   372|     +StrictMode: typeof StrictMode,
+-   373|     +Suspense: typeof Suspense,
+-   374|     +useContext: typeof useContext,
+-   375|     +useState: typeof useState,
+-   376|     +useReducer: typeof useReducer,
+-   377|     +useRef: typeof useRef,
+-   378|     +useEffect: typeof useEffect,
+-   379|     +useLayoutEffect: typeof useLayoutEffect,
+-   380|     +useCallback: typeof useCallback,
+-   381|     +useMemo: typeof useMemo,
+-   382|     +useImperativeHandle: typeof useImperativeHandle,
+-   383|   |};
++   372|     +Fragment: typeof Fragment,
++   373|     +Children: typeof Children,
++   374|     +ConcurrentMode: typeof ConcurrentMode,
++   375|     +StrictMode: typeof StrictMode,
++   376|     +Suspense: typeof Suspense,
++   377|     +useContext: typeof useContext,
++   378|     +useState: typeof useState,
++   379|     +useReducer: typeof useReducer,
++   380|     +useRef: typeof useRef,
++   381|     +useEffect: typeof useEffect,
++   382|     +useLayoutEffect: typeof useLayoutEffect,
++   383|     +useCallback: typeof useCallback,
++   384|     +useMemo: typeof useMemo,
++   385|     +useImperativeHandle: typeof useImperativeHandle,
++   386|   |};
+           -^ [1]
+ 
+ 
+@@ -3814,39 +3822,39 @@
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ 
+ References:
+-   <BUILTINS>/react.js:352:26
++   <BUILTINS>/react.js:355:26
+                                  v-
+-   352|   declare export default {|
+-   353|     +DOM: typeof DOM,
+-   354|     +PropTypes: typeof PropTypes,
+-   355|     +version: typeof version,
+-   356|     +checkPropTypes: typeof checkPropTypes,
+-   357|     +memo: typeof memo,
+-   358|     +lazy: typeof lazy,
+-   359|     +createClass: typeof createClass,
+-   360|     +createContext: typeof createContext,
+-   361|     +createElement: typeof createElement,
+-   362|     +cloneElement: typeof cloneElement,
+-   363|     +createFactory: typeof createFactory,
+-   364|     +createRef: typeof createRef,
+-   365|     +forwardRef: typeof forwardRef,
+-   366|     +isValidElement: typeof isValidElement,
++   355|   declare export default {|
++   356|     +DOM: typeof DOM,
++   357|     +PropTypes: typeof PropTypes,
++   358|     +version: typeof version,
++   359|     +checkPropTypes: typeof checkPropTypes,
++   360|     +memo: typeof memo,
++   361|     +lazy: typeof lazy,
++   362|     +createClass: typeof createClass,
++   363|     +createContext: typeof createContext,
++   364|     +createElement: typeof createElement,
++   365|     +cloneElement: typeof cloneElement,
++   366|     +createFactory: typeof createFactory,
++   367|     +createRef: typeof createRef,
++   368|     +forwardRef: typeof forwardRef,
++   369|     +isValidElement: typeof isValidElement,
+       :
+-   369|     +Fragment: typeof Fragment,
+-   370|     +Children: typeof Children,
+-   371|     +ConcurrentMode: typeof ConcurrentMode,
+-   372|     +StrictMode: typeof StrictMode,
+-   373|     +Suspense: typeof Suspense,
+-   374|     +useContext: typeof useContext,
+-   375|     +useState: typeof useState,
+-   376|     +useReducer: typeof useReducer,
+-   377|     +useRef: typeof useRef,
+-   378|     +useEffect: typeof useEffect,
+-   379|     +useLayoutEffect: typeof useLayoutEffect,
+-   380|     +useCallback: typeof useCallback,
+-   381|     +useMemo: typeof useMemo,
+-   382|     +useImperativeHandle: typeof useImperativeHandle,
+-   383|   |};
++   372|     +Fragment: typeof Fragment,
++   373|     +Children: typeof Children,
++   374|     +ConcurrentMode: typeof ConcurrentMode,
++   375|     +StrictMode: typeof StrictMode,
++   376|     +Suspense: typeof Suspense,
++   377|     +useContext: typeof useContext,
++   378|     +useState: typeof useState,
++   379|     +useReducer: typeof useReducer,
++   380|     +useRef: typeof useRef,
++   381|     +useEffect: typeof useEffect,
++   382|     +useLayoutEffect: typeof useLayoutEffect,
++   383|     +useCallback: typeof useCallback,
++   384|     +useMemo: typeof useMemo,
++   385|     +useImperativeHandle: typeof useImperativeHandle,
++   386|   |};
+           -^ [1]
+ 
+ 
+@@ -3859,39 +3867,39 @@
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^
+ 
+ References:
+-   <BUILTINS>/react.js:352:26
++   <BUILTINS>/react.js:355:26
+                                  v-
+-   352|   declare export default {|
+-   353|     +DOM: typeof DOM,
+-   354|     +PropTypes: typeof PropTypes,
+-   355|     +version: typeof version,
+-   356|     +checkPropTypes: typeof checkPropTypes,
+-   357|     +memo: typeof memo,
+-   358|     +lazy: typeof lazy,
+-   359|     +createClass: typeof createClass,
+-   360|     +createContext: typeof createContext,
+-   361|     +createElement: typeof createElement,
+-   362|     +cloneElement: typeof cloneElement,
+-   363|     +createFactory: typeof createFactory,
+-   364|     +createRef: typeof createRef,
+-   365|     +forwardRef: typeof forwardRef,
+-   366|     +isValidElement: typeof isValidElement,
++   355|   declare export default {|
++   356|     +DOM: typeof DOM,
++   357|     +PropTypes: typeof PropTypes,
++   358|     +version: typeof version,
++   359|     +checkPropTypes: typeof checkPropTypes,
++   360|     +memo: typeof memo,
++   361|     +lazy: typeof lazy,
++   362|     +createClass: typeof createClass,
++   363|     +createContext: typeof createContext,
++   364|     +createElement: typeof createElement,
++   365|     +cloneElement: typeof cloneElement,
++   366|     +createFactory: typeof createFactory,
++   367|     +createRef: typeof createRef,
++   368|     +forwardRef: typeof forwardRef,
++   369|     +isValidElement: typeof isValidElement,
+       :
+-   369|     +Fragment: typeof Fragment,
+-   370|     +Children: typeof Children,
+-   371|     +ConcurrentMode: typeof ConcurrentMode,
+-   372|     +StrictMode: typeof StrictMode,
+-   373|     +Suspense: typeof Suspense,
+-   374|     +useContext: typeof useContext,
+-   375|     +useState: typeof useState,
+-   376|     +useReducer: typeof useReducer,
+-   377|     +useRef: typeof useRef,
+-   378|     +useEffect: typeof useEffect,
+-   379|     +useLayoutEffect: typeof useLayoutEffect,
+-   380|     +useCallback: typeof useCallback,
+-   381|     +useMemo: typeof useMemo,
+-   382|     +useImperativeHandle: typeof useImperativeHandle,
+-   383|   |};
++   372|     +Fragment: typeof Fragment,
++   373|     +Children: typeof Children,
++   374|     +ConcurrentMode: typeof ConcurrentMode,
++   375|     +StrictMode: typeof StrictMode,
++   376|     +Suspense: typeof Suspense,
++   377|     +useContext: typeof useContext,
++   378|     +useState: typeof useState,
++   379|     +useReducer: typeof useReducer,
++   380|     +useRef: typeof useRef,
++   381|     +useEffect: typeof useEffect,
++   382|     +useLayoutEffect: typeof useLayoutEffect,
++   383|     +useCallback: typeof useCallback,
++   384|     +useMemo: typeof useMemo,
++   385|     +useImperativeHandle: typeof useImperativeHandle,
++   386|   |};
+           -^ [1]
+ 
+ 
+@@ -3904,39 +3912,39 @@
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ 
+ References:
+-   <BUILTINS>/react.js:352:26
++   <BUILTINS>/react.js:355:26
+                                  v-
+-   352|   declare export default {|
+-   353|     +DOM: typeof DOM,
+-   354|     +PropTypes: typeof PropTypes,
+-   355|     +version: typeof version,
+-   356|     +checkPropTypes: typeof checkPropTypes,
+-   357|     +memo: typeof memo,
+-   358|     +lazy: typeof lazy,
+-   359|     +createClass: typeof createClass,
+-   360|     +createContext: typeof createContext,
+-   361|     +createElement: typeof createElement,
+-   362|     +cloneElement: typeof cloneElement,
+-   363|     +createFactory: typeof createFactory,
+-   364|     +createRef: typeof createRef,
+-   365|     +forwardRef: typeof forwardRef,
+-   366|     +isValidElement: typeof isValidElement,
++   355|   declare export default {|
++   356|     +DOM: typeof DOM,
++   357|     +PropTypes: typeof PropTypes,
++   358|     +version: typeof version,
++   359|     +checkPropTypes: typeof checkPropTypes,
++   360|     +memo: typeof memo,
++   361|     +lazy: typeof lazy,
++   362|     +createClass: typeof createClass,
++   363|     +createContext: typeof createContext,
++   364|     +createElement: typeof createElement,
++   365|     +cloneElement: typeof cloneElement,
++   366|     +createFactory: typeof createFactory,
++   367|     +createRef: typeof createRef,
++   368|     +forwardRef: typeof forwardRef,
++   369|     +isValidElement: typeof isValidElement,
+       :
+-   369|     +Fragment: typeof Fragment,
+-   370|     +Children: typeof Children,
+-   371|     +ConcurrentMode: typeof ConcurrentMode,
+-   372|     +StrictMode: typeof StrictMode,
+-   373|     +Suspense: typeof Suspense,
+-   374|     +useContext: typeof useContext,
+-   375|     +useState: typeof useState,
+-   376|     +useReducer: typeof useReducer,
+-   377|     +useRef: typeof useRef,
+-   378|     +useEffect: typeof useEffect,
+-   379|     +useLayoutEffect: typeof useLayoutEffect,
+-   380|     +useCallback: typeof useCallback,
+-   381|     +useMemo: typeof useMemo,
+-   382|     +useImperativeHandle: typeof useImperativeHandle,
+-   383|   |};
++   372|     +Fragment: typeof Fragment,
++   373|     +Children: typeof Children,
++   374|     +ConcurrentMode: typeof ConcurrentMode,
++   375|     +StrictMode: typeof StrictMode,
++   376|     +Suspense: typeof Suspense,
++   377|     +useContext: typeof useContext,
++   378|     +useState: typeof useState,
++   379|     +useReducer: typeof useReducer,
++   380|     +useRef: typeof useRef,
++   381|     +useEffect: typeof useEffect,
++   382|     +useLayoutEffect: typeof useLayoutEffect,
++   383|     +useCallback: typeof useCallback,
++   384|     +useMemo: typeof useMemo,
++   385|     +useImperativeHandle: typeof useImperativeHandle,
++   386|   |};
+           -^ [1]
+ 
+ 
+@@ -3949,13 +3957,13 @@
+           ^^^^^^^^^^^^^^^^^^
+ 
+ References:
+-   <BUILTINS>/react.js:316:37
++   <BUILTINS>/react.js:319:37
+                                             v------
+-   316|   declare export function useReducer<S, A>(
+-   317|     reducer: (S, A) => S,
+-   318|     initialState: S,
+-   319|     initialAction: ?A,
+-   320|   ): [S, A => void];
++   319|   declare export function useReducer<S, A>(
++   320|     reducer: (S, A) => S,
++   321|     initialState: S,
++   322|     initialAction: ?A,
++   323|   ): [S, A => void];
+           ----------------^ [1]
+ 
+ 
+@@ -4099,7 +4107,7 @@
+ 
+ 
+ 
+-Found 240 errors
++Found 241 errors
+ 
+ Only showing the most relevant union/intersection branches.
+ To see all branches, re-run Flow with --show-all-branches

--- a/tests/react_16_3/react_16_3.diff
+++ b/tests/react_16_3/react_16_3.diff
@@ -1,0 +1,13 @@
+--- react_16_3.exp
++++ react_16_3.out
+@@ -43,8 +43,8 @@
+    <BUILTINS>/react-dom.js:284:22
+    284|   button: {instance: HTMLButtonElement, props: {children?: React$Node, [key: string]: any}},
+                              ^^^^^^^^^^^^^^^^^ [2]
+-   <BUILTINS>/react.js:237:6
+-   237|   ): {current: null | T};
++   <BUILTINS>/react.js:240:6
++   240|   ): {current: null | T};
+              ^^^^^^^^^^^^^^^^^^^ [3]
+    <BUILTINS>/react.js:195:6
+    195|   | ((React$ElementRef<ElementType> | null) => mixed)

--- a/tests/react_16_6/react_16_6.diff
+++ b/tests/react_16_6/react_16_6.diff
@@ -1,0 +1,57 @@
+--- react_16_6.exp
++++ react_16_6.out
+@@ -10,8 +10,8 @@
+    Suspense.js:12:48
+     12|   <Suspense fallback={<Loading />} maxDuration="abc" /> // Error: string is incompatible with number
+                                                        ^^^^^ [1]
+-   <BUILTINS>/react.js:264:19
+-   264|     maxDuration?: number
++   <BUILTINS>/react.js:267:19
++   267|     maxDuration?: number
+                           ^^^^^^ [2]
+ 
+ 
+@@ -54,8 +54,8 @@
+    lazy.js:6:1
+      6| function FunctionComponent(x: Props): React.Node { return null }
+         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
+-   <BUILTINS>/react.js:302:22
+-   302|     component: () => Promise<{ default: React$ComponentType<P> }>,
++   <BUILTINS>/react.js:305:22
++   305|     component: () => Promise<{ default: React$ComponentType<P> }>,
+                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [2]
+ 
+ 
+@@ -72,8 +72,8 @@
+    lazy.js:7:7
+      7| class ClassComponent extends React.Component<Props> {}
+               ^^^^^^^^^^^^^^ [1]
+-   <BUILTINS>/react.js:302:22
+-   302|     component: () => Promise<{ default: React$ComponentType<P> }>,
++   <BUILTINS>/react.js:305:22
++   305|     component: () => Promise<{ default: React$ComponentType<P> }>,
+                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [2]
+ 
+ 
+@@ -90,8 +90,8 @@
+    lazy.js:6:1
+      6| function FunctionComponent(x: Props): React.Node { return null }
+         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
+-   <BUILTINS>/react.js:302:30
+-   302|     component: () => Promise<{ default: React$ComponentType<P> }>,
++   <BUILTINS>/react.js:305:30
++   305|     component: () => Promise<{ default: React$ComponentType<P> }>,
+                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [2]
+    <BUILTINS>/core.js:613:24
+    613| declare class Promise<+R> {
+@@ -111,8 +111,8 @@
+    lazy.js:7:7
+      7| class ClassComponent extends React.Component<Props> {}
+               ^^^^^^^^^^^^^^ [1]
+-   <BUILTINS>/react.js:302:30
+-   302|     component: () => Promise<{ default: React$ComponentType<P> }>,
++   <BUILTINS>/react.js:305:30
++   305|     component: () => Promise<{ default: React$ComponentType<P> }>,
+                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [2]
+    <BUILTINS>/core.js:613:24
+    613| declare class Promise<+R> {

--- a/tests/react_abstract_component/react_abstract_component.diff
+++ b/tests/react_abstract_component/react_abstract_component.diff
@@ -1,0 +1,13 @@
+--- react_abstract_component.exp
++++ react_abstract_component.out
+@@ -253,8 +253,8 @@
+    create_element.js:5:94
+      5| declare var C: React$AbstractComponent<{+foo?: number, +bar: number | string, +baz: number}, number>;
+                                                                                                      ^^^^^^ [2]
+-   <BUILTINS>/react.js:237:6
+-   237|   ): {current: null | T};
++   <BUILTINS>/react.js:240:6
++   240|   ): {current: null | T};
+              ^^^^^^^^^^^^^^^^^^^ [3]
+    <BUILTINS>/react.js:195:6
+    195|   | ((React$ElementRef<ElementType> | null) => mixed)

--- a/tests/react_children/react_children.diff
+++ b/tests/react_children/react_children.diff
@@ -1,0 +1,35 @@
+--- react_children.exp
++++ react_children.out
+@@ -68,8 +68,8 @@
+    api.js:14:25
+     14| Children.forEach(a, (x: number) => {}); // Error
+                                 ^^^^^^ [2]
+-   <BUILTINS>/react.js:272:38
+-   272|   declare export type ChildrenArray<+T> = $ReadOnlyArray<ChildrenArray<T>> | T;
++   <BUILTINS>/react.js:275:38
++   275|   declare export type ChildrenArray<+T> = $ReadOnlyArray<ChildrenArray<T>> | T;
+                                              ^ [3]
+ 
+ 
+@@ -90,8 +90,8 @@
+    api.js:16:25
+     16| Children.forEach(a, (x: string) => {}); // Error
+                                 ^^^^^^ [2]
+-   <BUILTINS>/react.js:272:38
+-   272|   declare export type ChildrenArray<+T> = $ReadOnlyArray<ChildrenArray<T>> | T;
++   <BUILTINS>/react.js:275:38
++   275|   declare export type ChildrenArray<+T> = $ReadOnlyArray<ChildrenArray<T>> | T;
+                                              ^ [3]
+    api.js:5:25
+      5| const a: ChildrenArray<?number> = [
+@@ -107,8 +107,8 @@
+           ^^^^^^^^^^^^^^^^^
+ 
+ References:
+-   <BUILTINS>/react.js:284:42
+-   284|     count(children: ChildrenArray<any>): number;
++   <BUILTINS>/react.js:287:42
++   287|     count(children: ChildrenArray<any>): number;
+                                                  ^^^^^^ [1]
+    api.js:29:15
+     29| function s(x: string) {}

--- a/tests/react_imports/react_imports.diff
+++ b/tests/react_imports/react_imports.diff
@@ -1,0 +1,237 @@
+--- react_imports.exp
++++ react_imports.out
+@@ -47,8 +47,8 @@
+                ^^^^^^^^^^^^^
+ 
+ References:
+-   <BUILTINS>/react.js:389:27
+-   389|   declare module.exports: $Exports<'react'>;
++   <BUILTINS>/react.js:392:27
++   392|   declare module.exports: $Exports<'react'>;
+                                   ^^^^^^^^^^^^^^^^^ [1]
+ 
+ 
+@@ -155,8 +155,8 @@
+                ^^^^^^^^^^^^^
+ 
+ References:
+-   <BUILTINS>/react.js:389:27
+-   389|   declare module.exports: $Exports<'react'>;
++   <BUILTINS>/react.js:392:27
++   392|   declare module.exports: $Exports<'react'>;
+                                   ^^^^^^^^^^^^^^^^^ [1]
+ 
+ 
+@@ -186,39 +186,39 @@
+                           ^^^^^^^^^^
+ 
+ References:
+-   <BUILTINS>/react.js:352:26
++   <BUILTINS>/react.js:355:26
+                                  v-
+-   352|   declare export default {|
+-   353|     +DOM: typeof DOM,
+-   354|     +PropTypes: typeof PropTypes,
+-   355|     +version: typeof version,
+-   356|     +checkPropTypes: typeof checkPropTypes,
+-   357|     +memo: typeof memo,
+-   358|     +lazy: typeof lazy,
+-   359|     +createClass: typeof createClass,
+-   360|     +createContext: typeof createContext,
+-   361|     +createElement: typeof createElement,
+-   362|     +cloneElement: typeof cloneElement,
+-   363|     +createFactory: typeof createFactory,
+-   364|     +createRef: typeof createRef,
+-   365|     +forwardRef: typeof forwardRef,
+-   366|     +isValidElement: typeof isValidElement,
++   355|   declare export default {|
++   356|     +DOM: typeof DOM,
++   357|     +PropTypes: typeof PropTypes,
++   358|     +version: typeof version,
++   359|     +checkPropTypes: typeof checkPropTypes,
++   360|     +memo: typeof memo,
++   361|     +lazy: typeof lazy,
++   362|     +createClass: typeof createClass,
++   363|     +createContext: typeof createContext,
++   364|     +createElement: typeof createElement,
++   365|     +cloneElement: typeof cloneElement,
++   366|     +createFactory: typeof createFactory,
++   367|     +createRef: typeof createRef,
++   368|     +forwardRef: typeof forwardRef,
++   369|     +isValidElement: typeof isValidElement,
+       :
+-   369|     +Fragment: typeof Fragment,
+-   370|     +Children: typeof Children,
+-   371|     +ConcurrentMode: typeof ConcurrentMode,
+-   372|     +StrictMode: typeof StrictMode,
+-   373|     +Suspense: typeof Suspense,
+-   374|     +useContext: typeof useContext,
+-   375|     +useState: typeof useState,
+-   376|     +useReducer: typeof useReducer,
+-   377|     +useRef: typeof useRef,
+-   378|     +useEffect: typeof useEffect,
+-   379|     +useLayoutEffect: typeof useLayoutEffect,
+-   380|     +useCallback: typeof useCallback,
+-   381|     +useMemo: typeof useMemo,
+-   382|     +useImperativeHandle: typeof useImperativeHandle,
+-   383|   |};
++   372|     +Fragment: typeof Fragment,
++   373|     +Children: typeof Children,
++   374|     +ConcurrentMode: typeof ConcurrentMode,
++   375|     +StrictMode: typeof StrictMode,
++   376|     +Suspense: typeof Suspense,
++   377|     +useContext: typeof useContext,
++   378|     +useState: typeof useState,
++   379|     +useReducer: typeof useReducer,
++   380|     +useRef: typeof useRef,
++   381|     +useEffect: typeof useEffect,
++   382|     +useLayoutEffect: typeof useLayoutEffect,
++   383|     +useCallback: typeof useCallback,
++   384|     +useMemo: typeof useMemo,
++   385|     +useImperativeHandle: typeof useImperativeHandle,
++   386|   |};
+           -^ [1]
+ 
+ 
+@@ -231,39 +231,39 @@
+              ^^^^^^^^^^
+ 
+ References:
+-   <BUILTINS>/react.js:352:26
++   <BUILTINS>/react.js:355:26
+                                  v-
+-   352|   declare export default {|
+-   353|     +DOM: typeof DOM,
+-   354|     +PropTypes: typeof PropTypes,
+-   355|     +version: typeof version,
+-   356|     +checkPropTypes: typeof checkPropTypes,
+-   357|     +memo: typeof memo,
+-   358|     +lazy: typeof lazy,
+-   359|     +createClass: typeof createClass,
+-   360|     +createContext: typeof createContext,
+-   361|     +createElement: typeof createElement,
+-   362|     +cloneElement: typeof cloneElement,
+-   363|     +createFactory: typeof createFactory,
+-   364|     +createRef: typeof createRef,
+-   365|     +forwardRef: typeof forwardRef,
+-   366|     +isValidElement: typeof isValidElement,
++   355|   declare export default {|
++   356|     +DOM: typeof DOM,
++   357|     +PropTypes: typeof PropTypes,
++   358|     +version: typeof version,
++   359|     +checkPropTypes: typeof checkPropTypes,
++   360|     +memo: typeof memo,
++   361|     +lazy: typeof lazy,
++   362|     +createClass: typeof createClass,
++   363|     +createContext: typeof createContext,
++   364|     +createElement: typeof createElement,
++   365|     +cloneElement: typeof cloneElement,
++   366|     +createFactory: typeof createFactory,
++   367|     +createRef: typeof createRef,
++   368|     +forwardRef: typeof forwardRef,
++   369|     +isValidElement: typeof isValidElement,
+       :
+-   369|     +Fragment: typeof Fragment,
+-   370|     +Children: typeof Children,
+-   371|     +ConcurrentMode: typeof ConcurrentMode,
+-   372|     +StrictMode: typeof StrictMode,
+-   373|     +Suspense: typeof Suspense,
+-   374|     +useContext: typeof useContext,
+-   375|     +useState: typeof useState,
+-   376|     +useReducer: typeof useReducer,
+-   377|     +useRef: typeof useRef,
+-   378|     +useEffect: typeof useEffect,
+-   379|     +useLayoutEffect: typeof useLayoutEffect,
+-   380|     +useCallback: typeof useCallback,
+-   381|     +useMemo: typeof useMemo,
+-   382|     +useImperativeHandle: typeof useImperativeHandle,
+-   383|   |};
++   372|     +Fragment: typeof Fragment,
++   373|     +Children: typeof Children,
++   374|     +ConcurrentMode: typeof ConcurrentMode,
++   375|     +StrictMode: typeof StrictMode,
++   376|     +Suspense: typeof Suspense,
++   377|     +useContext: typeof useContext,
++   378|     +useState: typeof useState,
++   379|     +useReducer: typeof useReducer,
++   380|     +useRef: typeof useRef,
++   381|     +useEffect: typeof useEffect,
++   382|     +useLayoutEffect: typeof useLayoutEffect,
++   383|     +useCallback: typeof useCallback,
++   384|     +useMemo: typeof useMemo,
++   385|     +useImperativeHandle: typeof useImperativeHandle,
++   386|   |};
+           -^ [1]
+ 
+ 
+@@ -276,39 +276,39 @@
+                ^^^^^^^^^^^^^
+ 
+ References:
+-   <BUILTINS>/react.js:352:26
++   <BUILTINS>/react.js:355:26
+                                  v-
+-   352|   declare export default {|
+-   353|     +DOM: typeof DOM,
+-   354|     +PropTypes: typeof PropTypes,
+-   355|     +version: typeof version,
+-   356|     +checkPropTypes: typeof checkPropTypes,
+-   357|     +memo: typeof memo,
+-   358|     +lazy: typeof lazy,
+-   359|     +createClass: typeof createClass,
+-   360|     +createContext: typeof createContext,
+-   361|     +createElement: typeof createElement,
+-   362|     +cloneElement: typeof cloneElement,
+-   363|     +createFactory: typeof createFactory,
+-   364|     +createRef: typeof createRef,
+-   365|     +forwardRef: typeof forwardRef,
+-   366|     +isValidElement: typeof isValidElement,
++   355|   declare export default {|
++   356|     +DOM: typeof DOM,
++   357|     +PropTypes: typeof PropTypes,
++   358|     +version: typeof version,
++   359|     +checkPropTypes: typeof checkPropTypes,
++   360|     +memo: typeof memo,
++   361|     +lazy: typeof lazy,
++   362|     +createClass: typeof createClass,
++   363|     +createContext: typeof createContext,
++   364|     +createElement: typeof createElement,
++   365|     +cloneElement: typeof cloneElement,
++   366|     +createFactory: typeof createFactory,
++   367|     +createRef: typeof createRef,
++   368|     +forwardRef: typeof forwardRef,
++   369|     +isValidElement: typeof isValidElement,
+       :
+-   369|     +Fragment: typeof Fragment,
+-   370|     +Children: typeof Children,
+-   371|     +ConcurrentMode: typeof ConcurrentMode,
+-   372|     +StrictMode: typeof StrictMode,
+-   373|     +Suspense: typeof Suspense,
+-   374|     +useContext: typeof useContext,
+-   375|     +useState: typeof useState,
+-   376|     +useReducer: typeof useReducer,
+-   377|     +useRef: typeof useRef,
+-   378|     +useEffect: typeof useEffect,
+-   379|     +useLayoutEffect: typeof useLayoutEffect,
+-   380|     +useCallback: typeof useCallback,
+-   381|     +useMemo: typeof useMemo,
+-   382|     +useImperativeHandle: typeof useImperativeHandle,
+-   383|   |};
++   372|     +Fragment: typeof Fragment,
++   373|     +Children: typeof Children,
++   374|     +ConcurrentMode: typeof ConcurrentMode,
++   375|     +StrictMode: typeof StrictMode,
++   376|     +Suspense: typeof Suspense,
++   377|     +useContext: typeof useContext,
++   378|     +useState: typeof useState,
++   379|     +useReducer: typeof useReducer,
++   380|     +useRef: typeof useRef,
++   381|     +useEffect: typeof useEffect,
++   382|     +useLayoutEffect: typeof useLayoutEffect,
++   383|     +useCallback: typeof useCallback,
++   384|     +useMemo: typeof useMemo,
++   385|     +useImperativeHandle: typeof useImperativeHandle,
++   386|   |};
+           -^ [1]
+ 
+ 

--- a/tests/react_jsx/react_jsx.diff
+++ b/tests/react_jsx/react_jsx.diff
@@ -1,0 +1,79 @@
+--- react_jsx.exp
++++ react_jsx.out
+@@ -93,8 +93,8 @@
+    test.js:105:12
+    105|   string1={null}
+                    ^^^^ [1]
+-   <BUILTINS>/react.js:424:36
+-   424|   string: React$PropType$Primitive<string>;
++   <BUILTINS>/react.js:427:36
++   427|   string: React$PropType$Primitive<string>;
+                                            ^^^^^^ [2]
+    test.js:106:12
+    106|   string2={null}
+@@ -102,8 +102,8 @@
+    test.js:107:13
+    107|   boolean1={null}
+                     ^^^^ [4]
+-   <BUILTINS>/react.js:420:34
+-   420|   bool: React$PropType$Primitive<boolean>;
++   <BUILTINS>/react.js:423:34
++   423|   bool: React$PropType$Primitive<boolean>;
+                                          ^^^^^^^ [5]
+    test.js:108:13
+    108|   boolean2={null}
+@@ -111,8 +111,8 @@
+    test.js:109:11
+    109|   number={null}
+                   ^^^^ [7]
+-   <BUILTINS>/react.js:422:36
+-   422|   number: React$PropType$Primitive<number>;
++   <BUILTINS>/react.js:425:36
++   425|   number: React$PropType$Primitive<number>;
+                                            ^^^^^^ [8]
+ 
+ 
+@@ -161,8 +161,8 @@
+    test.js:135:54
+    135|   {...{string1: 'foo', string2: 'bar', number: (any: ?number)}}
+                                                              ^^^^^^^ [1]
+-   <BUILTINS>/react.js:422:36
+-   422|   number: React$PropType$Primitive<number>;
++   <BUILTINS>/react.js:425:36
++   425|   number: React$PropType$Primitive<number>;
+                                            ^^^^^^ [2]
+ 
+ 
+@@ -1654,8 +1654,8 @@
+    <BUILTINS>/core.js:13:24
+     13| declare var undefined: void;
+                                ^^^^ [1]
+-   <BUILTINS>/react.js:422:36
+-   422|   number: React$PropType$Primitive<number>;
++   <BUILTINS>/react.js:425:36
++   425|   number: React$PropType$Primitive<number>;
+                                            ^^^^^^ [2]
+ 
+ 
+@@ -1675,8 +1675,8 @@
+    test.js:788:7
+    788|   foo="nope"
+               ^^^^^^ [1]
+-   <BUILTINS>/react.js:422:36
+-   422|   number: React$PropType$Primitive<number>;
++   <BUILTINS>/react.js:425:36
++   425|   number: React$PropType$Primitive<number>;
+                                            ^^^^^^ [2]
+ 
+ 
+@@ -1696,8 +1696,8 @@
+    test.js:793:7
+    793|   bar="nope"
+               ^^^^^^ [1]
+-   <BUILTINS>/react.js:422:36
+-   422|   number: React$PropType$Primitive<number>;
++   <BUILTINS>/react.js:425:36
++   425|   number: React$PropType$Primitive<number>;
+                                            ^^^^^^ [2]
+ 
+ 

--- a/tests/type-at-pos_react/type-at-pos_react.diff
+++ b/tests/type-at-pos_react/type-at-pos_react.diff
@@ -1,0 +1,20 @@
+--- type-at-pos_react.exp
++++ type-at-pos_react.out
+@@ -113,7 +113,7 @@
+     "kind":"Generic",
+     "typeArgs":[{"kind":"Num"}],
+     "type":{
+-      "provenance":{"kind":"Library","loc":"[LIB] react.js:245:43-61"},
++      "provenance":{"kind":"Library","loc":"[LIB] react.js:248:43-61"},
+       "name":"ComponentType"
+     },
+     "kind":"type alias"
+@@ -136,7 +136,7 @@
+   "expanded_type":{
+     "kind":"TypeAlias",
+     "name":{
+-      "provenance":{"kind":"Library","loc":"[LIB] react.js:245:43-61"},
++      "provenance":{"kind":"Library","loc":"[LIB] react.js:248:43-61"},
+       "name":"ComponentType"
+     },
+     "typeParams":[{"name":"P","bound":null,"polarity":"Negative"}],


### PR DESCRIPTION
Related: https://github.com/facebook/react/issues/12695#issuecomment-456979851

Context providers and consumers [support a custom display in React DevTools](https://github.com/facebook/react-devtools/blob/38fe9782f82fbcb4f6137e5b920147d35ebe1992/backend/attachRendererFiber.js#L362-L387) like so:

```js
const ThemeContext = React.createContext("light");
ThemeContext.displayName = 'ThemeContext';

<ThemeContext.Provider> // "ThemeContext.Provider" in DevTools
<ThemeContext.Consumer> // "ThemeContext.Consumer" in DevTools
```

cc @jbrown215 