### PR TITLE
docs: add `declarations` page to config

### DIFF
--- a/website/_data/guides.yml
+++ b/website/_data/guides.yml
@@ -86,6 +86,7 @@
 - id: config
   pages:
     - path: "/docs/config/"
+    - path: "/docs/config/declarations/"
     - path: "/docs/config/include/"
     - path: "/docs/config/ignore/"
     - path: "/docs/config/untyped/"


### PR DESCRIPTION
Hi,

`[declarations]` is missing in the page config. Hence no TOC, no title. 
https://flow.org/en/docs/config/declarations 

