### PR TITLE
Model indexer keys as contravariant (update)

### DIFF
--- a/src/typing/class_sig.ml
+++ b/src/typing/class_sig.ml
@@ -134,7 +134,7 @@ let add_field ~static name loc polarity field x =
 let add_indexer ~static polarity ~key ~value x =
   let kloc, k = key in
   let vloc, v = value in
-  x |> add_field ~static "$key" kloc polarity (Annot k)
+  x |> add_field ~static "$key" kloc Type.Negative (Annot k)
     |> add_field ~static "$value" vloc polarity (Annot v)
 
 let add_name_field x =

--- a/tests/dictionary/dictionary.exp
+++ b/tests/dictionary/dictionary.exp
@@ -264,36 +264,19 @@ References:
 
 Error --------------------------------------------------------------------------------------------- dictionary.js:167:24
 
-Cannot assign `x` to `a` because `B` [1] is incompatible with `A` [2] in the indexer property's key.
+Cannot assign `x` to `a` because `A` [1] is incompatible with `B` [2] in the indexer property's key.
 
    dictionary.js:167:24
    167|   let a: {[k:A]:any} = x; // error
                                ^
 
 References:
-   dictionary.js:165:10
-   165|   x: {[k:B]:any},
-                 ^ [1]
    dictionary.js:167:14
    167|   let a: {[k:A]:any} = x; // error
-                     ^ [2]
-
-
-Error --------------------------------------------------------------------------------------------- dictionary.js:169:24
-
-Cannot assign `x` to `c` because `B` [1] is incompatible with `C` [2] in the indexer property's key.
-
-   dictionary.js:169:24
-   169|   let c: {[k:C]:any} = x; // error
-                               ^
-
-References:
+                     ^ [1]
    dictionary.js:165:10
    165|   x: {[k:B]:any},
-                 ^ [1]
-   dictionary.js:169:14
-   169|   let c: {[k:C]:any} = x; // error
-                     ^ [2]
+                 ^ [2]
 
 
 Error --------------------------------------------------------------------------------------------- dictionary.js:175:39
@@ -827,18 +810,18 @@ References:
 
 Error --------------------------------------------------------------------------------------------- incompatible.js:5:35
 
-Cannot assign `x` to `z` because string [1] is incompatible with number [2] in the indexer property's key.
+Cannot assign `x` to `z` because number [1] is incompatible with string [2] in the indexer property's key.
 
    incompatible.js:5:35
    5| var z : {[key: number]: string} = x; // 2 errors, string !~> number & vice versa
                                         ^
 
 References:
-   incompatible.js:3:16
-   3| var x : {[key: string]: string} = {};
-                     ^^^^^^ [1]
    incompatible.js:5:16
    5| var z : {[key: number]: string} = x; // 2 errors, string !~> number & vice versa
+                     ^^^^^^ [1]
+   incompatible.js:3:16
+   3| var x : {[key: string]: string} = {};
                      ^^^^^^ [2]
 
 
@@ -1041,4 +1024,4 @@ References:
 
 
 
-Found 61 errors
+Found 60 errors

--- a/tests/dictionary/dictionary.js
+++ b/tests/dictionary/dictionary.js
@@ -161,12 +161,12 @@ function unification_dict_keys_invariant(
   let c: Array<{[k:C]:any}> = x; // error
 }
 
