### PR TITLE
Add Node.js strict mode assert typedef

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -2107,6 +2107,25 @@ declare module "zlib" {
 
 declare module "assert" {
   declare class AssertionError extends Error {}
+
+  declare type AssertStrict = {
+    (value: any, message?: string): void;
+    ok(value: any, message?: string): void;
+    fail(actual: any, expected: any, message: string, operator: string): void;
+    equal(actual: any, expected: any, message?: string): void;
+    notEqual(actual: any, expected: any, message?: string): void;
+    deepEqual(actual: any, expected: any, message?: string): void;
+    notDeepEqual(actual: any, expected: any, message?: string): void;
+    throws(
+      block: Function,
+      error?: Function | RegExp | (err: any) => boolean,
+      message?: string
+    ): void;
+    doesNotThrow(block: Function, message?: string): void;
+    ifError(value: any): void;
+    AssertionError: typeof AssertionError;
+  };
+
   declare module.exports: {
     (value: any, message?: string): void;
     ok(value: any, message?: string): void;
@@ -2127,6 +2146,7 @@ declare module "assert" {
     doesNotThrow(block: Function, message?: string): void;
     ifError(value: any): void;
     AssertionError: typeof AssertionError;
+    strict: AssertStrict;
   }
 }
 


### PR DESCRIPTION
Closes #7217 

Node 8.13 / 9.9 introduced [strict mode for asserts](https://nodejs.org/docs/latest-v10.x/api/assert.html#assert_strict_mode). The object is imported via 

```js
const assert = require('assert').strict
``` 

and it has the same shape as the original assert minus all of the `*Strict` functions 

``` js 
> const assert = require('assert').strict 
undefined
> typeof assert 
'function'
> typeof assert.AssertionError
'function'
> typeof assert.deepEqualStrict 
'undefined'
> typeof assert.deepEqual
'function'
> typeof assert.ok
'function'
> typeof assert.throws
'function'
> typeof assert.ifError
'function'
```

so I've copied the original definition and deleted all of the functions that aren't there any more. I've tested this by copying the `assert` module definition into my own project, and it seems to work. 