### PR TITLE
Make useRef type not nullable

### DIFF
--- a/lib/react.js
+++ b/lib/react.js
@@ -322,7 +322,7 @@ declare module react {
     initialAction: ?A,
   ): [S, A => void];
 
-  declare export function useRef<T>(initialValue: ?T): {current: T | null};
+  declare export function useRef<T>(initialValue: T): {current: T};
 
   declare export function useDebugValue(value: any): void;
 

--- a/tests/react/useRef_hook.js
+++ b/tests/react/useRef_hook.js
@@ -6,9 +6,9 @@ class Foo extends React.Component<{}, void> {}
 class Bar extends React.Component<{}, void> {}
 
 {
-  const stringValue: {current: string | null} = React.useRef("abc"); // Ok
-  const numberValue: {current: number | null} = React.useRef(123); // Ok
-  const booleanValue: {current: boolean | null} = React.useRef(true); // Ok
+  const stringValue: {current: string} = React.useRef("abc"); // Ok
+  const numberValue: {current: number} = React.useRef(123); // Ok
+  const booleanValue: {current: boolean} = React.useRef(true); // Ok
   const nullValue: {current: null} = React.useRef(null); // Ok
 }
 
@@ -19,7 +19,7 @@ class Bar extends React.Component<{}, void> {}
 }
 
 {
-  const stringValue: {current: string | null} = React.useRef();
+  const stringValue: {current: string | null} = React.useRef(null);
   stringValue.current = "foo"; // Ok
   stringValue.current = 123; // Error: number is incompatible with string in property current
 }


### PR DESCRIPTION
Ref https://github.com/facebook/flow/issues/7226

In this diff I made two changes
- made initialValue of useRef required
- made useRef type non nullable

This should dramatically simplify using refs for things other than
react elements.

I didn't get how to regenerate tests.

/cc @jbrown215 @bvaughn 