### PR TITLE
[DOCS] Fix typo in react hoc doc

### DIFF
--- a/website/en/docs/react/hoc.md
+++ b/website/en/docs/react/hoc.md
@@ -44,7 +44,7 @@ do anything at all. Let's take a look at some more complex examples.
 ### Injecting Props <a class="toc" id="toc-injecting-props" href="#toc-injecting-props"></a>
 
 A common use case for higher-order components is to inject a prop.
-The HOC automatically sets a prop and returns a component which no long requires
+The HOC automatically sets a prop and returns a component which no longer requires
 that prop. For example, consider a navigation prop, or in the case of
 [`react-redux` a `store` prop][]. How would one type this?
 


### PR DESCRIPTION
<!--
  If this is a change to library defintions, please include links to relevant documentation.
  If this is a documentation change, please prefix the title with [DOCS].

  If this is neither, ensure you opened a discussion issue and link it in the PR description.
-->

Fix a typo in react hoc doc:

> The HOC automatically sets a prop and returns a component which ~~no long~~ -> _no longer_ requires that prop.
