### PR TITLE
fix: add missing ocaml includes for flow-parser-bin

### DIFF
--- a/packages/flow-parser-bin/binding.gyp
+++ b/packages/flow-parser-bin/binding.gyp
@@ -13,12 +13,16 @@
         "src/flow_parser_node.cc",
       ],
       "include_dirs": [
+        "<!(opam config var lib)/ocaml",
         "include/",
         "<!(node -e \"require('nan')\")",
       ],
       "libraries": [
         "-L../lib/<(platform)",
+        "-L<!(opam config var lib)/ocaml",
         "-lflowparser",
+        "-lbigarray",
+        "-lunix"
       ],
       "conditions": [
         ['OS=="mac"', {

--- a/packages/flow-parser-bin/package.json
+++ b/packages/flow-parser-bin/package.json
@@ -26,6 +26,11 @@
     "Makefile",
     "SHASUM256.txt"
   ],
-  "os": ["darwin", "linux"],
-  "cpu": ["x64"]
+  "os": [
+    "darwin",
+    "linux"
+  ],
+  "cpu": [
+    "x64"
+  ]
 }

--- a/packages/flow-parser-bin/yarn.lock
+++ b/packages/flow-parser-bin/yarn.lock
@@ -5,7 +5,9 @@
 bindings@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.3.0.tgz#b346f6ecf6a95f5a815c5839fc7cdb22502f1ed7"
+  integrity sha512-DpLh5EzMR2kzvX1KIlVC0VkC3iZtHKTgdtZ0a3pglBZdaQFjt5S9g9xd1lE+YvXyfd6mtCeRnrUfOLYiTMlNSw==
 
 nan@^2.8.0:
   version "2.8.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.8.0.tgz#ed715f3fe9de02b57a5e6252d90a96675e1f085a"
+  integrity sha1-7XFfP+neArV6XmJS2QqWZ14fCFo=


### PR DESCRIPTION
<!--
  If this is a change to library defintions, please include links to relevant documentation.
  If this is a documentation change, please prefix the title with [DOCS].

  If this is neither, ensure you opened a discussion issue and link it in the PR description.
-->

flow-parser-bin requires opam and ocaml static libs to be installed, from what I gather. Maybe it requires a dynamic lib instead, but I was unable to find it for osx. Suggestions welcome!