-function subtype_dict_keys_invariant(
+function subtype_dict_keys_contravariant(
   x: {[k:B]:any},
 ) {
   let a: {[k:A]:any} = x; // error
   let b: {[k:B]:any} = x; // ok
-  let c: {[k:C]:any} = x; // error
+  let c: {[k:C]:any} = x; // ok
 }
 
 function unification_mix_with_declared_props_invariant_l(

--- a/tests/friendly_errors/friendly_errors.exp
+++ b/tests/friendly_errors/friendly_errors.exp
@@ -420,19 +420,19 @@ References:
 
 Error --------------------------------------------------------------------------------- indexer-key-compatibility.js:7:2
 
-Cannot cast `o` to object type because number [1] is incompatible with string [2] in the indexer property's key.
+Cannot cast `o` to object type because string [1] is incompatible with number [2] in the indexer property's key.
 
    indexer-key-compatibility.js:7:2
    7| (o: {[k: string]: any});
        ^
 
 References:
-   indexer-key-compatibility.js:6:21
-   6| declare var o: {[k: number]: any};
-                          ^^^^^^ [1]
    indexer-key-compatibility.js:7:10
    7| (o: {[k: string]: any});
-               ^^^^^^ [2]
+               ^^^^^^ [1]
+   indexer-key-compatibility.js:6:21
+   6| declare var o: {[k: number]: any};
+                          ^^^^^^ [2]
 
 
 Error ----------------------------------------------------------------------------- loc-primary-for-covariant-ops.js:8:3

--- a/tests/indexer/indexer.exp
+++ b/tests/indexer/indexer.exp
@@ -95,5 +95,114 @@ Multiple indexers are not supported.
             ^^^^^^^^^^^^^^^^^^^^
 
 
+Error -------------------------------------------------------------------------------------------------- variance.js:5:2
 
-Found 8 errors
+Cannot get `w[0]` because an indexer property is not readable.
+
+   5| (w[0]: number); //ng
+       ^^^^
+
+
+Error -------------------------------------------------------------------------------------------------- variance.js:8:1
+
+Cannot assign `3` to `w[null]` because:
+ - Either null [1] is incompatible with number [2].
+ - Or null [1] is incompatible with string [3].
+
+   variance.js:8:1
+   8| w[null] = 3; //ng
+      ^^^^^^^
+
+References:
+   variance.js:8:3
+   8| w[null] = 3; //ng
+        ^^^^ [1]
+   variance.js:2:5
+   2|   -[number | string]: number;
+          ^^^^^^ [2]
+   variance.js:2:14
+   2|   -[number | string]: number;
+                   ^^^^^^ [3]
+
+
+Error ------------------------------------------------------------------------------------------------- variance.js:15:1
+
+Cannot assign `5.5` to `r[5]` because an indexer property is not writable.
+
+   15| r[5] = 5.5; //ng
+       ^^^^
+
+
+Error ------------------------------------------------------------------------------------------------- variance.js:16:1
+
+Cannot assign `6` to `r["another string"]` because an indexer property is not writable.
+
+   16| r["another string"] = 6; //ng
+       ^^^^^^^^^^^^^^^^^^^
+
+
+Error ------------------------------------------------------------------------------------------------- variance.js:17:1
+
+Cannot assign `7` to `r[null]` because:
+ - an indexer property is not writable.
+ - all branches are incompatible:
+    - Either null [1] is incompatible with number [2].
+    - Or null [1] is incompatible with string [3].
+
+   variance.js:17:1
+   17| r[null] = 7; //ng
+       ^^^^^^^
+
+References:
+   variance.js:17:3
+   17| r[null] = 7; //ng
+         ^^^^ [1]
+   variance.js:11:5
+   11|   +[number | string]: number;
+           ^^^^^^ [2]
+   variance.js:11:14
+   11|   +[number | string]: number;
+                    ^^^^^^ [3]
+
+
+Error ------------------------------------------------------------------------------------------------- variance.js:26:1
+
+Cannot assign `11` to `rw[null]` because:
+ - Either null [1] is incompatible with number [2].
+ - Or null [1] is incompatible with string [3].
+
+   variance.js:26:1
+   26| rw[null] = 11; //ng
+       ^^^^^^^^
+
+References:
+   variance.js:26:4
+   26| rw[null] = 11; //ng
+          ^^^^ [1]
+   variance.js:20:4
+   20|   [number | string]: number
+          ^^^^^^ [2]
+   variance.js:20:13
+   20|   [number | string]: number
+                   ^^^^^^ [3]
+
+
+Error ------------------------------------------------------------------------------------------------- variance.js:32:2
+
+Cannot cast `b` to object type because string [1] is incompatible with number [2] in the indexer property's key.
+
+   variance.js:32:2
+   32| (b: { +[number | string]: number }); //ng
+        ^
+
+References:
+   variance.js:32:18
+   32| (b: { +[number | string]: number }); //ng
+                        ^^^^^^ [1]
+   variance.js:31:14
+   31| const b: { +[number]: number } = {};
+                    ^^^^^^ [2]
+
+
+
+Found 16 errors

--- a/tests/indexer/variance.js
+++ b/tests/indexer/variance.js
@@ -30,3 +30,25 @@ const a: { +[number | string]: number } = {};
 
 const b: { +[number]: number } = {};
 (b: { +[number | string]: number }); //ng
+
+type U_W = {
+  -[number | string | null]: number
+};
+type U_R = {
+  +[number | string | null]: number
+};
+type U_RW = {
+  [number | string | null]: number
+};
+(w: U_W);
+(r: U_R);
+(rw: U_W);
+(rw: U_R);
+(rw: U_RW);
+
+/* TODO: Fix false positives
+(w: U_R);
+(w: U_RW);
+(r: U_W);
+(r: U_RW);
+*/

--- a/tests/indexer/variance.js
+++ b/tests/indexer/variance.js
@@ -1,0 +1,32 @@
+declare class W {
+  -[number | string]: number;
+}
+declare var w: W;
+(w[0]: number); //ng
+w[1] = 1.5;
+w["a string"] = 2;
+w[null] = 3; //ng
+
+declare class R {
+  +[number | string]: number;
+}
+declare var r: R;
+(r[4]: number);
+r[5] = 5.5; //ng
+r["another string"] = 6; //ng
+r[null] = 7; //ng
+
+declare class RW {
+  [number | string]: number
+}
+declare var rw: RW;
+(rw[8]: number);
+rw[9] = 9.5;
+rw["yet another string"] = 10;
+rw[null] = 11; //ng
+
+const a: { +[number | string]: number } = {};
+(a: { +[number]: number });
+
+const b: { +[number]: number } = {};
+(b: { +[number | string]: number }); //ng


### PR DESCRIPTION
Currently Flow applies indexer variance to both indexer key and indexer value. Indexer keys should be modelled contravariant regardless of the indexer variance. Fixes #5566.