### PR TITLE
adds type definitions for String.prototype.trimStart/trimEnd

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -319,8 +319,10 @@ declare class String {
     toLowerCase(): string;
     toUpperCase(): string;
     trim(): string;
+    trimEnd(): string;
     trimLeft(): string;
     trimRight(): string;
+    trimStart(): string;
     valueOf(): string;
     toString(): string;
     length: number;


### PR DESCRIPTION
`String.prototype.trimStart/trimEnd` has been added to the ECMAScript 2019 spec and feature set.

additional info:
http://2ality.com/2018/02/ecmascript-2019.html
http://2ality.com/2019/01/string-prototype-trimstart-trimend.html
