### PR TITLE
Update the JSON.stringify

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -475,7 +475,7 @@ declare class URIError extends Error {
 declare class JSON {
     static parse(text: string, reviver?: (key: any, value: any) => any): any;
     static stringify(
-      value: null | string | number | boolean | Symbol | {} | $ReadOnlyArray<mixed>,
+      value: null | string | number | boolean | {} | $ReadOnlyArray<mixed>,
       replacer?: ?((key: string, value: any) => any) | Array<any>,
       space?: string | number
     ): string;

--- a/lib/core.js
+++ b/lib/core.js
@@ -475,7 +475,7 @@ declare class URIError extends Error {
 declare class JSON {
     static parse(text: string, reviver?: (key: any, value: any) => any): any;
     static stringify(
-      value: any,
+      value: null | string | number | boolean | Symbol | {} | $ReadOnlyArray<mixed>,
       replacer?: ?((key: string, value: any) => any) | Array<any>,
       space?: string | number
     ): string;


### PR DESCRIPTION
To disallow undefined and functions from being passed in.
JSON.stringify will return undefined if undefined or a function is passed in.

if we allow undefined and functions to be passed in, we would need to change the return value to be `void | string` to be correct. Since that would cause way more trouble for users of JSON.stringify, disallowing the problematic inputs seems like the correct approach here.

<!--
  If this is a change to library defintions, please include links to relevant documentation.
  If this is a documentation change, please prefix the title with [DOCS].

  If this is neither, ensure you opened a discussion issue and link it in the PR description.
-->
