### PR TITLE
BigInt types

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -684,7 +684,7 @@ type $ArrayBufferView = $TypedArray | DataView;
 declare class $TypedArray {
     static BYTES_PER_ELEMENT: number;
     static from(iterable: Iterable<number>): this;
-    static from<U>(iterable: Iterable<U>, mapFn?: (element: U, k: number) => number, thisArg?: any): this;
+    static from<U>(iterable: Iterable<U>, mapFn: (element: U, k: number) => number, thisArg?: any): this;
     static of(...values: number[]): this;
 
     constructor(length: number): void;
@@ -741,50 +741,50 @@ declare class $TypedArray {
 }
 
 declare class $TypedBigIntArray extends $TypedArray {
-  static from(iterable: Iterable<bigint>): this;
-  static from<U>(iterable: Iterable<U>, mapFn?: (element: U, k: number) => bigint, thisArg?: any): this;
-  static of(...values: bigint[]): this;
+    static from(iterable: Iterable<bigint>): this;
+    static from<U>(iterable: Iterable<U>, mapFn: (element: U, k: number) => bigint, thisArg?: any): this;
+    static of(...values: bigint[]): this;
 
-  constructor(length: number): void;
-  constructor(typedArray: $TypedArray): void;
-  constructor(iterable: Iterable<bigint>): void;
-  constructor(buffer: ArrayBuffer, byteOffset?: number, length?: number): void;
+    constructor(length: number): void;
+    constructor(typedArray: $TypedArray): void;
+    constructor(iterable: Iterable<bigint>): void;
+    constructor(buffer: ArrayBuffer, byteOffset?: number, length?: number): void;
 
-  [index: number]: bigint;
+    [index: number]: bigint;
 
-  @@iterator(): Iterator<bigint>;
+    @@iterator(): Iterator<bigint>;
 
-  entries(): Iterator<[number, bigint]>;
-  every(callback: (value: bigint, index: number, array: this) => mixed, thisArg?: any): boolean;
-  fill(value: bigint, start?: number, end?: number): this;
-  filter(callback: (value: bigint, index: number, array: this) => mixed, thisArg?: any): this;
-  find(callback: (value: bigint, index: number, array: this) => mixed, thisArg?: any): bigint | void;
-  findIndex(callback: (value: bigint, index: number, array: this) => mixed, thisArg?: any): number;
-  forEach(callback: (value: bigint, index: number, array: this) => mixed, thisArg?: any): void;
-  includes(searchElement: bigint, fromIndex?: number): boolean;
-  indexOf(searchElement: bigint, fromIndex?: number): number; // -1 if not present
-  lastIndexOf(searchElement: bigint, fromIndex?: number): number; // -1 if not present
-  map(callback: (currentValue: bigint, index: number, array: this) => number, thisArg?: any): this;
-  reduce(
-      callback: (previousValue: bigint, currentValue: bigint, index: number, array: this) => number,
-      initialValue: void
-  ): number;
-  reduce<U>(
-      callback: (previousValue: U, currentValue: bigint, index: number, array: this) => U,
-      initialValue: U
-  ): U;
-  reduceRight(
-      callback: (previousValue: bigint, currentValue: bigint, index: number, array: this) => number,
-      initialValue: void
-  ): number;
-  reduceRight<U>(
-      callback: (previousValue: U, currentValue: bigint, index: number, array: this) => U,
-      initialValue: U
-  ): U;
-  set(array: Array<bigint> | $TypedArray, offset?: number): void;
-  some(callback: (value: bigint, index: number, array: this) => mixed, thisArg?: any): boolean;
-  sort(compare?: (a: bigint, b: bigint) => number | bigint): void;
-  values(): Iterator<bigint>;
+    entries(): Iterator<[number, bigint]>;
+    every(callback: (value: bigint, index: number, array: this) => mixed, thisArg?: any): boolean;
+    fill(value: bigint, start?: number, end?: number): this;
+    filter(callback: (value: bigint, index: number, array: this) => mixed, thisArg?: any): this;
+    find(callback: (value: bigint, index: number, array: this) => mixed, thisArg?: any): bigint | void;
+    findIndex(callback: (value: bigint, index: number, array: this) => mixed, thisArg?: any): number;
+    forEach(callback: (value: bigint, index: number, array: this) => mixed, thisArg?: any): void;
+    includes(searchElement: bigint, fromIndex?: number): boolean;
+    indexOf(searchElement: bigint, fromIndex?: number): number; // -1 if not present
+    lastIndexOf(searchElement: bigint, fromIndex?: number): number; // -1 if not present
+    map(callback: (currentValue: bigint, index: number, array: this) => number, thisArg?: any): this;
+    reduce(
+        callback: (previousValue: bigint, currentValue: bigint, index: number, array: this) => number,
+        initialValue: void
+    ): number;
+    reduce<U>(
+        callback: (previousValue: U, currentValue: bigint, index: number, array: this) => U,
+        initialValue: U
+    ): U;
+    reduceRight(
+        callback: (previousValue: bigint, currentValue: bigint, index: number, array: this) => number,
+        initialValue: void
+    ): number;
+    reduceRight<U>(
+        callback: (previousValue: U, currentValue: bigint, index: number, array: this) => U,
+        initialValue: U
+    ): U;
+    set(array: Array<bigint> | $TypedArray, offset?: number): void;
+    some(callback: (value: bigint, index: number, array: this) => mixed, thisArg?: any): boolean;
+    sort(compare?: (a: bigint, b: bigint) => number | bigint): void;
+    values(): Iterator<bigint>;
 }
 
 declare class Int8Array extends $TypedArray {}

--- a/lib/core.js
+++ b/lib/core.js
@@ -696,10 +696,10 @@ declare class $TypedArray<V: bigint | number> {
 
     @@iterator(): Iterator<V>;
 
-    buffer: ArrayBuffer;
-    byteLength: number;
-    byteOffset: number;
-    length: number;
+    +buffer: ArrayBuffer;
+    +byteLength: number;
+    +byteOffset: number;
+    +length: number;
 
     copyWithin(target: number, start: number, end?: number): void;
     entries(): Iterator<[number, V]>;

--- a/lib/core.js
+++ b/lib/core.js
@@ -681,7 +681,7 @@ type $ArrayBufferView = $TypedArray<number> | $TypedArray<bigint> | DataView;
 // The TypedArray intrinsic object is a constructor function, but does not have
 // a global name or appear as a property of the global object.
 // http://www.ecma-international.org/ecma-262/6.0/#sec-%typedarray%-intrinsic-object
-declare class $TypedArray<V> {
+declare class $TypedArray<V: bigint | number> {
     static BYTES_PER_ELEMENT: number;
     static from(iterable: Iterable<V>): this;
     static from<U>(iterable: Iterable<U>, mapFn: (element: U, k: number) => number, thisArg?: any): this;
@@ -740,10 +740,6 @@ declare class $TypedArray<V> {
     values(): Iterator<V>;
 }
 
-declare class $TypedBigIntArray extends $TypedArray<bigint> {
-    sort(compare?: (a: bigint, b: bigint) => number | bigint): void;
-}
-
 declare class Int8Array extends $TypedArray<number> {}
 declare class Uint8Array extends $TypedArray<number> {}
 declare class Uint8ClampedArray extends $TypedArray<number> {}
@@ -753,8 +749,8 @@ declare class Int32Array extends $TypedArray<number> {}
 declare class Uint32Array extends $TypedArray<number> {}
 declare class Float32Array extends $TypedArray<number> {}
 declare class Float64Array extends $TypedArray<number> {}
-declare class BigInt64Array extends $TypedBigIntArray {}
-declare class BigUint64Array extends $TypedBigIntArray {}
+declare class BigInt64Array extends $TypedArray<bigint> {}
+declare class BigUint64Array extends $TypedArray<bigint> {}
 
 declare class DataView {
     constructor(buffer: ArrayBuffer, byteOffset?: number, length?: number): void;

--- a/lib/core.js
+++ b/lib/core.js
@@ -149,6 +149,15 @@ declare class Number {
     valueOf(): number;
 }
 
+declare class BigInt {
+  static asIntN(bits: number, int: bigint): bigint;
+  static asUintN(bits: number, int: bigint): bigint;
+  static (value?: any): bigint;
+  toString(radix?: number): string;
+  toLocaleString(): string;
+  valueOf(): bigint;
+}
+
 declare var Math: {
     E: number;
     LN10: number;
@@ -674,7 +683,8 @@ type $ArrayBufferView = $TypedArray | DataView;
 // http://www.ecma-international.org/ecma-262/6.0/#sec-%typedarray%-intrinsic-object
 declare class $TypedArray {
     static BYTES_PER_ELEMENT: number;
-    static from(iterable: Iterable<number>, mapFn?: (element: number) => number, thisArg?: any): this;
+    static from(iterable: Iterable<number>): this;
+    static from<U>(iterable: Iterable<U>, mapFn?: (element: U, k: number) => number, thisArg?: any): this;
     static of(...values: number[]): this;
 
     constructor(length: number): void;
@@ -730,6 +740,53 @@ declare class $TypedArray {
     values(): Iterator<number>;
 }
 
+declare class $TypedBigIntArray extends $TypedArray {
+  static from(iterable: Iterable<bigint>): this;
+  static from<U>(iterable: Iterable<U>, mapFn?: (element: U, k: number) => bigint, thisArg?: any): this;
+  static of(...values: bigint[]): this;
+
+  constructor(length: number): void;
+  constructor(typedArray: $TypedArray): void;
+  constructor(iterable: Iterable<bigint>): void;
+  constructor(buffer: ArrayBuffer, byteOffset?: number, length?: number): void;
+
+  [index: number]: bigint;
+
+  @@iterator(): Iterator<bigint>;
+
+  entries(): Iterator<[number, bigint]>;
+  every(callback: (value: bigint, index: number, array: this) => mixed, thisArg?: any): boolean;
+  fill(value: bigint, start?: number, end?: number): this;
+  filter(callback: (value: bigint, index: number, array: this) => mixed, thisArg?: any): this;
+  find(callback: (value: bigint, index: number, array: this) => mixed, thisArg?: any): bigint | void;
+  findIndex(callback: (value: bigint, index: number, array: this) => mixed, thisArg?: any): number;
+  forEach(callback: (value: bigint, index: number, array: this) => mixed, thisArg?: any): void;
+  includes(searchElement: bigint, fromIndex?: number): boolean;
+  indexOf(searchElement: bigint, fromIndex?: number): number; // -1 if not present
+  lastIndexOf(searchElement: bigint, fromIndex?: number): number; // -1 if not present
+  map(callback: (currentValue: bigint, index: number, array: this) => number, thisArg?: any): this;
+  reduce(
+      callback: (previousValue: bigint, currentValue: bigint, index: number, array: this) => number,
+      initialValue: void
+  ): number;
+  reduce<U>(
+      callback: (previousValue: U, currentValue: bigint, index: number, array: this) => U,
+      initialValue: U
+  ): U;
+  reduceRight(
+      callback: (previousValue: bigint, currentValue: bigint, index: number, array: this) => number,
+      initialValue: void
+  ): number;
+  reduceRight<U>(
+      callback: (previousValue: U, currentValue: bigint, index: number, array: this) => U,
+      initialValue: U
+  ): U;
+  set(array: Array<bigint> | $TypedArray, offset?: number): void;
+  some(callback: (value: bigint, index: number, array: this) => mixed, thisArg?: any): boolean;
+  sort(compare?: (a: bigint, b: bigint) => number | bigint): void;
+  values(): Iterator<bigint>;
+}
+
 declare class Int8Array extends $TypedArray {}
 declare class Uint8Array extends $TypedArray {}
 declare class Uint8ClampedArray extends $TypedArray {}
@@ -739,6 +796,8 @@ declare class Int32Array extends $TypedArray {}
 declare class Uint32Array extends $TypedArray {}
 declare class Float32Array extends $TypedArray {}
 declare class Float64Array extends $TypedArray {}
+declare class BigInt64Array extends $TypedBigIntArray {}
+declare class BigUint64Array extends $TypedBigIntArray {}
 
 declare class DataView {
     constructor(buffer: ArrayBuffer, byteOffset?: number, length?: number): void;
@@ -761,6 +820,10 @@ declare class DataView {
     setUint32(byteOffset: number, value: number, littleEndian?: boolean): void;
     setFloat32(byteOffset: number, value: number, littleEndian?: boolean): void;
     setFloat64(byteOffset: number, value: number, littleEndian?: boolean): void;
+    getBigInt64(byteOffset: number, littleEndian?: boolean): bigint;
+    getBigUint64(byteOffset: number, littleEndian?: boolean): bigint;
+    setBigInt64(byteOffset: number, value: bigint, littleEndian?: boolean): void;
+    setBigUint64(byteOffset: number, value: bigint, littleEndian?: boolean): void;
 }
 
 declare function btoa(rawString: string): string;

--- a/lib/core.js
+++ b/lib/core.js
@@ -676,25 +676,25 @@ declare class ArrayBuffer {
 // This is a helper type to simplify the specification, it isn't an interface
 // and there are no objects implementing it.
 // https://developer.mozilla.org/en-US/docs/Web/API/ArrayBufferView
-type $ArrayBufferView = $TypedArray | DataView;
+type $ArrayBufferView = $TypedArray<mixed> | DataView;
 
 // The TypedArray intrinsic object is a constructor function, but does not have
 // a global name or appear as a property of the global object.
 // http://www.ecma-international.org/ecma-262/6.0/#sec-%typedarray%-intrinsic-object
-declare class $TypedArray {
+declare class $TypedArray<V: bigint | number> {
     static BYTES_PER_ELEMENT: number;
-    static from(iterable: Iterable<number>): this;
+    static from(iterable: Iterable<V>): this;
     static from<U>(iterable: Iterable<U>, mapFn: (element: U, k: number) => number, thisArg?: any): this;
-    static of(...values: number[]): this;
+    static of(...values: V[]): this;
 
     constructor(length: number): void;
-    constructor(typedArray: $TypedArray): void;
-    constructor(iterable: Iterable<number>): void;
+    constructor(typedArray: $TypedArray<V>): void;
+    constructor(iterable: Iterable<V>): void;
     constructor(buffer: ArrayBuffer, byteOffset?: number, length?: number): void;
 
-    [index: number]: number;
+    [index: number]: V;
 
-    @@iterator(): Iterator<number>;
+    @@iterator(): Iterator<V>;
 
     buffer: ArrayBuffer;
     byteLength: number;
@@ -702,100 +702,57 @@ declare class $TypedArray {
     length: number;
 
     copyWithin(target: number, start: number, end?: number): void;
-    entries(): Iterator<[number, number]>;
-    every(callback: (value: number, index: number, array: this) => mixed, thisArg?: any): boolean;
-    fill(value: number, start?: number, end?: number): this;
-    filter(callback: (value: number, index: number, array: this) => mixed, thisArg?: any): this;
-    find(callback: (value: number, index: number, array: this) => mixed, thisArg?: any): number | void;
-    findIndex(callback: (value: number, index: number, array: this) => mixed, thisArg?: any): number;
-    forEach(callback: (value: number, index: number, array: this) => mixed, thisArg?: any): void;
-    includes(searchElement: number, fromIndex?: number): boolean;
-    indexOf(searchElement: number, fromIndex?: number): number; // -1 if not present
+    entries(): Iterator<[number, V]>;
+    every(callback: (value: V, index: number, array: this) => mixed, thisArg?: any): boolean;
+    fill(value: V, start?: number, end?: number): this;
+    filter(callback: (value: V, index: number, array: this) => mixed, thisArg?: any): this;
+    find(callback: (value: V, index: number, array: this) => mixed, thisArg?: any): V | void;
+    findIndex(callback: (value: V, index: number, array: this) => mixed, thisArg?: any): number;
+    forEach(callback: (value: V, index: number, array: this) => mixed, thisArg?: any): void;
+    includes(searchElement: V, fromIndex?: number): boolean;
+    indexOf(searchElement: V, fromIndex?: number): number; // -1 if not present
     join(separator?: string): string;
     keys(): Iterator<number>;
-    lastIndexOf(searchElement: number, fromIndex?: number): number; // -1 if not present
-    map(callback: (currentValue: number, index: number, array: this) => number, thisArg?: any): this;
+    lastIndexOf(searchElement: V, fromIndex?: number): number; // -1 if not present
+    map(callback: (currentValue: V, index: number, array: this) => number, thisArg?: any): this;
     reduce(
-      callback: (previousValue: number, currentValue: number, index: number, array: this) => number,
+      callback: (previousValue: V, currentValue: V, index: number, array: this) => V,
       initialValue: void
     ): number;
     reduce<U>(
-      callback: (previousValue: U, currentValue: number, index: number, array: this) => U,
+      callback: (previousValue: U, currentValue: V, index: number, array: this) => U,
       initialValue: U
     ): U;
     reduceRight(
-      callback: (previousValue: number, currentValue: number, index: number, array: this) => number,
+      callback: (previousValue: V, currentValue: V, index: number, array: this) => V,
       initialValue: void
     ): number;
     reduceRight<U>(
-      callback: (previousValue: U, currentValue: number, index: number, array: this) => U,
+      callback: (previousValue: U, currentValue: V, index: number, array: this) => U,
       initialValue: U
     ): U;
     reverse(): this;
-    set(array: Array<number> | $TypedArray, offset?: number): void;
+    set(array: Array<V> | $TypedArray<V>, offset?: number): void;
     slice(begin?: number, end?: number): this;
-    some(callback: (value: number, index: number, array: this) => mixed, thisArg?: any): boolean;
-    sort(compare?: (a: number, b: number) => number): void;
+    some(callback: (value: V, index: number, array: this) => mixed, thisArg?: any): boolean;
+    sort(compare?: (a: V, b: V) => number): void;
     subarray(begin?: number, end?: number): this;
-    values(): Iterator<number>;
+    values(): Iterator<V>;
 }
 
-declare class $TypedBigIntArray extends $TypedArray {
-    static from(iterable: Iterable<bigint>): this;
-    static from<U>(iterable: Iterable<U>, mapFn: (element: U, k: number) => bigint, thisArg?: any): this;
-    static of(...values: bigint[]): this;
-
-    constructor(length: number): void;
-    constructor(typedArray: $TypedArray): void;
-    constructor(iterable: Iterable<bigint>): void;
-    constructor(buffer: ArrayBuffer, byteOffset?: number, length?: number): void;
-
-    [index: number]: bigint;
-
-    @@iterator(): Iterator<bigint>;
-
-    entries(): Iterator<[number, bigint]>;
-    every(callback: (value: bigint, index: number, array: this) => mixed, thisArg?: any): boolean;
-    fill(value: bigint, start?: number, end?: number): this;
-    filter(callback: (value: bigint, index: number, array: this) => mixed, thisArg?: any): this;
-    find(callback: (value: bigint, index: number, array: this) => mixed, thisArg?: any): bigint | void;
-    findIndex(callback: (value: bigint, index: number, array: this) => mixed, thisArg?: any): number;
-    forEach(callback: (value: bigint, index: number, array: this) => mixed, thisArg?: any): void;
-    includes(searchElement: bigint, fromIndex?: number): boolean;
-    indexOf(searchElement: bigint, fromIndex?: number): number; // -1 if not present
-    lastIndexOf(searchElement: bigint, fromIndex?: number): number; // -1 if not present
-    map(callback: (currentValue: bigint, index: number, array: this) => number, thisArg?: any): this;
-    reduce(
-        callback: (previousValue: bigint, currentValue: bigint, index: number, array: this) => number,
-        initialValue: void
-    ): number;
-    reduce<U>(
-        callback: (previousValue: U, currentValue: bigint, index: number, array: this) => U,
-        initialValue: U
-    ): U;
-    reduceRight(
-        callback: (previousValue: bigint, currentValue: bigint, index: number, array: this) => number,
-        initialValue: void
-    ): number;
-    reduceRight<U>(
-        callback: (previousValue: U, currentValue: bigint, index: number, array: this) => U,
-        initialValue: U
-    ): U;
-    set(array: Array<bigint> | $TypedArray, offset?: number): void;
-    some(callback: (value: bigint, index: number, array: this) => mixed, thisArg?: any): boolean;
+declare class $TypedBigIntArray extends $TypedArray<bigint> {
     sort(compare?: (a: bigint, b: bigint) => number | bigint): void;
-    values(): Iterator<bigint>;
 }
 
-declare class Int8Array extends $TypedArray {}
-declare class Uint8Array extends $TypedArray {}
-declare class Uint8ClampedArray extends $TypedArray {}
-declare class Int16Array extends $TypedArray {}
-declare class Uint16Array extends $TypedArray {}
-declare class Int32Array extends $TypedArray {}
-declare class Uint32Array extends $TypedArray {}
-declare class Float32Array extends $TypedArray {}
-declare class Float64Array extends $TypedArray {}
+declare class Int8Array extends $TypedArray<number> {}
+declare class Uint8Array extends $TypedArray<number> {}
+declare class Uint8ClampedArray extends $TypedArray<number> {}
+declare class Int16Array extends $TypedArray<number> {}
+declare class Uint16Array extends $TypedArray<number> {}
+declare class Int32Array extends $TypedArray<number> {}
+declare class Uint32Array extends $TypedArray<number> {}
+declare class Float32Array extends $TypedArray<number> {}
+declare class Float64Array extends $TypedArray<number> {}
 declare class BigInt64Array extends $TypedBigIntArray {}
 declare class BigUint64Array extends $TypedBigIntArray {}
 

--- a/lib/core.js
+++ b/lib/core.js
@@ -676,12 +676,12 @@ declare class ArrayBuffer {
 // This is a helper type to simplify the specification, it isn't an interface
 // and there are no objects implementing it.
 // https://developer.mozilla.org/en-US/docs/Web/API/ArrayBufferView
-type $ArrayBufferView = $TypedArray<mixed> | DataView;
+type $ArrayBufferView = $TypedArray<number> | $TypedArray<bigint> | DataView;
 
 // The TypedArray intrinsic object is a constructor function, but does not have
 // a global name or appear as a property of the global object.
 // http://www.ecma-international.org/ecma-262/6.0/#sec-%typedarray%-intrinsic-object
-declare class $TypedArray<V: bigint | number> {
+declare class $TypedArray<V> {
     static BYTES_PER_ELEMENT: number;
     static from(iterable: Iterable<V>): this;
     static from<U>(iterable: Iterable<U>, mapFn: (element: U, k: number) => number, thisArg?: any): this;

--- a/lib/node.js
+++ b/lib/node.js
@@ -106,7 +106,7 @@ declare class Buffer mixins Uint8Array {
   static alloc(size: number, fill?: string | number, encoding?: buffer$Encoding): Buffer;
   static allocUnsafe(size: number): Buffer;
   static allocUnsafeSlow(size: number): Buffer;
-  static byteLength(string: string | Buffer | $TypedArray | DataView | ArrayBuffer, encoding?: buffer$Encoding): number;
+  static byteLength(string: string | Buffer | $TypedArray<number> | $TypedArray<bigint> | DataView | ArrayBuffer, encoding?: buffer$Encoding): number;
   static compare(buf1: Buffer, buf2: Buffer): number;
   static concat(list: Array<Buffer>, totalLength?: number): Buffer;
 
@@ -153,7 +153,7 @@ type child_process$execCallback = (error: ?child_process$Error, stdout: string |
 
 type child_process$execSyncOpts = {
   cwd?: string;
-  input?: string | Buffer | $TypedArray | DataView;
+  input?: string | Buffer | $TypedArray<number> | $TypedArray<bigint> | DataView;
   stdio?: string | Array<any>;
   env?: Object;
   shell?: string,
@@ -184,7 +184,7 @@ type child_process$execFileCallback = (error: ?child_process$Error, stdout: stri
 
 type child_process$execFileSyncOpts = {
   cwd?: string;
-  input?: string | Buffer | $TypedArray | DataView;
+  input?: string | Buffer | $TypedArray<number> | $TypedArray<bigint> | DataView;
   stdio?: string | Array<any>;
   env?: Object;
   uid?: number;
@@ -426,14 +426,14 @@ type crypto$ECDH$Format = 'compressed' | 'uncompressed';
 
 declare class crypto$ECDH {
   computeSecret(
-    other_public_key: Buffer | $TypedArray | DataView
+    other_public_key: Buffer | $TypedArray<number> | $TypedArray<bigint> | DataView
   ): Buffer,
   computeSecret(
     other_public_key: string,
     input_encoding: crypto$ECDH$Encoding
   ): Buffer,
   computeSecret(
-    other_public_key: Buffer | $TypedArray | DataView,
+    other_public_key: Buffer | $TypedArray<number> | $TypedArray<bigint> | DataView,
     output_encoding: crypto$ECDH$Encoding
   ): string,
   computeSecret(
@@ -447,7 +447,7 @@ declare class crypto$ECDH {
   getPrivateKey(encoding: crypto$ECDH$Encoding): string,
   getPublicKey(format?: crypto$ECDH$Format): Buffer,
   getPublicKey(encoding: crypto$ECDH$Encoding, format?: crypto$ECDH$Format): string,
-  setPrivateKey(private_key: Buffer | $TypedArray | DataView): void,
+  setPrivateKey(private_key: Buffer | $TypedArray<number> | $TypedArray<bigint> | DataView): void,
   setPrivateKey(private_key: string, encoding: crypto$ECDH$Encoding): void
 }
 
@@ -522,7 +522,7 @@ declare class crypto$Verify extends stream$Writable {
   'binary' ): crypto$Verify;
   verify(
     object: string,
-    signature: string | Buffer | $TypedArray | DataView,
+    signature: string | Buffer | $TypedArray<number> | $TypedArray<bigint> | DataView,
     signature_format: 'latin1' | 'binary' | 'hex' | 'base64'
   ): boolean;
   verify(object: string, signature: Buffer, signature_format: void): boolean;
@@ -635,8 +635,8 @@ declare module "crypto" {
     callback: (err: ?Error, buffer: Buffer) => void
   ): void
   declare function timingSafeEqual(
-    a: Buffer | $TypedArray | DataView,
-    b: Buffer | $TypedArray | DataView
+    a: Buffer | $TypedArray<number> | $TypedArray<bigint> | DataView,
+    b: Buffer | $TypedArray<number> | $TypedArray<bigint> | DataView
   ): boolean;
 }
 
@@ -769,8 +769,8 @@ declare module "dns" {
     callback: (err: ?Error, domains: Array<any>) => void
   ): void;
   declare function timingSafeEqual(
-    a: Buffer | $TypedArray | DataView,
-    b: Buffer | $TypedArray | DataView
+    a: Buffer | $TypedArray<number> | $TypedArray<bigint> | DataView,
+    b: Buffer | $TypedArray<number> | $TypedArray<bigint> | DataView
   ): boolean;
 }
 

--- a/lib/node.js
+++ b/lib/node.js
@@ -27,7 +27,7 @@ type buffer$NonBufferEncoding =
 type buffer$Encoding = buffer$NonBufferEncoding | 'buffer'
 type buffer$ToJSONRet = { type: string, data: Array<number> }
 
-declare class Buffer extends Uint8Array {
+declare class Buffer mixins Uint8Array {
   constructor(
     value: Array<number> | number | string | Buffer | ArrayBuffer,
     encoding?: buffer$Encoding

--- a/lib/node.js
+++ b/lib/node.js
@@ -2340,7 +2340,10 @@ declare class Process extends events$EventEmitter {
   getgid? : () => number;
   getgroups? : () => Array<number>;
   getuid? : () => number;
-  hrtime(time?: [ number, number ]) : [ number, number ];
+  hrtime: {|
+    [[call]]: (time?: [number, number]) => [number, number];
+    bigint(): bigint;
+  |};
   initgroups? : (user : number | string, extra_group : number | string) => void;
   kill(pid : number, signal? : string | number) : void;
   mainModule : Object;

--- a/lib/streams.js
+++ b/lib/streams.js
@@ -27,12 +27,12 @@ declare class ReadableStreamController {
 }
 
 declare class ReadableStreamBYOBRequest {
-  constructor(controller: ReadableStreamController, view: $TypedArray): void,
+  constructor(controller: ReadableStreamController, view: $TypedArray<number> | $TypedArray<bigint>): void,
 
-  view: $TypedArray,
+  view: $TypedArray<number> | $TypedArray<bigint>,
 
   respond(bytesWritten: number): ?any,
-  respondWithNewView(view: $TypedArray): ?any,
+  respondWithNewView(view: $TypedArray<number> | $TypedArray<bigint>): ?any,
 }
 
 declare class ReadableByteStreamController extends ReadableStreamController {

--- a/lib/webassembly.js
+++ b/lib/webassembly.js
@@ -2,7 +2,7 @@
 // https://developer.mozilla.org/en-US/docs/WebAssembly
 // https://github.com/WebAssembly/design/blob/master/Web.md
 
-type BufferSource = $TypedArray | ArrayBuffer;
+type BufferSource = $TypedArray<number> | $TypedArray<bigint> | ArrayBuffer;
 type ImportExportKind = 'function' | 'table' | 'memory' | 'global';
 type ImportObject = Object;
 type ResultObject = { module: WebAssembly$Module, instance: WebAssembly$Instance };

--- a/prelude/prelude.js
+++ b/prelude/prelude.js
@@ -6,6 +6,8 @@ declare class Boolean {}
 
 declare class Number {}
 
+declare class BigInt {}
+
 declare class String {
   @@iterator(): Iterator<string>;
 }
@@ -25,34 +27,34 @@ declare function $await<T>(p: Promise<T> | T): T;
 
 // Iterable/Iterator/Generator
 
-interface $Iterator<+Yield,+Return,-Next> {
-  @@iterator(): $Iterator<Yield,Return,Next>;
+interface $Iterator<+Yield, +Return, -Next> {
+  @@iterator(): $Iterator<Yield, Return, Next>;
 }
-interface $Iterable<+Yield,+Return,-Next> {
-  @@iterator(): $Iterator<Yield,Return,Next>;
+interface $Iterable<+Yield, +Return, -Next> {
+  @@iterator(): $Iterator<Yield, Return, Next>;
 }
-interface Generator<+Yield,+Return,-Next> {
-  @@iterator(): $Iterator<Yield,Return,Next>;
+interface Generator<+Yield, +Return, -Next> {
+  @@iterator(): $Iterator<Yield, Return, Next>;
 }
 
-type Iterator<+T> = $Iterator<T,void,void>;
-type Iterable<+T> = $Iterable<T,void,void>;
+type Iterator<+T> = $Iterator<T, void, void>;
+type Iterable<+T> = $Iterable<T, void, void>;
 
 declare function $iterate<T>(p: Iterable<T>): T;
 
 // Async Iterable/Iterator/Generator
 
-interface $AsyncIterator<+Yield,+Return,-Next> {
-  @@asyncIterator(): $AsyncIterator<Yield,Return,Next>;
+interface $AsyncIterator<+Yield, +Return, -Next> {
+  @@asyncIterator(): $AsyncIterator<Yield, Return, Next>;
 }
-interface $AsyncIterable<+Yield,+Return,-Next> {
-  @@asyncIterator(): $AsyncIterator<Yield,Return,Next>;
+interface $AsyncIterable<+Yield, +Return, -Next> {
+  @@asyncIterator(): $AsyncIterator<Yield, Return, Next>;
 }
-interface AsyncGenerator<+Yield,+Return,-Next> {
-  @@asyncIterator(): $AsyncIterator<Yield,Return,Next>;
+interface AsyncGenerator<+Yield, +Return, -Next> {
+  @@asyncIterator(): $AsyncIterator<Yield, Return, Next>;
 }
 
-type AsyncIterator<+T> = $AsyncIterator<T,void,void>;
-type AsyncIterable<+T> = $AsyncIterable<T,void,void>;
+type AsyncIterator<+T> = $AsyncIterator<T, void, void>;
+type AsyncIterable<+T> = $AsyncIterable<T, void, void>;
 
 declare function $asyncIterator<T>(p: AsyncIterable<T>): T;


### PR DESCRIPTION
<!--
  If this is a change to library defintions, please include links to relevant documentation.
  If this is a documentation change, please prefix the title with [DOCS].

  If this is neither, ensure you opened a discussion issue and link it in the PR description.
-->

Follow up to #7471
(Currently these types are useless because `bigint` resolves to `any`)

#### Proposal
https://github.com/tc39/proposal-bigint
#### Docs
https://tc39.github.io/proposal-bigint/#sec-bigint-objects
https://tc39.github.io/proposal-bigint/#sec-typedarray-objects
https://tc39.github.io/proposal-bigint/#sec-dataview.prototype.getbigint64
https://tc39.github.io/proposal-bigint/#sec-dataview.prototype.getbituint64
https://tc39.github.io/proposal-bigint/#sec-dataview.prototype.setbigint64
https://tc39.github.io/proposal-bigint/#sec-dataview.prototype.setbiguint64
