### PR TITLE
[Library definitions] Add optional `propTypes` to `React.AbstractComponentStatics`

### DIFF
--- a/lib/react.js
+++ b/lib/react.js
@@ -134,7 +134,7 @@ declare type React$AbstractComponentStatics = {
   // This is only on function components, but trying to access name when
   // displayName is undefined is a common pattern.
   name?: ?string,
-  propTypes?: any,
+  propTypes?: {},
 };
 
 /**

--- a/lib/react.js
+++ b/lib/react.js
@@ -134,6 +134,7 @@ declare type React$AbstractComponentStatics = {
   // This is only on function components, but trying to access name when
   // displayName is undefined is a common pattern.
   name?: ?string,
+  propTypes?: any,
 };
 
 /**

--- a/tests/getters_and_setters/getters_and_setters.exp
+++ b/tests/getters_and_setters/getters_and_setters.exp
@@ -465,8 +465,8 @@ References:
    react.js:17:13
     17| (<Example a="bad" />); // error: number ~> string
                     ^^^^^ [1]
-   <BUILTINS>/react.js:438:36
-   438|   number: React$PropType$Primitive<number>;
+   <BUILTINS>/react.js:439:36
+   439|   number: React$PropType$Primitive<number>;
                                            ^^^^^^ [2]
 
 
@@ -482,8 +482,8 @@ References:
    react.js:18:20
     18| (<Example a={0} c={0} />); // error: number ~> string
                            ^ [1]
-   <BUILTINS>/react.js:440:36
-   440|   string: React$PropType$Primitive<string>;
+   <BUILTINS>/react.js:441:36
+   441|   string: React$PropType$Primitive<string>;
                                            ^^^^^^ [2]
 
 

--- a/tests/more_react/more_react.exp
+++ b/tests/more_react/more_react.exp
@@ -58,15 +58,15 @@ Cannot call `checkPropTypes` because function [1] requires another argument.
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/react.js:221:41
+   <BUILTINS>/react.js:222:41
                                                 v---
-   221|   declare export function checkPropTypes<V>(
-   222|     propTypes : any,
-   223|     values: V,
-   224|     location: string,
-   225|     componentName: string,
-   226|     getStack: ?(() => ?string)
-   227|   ) : void;
+   222|   declare export function checkPropTypes<V>(
+   223|     propTypes : any,
+   224|     values: V,
+   225|     location: string,
+   226|     componentName: string,
+   227|     getStack: ?(() => ?string)
+   228|   ) : void;
           -------^ [1]
 
 
@@ -79,15 +79,15 @@ Cannot call `checkPropTypes` because function [1] requires another argument.
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/react.js:221:41
+   <BUILTINS>/react.js:222:41
                                                 v---
-   221|   declare export function checkPropTypes<V>(
-   222|     propTypes : any,
-   223|     values: V,
-   224|     location: string,
-   225|     componentName: string,
-   226|     getStack: ?(() => ?string)
-   227|   ) : void;
+   222|   declare export function checkPropTypes<V>(
+   223|     propTypes : any,
+   224|     values: V,
+   225|     location: string,
+   226|     componentName: string,
+   227|     getStack: ?(() => ?string)
+   228|   ) : void;
           -------^ [1]
 
 
@@ -104,8 +104,8 @@ References:
    checkPropTypes.js:12:91
     12| checkPropTypes({ foo: PropTypes.string }, { foo: 'foo' }, 'value', 'TestComponent', () => 123); // error: number ~> string
                                                                                                   ^^^ [1]
-   <BUILTINS>/react.js:226:24
-   226|     getStack: ?(() => ?string)
+   <BUILTINS>/react.js:227:24
+   227|     getStack: ?(() => ?string)
                                ^^^^^^ [2]
 
 

--- a/tests/new_react/new_react.exp
+++ b/tests/new_react/new_react.exp
@@ -179,8 +179,8 @@ References:
    classes.js:39:15
     39| var foo: $jsx<number> = <Foo/>;
                       ^^^^^^ [1]
-   <BUILTINS>/react.js:170:5
-   170|   | string
+   <BUILTINS>/react.js:171:5
+   171|   | string
             ^^^^^^ [2]
 
 
@@ -193,8 +193,8 @@ Cannot assign `this.props.x` to `_` because number [1] is incompatible with stri
                             ^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/react.js:438:36
-   438|   number: React$PropType$Primitive<number>;
+   <BUILTINS>/react.js:439:36
+   439|   number: React$PropType$Primitive<number>;
                                            ^^^^^^ [1]
    classes.js:57:12
     57|     var _: string = this.props.x;
@@ -348,8 +348,8 @@ References:
    classes.js:79:22
     79| var foo_legacy: $jsx<number> = <FooLegacy/>;
                              ^^^^^^ [1]
-   <BUILTINS>/react.js:170:5
-   170|   | string
+   <BUILTINS>/react.js:171:5
+   171|   | string
             ^^^^^^ [2]
 
 
@@ -420,8 +420,8 @@ Cannot assign `this.props.z` to `qux` because:
                                   ^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/react.js:438:36
-   438|   number: React$PropType$Primitive<number>;
+   <BUILTINS>/react.js:439:36
+   439|   number: React$PropType$Primitive<number>;
                                            ^^^^^^ [1]
    new_react.js:19:18
     19|         var qux: string = this.props.z;
@@ -437,8 +437,8 @@ Cannot assign `this.props.x` to `w` because string [1] is incompatible with numb
                                ^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/react.js:440:36
-   440|   string: React$PropType$Primitive<string>;
+   <BUILTINS>/react.js:441:36
+   441|   string: React$PropType$Primitive<string>;
                                            ^^^^^^ [1]
    new_react.js:20:15
     20|         var w:number = this.props.x;
@@ -471,8 +471,8 @@ References:
    new_react.js:29:23
     29| var element = <C x = {0}/>;
                               ^ [1]
-   <BUILTINS>/react.js:440:36
-   440|   string: React$PropType$Primitive<string>;
+   <BUILTINS>/react.js:441:36
+   441|   string: React$PropType$Primitive<string>;
                                            ^^^^^^ [2]
 
 
@@ -529,8 +529,8 @@ Cannot assign `this.props.x` to `a` because:
                                 ^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/react.js:440:36
-   440|   string: React$PropType$Primitive<string>;
+   <BUILTINS>/react.js:441:36
+   441|   string: React$PropType$Primitive<string>;
                                            ^^^^^^ [1]
    props.js:14:16
     14|         var a: number = this.props.x; // error
@@ -566,8 +566,8 @@ Cannot assign `this.props.z` to `c` because:
                                 ^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/react.js:438:36
-   438|   number: React$PropType$Primitive<number>;
+   <BUILTINS>/react.js:439:36
+   439|   number: React$PropType$Primitive<number>;
                                            ^^^^^^ [1]
    props.js:16:16
     16|         var c: string = this.props.z; // error
@@ -588,14 +588,14 @@ References:
    props.js:20:29
     20| var element = <TestProps x={false} y={false} z={false} />; // 3 errors
                                     ^^^^^ [1]
-   <BUILTINS>/react.js:440:36
-   440|   string: React$PropType$Primitive<string>;
+   <BUILTINS>/react.js:441:36
+   441|   string: React$PropType$Primitive<string>;
                                            ^^^^^^ [2]
    props.js:20:49
     20| var element = <TestProps x={false} y={false} z={false} />; // 3 errors
                                                         ^^^^^ [3]
-   <BUILTINS>/react.js:438:36
-   438|   number: React$PropType$Primitive<number>;
+   <BUILTINS>/react.js:439:36
+   439|   number: React$PropType$Primitive<number>;
                                            ^^^^^^ [4]
 
 
@@ -652,8 +652,8 @@ References:
    props2.js:9:41
      9|     getInitialState: function(): { bar: number } {
                                                 ^^^^^^ [1]
-   <BUILTINS>/react.js:440:36
-   440|   string: React$PropType$Primitive<string>;
+   <BUILTINS>/react.js:441:36
+   441|   string: React$PropType$Primitive<string>;
                                            ^^^^^^ [2]
    props2.js:15:42
     15|         return <C {...this.state} foo = {0} />;
@@ -669,8 +669,8 @@ Cannot get `React.PropTypes.imaginaryType` because property `imaginaryType` is m
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/react.js:218:33
-   218|   declare export var PropTypes: ReactPropTypes;
+   <BUILTINS>/react.js:219:33
+   219|   declare export var PropTypes: ReactPropTypes;
                                         ^^^^^^^^^^^^^^ [1]
 
 
@@ -684,12 +684,12 @@ Cannot get `React.PropTypes.string.inRequired` because property `inRequired` is 
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/react.js:414:39
+   <BUILTINS>/react.js:415:39
                                               v
-   414| type ReactPropsChainableTypeChecker = {
-   415|   isRequired: ReactPropsCheckType;
-   416|   (props: any, propName: string, componentName: string, href?: string): ?Error;
-   417| };
+   415| type ReactPropsChainableTypeChecker = {
+   416|   isRequired: ReactPropsCheckType;
+   417|   (props: any, propName: string, componentName: string, href?: string): ?Error;
+   418| };
         ^ [1]
 
 

--- a/tests/react/hoc.js
+++ b/tests/react/hoc.js
@@ -6,6 +6,7 @@ function myHOC(
   Component: React$ComponentType<{foo: number, bar: number}>,
 ): React$ComponentType<{foo: number}> {
   return class extends React.Component<{foo: number}, {bar: number}> {
+    static propTypes = { ...Component.propTypes, bar: undefined };
     state = {bar: 2};
     render() {
       <Component />; // Error: `foo` is required.

--- a/tests/react/react.exp
+++ b/tests/react/react.exp
@@ -88,8 +88,8 @@ Cannot cast `this.props.foo` to empty because string [1] is incompatible with em
              ^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/react.js:440:36
-   440|   string: React$PropType$Primitive<string>;
+   <BUILTINS>/react.js:441:36
+   441|   string: React$PropType$Primitive<string>;
                                            ^^^^^^ [1]
    create_class.js:7:22
      7|     (this.props.foo: empty); // error: string ~> empty
@@ -105,8 +105,8 @@ Cannot cast `this.props.bar` to empty because number [1] is incompatible with em
              ^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/react.js:438:36
-   438|   number: React$PropType$Primitive<number>;
+   <BUILTINS>/react.js:439:36
+   439|   number: React$PropType$Primitive<number>;
                                            ^^^^^^ [1]
    create_class.js:8:22
      8|     (this.props.bar: empty); // error: number ~> empty
@@ -259,8 +259,8 @@ Cannot cast `this.props.foo` to empty because string [1] is incompatible with em
              ^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/react.js:440:36
-   440|   string: React$PropType$Primitive<string>;
+   <BUILTINS>/react.js:441:36
+   441|   string: React$PropType$Primitive<string>;
                                            ^^^^^^ [1]
    create_class.js:117:22
    117|     (this.props.foo: empty); // string ~> empty
@@ -276,8 +276,8 @@ Cannot cast `this.state.foo` to empty because string [1] is incompatible with em
              ^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/react.js:440:36
-   440|   string: React$PropType$Primitive<string>;
+   <BUILTINS>/react.js:441:36
+   441|   string: React$PropType$Primitive<string>;
                                            ^^^^^^ [1]
    create_class.js:118:22
    118|     (this.state.foo: empty); // string ~> empty
@@ -293,8 +293,8 @@ Cannot cast `this.props.foo` to empty because string [1] is incompatible with em
              ^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/react.js:440:36
-   440|   string: React$PropType$Primitive<string>;
+   <BUILTINS>/react.js:441:36
+   441|   string: React$PropType$Primitive<string>;
                                            ^^^^^^ [1]
    create_class.js:133:22
    133|     (this.props.foo: empty); // string ~> empty
@@ -310,8 +310,8 @@ Cannot cast `this.props.foo` to empty because string [1] is incompatible with em
              ^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/react.js:440:36
-   440|   string: React$PropType$Primitive<string>;
+   <BUILTINS>/react.js:441:36
+   441|   string: React$PropType$Primitive<string>;
                                            ^^^^^^ [1]
    create_class.js:137:22
    137|     (this.props.foo: empty); // string ~> empty
@@ -327,8 +327,8 @@ Cannot cast `this.props.foo` to empty because string [1] is incompatible with em
              ^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/react.js:440:36
-   440|   string: React$PropType$Primitive<string>;
+   <BUILTINS>/react.js:441:36
+   441|   string: React$PropType$Primitive<string>;
                                            ^^^^^^ [1]
    create_class.js:141:22
    141|     (this.props.foo: empty); // string ~> empty
@@ -344,8 +344,8 @@ Cannot cast `nextProps.foo` to empty because string [1] is incompatible with emp
              ^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/react.js:440:36
-   440|   string: React$PropType$Primitive<string>;
+   <BUILTINS>/react.js:441:36
+   441|   string: React$PropType$Primitive<string>;
                                            ^^^^^^ [1]
    create_class.js:142:21
    142|     (nextProps.foo: empty); // string ~> empty
@@ -361,8 +361,8 @@ Cannot cast `this.props.foo` to empty because string [1] is incompatible with em
              ^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/react.js:440:36
-   440|   string: React$PropType$Primitive<string>;
+   <BUILTINS>/react.js:441:36
+   441|   string: React$PropType$Primitive<string>;
                                            ^^^^^^ [1]
    create_class.js:146:22
    146|     (this.props.foo: empty); // string ~> empty
@@ -395,8 +395,8 @@ Cannot cast `nextProps.foo` to empty because string [1] is incompatible with emp
              ^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/react.js:440:36
-   440|   string: React$PropType$Primitive<string>;
+   <BUILTINS>/react.js:441:36
+   441|   string: React$PropType$Primitive<string>;
                                            ^^^^^^ [1]
    create_class.js:148:21
    148|     (nextProps.foo: empty); // string ~> empty
@@ -443,8 +443,8 @@ Cannot cast `this.props.foo` to empty because string [1] is incompatible with em
              ^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/react.js:440:36
-   440|   string: React$PropType$Primitive<string>;
+   <BUILTINS>/react.js:441:36
+   441|   string: React$PropType$Primitive<string>;
                                            ^^^^^^ [1]
    create_class.js:153:22
    153|     (this.props.foo: empty); // string ~> empty
@@ -477,8 +477,8 @@ Cannot cast `nextProps.foo` to empty because string [1] is incompatible with emp
              ^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/react.js:440:36
-   440|   string: React$PropType$Primitive<string>;
+   <BUILTINS>/react.js:441:36
+   441|   string: React$PropType$Primitive<string>;
                                            ^^^^^^ [1]
    create_class.js:155:21
    155|     (nextProps.foo: empty); // string ~> empty
@@ -511,8 +511,8 @@ Cannot cast `this.props.foo` to empty because string [1] is incompatible with em
              ^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/react.js:440:36
-   440|   string: React$PropType$Primitive<string>;
+   <BUILTINS>/react.js:441:36
+   441|   string: React$PropType$Primitive<string>;
                                            ^^^^^^ [1]
    create_class.js:160:22
    160|     (this.props.foo: empty); // string ~> empty
@@ -545,8 +545,8 @@ Cannot cast `nextProps.foo` to empty because string [1] is incompatible with emp
              ^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/react.js:440:36
-   440|   string: React$PropType$Primitive<string>;
+   <BUILTINS>/react.js:441:36
+   441|   string: React$PropType$Primitive<string>;
                                            ^^^^^^ [1]
    create_class.js:162:21
    162|     (nextProps.foo: empty); // string ~> empty
@@ -579,8 +579,8 @@ Cannot cast `this.props.foo` to empty because string [1] is incompatible with em
              ^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/react.js:440:36
-   440|   string: React$PropType$Primitive<string>;
+   <BUILTINS>/react.js:441:36
+   441|   string: React$PropType$Primitive<string>;
                                            ^^^^^^ [1]
    create_class.js:167:22
    167|     (this.props.foo: empty); // string ~> empty
@@ -1294,14 +1294,14 @@ References:
                                         ^^^^^^^^^^^ [2]
 
 
-Error ------------------------------------------------------------------------------------------------------ hoc.js:11:7
+Error ------------------------------------------------------------------------------------------------------ hoc.js:12:7
 
 Cannot create `Component` element because:
  - property `bar` is missing in props [1] but exists in object type [2].
  - property `foo` is missing in props [1] but exists in object type [2].
 
-   hoc.js:11:7
-   11|       <Component />; // Error: `foo` is required.
+   hoc.js:12:7
+   12|       <Component />; // Error: `foo` is required.
              ^^^^^^^^^^^^^ [1]
 
 References:
@@ -1310,12 +1310,12 @@ References:
                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^ [2]
 
 
-Error ------------------------------------------------------------------------------------------------------ hoc.js:12:7
+Error ------------------------------------------------------------------------------------------------------ hoc.js:13:7
 
 Cannot create `Component` element because property `bar` is missing in props [1] but exists in object type [2].
 
-   hoc.js:12:7
-   12|       <Component foo={42} />; // Error: `bar` is required.
+   hoc.js:13:7
+   13|       <Component foo={42} />; // Error: `bar` is required.
              ^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 References:
@@ -1324,25 +1324,25 @@ References:
                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^ [2]
 
 
-Error ------------------------------------------------------------------------------------------------------ hoc.js:35:7
+Error ------------------------------------------------------------------------------------------------------ hoc.js:36:7
 
 Cannot call `myHOC` with `class { ... }` bound to `Component` because string [1] is incompatible with number [2] in
 property `foo`.
 
-   hoc.js:35:7
-   35| myHOC(class Empty extends React.Component<{foo: string}, void> {}); // Error
+   hoc.js:36:7
+   36| myHOC(class Empty extends React.Component<{foo: string}, void> {}); // Error
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   hoc.js:35:49
-   35| myHOC(class Empty extends React.Component<{foo: string}, void> {}); // Error
+   hoc.js:36:49
+   36| myHOC(class Empty extends React.Component<{foo: string}, void> {}); // Error
                                                        ^^^^^^ [1]
    hoc.js:6:40
     6|   Component: React$ComponentType<{foo: number, bar: number}>,
                                               ^^^^^^ [2]
 
 
-Error ------------------------------------------------------------------------------------------------------ hoc.js:36:7
+Error ------------------------------------------------------------------------------------------------------ hoc.js:37:7
 
 Cannot call `myHOC` with function bound to `Component` because:
  - string [1] is incompatible with number [2] in property `foo`.
@@ -1350,19 +1350,19 @@ Cannot call `myHOC` with function bound to `Component` because:
     - Either undefined [3] is incompatible with null [4].
     - Or property `@@iterator` is missing in undefined [3] but exists in `$Iterable` [5].
 
-   hoc.js:36:7
-   36| myHOC(function Empty(props: {foo: string}) {}); // Error
+   hoc.js:37:7
+   37| myHOC(function Empty(props: {foo: string}) {}); // Error
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   hoc.js:36:35
-   36| myHOC(function Empty(props: {foo: string}) {}); // Error
+   hoc.js:37:35
+   37| myHOC(function Empty(props: {foo: string}) {}); // Error
                                          ^^^^^^ [1]
    hoc.js:6:40
     6|   Component: React$ComponentType<{foo: number, bar: number}>,
                                               ^^^^^^ [2]
-   hoc.js:36:43
-   36| myHOC(function Empty(props: {foo: string}) {}); // Error
+   hoc.js:37:43
+   37| myHOC(function Empty(props: {foo: string}) {}); // Error
                                                  ^ [3]
    <BUILTINS>/react.js:14:5
    14|   | null
@@ -1372,26 +1372,26 @@ References:
            ^^^^^^^^^^^^^^^^^^^^^ [5]
 
 
-Error ------------------------------------------------------------------------------------------------------ hoc.js:41:1
+Error ------------------------------------------------------------------------------------------------------ hoc.js:42:1
 
 Cannot create `Wrapped` element because property `foo` is missing in props [1] but exists in object type [2].
 
-   hoc.js:41:1
-   41| <Wrapped nonsense="what" />; // Error: `foo` is required.
+   hoc.js:42:1
+   42| <Wrapped nonsense="what" />; // Error: `foo` is required.
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 References:
-   hoc.js:38:36
-   38| const Wrapped: React$ComponentType<{foo: number}> = myHOC(Unwrapped);
+   hoc.js:39:36
+   39| const Wrapped: React$ComponentType<{foo: number}> = myHOC(Unwrapped);
                                           ^^^^^^^^^^^^^ [2]
 
 
-Error ------------------------------------------------------------------------------------------------------ hoc.js:43:1
+Error ------------------------------------------------------------------------------------------------------ hoc.js:44:1
 
 Cannot create `WrappedFun` element because property `foo` is missing in props [1] but exists in object type [2].
 
-   hoc.js:43:1
-   43| <WrappedFun />; // Error: `foo` is required.
+   hoc.js:44:1
+   44| <WrappedFun />; // Error: `foo` is required.
        ^^^^^^^^^^^^^^ [1]
 
 References:
@@ -1848,8 +1848,8 @@ References:
    jsx_spread.js:10:19
     10| var props = {bar: 42};
                           ^^ [1]
-   <BUILTINS>/react.js:440:36
-   440|   string: React$PropType$Primitive<string>;
+   <BUILTINS>/react.js:441:36
+   441|   string: React$PropType$Primitive<string>;
                                            ^^^^^^ [2]
 
 
@@ -1867,11 +1867,11 @@ References:
    key.js:12:11
     12| <Foo key={true} />; // Error
                   ^^^^ [1]
-   <BUILTINS>/react.js:188:26
-   188| declare type React$Key = string | number;
+   <BUILTINS>/react.js:189:26
+   189| declare type React$Key = string | number;
                                  ^^^^^^ [2]
-   <BUILTINS>/react.js:188:35
-   188| declare type React$Key = string | number;
+   <BUILTINS>/react.js:189:35
+   189| declare type React$Key = string | number;
                                           ^^^^^^ [3]
 
 
@@ -1889,11 +1889,11 @@ References:
    key.js:21:16
     21| <FooExact key={true} />; // Error
                        ^^^^ [1]
-   <BUILTINS>/react.js:188:26
-   188| declare type React$Key = string | number;
+   <BUILTINS>/react.js:189:26
+   189| declare type React$Key = string | number;
                                  ^^^^^^ [2]
-   <BUILTINS>/react.js:188:35
-   188| declare type React$Key = string | number;
+   <BUILTINS>/react.js:189:35
+   189| declare type React$Key = string | number;
                                           ^^^^^^ [3]
 
 
@@ -1962,8 +1962,8 @@ References:
    proptype_arrayOf.js:15:45
     15| var fail_mistyped_elems = <Example arr={[1, "foo"]} />
                                                     ^^^^^ [1]
-   <BUILTINS>/react.js:438:36
-   438|   number: React$PropType$Primitive<number>;
+   <BUILTINS>/react.js:439:36
+   439|   number: React$PropType$Primitive<number>;
                                            ^^^^^^ [2]
 
 
@@ -1979,8 +1979,8 @@ References:
    proptype_arrayOf.js:20:36
     20| var todo_required = <Example arr={[null]} />
                                            ^^^^ [1]
-   <BUILTINS>/react.js:438:36
-   438|   number: React$PropType$Primitive<number>;
+   <BUILTINS>/react.js:439:36
+   439|   number: React$PropType$Primitive<number>;
                                            ^^^^^^ [2]
 
 
@@ -1997,8 +1997,8 @@ References:
    proptype_arrayOf.js:30:25
     30| (<OptionalExample arr={[""]} />); // error: string ~> number
                                 ^^ [1]
-   <BUILTINS>/react.js:438:36
-   438|   number: React$PropType$Primitive<number>;
+   <BUILTINS>/react.js:439:36
+   439|   number: React$PropType$Primitive<number>;
                                            ^^^^^^ [2]
 
 
@@ -2036,8 +2036,8 @@ Cannot cast `propName` to empty because string [1] is incompatible with empty [2
                ^^^^^^^^
 
 References:
-   <BUILTINS>/react.js:410:13
-   410|   propName: string,
+   <BUILTINS>/react.js:411:13
+   411|   propName: string,
                     ^^^^^^ [1]
    proptype_custom_validator.js:8:18
      8|       (propName: empty); // error: propName is a string
@@ -2053,8 +2053,8 @@ Cannot cast `componentName` to empty because string [1] is incompatible with emp
                ^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/react.js:411:18
-   411|   componentName: string,
+   <BUILTINS>/react.js:412:18
+   412|   componentName: string,
                          ^^^^^^ [1]
    proptype_custom_validator.js:9:23
      9|       (componentName: empty); // error: componentName is a string
@@ -2072,8 +2072,8 @@ Cannot cast `href` to empty because:
                ^^^^
 
 References:
-   <BUILTINS>/react.js:412:10
-   412|   href?: string) => ?Error;
+   <BUILTINS>/react.js:413:10
+   413|   href?: string) => ?Error;
                  ^^^^^^ [1]
    proptype_custom_validator.js:10:14
     10|       (href: empty); // error: href is an optional string
@@ -2092,8 +2092,8 @@ References:
    proptype_custom_validator.js:11:18
     11|       return (0: mixed); // error: should return ?Error
                          ^^^^^ [1]
-   <BUILTINS>/react.js:412:22
-   412|   href?: string) => ?Error;
+   <BUILTINS>/react.js:413:22
+   413|   href?: string) => ?Error;
                              ^^^^^ [2]
 
 
@@ -2186,8 +2186,8 @@ References:
    proptype_objectOf.js:15:47
     15| var fail_mistyped_props = <Example obj={{foo: "foo"}} />
                                                       ^^^^^ [1]
-   <BUILTINS>/react.js:438:36
-   438|   number: React$PropType$Primitive<number>;
+   <BUILTINS>/react.js:439:36
+   439|   number: React$PropType$Primitive<number>;
                                            ^^^^^^ [2]
 
 
@@ -2203,8 +2203,8 @@ References:
    proptype_objectOf.js:20:38
     20| var todo_required = <Example obj={{p:null}} />
                                              ^^^^ [1]
-   <BUILTINS>/react.js:438:36
-   438|   number: React$PropType$Primitive<number>;
+   <BUILTINS>/react.js:439:36
+   439|   number: React$PropType$Primitive<number>;
                                            ^^^^^^ [2]
 
 
@@ -2220,8 +2220,8 @@ References:
    proptype_objectOf.js:30:27
     30| (<OptionalExample obj={{p:""}} />); // error: string ~> number
                                   ^^ [1]
-   <BUILTINS>/react.js:438:36
-   438|   number: React$PropType$Primitive<number>;
+   <BUILTINS>/react.js:439:36
+   439|   number: React$PropType$Primitive<number>;
                                            ^^^^^^ [2]
 
 
@@ -2396,11 +2396,11 @@ References:
    proptype_oneOfType.js:24:32
     24| var fail_bool = <Example prop={true} />;
                                        ^^^^ [1]
-   <BUILTINS>/react.js:440:36
-   440|   string: React$PropType$Primitive<string>;
+   <BUILTINS>/react.js:441:36
+   441|   string: React$PropType$Primitive<string>;
                                            ^^^^^^ [2]
-   <BUILTINS>/react.js:438:36
-   438|   number: React$PropType$Primitive<number>;
+   <BUILTINS>/react.js:439:36
+   439|   number: React$PropType$Primitive<number>;
                                            ^^^^^^ [3]
 
 
@@ -2418,11 +2418,11 @@ References:
    proptype_oneOfType.js:29:36
     29| var todo_required = <Example prop={null} />;
                                            ^^^^ [1]
-   <BUILTINS>/react.js:440:36
-   440|   string: React$PropType$Primitive<string>;
+   <BUILTINS>/react.js:441:36
+   441|   string: React$PropType$Primitive<string>;
                                            ^^^^^^ [2]
-   <BUILTINS>/react.js:438:36
-   438|   number: React$PropType$Primitive<number>;
+   <BUILTINS>/react.js:439:36
+   439|   number: React$PropType$Primitive<number>;
                                            ^^^^^^ [3]
 
 
@@ -2438,8 +2438,8 @@ References:
    proptype_oneOfType.js:41:22
     41| (<OptionalExample p={0} />); // error: number ~> string
                              ^ [1]
-   <BUILTINS>/react.js:440:36
-   440|   string: React$PropType$Primitive<string>;
+   <BUILTINS>/react.js:441:36
+   441|   string: React$PropType$Primitive<string>;
                                            ^^^^^^ [2]
 
 
@@ -2521,14 +2521,14 @@ Cannot cast `React.PropTypes.arrayOf` to `NoFun` because:
          ^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/react.js:420:17
-   420|   (typeChecker: ReactPropsCheckType) => ReactPropsChainableTypeChecker;
+   <BUILTINS>/react.js:421:17
+   421|   (typeChecker: ReactPropsCheckType) => ReactPropsChainableTypeChecker;
                         ^^^^^^^^^^^^^^^^^^^ [1]
    proptypes_builtins.js:3:14
      3| type NoFun = mixed => empty;
                      ^^^^^ [2]
-   <BUILTINS>/react.js:420:41
-   420|   (typeChecker: ReactPropsCheckType) => ReactPropsChainableTypeChecker;
+   <BUILTINS>/react.js:421:41
+   421|   (typeChecker: ReactPropsCheckType) => ReactPropsChainableTypeChecker;
                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [3]
    proptypes_builtins.js:3:23
      3| type NoFun = mixed => empty;
@@ -2545,8 +2545,8 @@ empty [2] in the return value.
          ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/react.js:422:27
-   422|   (expectedClass: any) => ReactPropsChainableTypeChecker;
+   <BUILTINS>/react.js:423:27
+   423|   (expectedClass: any) => ReactPropsChainableTypeChecker;
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
    proptypes_builtins.js:3:23
      3| type NoFun = mixed => empty;
@@ -2564,14 +2564,14 @@ Cannot cast `React.PropTypes.objectOf` to `NoFun` because:
          ^^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/react.js:424:17
-   424|   (typeChecker: ReactPropsCheckType) => ReactPropsChainableTypeChecker;
+   <BUILTINS>/react.js:425:17
+   425|   (typeChecker: ReactPropsCheckType) => ReactPropsChainableTypeChecker;
                         ^^^^^^^^^^^^^^^^^^^ [1]
    proptypes_builtins.js:3:14
      3| type NoFun = mixed => empty;
                      ^^^^^ [2]
-   <BUILTINS>/react.js:424:41
-   424|   (typeChecker: ReactPropsCheckType) => ReactPropsChainableTypeChecker;
+   <BUILTINS>/react.js:425:41
+   425|   (typeChecker: ReactPropsCheckType) => ReactPropsChainableTypeChecker;
                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [3]
    proptypes_builtins.js:3:23
      3| type NoFun = mixed => empty;
@@ -2589,14 +2589,14 @@ Cannot cast `React.PropTypes.oneOf` to `NoFun` because:
          ^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/react.js:426:20
-   426|   (expectedValues: Array<any>) => ReactPropsChainableTypeChecker;
+   <BUILTINS>/react.js:427:20
+   427|   (expectedValues: Array<any>) => ReactPropsChainableTypeChecker;
                            ^^^^^^^^^^ [1]
    proptypes_builtins.js:3:14
      3| type NoFun = mixed => empty;
                      ^^^^^ [2]
-   <BUILTINS>/react.js:426:35
-   426|   (expectedValues: Array<any>) => ReactPropsChainableTypeChecker;
+   <BUILTINS>/react.js:427:35
+   427|   (expectedValues: Array<any>) => ReactPropsChainableTypeChecker;
                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [3]
    proptypes_builtins.js:3:23
      3| type NoFun = mixed => empty;
@@ -2614,14 +2614,14 @@ Cannot cast `React.PropTypes.oneOfType` to `NoFun` because:
          ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/react.js:428:25
-   428|   (arrayOfTypeCheckers: Array<ReactPropsCheckType>) =>
+   <BUILTINS>/react.js:429:25
+   429|   (arrayOfTypeCheckers: Array<ReactPropsCheckType>) =>
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
    proptypes_builtins.js:3:14
      3| type NoFun = mixed => empty;
                      ^^^^^ [2]
-   <BUILTINS>/react.js:429:5
-   429|     ReactPropsChainableTypeChecker;
+   <BUILTINS>/react.js:430:5
+   430|     ReactPropsChainableTypeChecker;
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [3]
    proptypes_builtins.js:3:23
      3| type NoFun = mixed => empty;
@@ -2639,14 +2639,14 @@ Cannot cast `React.PropTypes.shape` to `NoFun` because:
          ^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/react.js:431:16
-   431|   (shapeTypes: { [key: string]: ReactPropsCheckType }) =>
+   <BUILTINS>/react.js:432:16
+   432|   (shapeTypes: { [key: string]: ReactPropsCheckType }) =>
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
    proptypes_builtins.js:3:14
      3| type NoFun = mixed => empty;
                      ^^^^^ [2]
-   <BUILTINS>/react.js:432:5
-   432|     ReactPropsChainableTypeChecker;
+   <BUILTINS>/react.js:433:5
+   433|     ReactPropsChainableTypeChecker;
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [3]
    proptypes_builtins.js:3:23
      3| type NoFun = mixed => empty;
@@ -2713,8 +2713,8 @@ Cannot cast `foo` to `Foo` because null [1] is incompatible with `Foo` [2].
                           ^^^
 
 References:
-   <BUILTINS>/react.js:195:39
-   195|   | ((React$ElementRef<ElementType> | null) => mixed)
+   <BUILTINS>/react.js:196:39
+   196|   | ((React$ElementRef<ElementType> | null) => mixed)
                                               ^^^^ [1]
    ref.js:13:24
     13| <Foo ref={foo => (foo: Foo)} />; // Error: `Foo` may be null.
@@ -2765,8 +2765,8 @@ Cannot cast `foo` to `FooExact` because null [1] is incompatible with `FooExact`
                                ^^^
 
 References:
-   <BUILTINS>/react.js:195:39
-   195|   | ((React$ElementRef<ElementType> | null) => mixed)
+   <BUILTINS>/react.js:196:39
+   196|   | ((React$ElementRef<ElementType> | null) => mixed)
                                               ^^^^ [1]
    ref.js:24:29
     24| <FooExact ref={foo => (foo: FooExact)} />; // Error: `FooExact` may be null.
@@ -3142,12 +3142,12 @@ Cannot call `React.useCallback` because function [1] requires another argument.
           ^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/react.js:352:38
+   <BUILTINS>/react.js:353:38
                                              v----------------------------------------------
-   352|   declare export function useCallback<T: (...args: $ReadOnlyArray<empty>) => mixed>(
-   353|     callback: T,
-   354|     inputs: ?$ReadOnlyArray<mixed>,
-   355|   ): T;
+   353|   declare export function useCallback<T: (...args: $ReadOnlyArray<empty>) => mixed>(
+   354|     callback: T,
+   355|     inputs: ?$ReadOnlyArray<mixed>,
+   356|   ): T;
           ---^ [1]
 
 
@@ -3223,39 +3223,39 @@ Cannot call `React.useMutationEffect` because property `useMutationEffect` is mi
           ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/react.js:368:26
+   <BUILTINS>/react.js:369:26
                                  v-
-   368|   declare export default {|
-   369|     +DOM: typeof DOM,
-   370|     +PropTypes: typeof PropTypes,
-   371|     +version: typeof version,
-   372|     +checkPropTypes: typeof checkPropTypes,
-   373|     +memo: typeof memo,
-   374|     +lazy: typeof lazy,
-   375|     +createClass: typeof createClass,
-   376|     +createContext: typeof createContext,
-   377|     +createElement: typeof createElement,
-   378|     +cloneElement: typeof cloneElement,
-   379|     +createFactory: typeof createFactory,
-   380|     +createRef: typeof createRef,
-   381|     +forwardRef: typeof forwardRef,
-   382|     +isValidElement: typeof isValidElement,
+   369|   declare export default {|
+   370|     +DOM: typeof DOM,
+   371|     +PropTypes: typeof PropTypes,
+   372|     +version: typeof version,
+   373|     +checkPropTypes: typeof checkPropTypes,
+   374|     +memo: typeof memo,
+   375|     +lazy: typeof lazy,
+   376|     +createClass: typeof createClass,
+   377|     +createContext: typeof createContext,
+   378|     +createElement: typeof createElement,
+   379|     +cloneElement: typeof cloneElement,
+   380|     +createFactory: typeof createFactory,
+   381|     +createRef: typeof createRef,
+   382|     +forwardRef: typeof forwardRef,
+   383|     +isValidElement: typeof isValidElement,
       :
-   385|     +Fragment: typeof Fragment,
-   386|     +Children: typeof Children,
-   387|     +ConcurrentMode: typeof ConcurrentMode,
-   388|     +StrictMode: typeof StrictMode,
-   389|     +Suspense: typeof Suspense,
-   390|     +useContext: typeof useContext,
-   391|     +useState: typeof useState,
-   392|     +useReducer: typeof useReducer,
-   393|     +useRef: typeof useRef,
-   394|     +useEffect: typeof useEffect,
-   395|     +useLayoutEffect: typeof useLayoutEffect,
-   396|     +useCallback: typeof useCallback,
-   397|     +useMemo: typeof useMemo,
-   398|     +useImperativeHandle: typeof useImperativeHandle,
-   399|   |};
+   386|     +Fragment: typeof Fragment,
+   387|     +Children: typeof Children,
+   388|     +ConcurrentMode: typeof ConcurrentMode,
+   389|     +StrictMode: typeof StrictMode,
+   390|     +Suspense: typeof Suspense,
+   391|     +useContext: typeof useContext,
+   392|     +useState: typeof useState,
+   393|     +useReducer: typeof useReducer,
+   394|     +useRef: typeof useRef,
+   395|     +useEffect: typeof useEffect,
+   396|     +useLayoutEffect: typeof useLayoutEffect,
+   397|     +useCallback: typeof useCallback,
+   398|     +useMemo: typeof useMemo,
+   399|     +useImperativeHandle: typeof useImperativeHandle,
+   400|   |};
           -^ [1]
 
 
@@ -3292,8 +3292,8 @@ References:
    useContext_hook.js:23:39
     23|   const InvalidContext: React$Context<CustomType> = React.createContext('hello'); // Error: inexact string is incompatible with exact CustomType
                                               ^^^^^^^^^^ [2]
-   <BUILTINS>/react.js:202:28
-   202| declare type React$Context<T> = {
+   <BUILTINS>/react.js:203:28
+   203| declare type React$Context<T> = {
                                    ^ [3]
 
 
@@ -3340,39 +3340,39 @@ Cannot call `React.useDebugValue` because property `useDebugValue` is missing in
                                ^^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/react.js:368:26
+   <BUILTINS>/react.js:369:26
                                  v-
-   368|   declare export default {|
-   369|     +DOM: typeof DOM,
-   370|     +PropTypes: typeof PropTypes,
-   371|     +version: typeof version,
-   372|     +checkPropTypes: typeof checkPropTypes,
-   373|     +memo: typeof memo,
-   374|     +lazy: typeof lazy,
-   375|     +createClass: typeof createClass,
-   376|     +createContext: typeof createContext,
-   377|     +createElement: typeof createElement,
-   378|     +cloneElement: typeof cloneElement,
-   379|     +createFactory: typeof createFactory,
-   380|     +createRef: typeof createRef,
-   381|     +forwardRef: typeof forwardRef,
-   382|     +isValidElement: typeof isValidElement,
+   369|   declare export default {|
+   370|     +DOM: typeof DOM,
+   371|     +PropTypes: typeof PropTypes,
+   372|     +version: typeof version,
+   373|     +checkPropTypes: typeof checkPropTypes,
+   374|     +memo: typeof memo,
+   375|     +lazy: typeof lazy,
+   376|     +createClass: typeof createClass,
+   377|     +createContext: typeof createContext,
+   378|     +createElement: typeof createElement,
+   379|     +cloneElement: typeof cloneElement,
+   380|     +createFactory: typeof createFactory,
+   381|     +createRef: typeof createRef,
+   382|     +forwardRef: typeof forwardRef,
+   383|     +isValidElement: typeof isValidElement,
       :
-   385|     +Fragment: typeof Fragment,
-   386|     +Children: typeof Children,
-   387|     +ConcurrentMode: typeof ConcurrentMode,
-   388|     +StrictMode: typeof StrictMode,
-   389|     +Suspense: typeof Suspense,
-   390|     +useContext: typeof useContext,
-   391|     +useState: typeof useState,
-   392|     +useReducer: typeof useReducer,
-   393|     +useRef: typeof useRef,
-   394|     +useEffect: typeof useEffect,
-   395|     +useLayoutEffect: typeof useLayoutEffect,
-   396|     +useCallback: typeof useCallback,
-   397|     +useMemo: typeof useMemo,
-   398|     +useImperativeHandle: typeof useImperativeHandle,
-   399|   |};
+   386|     +Fragment: typeof Fragment,
+   387|     +Children: typeof Children,
+   388|     +ConcurrentMode: typeof ConcurrentMode,
+   389|     +StrictMode: typeof StrictMode,
+   390|     +Suspense: typeof Suspense,
+   391|     +useContext: typeof useContext,
+   392|     +useState: typeof useState,
+   393|     +useReducer: typeof useReducer,
+   394|     +useRef: typeof useRef,
+   395|     +useEffect: typeof useEffect,
+   396|     +useLayoutEffect: typeof useLayoutEffect,
+   397|     +useCallback: typeof useCallback,
+   398|     +useMemo: typeof useMemo,
+   399|     +useImperativeHandle: typeof useImperativeHandle,
+   400|   |};
           -^ [1]
 
 
@@ -3385,12 +3385,12 @@ Cannot call `React.useEffect` because function [1] requires another argument.
           ^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/react.js:342:36
+   <BUILTINS>/react.js:343:36
                                            v
-   342|   declare export function useEffect(
-   343|     create: () => MaybeCleanUpFn,
-   344|     inputs: ?$ReadOnlyArray<mixed>,
-   345|   ): void;
+   343|   declare export function useEffect(
+   344|     create: () => MaybeCleanUpFn,
+   345|     inputs: ?$ReadOnlyArray<mixed>,
+   346|   ): void;
           ------^ [1]
 
 
@@ -3403,8 +3403,8 @@ Cannot call `React.useEffect` with `1` bound to `create` because number [1] is i
                           ^ [1]
 
 References:
-   <BUILTINS>/react.js:343:13
-   343|     create: () => MaybeCleanUpFn,
+   <BUILTINS>/react.js:344:13
+   344|     create: () => MaybeCleanUpFn,
                     ^^^^^^^^^^^^^^^^^^^^ [2]
 
 
@@ -3418,8 +3418,8 @@ type [2].
                                     ^ [1]
 
 References:
-   <BUILTINS>/react.js:344:14
-   344|     inputs: ?$ReadOnlyArray<mixed>,
+   <BUILTINS>/react.js:345:14
+   345|     inputs: ?$ReadOnlyArray<mixed>,
                      ^^^^^^^^^^^^^^^^^^^^^ [2]
 
 
@@ -3436,8 +3436,8 @@ References:
    useEffect_hook.js:24:30
     24|   React.useEffect(async () => {}) // Error: promise is incompatible with function return type
                                      ^ [1]
-   <BUILTINS>/react.js:308:41
-   308|   declare type MaybeCleanUpFn = void | (() => void);
+   <BUILTINS>/react.js:309:41
+   309|   declare type MaybeCleanUpFn = void | (() => void);
                                                 ^^^^^^^^^^ [2]
 
 
@@ -3454,8 +3454,8 @@ References:
    useEffect_hook.js:25:31
     25|   React.useEffect(() => () => 123) // Error: cleanup function should not return a value
                                       ^^^ [1]
-   <BUILTINS>/react.js:308:47
-   308|   declare type MaybeCleanUpFn = void | (() => void);
+   <BUILTINS>/react.js:309:47
+   309|   declare type MaybeCleanUpFn = void | (() => void);
                                                       ^^^^ [2]
 
 
@@ -3468,13 +3468,13 @@ Cannot call `React.useImperativeHandle` because function [1] requires another ar
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/react.js:362:46
+   <BUILTINS>/react.js:363:46
                                                      v---
-   362|   declare export function useImperativeHandle<T>(
-   363|     ref: {current: T | null} | ((inst: T | null) => mixed) | null | void,
-   364|     create: () => T,
-   365|     inputs: ?$ReadOnlyArray<mixed>,
-   366|   ): void;
+   363|   declare export function useImperativeHandle<T>(
+   364|     ref: {current: T | null} | ((inst: T | null) => mixed) | null | void,
+   365|     create: () => T,
+   366|     inputs: ?$ReadOnlyArray<mixed>,
+   367|   ): void;
           ------^ [1]
 
 
@@ -3523,12 +3523,12 @@ Cannot call `React.useLayoutEffect` because function [1] requires another argume
           ^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/react.js:347:42
+   <BUILTINS>/react.js:348:42
                                                  v
-   347|   declare export function useLayoutEffect(
-   348|     create: () => MaybeCleanUpFn,
-   349|     inputs: ?$ReadOnlyArray<mixed>,
-   350|   ): void;
+   348|   declare export function useLayoutEffect(
+   349|     create: () => MaybeCleanUpFn,
+   350|     inputs: ?$ReadOnlyArray<mixed>,
+   351|   ): void;
           ------^ [1]
 
 
@@ -3542,8 +3542,8 @@ type [2].
                                 ^ [1]
 
 References:
-   <BUILTINS>/react.js:348:13
-   348|     create: () => MaybeCleanUpFn,
+   <BUILTINS>/react.js:349:13
+   349|     create: () => MaybeCleanUpFn,
                     ^^^^^^^^^^^^^^^^^^^^ [2]
 
 
@@ -3557,8 +3557,8 @@ type [2].
                                           ^ [1]
 
 References:
-   <BUILTINS>/react.js:349:14
-   349|     inputs: ?$ReadOnlyArray<mixed>,
+   <BUILTINS>/react.js:350:14
+   350|     inputs: ?$ReadOnlyArray<mixed>,
                      ^^^^^^^^^^^^^^^^^^^^^ [2]
 
 
@@ -3575,8 +3575,8 @@ References:
    useLayoutEffect_hook.js:24:36
     24|   React.useLayoutEffect(async () => {}) // Error: promise is incompatible with function return type
                                            ^ [1]
-   <BUILTINS>/react.js:308:41
-   308|   declare type MaybeCleanUpFn = void | (() => void);
+   <BUILTINS>/react.js:309:41
+   309|   declare type MaybeCleanUpFn = void | (() => void);
                                                 ^^^^^^^^^^ [2]
 
 
@@ -3593,8 +3593,8 @@ References:
    useLayoutEffect_hook.js:25:37
     25|   React.useLayoutEffect(() => () => 123) // Error: cleanup function should not return a value
                                             ^^^ [1]
-   <BUILTINS>/react.js:308:47
-   308|   declare type MaybeCleanUpFn = void | (() => void);
+   <BUILTINS>/react.js:309:47
+   309|   declare type MaybeCleanUpFn = void | (() => void);
                                                       ^^^^ [2]
 
 
@@ -3607,12 +3607,12 @@ Cannot call `React.useMemo` because function [1] requires another argument.
           ^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/react.js:357:34
+   <BUILTINS>/react.js:358:34
                                          v---
-   357|   declare export function useMemo<T>(
-   358|     create: () => T,
-   359|     inputs: ?$ReadOnlyArray<mixed>,
-   360|   ): T;
+   358|   declare export function useMemo<T>(
+   359|     create: () => T,
+   360|     inputs: ?$ReadOnlyArray<mixed>,
+   361|   ): T;
           ---^ [1]
 
 
@@ -3642,39 +3642,39 @@ Cannot call `React.useMutationEffect` because property `useMutationEffect` is mi
           ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/react.js:368:26
+   <BUILTINS>/react.js:369:26
                                  v-
-   368|   declare export default {|
-   369|     +DOM: typeof DOM,
-   370|     +PropTypes: typeof PropTypes,
-   371|     +version: typeof version,
-   372|     +checkPropTypes: typeof checkPropTypes,
-   373|     +memo: typeof memo,
-   374|     +lazy: typeof lazy,
-   375|     +createClass: typeof createClass,
-   376|     +createContext: typeof createContext,
-   377|     +createElement: typeof createElement,
-   378|     +cloneElement: typeof cloneElement,
-   379|     +createFactory: typeof createFactory,
-   380|     +createRef: typeof createRef,
-   381|     +forwardRef: typeof forwardRef,
-   382|     +isValidElement: typeof isValidElement,
+   369|   declare export default {|
+   370|     +DOM: typeof DOM,
+   371|     +PropTypes: typeof PropTypes,
+   372|     +version: typeof version,
+   373|     +checkPropTypes: typeof checkPropTypes,
+   374|     +memo: typeof memo,
+   375|     +lazy: typeof lazy,
+   376|     +createClass: typeof createClass,
+   377|     +createContext: typeof createContext,
+   378|     +createElement: typeof createElement,
+   379|     +cloneElement: typeof cloneElement,
+   380|     +createFactory: typeof createFactory,
+   381|     +createRef: typeof createRef,
+   382|     +forwardRef: typeof forwardRef,
+   383|     +isValidElement: typeof isValidElement,
       :
-   385|     +Fragment: typeof Fragment,
-   386|     +Children: typeof Children,
-   387|     +ConcurrentMode: typeof ConcurrentMode,
-   388|     +StrictMode: typeof StrictMode,
-   389|     +Suspense: typeof Suspense,
-   390|     +useContext: typeof useContext,
-   391|     +useState: typeof useState,
-   392|     +useReducer: typeof useReducer,
-   393|     +useRef: typeof useRef,
-   394|     +useEffect: typeof useEffect,
-   395|     +useLayoutEffect: typeof useLayoutEffect,
-   396|     +useCallback: typeof useCallback,
-   397|     +useMemo: typeof useMemo,
-   398|     +useImperativeHandle: typeof useImperativeHandle,
-   399|   |};
+   386|     +Fragment: typeof Fragment,
+   387|     +Children: typeof Children,
+   388|     +ConcurrentMode: typeof ConcurrentMode,
+   389|     +StrictMode: typeof StrictMode,
+   390|     +Suspense: typeof Suspense,
+   391|     +useContext: typeof useContext,
+   392|     +useState: typeof useState,
+   393|     +useReducer: typeof useReducer,
+   394|     +useRef: typeof useRef,
+   395|     +useEffect: typeof useEffect,
+   396|     +useLayoutEffect: typeof useLayoutEffect,
+   397|     +useCallback: typeof useCallback,
+   398|     +useMemo: typeof useMemo,
+   399|     +useImperativeHandle: typeof useImperativeHandle,
+   400|   |};
           -^ [1]
 
 
@@ -3687,39 +3687,39 @@ Cannot call `React.useMutationEffect` because property `useMutationEffect` is mi
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/react.js:368:26
+   <BUILTINS>/react.js:369:26
                                  v-
-   368|   declare export default {|
-   369|     +DOM: typeof DOM,
-   370|     +PropTypes: typeof PropTypes,
-   371|     +version: typeof version,
-   372|     +checkPropTypes: typeof checkPropTypes,
-   373|     +memo: typeof memo,
-   374|     +lazy: typeof lazy,
-   375|     +createClass: typeof createClass,
-   376|     +createContext: typeof createContext,
-   377|     +createElement: typeof createElement,
-   378|     +cloneElement: typeof cloneElement,
-   379|     +createFactory: typeof createFactory,
-   380|     +createRef: typeof createRef,
-   381|     +forwardRef: typeof forwardRef,
-   382|     +isValidElement: typeof isValidElement,
+   369|   declare export default {|
+   370|     +DOM: typeof DOM,
+   371|     +PropTypes: typeof PropTypes,
+   372|     +version: typeof version,
+   373|     +checkPropTypes: typeof checkPropTypes,
+   374|     +memo: typeof memo,
+   375|     +lazy: typeof lazy,
+   376|     +createClass: typeof createClass,
+   377|     +createContext: typeof createContext,
+   378|     +createElement: typeof createElement,
+   379|     +cloneElement: typeof cloneElement,
+   380|     +createFactory: typeof createFactory,
+   381|     +createRef: typeof createRef,
+   382|     +forwardRef: typeof forwardRef,
+   383|     +isValidElement: typeof isValidElement,
       :
-   385|     +Fragment: typeof Fragment,
-   386|     +Children: typeof Children,
-   387|     +ConcurrentMode: typeof ConcurrentMode,
-   388|     +StrictMode: typeof StrictMode,
-   389|     +Suspense: typeof Suspense,
-   390|     +useContext: typeof useContext,
-   391|     +useState: typeof useState,
-   392|     +useReducer: typeof useReducer,
-   393|     +useRef: typeof useRef,
-   394|     +useEffect: typeof useEffect,
-   395|     +useLayoutEffect: typeof useLayoutEffect,
-   396|     +useCallback: typeof useCallback,
-   397|     +useMemo: typeof useMemo,
-   398|     +useImperativeHandle: typeof useImperativeHandle,
-   399|   |};
+   386|     +Fragment: typeof Fragment,
+   387|     +Children: typeof Children,
+   388|     +ConcurrentMode: typeof ConcurrentMode,
+   389|     +StrictMode: typeof StrictMode,
+   390|     +Suspense: typeof Suspense,
+   391|     +useContext: typeof useContext,
+   392|     +useState: typeof useState,
+   393|     +useReducer: typeof useReducer,
+   394|     +useRef: typeof useRef,
+   395|     +useEffect: typeof useEffect,
+   396|     +useLayoutEffect: typeof useLayoutEffect,
+   397|     +useCallback: typeof useCallback,
+   398|     +useMemo: typeof useMemo,
+   399|     +useImperativeHandle: typeof useImperativeHandle,
+   400|   |};
           -^ [1]
 
 
@@ -3732,39 +3732,39 @@ Cannot call `React.useMutationEffect` because property `useMutationEffect` is mi
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/react.js:368:26
+   <BUILTINS>/react.js:369:26
                                  v-
-   368|   declare export default {|
-   369|     +DOM: typeof DOM,
-   370|     +PropTypes: typeof PropTypes,
-   371|     +version: typeof version,
-   372|     +checkPropTypes: typeof checkPropTypes,
-   373|     +memo: typeof memo,
-   374|     +lazy: typeof lazy,
-   375|     +createClass: typeof createClass,
-   376|     +createContext: typeof createContext,
-   377|     +createElement: typeof createElement,
-   378|     +cloneElement: typeof cloneElement,
-   379|     +createFactory: typeof createFactory,
-   380|     +createRef: typeof createRef,
-   381|     +forwardRef: typeof forwardRef,
-   382|     +isValidElement: typeof isValidElement,
+   369|   declare export default {|
+   370|     +DOM: typeof DOM,
+   371|     +PropTypes: typeof PropTypes,
+   372|     +version: typeof version,
+   373|     +checkPropTypes: typeof checkPropTypes,
+   374|     +memo: typeof memo,
+   375|     +lazy: typeof lazy,
+   376|     +createClass: typeof createClass,
+   377|     +createContext: typeof createContext,
+   378|     +createElement: typeof createElement,
+   379|     +cloneElement: typeof cloneElement,
+   380|     +createFactory: typeof createFactory,
+   381|     +createRef: typeof createRef,
+   382|     +forwardRef: typeof forwardRef,
+   383|     +isValidElement: typeof isValidElement,
       :
-   385|     +Fragment: typeof Fragment,
-   386|     +Children: typeof Children,
-   387|     +ConcurrentMode: typeof ConcurrentMode,
-   388|     +StrictMode: typeof StrictMode,
-   389|     +Suspense: typeof Suspense,
-   390|     +useContext: typeof useContext,
-   391|     +useState: typeof useState,
-   392|     +useReducer: typeof useReducer,
-   393|     +useRef: typeof useRef,
-   394|     +useEffect: typeof useEffect,
-   395|     +useLayoutEffect: typeof useLayoutEffect,
-   396|     +useCallback: typeof useCallback,
-   397|     +useMemo: typeof useMemo,
-   398|     +useImperativeHandle: typeof useImperativeHandle,
-   399|   |};
+   386|     +Fragment: typeof Fragment,
+   387|     +Children: typeof Children,
+   388|     +ConcurrentMode: typeof ConcurrentMode,
+   389|     +StrictMode: typeof StrictMode,
+   390|     +Suspense: typeof Suspense,
+   391|     +useContext: typeof useContext,
+   392|     +useState: typeof useState,
+   393|     +useReducer: typeof useReducer,
+   394|     +useRef: typeof useRef,
+   395|     +useEffect: typeof useEffect,
+   396|     +useLayoutEffect: typeof useLayoutEffect,
+   397|     +useCallback: typeof useCallback,
+   398|     +useMemo: typeof useMemo,
+   399|     +useImperativeHandle: typeof useImperativeHandle,
+   400|   |};
           -^ [1]
 
 
@@ -3777,39 +3777,39 @@ Cannot call `React.useMutationEffect` because property `useMutationEffect` is mi
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/react.js:368:26
+   <BUILTINS>/react.js:369:26
                                  v-
-   368|   declare export default {|
-   369|     +DOM: typeof DOM,
-   370|     +PropTypes: typeof PropTypes,
-   371|     +version: typeof version,
-   372|     +checkPropTypes: typeof checkPropTypes,
-   373|     +memo: typeof memo,
-   374|     +lazy: typeof lazy,
-   375|     +createClass: typeof createClass,
-   376|     +createContext: typeof createContext,
-   377|     +createElement: typeof createElement,
-   378|     +cloneElement: typeof cloneElement,
-   379|     +createFactory: typeof createFactory,
-   380|     +createRef: typeof createRef,
-   381|     +forwardRef: typeof forwardRef,
-   382|     +isValidElement: typeof isValidElement,
+   369|   declare export default {|
+   370|     +DOM: typeof DOM,
+   371|     +PropTypes: typeof PropTypes,
+   372|     +version: typeof version,
+   373|     +checkPropTypes: typeof checkPropTypes,
+   374|     +memo: typeof memo,
+   375|     +lazy: typeof lazy,
+   376|     +createClass: typeof createClass,
+   377|     +createContext: typeof createContext,
+   378|     +createElement: typeof createElement,
+   379|     +cloneElement: typeof cloneElement,
+   380|     +createFactory: typeof createFactory,
+   381|     +createRef: typeof createRef,
+   382|     +forwardRef: typeof forwardRef,
+   383|     +isValidElement: typeof isValidElement,
       :
-   385|     +Fragment: typeof Fragment,
-   386|     +Children: typeof Children,
-   387|     +ConcurrentMode: typeof ConcurrentMode,
-   388|     +StrictMode: typeof StrictMode,
-   389|     +Suspense: typeof Suspense,
-   390|     +useContext: typeof useContext,
-   391|     +useState: typeof useState,
-   392|     +useReducer: typeof useReducer,
-   393|     +useRef: typeof useRef,
-   394|     +useEffect: typeof useEffect,
-   395|     +useLayoutEffect: typeof useLayoutEffect,
-   396|     +useCallback: typeof useCallback,
-   397|     +useMemo: typeof useMemo,
-   398|     +useImperativeHandle: typeof useImperativeHandle,
-   399|   |};
+   386|     +Fragment: typeof Fragment,
+   387|     +Children: typeof Children,
+   388|     +ConcurrentMode: typeof ConcurrentMode,
+   389|     +StrictMode: typeof StrictMode,
+   390|     +Suspense: typeof Suspense,
+   391|     +useContext: typeof useContext,
+   392|     +useState: typeof useState,
+   393|     +useReducer: typeof useReducer,
+   394|     +useRef: typeof useRef,
+   395|     +useEffect: typeof useEffect,
+   396|     +useLayoutEffect: typeof useLayoutEffect,
+   397|     +useCallback: typeof useCallback,
+   398|     +useMemo: typeof useMemo,
+   399|     +useImperativeHandle: typeof useImperativeHandle,
+   400|   |};
           -^ [1]
 
 
@@ -3822,39 +3822,39 @@ Cannot call `React.useMutationEffect` because property `useMutationEffect` is mi
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/react.js:368:26
+   <BUILTINS>/react.js:369:26
                                  v-
-   368|   declare export default {|
-   369|     +DOM: typeof DOM,
-   370|     +PropTypes: typeof PropTypes,
-   371|     +version: typeof version,
-   372|     +checkPropTypes: typeof checkPropTypes,
-   373|     +memo: typeof memo,
-   374|     +lazy: typeof lazy,
-   375|     +createClass: typeof createClass,
-   376|     +createContext: typeof createContext,
-   377|     +createElement: typeof createElement,
-   378|     +cloneElement: typeof cloneElement,
-   379|     +createFactory: typeof createFactory,
-   380|     +createRef: typeof createRef,
-   381|     +forwardRef: typeof forwardRef,
-   382|     +isValidElement: typeof isValidElement,
+   369|   declare export default {|
+   370|     +DOM: typeof DOM,
+   371|     +PropTypes: typeof PropTypes,
+   372|     +version: typeof version,
+   373|     +checkPropTypes: typeof checkPropTypes,
+   374|     +memo: typeof memo,
+   375|     +lazy: typeof lazy,
+   376|     +createClass: typeof createClass,
+   377|     +createContext: typeof createContext,
+   378|     +createElement: typeof createElement,
+   379|     +cloneElement: typeof cloneElement,
+   380|     +createFactory: typeof createFactory,
+   381|     +createRef: typeof createRef,
+   382|     +forwardRef: typeof forwardRef,
+   383|     +isValidElement: typeof isValidElement,
       :
-   385|     +Fragment: typeof Fragment,
-   386|     +Children: typeof Children,
-   387|     +ConcurrentMode: typeof ConcurrentMode,
-   388|     +StrictMode: typeof StrictMode,
-   389|     +Suspense: typeof Suspense,
-   390|     +useContext: typeof useContext,
-   391|     +useState: typeof useState,
-   392|     +useReducer: typeof useReducer,
-   393|     +useRef: typeof useRef,
-   394|     +useEffect: typeof useEffect,
-   395|     +useLayoutEffect: typeof useLayoutEffect,
-   396|     +useCallback: typeof useCallback,
-   397|     +useMemo: typeof useMemo,
-   398|     +useImperativeHandle: typeof useImperativeHandle,
-   399|   |};
+   386|     +Fragment: typeof Fragment,
+   387|     +Children: typeof Children,
+   388|     +ConcurrentMode: typeof ConcurrentMode,
+   389|     +StrictMode: typeof StrictMode,
+   390|     +Suspense: typeof Suspense,
+   391|     +useContext: typeof useContext,
+   392|     +useState: typeof useState,
+   393|     +useReducer: typeof useReducer,
+   394|     +useRef: typeof useRef,
+   395|     +useEffect: typeof useEffect,
+   396|     +useLayoutEffect: typeof useLayoutEffect,
+   397|     +useCallback: typeof useCallback,
+   398|     +useMemo: typeof useMemo,
+   399|     +useImperativeHandle: typeof useImperativeHandle,
+   400|   |};
           -^ [1]
 
 
@@ -3867,39 +3867,39 @@ Cannot call `React.useMutationEffect` because property `useMutationEffect` is mi
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/react.js:368:26
+   <BUILTINS>/react.js:369:26
                                  v-
-   368|   declare export default {|
-   369|     +DOM: typeof DOM,
-   370|     +PropTypes: typeof PropTypes,
-   371|     +version: typeof version,
-   372|     +checkPropTypes: typeof checkPropTypes,
-   373|     +memo: typeof memo,
-   374|     +lazy: typeof lazy,
-   375|     +createClass: typeof createClass,
-   376|     +createContext: typeof createContext,
-   377|     +createElement: typeof createElement,
-   378|     +cloneElement: typeof cloneElement,
-   379|     +createFactory: typeof createFactory,
-   380|     +createRef: typeof createRef,
-   381|     +forwardRef: typeof forwardRef,
-   382|     +isValidElement: typeof isValidElement,
+   369|   declare export default {|
+   370|     +DOM: typeof DOM,
+   371|     +PropTypes: typeof PropTypes,
+   372|     +version: typeof version,
+   373|     +checkPropTypes: typeof checkPropTypes,
+   374|     +memo: typeof memo,
+   375|     +lazy: typeof lazy,
+   376|     +createClass: typeof createClass,
+   377|     +createContext: typeof createContext,
+   378|     +createElement: typeof createElement,
+   379|     +cloneElement: typeof cloneElement,
+   380|     +createFactory: typeof createFactory,
+   381|     +createRef: typeof createRef,
+   382|     +forwardRef: typeof forwardRef,
+   383|     +isValidElement: typeof isValidElement,
       :
-   385|     +Fragment: typeof Fragment,
-   386|     +Children: typeof Children,
-   387|     +ConcurrentMode: typeof ConcurrentMode,
-   388|     +StrictMode: typeof StrictMode,
-   389|     +Suspense: typeof Suspense,
-   390|     +useContext: typeof useContext,
-   391|     +useState: typeof useState,
-   392|     +useReducer: typeof useReducer,
-   393|     +useRef: typeof useRef,
-   394|     +useEffect: typeof useEffect,
-   395|     +useLayoutEffect: typeof useLayoutEffect,
-   396|     +useCallback: typeof useCallback,
-   397|     +useMemo: typeof useMemo,
-   398|     +useImperativeHandle: typeof useImperativeHandle,
-   399|   |};
+   386|     +Fragment: typeof Fragment,
+   387|     +Children: typeof Children,
+   388|     +ConcurrentMode: typeof ConcurrentMode,
+   389|     +StrictMode: typeof StrictMode,
+   390|     +Suspense: typeof Suspense,
+   391|     +useContext: typeof useContext,
+   392|     +useState: typeof useState,
+   393|     +useReducer: typeof useReducer,
+   394|     +useRef: typeof useRef,
+   395|     +useEffect: typeof useEffect,
+   396|     +useLayoutEffect: typeof useLayoutEffect,
+   397|     +useCallback: typeof useCallback,
+   398|     +useMemo: typeof useMemo,
+   399|     +useImperativeHandle: typeof useImperativeHandle,
+   400|   |};
           -^ [1]
 
 
@@ -3912,39 +3912,39 @@ Cannot call `React.useMutationEffect` because property `useMutationEffect` is mi
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/react.js:368:26
+   <BUILTINS>/react.js:369:26
                                  v-
-   368|   declare export default {|
-   369|     +DOM: typeof DOM,
-   370|     +PropTypes: typeof PropTypes,
-   371|     +version: typeof version,
-   372|     +checkPropTypes: typeof checkPropTypes,
-   373|     +memo: typeof memo,
-   374|     +lazy: typeof lazy,
-   375|     +createClass: typeof createClass,
-   376|     +createContext: typeof createContext,
-   377|     +createElement: typeof createElement,
-   378|     +cloneElement: typeof cloneElement,
-   379|     +createFactory: typeof createFactory,
-   380|     +createRef: typeof createRef,
-   381|     +forwardRef: typeof forwardRef,
-   382|     +isValidElement: typeof isValidElement,
+   369|   declare export default {|
+   370|     +DOM: typeof DOM,
+   371|     +PropTypes: typeof PropTypes,
+   372|     +version: typeof version,
+   373|     +checkPropTypes: typeof checkPropTypes,
+   374|     +memo: typeof memo,
+   375|     +lazy: typeof lazy,
+   376|     +createClass: typeof createClass,
+   377|     +createContext: typeof createContext,
+   378|     +createElement: typeof createElement,
+   379|     +cloneElement: typeof cloneElement,
+   380|     +createFactory: typeof createFactory,
+   381|     +createRef: typeof createRef,
+   382|     +forwardRef: typeof forwardRef,
+   383|     +isValidElement: typeof isValidElement,
       :
-   385|     +Fragment: typeof Fragment,
-   386|     +Children: typeof Children,
-   387|     +ConcurrentMode: typeof ConcurrentMode,
-   388|     +StrictMode: typeof StrictMode,
-   389|     +Suspense: typeof Suspense,
-   390|     +useContext: typeof useContext,
-   391|     +useState: typeof useState,
-   392|     +useReducer: typeof useReducer,
-   393|     +useRef: typeof useRef,
-   394|     +useEffect: typeof useEffect,
-   395|     +useLayoutEffect: typeof useLayoutEffect,
-   396|     +useCallback: typeof useCallback,
-   397|     +useMemo: typeof useMemo,
-   398|     +useImperativeHandle: typeof useImperativeHandle,
-   399|   |};
+   386|     +Fragment: typeof Fragment,
+   387|     +Children: typeof Children,
+   388|     +ConcurrentMode: typeof ConcurrentMode,
+   389|     +StrictMode: typeof StrictMode,
+   390|     +Suspense: typeof Suspense,
+   391|     +useContext: typeof useContext,
+   392|     +useState: typeof useState,
+   393|     +useReducer: typeof useReducer,
+   394|     +useRef: typeof useRef,
+   395|     +useEffect: typeof useEffect,
+   396|     +useLayoutEffect: typeof useLayoutEffect,
+   397|     +useCallback: typeof useCallback,
+   398|     +useMemo: typeof useMemo,
+   399|     +useImperativeHandle: typeof useImperativeHandle,
+   400|   |};
           -^ [1]
 
 
@@ -3957,39 +3957,39 @@ Cannot call `React.useMutationEffect` because property `useMutationEffect` is mi
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/react.js:368:26
+   <BUILTINS>/react.js:369:26
                                  v-
-   368|   declare export default {|
-   369|     +DOM: typeof DOM,
-   370|     +PropTypes: typeof PropTypes,
-   371|     +version: typeof version,
-   372|     +checkPropTypes: typeof checkPropTypes,
-   373|     +memo: typeof memo,
-   374|     +lazy: typeof lazy,
-   375|     +createClass: typeof createClass,
-   376|     +createContext: typeof createContext,
-   377|     +createElement: typeof createElement,
-   378|     +cloneElement: typeof cloneElement,
-   379|     +createFactory: typeof createFactory,
-   380|     +createRef: typeof createRef,
-   381|     +forwardRef: typeof forwardRef,
-   382|     +isValidElement: typeof isValidElement,
+   369|   declare export default {|
+   370|     +DOM: typeof DOM,
+   371|     +PropTypes: typeof PropTypes,
+   372|     +version: typeof version,
+   373|     +checkPropTypes: typeof checkPropTypes,
+   374|     +memo: typeof memo,
+   375|     +lazy: typeof lazy,
+   376|     +createClass: typeof createClass,
+   377|     +createContext: typeof createContext,
+   378|     +createElement: typeof createElement,
+   379|     +cloneElement: typeof cloneElement,
+   380|     +createFactory: typeof createFactory,
+   381|     +createRef: typeof createRef,
+   382|     +forwardRef: typeof forwardRef,
+   383|     +isValidElement: typeof isValidElement,
       :
-   385|     +Fragment: typeof Fragment,
-   386|     +Children: typeof Children,
-   387|     +ConcurrentMode: typeof ConcurrentMode,
-   388|     +StrictMode: typeof StrictMode,
-   389|     +Suspense: typeof Suspense,
-   390|     +useContext: typeof useContext,
-   391|     +useState: typeof useState,
-   392|     +useReducer: typeof useReducer,
-   393|     +useRef: typeof useRef,
-   394|     +useEffect: typeof useEffect,
-   395|     +useLayoutEffect: typeof useLayoutEffect,
-   396|     +useCallback: typeof useCallback,
-   397|     +useMemo: typeof useMemo,
-   398|     +useImperativeHandle: typeof useImperativeHandle,
-   399|   |};
+   386|     +Fragment: typeof Fragment,
+   387|     +Children: typeof Children,
+   388|     +ConcurrentMode: typeof ConcurrentMode,
+   389|     +StrictMode: typeof StrictMode,
+   390|     +Suspense: typeof Suspense,
+   391|     +useContext: typeof useContext,
+   392|     +useState: typeof useState,
+   393|     +useReducer: typeof useReducer,
+   394|     +useRef: typeof useRef,
+   395|     +useEffect: typeof useEffect,
+   396|     +useLayoutEffect: typeof useLayoutEffect,
+   397|     +useCallback: typeof useCallback,
+   398|     +useMemo: typeof useMemo,
+   399|     +useImperativeHandle: typeof useImperativeHandle,
+   400|   |};
           -^ [1]
 
 
@@ -4002,39 +4002,39 @@ Cannot call `React.useMutationEffect` because property `useMutationEffect` is mi
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/react.js:368:26
+   <BUILTINS>/react.js:369:26
                                  v-
-   368|   declare export default {|
-   369|     +DOM: typeof DOM,
-   370|     +PropTypes: typeof PropTypes,
-   371|     +version: typeof version,
-   372|     +checkPropTypes: typeof checkPropTypes,
-   373|     +memo: typeof memo,
-   374|     +lazy: typeof lazy,
-   375|     +createClass: typeof createClass,
-   376|     +createContext: typeof createContext,
-   377|     +createElement: typeof createElement,
-   378|     +cloneElement: typeof cloneElement,
-   379|     +createFactory: typeof createFactory,
-   380|     +createRef: typeof createRef,
-   381|     +forwardRef: typeof forwardRef,
-   382|     +isValidElement: typeof isValidElement,
+   369|   declare export default {|
+   370|     +DOM: typeof DOM,
+   371|     +PropTypes: typeof PropTypes,
+   372|     +version: typeof version,
+   373|     +checkPropTypes: typeof checkPropTypes,
+   374|     +memo: typeof memo,
+   375|     +lazy: typeof lazy,
+   376|     +createClass: typeof createClass,
+   377|     +createContext: typeof createContext,
+   378|     +createElement: typeof createElement,
+   379|     +cloneElement: typeof cloneElement,
+   380|     +createFactory: typeof createFactory,
+   381|     +createRef: typeof createRef,
+   382|     +forwardRef: typeof forwardRef,
+   383|     +isValidElement: typeof isValidElement,
       :
-   385|     +Fragment: typeof Fragment,
-   386|     +Children: typeof Children,
-   387|     +ConcurrentMode: typeof ConcurrentMode,
-   388|     +StrictMode: typeof StrictMode,
-   389|     +Suspense: typeof Suspense,
-   390|     +useContext: typeof useContext,
-   391|     +useState: typeof useState,
-   392|     +useReducer: typeof useReducer,
-   393|     +useRef: typeof useRef,
-   394|     +useEffect: typeof useEffect,
-   395|     +useLayoutEffect: typeof useLayoutEffect,
-   396|     +useCallback: typeof useCallback,
-   397|     +useMemo: typeof useMemo,
-   398|     +useImperativeHandle: typeof useImperativeHandle,
-   399|   |};
+   386|     +Fragment: typeof Fragment,
+   387|     +Children: typeof Children,
+   388|     +ConcurrentMode: typeof ConcurrentMode,
+   389|     +StrictMode: typeof StrictMode,
+   390|     +Suspense: typeof Suspense,
+   391|     +useContext: typeof useContext,
+   392|     +useState: typeof useState,
+   393|     +useReducer: typeof useReducer,
+   394|     +useRef: typeof useRef,
+   395|     +useEffect: typeof useEffect,
+   396|     +useLayoutEffect: typeof useLayoutEffect,
+   397|     +useCallback: typeof useCallback,
+   398|     +useMemo: typeof useMemo,
+   399|     +useImperativeHandle: typeof useImperativeHandle,
+   400|   |};
           -^ [1]
 
 
@@ -4050,28 +4050,28 @@ Cannot call `React.useReducer` because:
           ^^^^^^^^^^^^^^^^^^ [2]
 
 References:
-   <BUILTINS>/react.js:321:37
+   <BUILTINS>/react.js:322:37
                                             v------
-   321|   declare export function useReducer<S, A>(
-   322|     reducer: (S, A) => S,
-   323|     initialState: S,
-   324|   ): [S, Dispatch<A>];
+   322|   declare export function useReducer<S, A>(
+   323|     reducer: (S, A) => S,
+   324|     initialState: S,
+   325|   ): [S, Dispatch<A>];
           ------------------^ [1]
-   <BUILTINS>/react.js:326:37
+   <BUILTINS>/react.js:327:37
                                             v------
-   326|   declare export function useReducer<S, A>(
-   327|     reducer: (S, A) => S,
-   328|     initialState: S,
-   329|     init: void,
-   330|   ): [S, Dispatch<A>];
+   327|   declare export function useReducer<S, A>(
+   328|     reducer: (S, A) => S,
+   329|     initialState: S,
+   330|     init: void,
+   331|   ): [S, Dispatch<A>];
           ------------------^ [3]
-   <BUILTINS>/react.js:332:37
+   <BUILTINS>/react.js:333:37
                                             v---------
-   332|   declare export function useReducer<S, A, I>(
-   333|     reducer: (S, A) => S,
-   334|     initialArg: I,
-   335|     init: (I) => S,
-   336|   ): [S, Dispatch<A>];
+   333|   declare export function useReducer<S, A, I>(
+   334|     reducer: (S, A) => S,
+   335|     initialArg: I,
+   336|     init: (I) => S,
+   337|   ): [S, Dispatch<A>];
           ------------------^ [4]
 
 

--- a/tests/react_16_3/react_16_3.exp
+++ b/tests/react_16_3/react_16_3.exp
@@ -43,11 +43,11 @@ References:
    <BUILTINS>/react-dom.js:289:22
    289|   button: {instance: HTMLButtonElement, props: {children?: React$Node, [key: string]: any}},
                              ^^^^^^^^^^^^^^^^^ [2]
-   <BUILTINS>/react.js:240:6
-   240|   ): {current: null | T};
+   <BUILTINS>/react.js:241:6
+   241|   ): {current: null | T};
              ^^^^^^^^^^^^^^^^^^^ [3]
-   <BUILTINS>/react.js:195:6
-   195|   | ((React$ElementRef<ElementType> | null) => mixed)
+   <BUILTINS>/react.js:196:6
+   196|   | ((React$ElementRef<ElementType> | null) => mixed)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [4]
 
 
@@ -65,8 +65,8 @@ References:
    forwardRef.js:23:39
     23| const _g =  <FancyButton foo={3} ref={(x: null | HTMLDivElement) => x} />; // Incorrect ref type
                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
-   <BUILTINS>/react.js:194:5
-   194|   | {current: React$ElementRef<ElementType> | null}
+   <BUILTINS>/react.js:195:5
+   195|   | {current: React$ElementRef<ElementType> | null}
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [2]
    forwardRef.js:23:50
     23| const _g =  <FancyButton foo={3} ref={(x: null | HTMLDivElement) => x} />; // Incorrect ref type

--- a/tests/react_16_6/react_16_6.exp
+++ b/tests/react_16_6/react_16_6.exp
@@ -10,8 +10,8 @@ References:
    Suspense.js:12:48
     12|   <Suspense fallback={<Loading />} maxDuration="abc" /> // Error: string is incompatible with number
                                                        ^^^^^ [1]
-   <BUILTINS>/react.js:267:19
-   267|     maxDuration?: number
+   <BUILTINS>/react.js:268:19
+   268|     maxDuration?: number
                           ^^^^^^ [2]
 
 
@@ -54,8 +54,8 @@ References:
    lazy.js:6:1
      6| function FunctionComponent(x: Props): React.Node { return null }
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
-   <BUILTINS>/react.js:305:22
-   305|     component: () => Promise<{ default: React$ComponentType<P> }>,
+   <BUILTINS>/react.js:306:22
+   306|     component: () => Promise<{ default: React$ComponentType<P> }>,
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [2]
 
 
@@ -72,8 +72,8 @@ References:
    lazy.js:7:7
      7| class ClassComponent extends React.Component<Props> {}
               ^^^^^^^^^^^^^^ [1]
-   <BUILTINS>/react.js:305:22
-   305|     component: () => Promise<{ default: React$ComponentType<P> }>,
+   <BUILTINS>/react.js:306:22
+   306|     component: () => Promise<{ default: React$ComponentType<P> }>,
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [2]
 
 
@@ -90,8 +90,8 @@ References:
    lazy.js:6:1
      6| function FunctionComponent(x: Props): React.Node { return null }
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
-   <BUILTINS>/react.js:305:30
-   305|     component: () => Promise<{ default: React$ComponentType<P> }>,
+   <BUILTINS>/react.js:306:30
+   306|     component: () => Promise<{ default: React$ComponentType<P> }>,
                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [2]
    <BUILTINS>/core.js:615:24
    615| declare class Promise<+R> {
@@ -111,8 +111,8 @@ References:
    lazy.js:7:7
      7| class ClassComponent extends React.Component<Props> {}
               ^^^^^^^^^^^^^^ [1]
-   <BUILTINS>/react.js:305:30
-   305|     component: () => Promise<{ default: React$ComponentType<P> }>,
+   <BUILTINS>/react.js:306:30
+   306|     component: () => Promise<{ default: React$ComponentType<P> }>,
                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [2]
    <BUILTINS>/core.js:615:24
    615| declare class Promise<+R> {

--- a/tests/react_abstract_component/react_abstract_component.exp
+++ b/tests/react_abstract_component/react_abstract_component.exp
@@ -514,7 +514,7 @@ References:
    134|   // This is only on function components, but trying to access name when
    135|   // displayName is undefined is a common pattern.
    136|   name?: ?string,
-   137|   propTypes?: any,
+   137|   propTypes?: {},
    138| };
         ^ [1]
 
@@ -549,7 +549,7 @@ References:
    134|   // This is only on function components, but trying to access name when
    135|   // displayName is undefined is a common pattern.
    136|   name?: ?string,
-   137|   propTypes?: any,
+   137|   propTypes?: {},
    138| };
         ^ [1]
 

--- a/tests/react_abstract_component/react_abstract_component.exp
+++ b/tests/react_abstract_component/react_abstract_component.exp
@@ -253,11 +253,11 @@ References:
    create_element.js:5:94
      5| declare var C: React$AbstractComponent<{+foo?: number, +bar: number | string, +baz: number}, number>;
                                                                                                      ^^^^^^ [2]
-   <BUILTINS>/react.js:240:6
-   240|   ): {current: null | T};
+   <BUILTINS>/react.js:241:6
+   241|   ): {current: null | T};
              ^^^^^^^^^^^^^^^^^^^ [3]
-   <BUILTINS>/react.js:195:6
-   195|   | ((React$ElementRef<ElementType> | null) => mixed)
+   <BUILTINS>/react.js:196:6
+   196|   | ((React$ElementRef<ElementType> | null) => mixed)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [4]
 
 
@@ -275,11 +275,11 @@ References:
    create_element.js:19:49
     19| const _h = <C foo={3} bar="string" baz={4} key={{bad: 3}} />; // Error bad key
                                                         ^^^^^^^^ [1]
-   <BUILTINS>/react.js:188:26
-   188| declare type React$Key = string | number;
+   <BUILTINS>/react.js:189:26
+   189| declare type React$Key = string | number;
                                  ^^^^^^ [2]
-   <BUILTINS>/react.js:188:35
-   188| declare type React$Key = string | number;
+   <BUILTINS>/react.js:189:35
+   189| declare type React$Key = string | number;
                                           ^^^^^^ [3]
 
 
@@ -514,7 +514,8 @@ References:
    134|   // This is only on function components, but trying to access name when
    135|   // displayName is undefined is a common pattern.
    136|   name?: ?string,
-   137| };
+   137|   propTypes?: any,
+   138| };
         ^ [1]
 
 
@@ -548,7 +549,8 @@ References:
    134|   // This is only on function components, but trying to access name when
    135|   // displayName is undefined is a common pattern.
    136|   name?: ?string,
-   137| };
+   137|   propTypes?: any,
+   138| };
         ^ [1]
 
 

--- a/tests/react_children/react_children.exp
+++ b/tests/react_children/react_children.exp
@@ -68,8 +68,8 @@ References:
    api.js:14:25
     14| Children.forEach(a, (x: number) => {}); // Error
                                 ^^^^^^ [2]
-   <BUILTINS>/react.js:275:38
-   275|   declare export type ChildrenArray<+T> = $ReadOnlyArray<ChildrenArray<T>> | T;
+   <BUILTINS>/react.js:276:38
+   276|   declare export type ChildrenArray<+T> = $ReadOnlyArray<ChildrenArray<T>> | T;
                                              ^ [3]
 
 
@@ -90,8 +90,8 @@ References:
    api.js:16:25
     16| Children.forEach(a, (x: string) => {}); // Error
                                 ^^^^^^ [2]
-   <BUILTINS>/react.js:275:38
-   275|   declare export type ChildrenArray<+T> = $ReadOnlyArray<ChildrenArray<T>> | T;
+   <BUILTINS>/react.js:276:38
+   276|   declare export type ChildrenArray<+T> = $ReadOnlyArray<ChildrenArray<T>> | T;
                                              ^ [3]
    api.js:5:25
      5| const a: ChildrenArray<?number> = [
@@ -107,8 +107,8 @@ Cannot call `s` with `Children.count(...)` bound to `x` because number [1] is in
           ^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/react.js:287:42
-   287|     count(children: ChildrenArray<any>): number;
+   <BUILTINS>/react.js:288:42
+   288|     count(children: ChildrenArray<any>): number;
                                                  ^^^^^^ [1]
    api.js:29:15
     29| function s(x: string) {}

--- a/tests/react_custom_funs/react_custom_funs.exp
+++ b/tests/react_custom_funs/react_custom_funs.exp
@@ -23,14 +23,14 @@ Property `key` is missing in object literal [1] but exists in `React.Element` [2
                            ^^^^^^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/react.js:177:63
+   <BUILTINS>/react.js:178:63
                                                                       v-
-   177| declare type React$Element<+ElementType: React$ElementType> = {|
-   178|   +type: ElementType,
-   179|   +props: React$ElementProps<ElementType>,
-   180|   +key: React$Key | null,
-   181|   +ref: any,
-   182| |};
+   178| declare type React$Element<+ElementType: React$ElementType> = {|
+   179|   +type: ElementType,
+   180|   +props: React$ElementProps<ElementType>,
+   181|   +key: React$Key | null,
+   182|   +ref: any,
+   183| |};
         -^ [2]
 
 
@@ -43,14 +43,14 @@ Property `props` is missing in object literal [1] but exists in `React.Element` 
                            ^^^^^^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/react.js:177:63
+   <BUILTINS>/react.js:178:63
                                                                       v-
-   177| declare type React$Element<+ElementType: React$ElementType> = {|
-   178|   +type: ElementType,
-   179|   +props: React$ElementProps<ElementType>,
-   180|   +key: React$Key | null,
-   181|   +ref: any,
-   182| |};
+   178| declare type React$Element<+ElementType: React$ElementType> = {|
+   179|   +type: ElementType,
+   180|   +props: React$ElementProps<ElementType>,
+   181|   +key: React$Key | null,
+   182|   +ref: any,
+   183| |};
         -^ [2]
 
 
@@ -63,14 +63,14 @@ Property `ref` is missing in object literal [1] but exists in `React.Element` [2
                            ^^^^^^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/react.js:177:63
+   <BUILTINS>/react.js:178:63
                                                                       v-
-   177| declare type React$Element<+ElementType: React$ElementType> = {|
-   178|   +type: ElementType,
-   179|   +props: React$ElementProps<ElementType>,
-   180|   +key: React$Key | null,
-   181|   +ref: any,
-   182| |};
+   178| declare type React$Element<+ElementType: React$ElementType> = {|
+   179|   +type: ElementType,
+   180|   +props: React$ElementProps<ElementType>,
+   181|   +key: React$Key | null,
+   182|   +ref: any,
+   183| |};
         -^ [2]
 
 

--- a/tests/react_imports/react_imports.exp
+++ b/tests/react_imports/react_imports.exp
@@ -47,8 +47,8 @@ Cannot get `React.Missing` because property `Missing` is missing in module `reac
                ^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/react.js:405:27
-   405|   declare module.exports: $Exports<'react'>;
+   <BUILTINS>/react.js:406:27
+   406|   declare module.exports: $Exports<'react'>;
                                   ^^^^^^^^^^^^^^^^^ [1]
 
 
@@ -155,8 +155,8 @@ Cannot get `React.Missing` because property `Missing` is missing in module `reac
                ^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/react.js:405:27
-   405|   declare module.exports: $Exports<'react'>;
+   <BUILTINS>/react.js:406:27
+   406|   declare module.exports: $Exports<'react'>;
                                   ^^^^^^^^^^^^^^^^^ [1]
 
 
@@ -186,39 +186,39 @@ Cannot get `React.Node` because property `Node` is missing in object type [1].
                           ^^^^^^^^^^
 
 References:
-   <BUILTINS>/react.js:368:26
+   <BUILTINS>/react.js:369:26
                                  v-
-   368|   declare export default {|
-   369|     +DOM: typeof DOM,
-   370|     +PropTypes: typeof PropTypes,
-   371|     +version: typeof version,
-   372|     +checkPropTypes: typeof checkPropTypes,
-   373|     +memo: typeof memo,
-   374|     +lazy: typeof lazy,
-   375|     +createClass: typeof createClass,
-   376|     +createContext: typeof createContext,
-   377|     +createElement: typeof createElement,
-   378|     +cloneElement: typeof cloneElement,
-   379|     +createFactory: typeof createFactory,
-   380|     +createRef: typeof createRef,
-   381|     +forwardRef: typeof forwardRef,
-   382|     +isValidElement: typeof isValidElement,
+   369|   declare export default {|
+   370|     +DOM: typeof DOM,
+   371|     +PropTypes: typeof PropTypes,
+   372|     +version: typeof version,
+   373|     +checkPropTypes: typeof checkPropTypes,
+   374|     +memo: typeof memo,
+   375|     +lazy: typeof lazy,
+   376|     +createClass: typeof createClass,
+   377|     +createContext: typeof createContext,
+   378|     +createElement: typeof createElement,
+   379|     +cloneElement: typeof cloneElement,
+   380|     +createFactory: typeof createFactory,
+   381|     +createRef: typeof createRef,
+   382|     +forwardRef: typeof forwardRef,
+   383|     +isValidElement: typeof isValidElement,
       :
-   385|     +Fragment: typeof Fragment,
-   386|     +Children: typeof Children,
-   387|     +ConcurrentMode: typeof ConcurrentMode,
-   388|     +StrictMode: typeof StrictMode,
-   389|     +Suspense: typeof Suspense,
-   390|     +useContext: typeof useContext,
-   391|     +useState: typeof useState,
-   392|     +useReducer: typeof useReducer,
-   393|     +useRef: typeof useRef,
-   394|     +useEffect: typeof useEffect,
-   395|     +useLayoutEffect: typeof useLayoutEffect,
-   396|     +useCallback: typeof useCallback,
-   397|     +useMemo: typeof useMemo,
-   398|     +useImperativeHandle: typeof useImperativeHandle,
-   399|   |};
+   386|     +Fragment: typeof Fragment,
+   387|     +Children: typeof Children,
+   388|     +ConcurrentMode: typeof ConcurrentMode,
+   389|     +StrictMode: typeof StrictMode,
+   390|     +Suspense: typeof Suspense,
+   391|     +useContext: typeof useContext,
+   392|     +useState: typeof useState,
+   393|     +useReducer: typeof useReducer,
+   394|     +useRef: typeof useRef,
+   395|     +useEffect: typeof useEffect,
+   396|     +useLayoutEffect: typeof useLayoutEffect,
+   397|     +useCallback: typeof useCallback,
+   398|     +useMemo: typeof useMemo,
+   399|     +useImperativeHandle: typeof useImperativeHandle,
+   400|   |};
           -^ [1]
 
 
@@ -231,39 +231,39 @@ Cannot get `React.Node` because property `Node` is missing in object type [1].
              ^^^^^^^^^^
 
 References:
-   <BUILTINS>/react.js:368:26
+   <BUILTINS>/react.js:369:26
                                  v-
-   368|   declare export default {|
-   369|     +DOM: typeof DOM,
-   370|     +PropTypes: typeof PropTypes,
-   371|     +version: typeof version,
-   372|     +checkPropTypes: typeof checkPropTypes,
-   373|     +memo: typeof memo,
-   374|     +lazy: typeof lazy,
-   375|     +createClass: typeof createClass,
-   376|     +createContext: typeof createContext,
-   377|     +createElement: typeof createElement,
-   378|     +cloneElement: typeof cloneElement,
-   379|     +createFactory: typeof createFactory,
-   380|     +createRef: typeof createRef,
-   381|     +forwardRef: typeof forwardRef,
-   382|     +isValidElement: typeof isValidElement,
+   369|   declare export default {|
+   370|     +DOM: typeof DOM,
+   371|     +PropTypes: typeof PropTypes,
+   372|     +version: typeof version,
+   373|     +checkPropTypes: typeof checkPropTypes,
+   374|     +memo: typeof memo,
+   375|     +lazy: typeof lazy,
+   376|     +createClass: typeof createClass,
+   377|     +createContext: typeof createContext,
+   378|     +createElement: typeof createElement,
+   379|     +cloneElement: typeof cloneElement,
+   380|     +createFactory: typeof createFactory,
+   381|     +createRef: typeof createRef,
+   382|     +forwardRef: typeof forwardRef,
+   383|     +isValidElement: typeof isValidElement,
       :
-   385|     +Fragment: typeof Fragment,
-   386|     +Children: typeof Children,
-   387|     +ConcurrentMode: typeof ConcurrentMode,
-   388|     +StrictMode: typeof StrictMode,
-   389|     +Suspense: typeof Suspense,
-   390|     +useContext: typeof useContext,
-   391|     +useState: typeof useState,
-   392|     +useReducer: typeof useReducer,
-   393|     +useRef: typeof useRef,
-   394|     +useEffect: typeof useEffect,
-   395|     +useLayoutEffect: typeof useLayoutEffect,
-   396|     +useCallback: typeof useCallback,
-   397|     +useMemo: typeof useMemo,
-   398|     +useImperativeHandle: typeof useImperativeHandle,
-   399|   |};
+   386|     +Fragment: typeof Fragment,
+   387|     +Children: typeof Children,
+   388|     +ConcurrentMode: typeof ConcurrentMode,
+   389|     +StrictMode: typeof StrictMode,
+   390|     +Suspense: typeof Suspense,
+   391|     +useContext: typeof useContext,
+   392|     +useState: typeof useState,
+   393|     +useReducer: typeof useReducer,
+   394|     +useRef: typeof useRef,
+   395|     +useEffect: typeof useEffect,
+   396|     +useLayoutEffect: typeof useLayoutEffect,
+   397|     +useCallback: typeof useCallback,
+   398|     +useMemo: typeof useMemo,
+   399|     +useImperativeHandle: typeof useImperativeHandle,
+   400|   |};
           -^ [1]
 
 
@@ -276,39 +276,39 @@ Cannot get `React.Missing` because property `Missing` is missing in object type 
                ^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/react.js:368:26
+   <BUILTINS>/react.js:369:26
                                  v-
-   368|   declare export default {|
-   369|     +DOM: typeof DOM,
-   370|     +PropTypes: typeof PropTypes,
-   371|     +version: typeof version,
-   372|     +checkPropTypes: typeof checkPropTypes,
-   373|     +memo: typeof memo,
-   374|     +lazy: typeof lazy,
-   375|     +createClass: typeof createClass,
-   376|     +createContext: typeof createContext,
-   377|     +createElement: typeof createElement,
-   378|     +cloneElement: typeof cloneElement,
-   379|     +createFactory: typeof createFactory,
-   380|     +createRef: typeof createRef,
-   381|     +forwardRef: typeof forwardRef,
-   382|     +isValidElement: typeof isValidElement,
+   369|   declare export default {|
+   370|     +DOM: typeof DOM,
+   371|     +PropTypes: typeof PropTypes,
+   372|     +version: typeof version,
+   373|     +checkPropTypes: typeof checkPropTypes,
+   374|     +memo: typeof memo,
+   375|     +lazy: typeof lazy,
+   376|     +createClass: typeof createClass,
+   377|     +createContext: typeof createContext,
+   378|     +createElement: typeof createElement,
+   379|     +cloneElement: typeof cloneElement,
+   380|     +createFactory: typeof createFactory,
+   381|     +createRef: typeof createRef,
+   382|     +forwardRef: typeof forwardRef,
+   383|     +isValidElement: typeof isValidElement,
       :
-   385|     +Fragment: typeof Fragment,
-   386|     +Children: typeof Children,
-   387|     +ConcurrentMode: typeof ConcurrentMode,
-   388|     +StrictMode: typeof StrictMode,
-   389|     +Suspense: typeof Suspense,
-   390|     +useContext: typeof useContext,
-   391|     +useState: typeof useState,
-   392|     +useReducer: typeof useReducer,
-   393|     +useRef: typeof useRef,
-   394|     +useEffect: typeof useEffect,
-   395|     +useLayoutEffect: typeof useLayoutEffect,
-   396|     +useCallback: typeof useCallback,
-   397|     +useMemo: typeof useMemo,
-   398|     +useImperativeHandle: typeof useImperativeHandle,
-   399|   |};
+   386|     +Fragment: typeof Fragment,
+   387|     +Children: typeof Children,
+   388|     +ConcurrentMode: typeof ConcurrentMode,
+   389|     +StrictMode: typeof StrictMode,
+   390|     +Suspense: typeof Suspense,
+   391|     +useContext: typeof useContext,
+   392|     +useState: typeof useState,
+   393|     +useReducer: typeof useReducer,
+   394|     +useRef: typeof useRef,
+   395|     +useEffect: typeof useEffect,
+   396|     +useLayoutEffect: typeof useLayoutEffect,
+   397|     +useCallback: typeof useCallback,
+   398|     +useMemo: typeof useMemo,
+   399|     +useImperativeHandle: typeof useImperativeHandle,
+   400|   |};
           -^ [1]
 
 

--- a/tests/react_jsx/react_jsx.exp
+++ b/tests/react_jsx/react_jsx.exp
@@ -93,8 +93,8 @@ References:
    test.js:105:12
    105|   string1={null}
                    ^^^^ [1]
-   <BUILTINS>/react.js:440:36
-   440|   string: React$PropType$Primitive<string>;
+   <BUILTINS>/react.js:441:36
+   441|   string: React$PropType$Primitive<string>;
                                            ^^^^^^ [2]
    test.js:106:12
    106|   string2={null}
@@ -102,8 +102,8 @@ References:
    test.js:107:13
    107|   boolean1={null}
                     ^^^^ [4]
-   <BUILTINS>/react.js:436:34
-   436|   bool: React$PropType$Primitive<boolean>;
+   <BUILTINS>/react.js:437:34
+   437|   bool: React$PropType$Primitive<boolean>;
                                          ^^^^^^^ [5]
    test.js:108:13
    108|   boolean2={null}
@@ -111,8 +111,8 @@ References:
    test.js:109:11
    109|   number={null}
                   ^^^^ [7]
-   <BUILTINS>/react.js:438:36
-   438|   number: React$PropType$Primitive<number>;
+   <BUILTINS>/react.js:439:36
+   439|   number: React$PropType$Primitive<number>;
                                            ^^^^^^ [8]
 
 
@@ -161,8 +161,8 @@ References:
    test.js:135:54
    135|   {...{string1: 'foo', string2: 'bar', number: (any: ?number)}}
                                                              ^^^^^^^ [1]
-   <BUILTINS>/react.js:438:36
-   438|   number: React$PropType$Primitive<number>;
+   <BUILTINS>/react.js:439:36
+   439|   number: React$PropType$Primitive<number>;
                                            ^^^^^^ [2]
 
 
@@ -1654,8 +1654,8 @@ References:
    <BUILTINS>/core.js:13:24
     13| declare var undefined: void;
                                ^^^^ [1]
-   <BUILTINS>/react.js:438:36
-   438|   number: React$PropType$Primitive<number>;
+   <BUILTINS>/react.js:439:36
+   439|   number: React$PropType$Primitive<number>;
                                            ^^^^^^ [2]
 
 
@@ -1675,8 +1675,8 @@ References:
    test.js:788:7
    788|   foo="nope"
               ^^^^^^ [1]
-   <BUILTINS>/react.js:438:36
-   438|   number: React$PropType$Primitive<number>;
+   <BUILTINS>/react.js:439:36
+   439|   number: React$PropType$Primitive<number>;
                                            ^^^^^^ [2]
 
 
@@ -1696,8 +1696,8 @@ References:
    test.js:793:7
    793|   bar="nope"
               ^^^^^^ [1]
-   <BUILTINS>/react.js:438:36
-   438|   number: React$PropType$Primitive<number>;
+   <BUILTINS>/react.js:439:36
+   439|   number: React$PropType$Primitive<number>;
                                            ^^^^^^ [2]
 
 

--- a/tests/type-at-pos_react/type-at-pos_react.exp
+++ b/tests/type-at-pos_react/type-at-pos_react.exp
@@ -113,7 +113,7 @@ react_component.js:32:13 = {
     "kind":"Generic",
     "typeArgs":[{"kind":"Num"}],
     "type":{
-      "provenance":{"kind":"Library","loc":"[LIB] react.js:248:43-61"},
+      "provenance":{"kind":"Library","loc":"[LIB] react.js:249:43-61"},
       "name":"ComponentType"
     },
     "kind":"type alias"
@@ -136,7 +136,7 @@ react_component.js:32:29 = {
   "expanded_type":{
     "kind":"TypeAlias",
     "name":{
-      "provenance":{"kind":"Library","loc":"[LIB] react.js:248:43-61"},
+      "provenance":{"kind":"Library","loc":"[LIB] react.js:249:43-61"},
       "name":"ComponentType"
     },
     "typeParams":[{"name":"P","bound":null,"polarity":"Negative"}],
@@ -144,7 +144,7 @@ react_component.js:32:29 = {
       "kind":"Generic",
       "typeArgs":[{"kind":"Bound","bound":"P"}],
       "type":{
-        "provenance":{"kind":"Library","loc":"[LIB] react.js:159:45-80"},
+        "provenance":{"kind":"Library","loc":"[LIB] react.js:160:45-80"},
         "name":"React$ComponentType"
       },
       "kind":"type alias"


### PR DESCRIPTION
- fixes #7484
- add test accessing `Component.propTypes`
- fix line numbers for other tests due to shift in `lib/react.js`