### PR TITLE
Allow event name symbols in events$EventEmitter.

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -804,26 +804,25 @@ declare module "dns" {
 
 declare class events$EventEmitter {
   // deprecated
-  static listenerCount(emitter: events$EventEmitter, event: string): number;
+  static listenerCount(emitter: events$EventEmitter, event: string | Symbol): number;
   static defaultMaxListeners: number;
 
-  addListener(event: string, listener: Function): this;
-  emit(event: string, ...args:Array<any>): boolean;
-  eventNames(): Array<string>;
-  listeners(event: string): Array<Function>;
-  listenerCount(event: string): number;
-  on(event: string, listener: Function): this;
-  once(event: string, listener: Function): this;
-  prependListener(event: string, listener: Function): this;
-  prependOnceListener(event: string, listener: Function): this;
-  removeAllListeners(event?: string): this;
-  removeListener(event: string, listener: Function): this;
-  off(event: string, listener: Function): this;
+  addListener(event: string | Symbol, listener: Function): this;
+  emit(event: string | Symbol, ...args: Array<any>): boolean;
+  eventNames(): Array<string | Symbol>;
+  listeners(event: string | Symbol): Array<Function>;
+  listenerCount(event: string | Symbol): number;
+  on(event: string | Symbol, listener: Function): this;
+  once(event: string | Symbol, listener: Function): this;
+  prependListener(event: string | Symbol, listener: Function): this;
+  prependOnceListener(event: string | Symbol, listener: Function): this;
+  removeAllListeners(event?: string | Symbol): this;
+  removeListener(event: string | Symbol, listener: Function): this;
+  off(event: string | Symbol, listener: Function): this;
   setMaxListeners(n: number): this;
   getMaxListeners(): number;
-  rawListeners(event: string): Array<Function>;
+  rawListeners(event: string | Symbol): Array<Function>;
 }
-
 
 declare module "events" {
   // TODO: See the comment above the events$EventEmitter declaration


### PR DESCRIPTION
`events$EventEmitter` methods support Symbol as eventName https://nodejs.org/api/events.html#events_emitter_addlistener_eventname_listener - make sure flow library definition does match nodejs.