### PR TITLE
Fix website build

### DIFF
--- a/website/Makefile
+++ b/website/Makefile
@@ -23,15 +23,15 @@ flow_js:
 
 static/master/flow.js:
 	mkdir -p $(dir $@)
-	(cd $(dir $@); ln -sf "../../../bin/flow.js" "flow.js")
+	(cd $(dir $@); cp "../../../bin/flow.js" "flow.js")
 
 static/master/flowlib:
 	mkdir -p $(dir $@)
-	(cd $(dir $@); ln -sf "../../../lib" "flowlib")
+	(cd $(dir $@); cp -r "../../../lib" "flowlib")
 
 symlinks: static/master/flow.js static/master/flowlib
 
-serve: test-jekyll symlinks
+serve: test-jekyll flow_js symlinks
 	@bundle exec jekyll serve --host="::" --port=8080
 
 build: test-jekyll symlinks

--- a/website/Makefile
+++ b/website/Makefile
@@ -29,18 +29,18 @@ static/master/flowlib:
 	mkdir -p $(dir $@)
 	(cd $(dir $@); cp -r "../../../lib" "flowlib")
 
-symlinks: static/master/flow.js static/master/flowlib
+copies: static/master/flow.js static/master/flowlib
 
-serve: test-jekyll flow_js symlinks
+serve: test-jekyll flow_js copies
 	@bundle exec jekyll serve --host="::" --port=8080
 
-build: test-jekyll symlinks
+build: test-jekyll copies
 	bundle exec jekyll build $(BUILD_FLAGS)
 
-serve-production: test-jekyll flow_js symlinks
+serve-production: test-jekyll flow_js copies
 	@JEKYLL_ENV=production bundle exec jekyll serve --host="::" --port=8080
 
-build-production: test-jekyll flow_js symlinks
+build-production: test-jekyll flow_js copies
 	@JEKYLL_ENV=production bundle exec jekyll build $(BUILD_FLAGS)
 
 # crowdin-sync: test-crowdin

--- a/website/README.md
+++ b/website/README.md
@@ -40,6 +40,9 @@ $ bundle install
 
 ### Instructions
 
+First, make sure to follow the instructions on building Flow in the root
+directory of this repository.
+
 Use Jekyll to serve the website locally (by default, at
 `http://localhost:8080`):
 


### PR DESCRIPTION
Fixes #7408

I followed @wchargin's advice in https://github.com/facebook/flow/pull/6708 to produce this diff. 

There were two issues:
1. Jekyll has some weird behavior with symlinks. In @wchargin's own words:
>  Jekyll shallow-copies these, and the resulting broken
  symlinks cause a utimensat(2) call to fail with ENOENT
2. We need to have `flow.js` available in `bin` to make the website. To ensure that happens, i added the `flow_js` build rule as a dep to `serve`