### PR TITLE
Make React.Ref contra-variant.

### DIFF
--- a/lib/react.js
+++ b/lib/react.js
@@ -190,7 +190,7 @@ declare type React$Key = string | number;
 /**
  * The type of the ref prop available on all React components.
  */
-declare type React$Ref<ElementType: React$ElementType> =
+declare type React$Ref<-ElementType: React$ElementType> =
   | {-current: React$ElementRef<ElementType> | null}
   | ((React$ElementRef<ElementType> | null) => mixed)
   | string;
@@ -254,7 +254,7 @@ declare module react {
   declare export type Element<+C> = React$Element<C>;
   declare export var Fragment: ({children: ?React$Node}) => React$Node;
   declare export type Key = React$Key;
-  declare export type Ref<C> = React$Ref<C>;
+  declare export type Ref<-C> = React$Ref<C>;
   declare export type Node = React$Node;
   declare export type Context<T> = React$Context<T>;
   declare export type Portal = React$Portal;
@@ -292,7 +292,7 @@ declare module react {
   declare export function forwardRef<Config, Instance>(
     render: (
       props: Config,
-      ref: {current: null | Instance} | ((null | Instance) => mixed),
+      ref: {-current: null | Instance} | ((null | Instance) => mixed),
     ) => React$Node,
   ): React$AbstractComponent<Config, Instance>;
 


### PR DESCRIPTION
Elements only write to refs. This worked perfectly fine with functions refs. But in the case of the useRef style objects, there can be some problems.

By making the `current` key write only the type become contra-variant again. This means that you can pass the ref for A | B to an element that will give you A.

NOTE: this change will also require changes to the implementation of React$AbstractComponent to make the type write-only as well.

<!--
  If this is a change to library defintions, please include links to relevant documentation.
  If this is a documentation change, please prefix the title with [DOCS].

  If this is neither, ensure you opened a discussion issue and link it in the PR description.
-->
