### PR TITLE
Add type definitions for service worker PushManager

### DIFF
--- a/lib/serviceworkers.js
+++ b/lib/serviceworkers.js
@@ -97,16 +97,16 @@ declare class PushSubscriptionJSON {
 }
 
 declare class PushSubscription {
-  endpoint: string,
-  expirationTime: number | null,
-  options: PushSubscriptionOptions,
+  +endpoint: string,
+  +expirationTime: number | null,
+  +options: PushSubscriptionOptions,
   getKey(name: string): ArrayBuffer | null,
   toJSON(): PushSubscriptionJSON,
   unsubscribe(): Promise<boolean>,
 }
 
 declare class PushManager {
-  supportedContentEncodings: Array<string>,
+  +supportedContentEncodings: Array<string>,
   subscribe(options?: PushSubscriptionOptions): Promise<PushSubscription>,
   getSubscription(): Promise<PushSubscription | null>,
   permissionState(options?: PushSubscriptionOptions): Promise<'granted' | 'denied' | 'prompt'>,
@@ -115,13 +115,13 @@ declare class PushManager {
 type ServiceWorkerUpdateViaCache = 'imports' | 'all' | 'none';
 
 declare class ServiceWorkerRegistration extends EventTarget {
-  installing: ?ServiceWorker,
-  waiting: ?ServiceWorker,
-  active: ?ServiceWorker,
-  navigationPreload: NavigationPreloadManager,
-  scope: string,
-  updateViaCache: ServiceWorkerUpdateViaCache,
-  pushManager: PushManager,
+  +installing: ?ServiceWorker,
+  +waiting: ?ServiceWorker,
+  +active: ?ServiceWorker,
+  +navigationPreload: NavigationPreloadManager,
+  +scope: string,
+  +updateViaCache: ServiceWorkerUpdateViaCache,
+  +pushManager: PushManager,
 
   update(): Promise<void>,
   unregister(): Promise<boolean>,
@@ -138,8 +138,8 @@ type RegistrationOptions = {
 };
 
 declare class ServiceWorkerContainer extends EventTarget {
-  controller: ?ServiceWorker,
-  ready: Promise<ServiceWorkerRegistration>,
+  +controller: ?ServiceWorker,
+  +ready: Promise<ServiceWorkerRegistration>,
 
   getRegistration(clientURL: string): Promise<?ServiceWorkerRegistration>,
   getRegistrations(): Promise<Iterator<ServiceWorkerRegistration>>,
@@ -151,6 +151,7 @@ declare class ServiceWorkerContainer extends EventTarget {
 
   oncontrollerchange?: EventHandler,
   onmessage?: EventHandler,
+  onmessageerror?: EventHandler,
 }
 
 /**

--- a/lib/serviceworkers.js
+++ b/lib/serviceworkers.js
@@ -85,13 +85,43 @@ declare class NavigationPreloadManager {
   getState: Promise<NavigationPreloadState>,
 }
 
+type PushSubscriptionOptions = {
+  userVisibleOnly?: boolean,
+  applicationServerKey?: string | ArrayBuffer | $ArrayBufferView,
+}
+
+declare class PushSubscriptionJSON {
+  endpoint: string,
+  expirationTime: number | null,
+  keys: {[string]: string};
+}
+
+declare class PushSubscription {
+  endpoint: string,
+  expirationTime: number | null,
+  options: PushSubscriptionOptions,
+  getKey(name: string): ArrayBuffer | null,
+  toJSON(): PushSubscriptionJSON,
+  unsubscribe(): Promise<boolean>,
+}
+
+declare class PushManager {
+  supportedContentEncodings: Array<string>,
+  subscribe(options?: PushSubscriptionOptions): Promise<PushSubscription>,
+  getSubscription(): Promise<PushSubscription | null>,
+  permissionState(options?: PushSubscriptionOptions): Promise<'granted' | 'denied' | 'prompt'>,
+}
+
+type ServiceWorkerUpdateViaCache = 'imports' | 'all' | 'none';
+
 declare class ServiceWorkerRegistration extends EventTarget {
   installing: ?ServiceWorker,
   waiting: ?ServiceWorker,
   active: ?ServiceWorker,
   navigationPreload: NavigationPreloadManager,
-
   scope: string,
+  updateViaCache: ServiceWorkerUpdateViaCache,
+  pushManager: PushManager,
 
   update(): Promise<void>,
   unregister(): Promise<boolean>,
@@ -102,8 +132,9 @@ declare class ServiceWorkerRegistration extends EventTarget {
 type WorkerType = 'classic' | 'module';
 
 type RegistrationOptions = {
-  scope: string,
-  type: WorkerType,
+  scope?: string,
+  type?: WorkerType,
+  updateViaCache?: ServiceWorkerUpdateViaCache,
 };
 
 declare class ServiceWorkerContainer extends EventTarget {
@@ -114,7 +145,7 @@ declare class ServiceWorkerContainer extends EventTarget {
   getRegistrations(): Promise<Iterator<ServiceWorkerRegistration>>,
   register(
     scriptURL: string,
-    options: ?RegistrationOptions
+    options?: RegistrationOptions
   ): Promise<ServiceWorkerRegistration>,
   startMessages(): void,
 


### PR DESCRIPTION
Library definitions for service worker `PushManager` and some fixes in `ServiceWorkerRegistration` and `ServiceWorkerContainer` definitions.

https://w3c.github.io/push-api
https://w3c.github.io/ServiceWorker
