### PR TITLE
Tweaks to built-in http module.

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -1324,23 +1324,38 @@ declare class http$ServerResponse extends stream$Writable {
   writeHead(status: number, headers?: {[key: string] : string}): void;
 }
 
-declare module "http" {
-  declare class Server extends net$Server {
-    listen(port?: number, hostname?: string, backlog?: number, callback?: Function): Server;
-    // The following signatures are added to allow omitting intermediate arguments
-    listen(port?: number, backlog?: number, callback?: Function): Server;
-    listen(port?: number, hostname?: string, callback?: Function): Server;
-    listen(port?: number, callback?: Function): Server;
-    listen(path: string, callback?: Function): Server;
-    listen(handle: Object, callback?: Function): Server;
-    listening: boolean;
-    close(callback?: (error: ?Error) => mixed): Server;
-    maxHeadersCount: number;
-    keepAliveTimeout: number;
-    setTimeout(msecs: number, callback: Function): Server;
-    timeout: number;
-  }
+declare class http$Server extends net$Server {
+  listen(port?: number, hostname?: string, backlog?: number, callback?: Function): this;
+  // The following signatures are added to allow omitting intermediate arguments
+  listen(port?: number, backlog?: number, callback?: Function): this;
+  listen(port?: number, hostname?: string, callback?: Function): this;
+  listen(port?: number, callback?: Function): this;
+  listen(path: string, callback?: Function): this;
+  listen(handle: Object, callback?: Function): this;
+  listening: boolean;
+  close(callback?: (error: ?Error) => mixed): this;
+  maxHeadersCount: number;
+  keepAliveTimeout: number;
+  setTimeout(msecs: number, callback: Function): this;
+  timeout: number;
+}
 
+declare class https$Server extends tls$Server {
+  listen(port?: number, hostname?: string, backlog?: number, callback?: Function): this;
+  // The following signatures are added to allow omitting intermediate arguments
+  listen(port?: number, backlog?: number, callback?: Function): this;
+  listen(port?: number, hostname?: string, callback?: Function): this;
+  listen(port?: number, callback?: Function): this;
+  listen(path: string, callback?: Function): this;
+  listen(handle: Object, callback?: Function): this;
+  close(callback?: (error: ?Error) => mixed): this;
+  keepAliveTimeout: number;
+  setTimeout(msecs: number, callback: Function): this;
+  timeout: number;
+}
+
+declare module "http" {
+  declare class Server extends http$Server {}
   declare class Agent extends http$Agent<net$Socket> {
     createConnection(options: net$connectOptions, callback?: Function): net$Socket;
   }
@@ -1366,20 +1381,7 @@ declare module "http" {
 }
 
 declare module "https" {
-  declare class Server extends tls$Server {
-    listen(port?: number, hostname?: string, backlog?: number, callback?: Function): Server;
-    // The following signatures are added to allow omitting intermediate arguments
-    listen(port?: number, backlog?: number, callback?: Function): Server;
-    listen(port?: number, hostname?: string, callback?: Function): Server;
-    listen(port?: number, callback?: Function): Server;
-    listen(path: string, callback?: Function): Server;
-    listen(handle: Object, callback?: Function): Server;
-    close(callback?: (error: ?Error) => mixed): Server;
-    keepAliveTimeout: number;
-    setTimeout(msecs: number, callback: Function): Server;
-    timeout: number;
-  }
-
+  declare class Server extends https$Server {}
   declare class Agent extends http$Agent<tls$TLSSocket> {
     createConnection(port: ?number, host: ?string, options: tls$connectOptions): tls$TLSSocket;
     createConnection(port: ?number, options: tls$connectOptions): tls$TLSSocket;


### PR DESCRIPTION
In particular, it was not possible for libdefs
to import http$Server (making it difficult to type e.g. Express),
because imports in libdefs appear to coerce the module into a
broken type.

This makes http$Server and https$Server globals so they can be
easily used in libdefs without importing 'http'.

Additionally, added a third listen() form without the `backlog` arg.

Continued from #4091, ping @nmote.