### PR TITLE
Improve types of static functions on Object.

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -45,8 +45,8 @@ declare class Object {
     static create(o: any, properties?: PropertyDescriptorMap): any; // compiler magic
     static defineProperties(o: any, properties: PropertyDescriptorMap): any;
     static defineProperty<T>(o: any, p: any, attributes: PropertyDescriptor<T>): any;
-    static entries(object: any): Array<[string, mixed]>;
-    static freeze<T>(o: T): T;
+    static entries<TObj: {}>(object: TObj): Array<[$Keys<TObj>, $Values<TObj>]>;
+    static freeze<T: {}>(o: T): $ReadOnly<T>;
     static getOwnPropertyDescriptor<T>(o: any, p: any): PropertyDescriptor<T> | void;
     static getOwnPropertyDescriptors(o: any): PropertyDescriptorMap;
     static getOwnPropertyNames(o: any): Array<string>;
@@ -56,11 +56,11 @@ declare class Object {
     static isExtensible(o: any): boolean;
     static isFrozen(o: any): boolean;
     static isSealed(o: any): boolean;
-    static keys(o: any): Array<string>;
+    static keys<TObj: {}>(o: TObj): Array<$Keys<TObj>>;
     static preventExtensions<T>(o: T): T;
     static seal<T>(o: T): T;
     static setPrototypeOf(o: any, proto: ?Object): any;
-    static values(object: any): Array<mixed>;
+    static values<TObj: {}>(object: TObj): Array<$Values<TObj>>;
     hasOwnProperty(prop: any): boolean;
     isPrototypeOf(o: any): boolean;
     propertyIsEnumerable(prop: any): boolean;


### PR DESCRIPTION
The types were too generic so far, this makes it so that functions such as `Object.keys` and `Object.entries` are usable and don't just get rid of type information.

<!--
  If this is a change to library defintions, please include links to relevant documentation.
  If this is a documentation change, please prefix the title with [DOCS].

  If this is neither, ensure you opened a discussion issue and link it in the PR description.
-->
