### PR TITLE
Adds type definition for assert.fail

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -2129,6 +2129,8 @@ declare module "assert" {
   declare module.exports: {
     (value: any, message?: string): void;
     ok(value: any, message?: string): void;
+    fail(message?: string | Error): void;
+    // deprecated since v10.15 
     fail(actual: any, expected: any, message: string, operator: string): void;
     equal(actual: any, expected: any, message?: string): void;
     notEqual(actual: any, expected: any, message?: string): void;


### PR DESCRIPTION
New method overload:
https://nodejs.org/docs/latest-v10.x/api/assert.html#assert_assert_fail_message

Deprecated method: 
https://nodejs.org/docs/latest-v10.x/api/assert.html#assert_assert_fail_actual_expected_message_operator_stackstartfn