### PR TITLE
querySelector[All] is difficult to use effectively.

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -1021,6 +1021,7 @@ declare class Document extends Node {
   querySelector(selector: 'template'): HTMLTemplateElement | null;
   querySelector(selector: 'ul'): HTMLUListElement | null;
   querySelector(selector: string): HTMLElement | null;
+  querySelector<T: HTMLElement>(selector: string): T | null;
 
   querySelectorAll(selector: 'a'): NodeList<HTMLAnchorElement>;
   querySelectorAll(selector: 'area'): NodeList<HTMLAreaElement>;
@@ -1085,6 +1086,7 @@ declare class Document extends Node {
   querySelectorAll(selector: 'template'): NodeList<HTMLTemplateElement>;
   querySelectorAll(selector: 'ul'): NodeList<HTMLUListElement>;
   querySelectorAll(selector: string): NodeList<HTMLElement>;
+  querySelectorAll<T: HTMLElement>(selector: string): NodeList<T>;
 
   // Interface DocumentTraversal
   // http://www.w3.org/TR/2000/REC-DOM-Level-2-Traversal-Range-20001113/traversal.html#Traversal-Document
@@ -1211,7 +1213,9 @@ declare class DocumentFragment extends Node {
   prepend(...nodes: Array<string | Node>): void;
 
   querySelector(selector: string): HTMLElement | null;
+  querySelector<T: HTMLElement>(selector: string): T | null;
   querySelectorAll(selector: string): NodeList<HTMLElement>;
+  querySelectorAll<T: HTMLElement>(selector: string): NodeList<T>;
 }
 
 declare class Selection {
@@ -1530,6 +1534,7 @@ declare class Element extends Node {
   querySelector(selector: 'template'): HTMLTemplateElement | null;
   querySelector(selector: 'ul'): HTMLUListElement | null;
   querySelector(selector: string): HTMLElement | null;
+  querySelector<T: HTMLElement>(selector: string): T | null;
 
   querySelectorAll(selector: 'a'): NodeList<HTMLAnchorElement>;
   querySelectorAll(selector: 'area'): NodeList<HTMLAreaElement>;
@@ -1594,6 +1599,7 @@ declare class Element extends Node {
   querySelectorAll(selector: 'template'): NodeList<HTMLTemplateElement>;
   querySelectorAll(selector: 'ul'): NodeList<HTMLUListElement>;
   querySelectorAll(selector: string): NodeList<HTMLElement>;
+  querySelectorAll<T: HTMLElement>(selector: string): NodeList<T>;
 
   // from ChildNode interface
   after(...nodes: Array<string | Node>): void;


### PR DESCRIPTION
uses Casting Expressions Fixed #4559

The same things have in TypeScript:
```
querySelector<K extends keyof HTMLElementTagNameMap>(selectors: K): HTMLElementTagNameMap[K] | null;
    querySelector<K extends keyof SVGElementTagNameMap>(selectors: K): SVGElementTagNameMap[K] | null;
    querySelector<E extends Element = Element>(selectors: string): E | null;
    /**
     * Returns all element descendants of node that
     * match selectors.
     */
    querySelectorAll<K extends keyof HTMLElementTagNameMap>(selectors: K): NodeListOf<HTMLElementTagNameMap[K]>;
    querySelectorAll<K extends keyof SVGElementTagNameMap>(selectors: K): NodeListOf<SVGElementTagNameMap[K]>;
    querySelectorAll<E extends Element = Element>(selectors: string): NodeListOf<E>;
```