### PR TITLE
add type def for Symbol.prototype.description

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -85,6 +85,7 @@ declare class $SymbolUnscopables mixins Symbol {}
 declare class Symbol {
   static (value?:any): Symbol;
   static for(key: string): Symbol;
+  +description: string | void;
   static hasInstance: $SymbolHasInstance;
   static isConcatSpreadable: $SymboIsConcatSpreadable;
   static iterator: string; // polyfill '@@iterator'


### PR DESCRIPTION
`Symbol.prototype.description` has been added to the ECMAScript 2019 spec and feature set.

additional info:
http://2ality.com/2018/02/ecmascript-2019.html

http://2ality.com/2019/01/symbol-prototype-description.html

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/description