### PR TITLE
[DOCS] Add mention about benefits of covariance and pitfalls of destructuring unions

### DIFF
--- a/website/en/docs/faq/index.md
+++ b/website/en/docs/faq/index.md
@@ -213,6 +213,54 @@ fn(object);
 
 Example ([https://flow.org/try](https://flow.org/try/#0PTAEAEDMBsHsHcBQiSgOoEsAuALWBXLUAJwFMBDAE1gDtoBPALmQGNaBnIyGgRlAF5QAClgAjAFaNQAbwA+oclM7EMNAOahZAApr4AtqNLEtsgL4BKAQD4ZiAJCox4gHTkBoHgCYAzKBAA5AHkAFQBRAEIZbUVQZVUNM1AAB3J2dlJKUFUFGkzySCwjUFwMdiyieAJoTMNQXQMijEgFaDh4DPsyLHxiGlAnAG5EU1YOIidSFiweKTktGLj1TVN3aRiAcmV10FMhlDBuHhEJSenzAb8wAB4AWjvQfBo2PT1SGiJsyFhiUCNib-Y4XCyFQdzB4IhkKh0JhILAACUKNQ6PQbgA3IzsDC0ZiINg0TigbiedzHSRRUAAagWWBUS209UMPzMln4NmkiFAoAcYCcrncXl8ARCEVAAGVVCxSKB6AQFGQHlilmw0eQVOR3lEtNSlLT4podPomcsADQyuUsDXrIh6QjkQrlTqkbq9foSIYjPFjN3iU6eWbyGl0hIrQTSBRSTa07a7ZDEsl+85AA))
 
+### Why can't I refine union of objects?
+
+There are two potential reasons:
+1. You don't use exact objects
+2. You destructure the object. By destructuring Flow looses track of object properties
+
+Broken example:
+
+```js
+/* @flow */
+
+type Action = 
+  | {type: 'A', payload: string}  
+  | {type: 'B', payload: number};
+
+// Not OK
+const fn = ({type, payload}: Action) => {
+  switch (type) {
+    case 'A': return payload.length;
+    case 'B': return payload + 10;
+  }
+}
+```
+
+Fixed example:
+
+```js
+/* @flow */
+
+type Action = 
+  | {type: 'A', payload: string}  
+  | {type: 'B', payload: number};
+
+// OK
+const fn = (action: Action) => {
+  switch (action.type) {
+    case 'A': return action.payload.length;
+    case 'B': return action.payload + 10;
+  }
+}
+```
+
+([https://flow.org/try](https://flow.org/try/#0PQKgBAAgZgNg9gdzCYAoVAXAngBwKZgCCAxhgJZwB2YAvGKmGAD5gDe2+AXGAOSE8AaMDgCGWeCIAm3AM4YATmUoBzAL6MGzNhzzceAIUHCxE6WEoBXALYAjPPNUBudMGBgA8gGlUxKnLBQAIy0YAAUIqQUlNwk5FQAlLQAfGyaMghkGMQAFmERcZQAdDqJrJqMxCIyBHw83PJ4GBby1PlRhaLicFKFMHgqGNnOjBVVNYb1jc2tkVQdJt2SYADUYIEADMNgqqg7Lm4AcnAYHp5gFpS+Vlb9J1Bw8mD28g8yAISorr6U-lAATCFQuxcHghJ1TKoYrNKIkaCkyq5GOlMjkwiVUoiRpVqrx+JMmi1jF0en0BkNPm4sWNeBMwA0CdRwYsVmtNhTGDtEaogA))
+
+Second example:
+- broken: [https://flow.org/try](https://flow.org/try/#0PTAEAEDMBsHsHcBQBLAtgB1gJwC6gFSgCGAzqAEoCmRAxnpFrKqAORbV0uKI4Ce6lUAGUArgCMAjAAVG6MgF5QAb2IAuUADsRqMZSwAaUGPVade0AF8A3D36DRYgEwzYc0IpVF1JHFmQaAc0Mab19-AMsbRBpYDR9hcQl3UAAKdFkSdQdpDIBKdwA+UAAeABNkADdQYAKbGLi8B0dktIys8Wc8wpLyqpqo+viAYSYWpURQUBJKaEo6bH0J0AA6VfTXEkQLdRVp2fmsdV8RSkNV5eyXNwtQAB9lKZm5nGx1SCJoabPVpquyC3y8gKSz2z2woAA-CVsspzus5DcaqB1MUmrC1hlEbUgA)
+- fixed: [https://flow.org/try](https://flow.org/try/#0PTAEAEDMBsHsHcBQBLAtgB1gJwC6gFSgCGAzqAEoCmRAxnpFrKqAORbV0uKI4Ce6lUAGUArgCMAjAAVG6MgF5QAbwA+xAFygAdiNRjKWADSgxmnXoOgVAXwDcPfoNFiATDNhzQi1RtAkcWMhaAObGNJr+gSFWdtw0sFr+wuISXqAAFOiyJJrO0tkAlF4AfKAAPAAmyABuoMDF9vGJeM4uaZnZueJuhSXlVbX19ohNSQDCTO1ZHjnKaiSU0JR02JoBIpTGAHQ7ee6eNlZzfovLOKugkETQC9u73ftkNkXypUqIoKDIkBnTclsLJYrLBFd6fT5LPBKQFnbB3LbsfzWNJ-Ej2cGgdg4ERYLTlPLKHYIyhIuoND6gZGLBbKCkQyhQmHA+GInDIxSo9HgrE4vFlVqEnas5FDCnWRDWIA)
+
 ### I got a "Missing type annotation" error. Where does it come from? <a class="toc" id="toc-i-got-a-missing-type-annotation-error-where-does-it-come-from" href="#toc-i-got-a-missing-type-annotation-error-where-does-it-come-from"></a>
 
 Flow requires type annotations at module boundaries to make sure it can scale. To read more about that, check out our [blog post](https://medium.com/flow-type/asking-for-required-annotations-64d4f9c1edf8) about that.

--- a/website/en/docs/faq/index.md
+++ b/website/en/docs/faq/index.md
@@ -143,6 +143,76 @@ const isNumber = (valueToRefine: ?number): %checks => typeof valueToRefine === '
 if (isNumber(val)) add(val, 2);
 ```
 
+### Why can't I pass Array<string> to function that takes Array<string | number>
+
+The function allows string values in an array, but in this case Flow protects the original array. In the function you would be able to push number to it which means that the type of original array would not be true. You can get rid of this by changing the argument to `$ReadOnlyArray<string | number>`. This prevents following code to push anything which makes it safe to pass stricter types to it.
+
+This would not work:
+
+```js
+// @flow
+
+const fn = (arr: Array<string | number>) => {
+	// arr.push(123) // NOTE! Array<string> passed in and after this it would also include numbers if allowed
+	return arr;
+};
+
+const arr: Array<string> = ['abc'];
+
+fn(arr); // Error!
+```
+
+but with $ReadOnlyArray you can achieve what you were looking for:
+
+```js
+// @flow
+const fn = (arr: $ReadOnlyArray<string | number>) => {
+    // arr.push(321) // NOTE! Since you are using $ReadOnlyArray<...> you cannot push anything to it
+	return arr;
+};
+
+const arr: Array<string> = ['abc'];
+
+fn(arr);
+```
+
+Example ([https://flow.org/try](https://flow.org/try/#0PTAEAEDMBsHsHcBQiSgOoEsAuALWBXLUAJwFMBDAE1gDtoBPALmQGNaBnIyGgRlAF5QACnLFijUAEEx5egB5OxDDQDmoAD4ACmvgC2AI1LEAfAEoBx0AG9EASFSjiAOgAO+djiE8ATAGZzqAByAPIAKgCiAIRSMvKKyiqWLuTs7KSUoMqg5DQZ5JBYRqC4GOyZRPAE0HnQ7LCZNCzQ+JSkoDoGRmUYkNnQcPDpdmRY+MQ02WIA3IgAvqwcRI48EtLEsgpYSqqWggDaAOTk+iwHALozKGDcPCJiplOgqHIAtG+g+I2wurqkNFywYigIzEQHsSKRZCoN4w2Fw+EIxFIqFgABKFGodHoLwAbl0MLRmIg2DROKBuN4BMJHBIACToqjBLFrDbxVQabR6Qwmcz8Sw2UCCp5gRyudyeXzeHgBMAhCLRADKyhYbXoBEmbXcCVA9IxTIYLPkTmNljV+FALByNFgRDcHmyNHoJXZWHq2GGpFG40mxDmC1JSzE3lWsU220SVMOx1OF2QFLuxG8DyAA))
+
+### Why can't I pass { a: string } to function that takes { a: string | number }
+
+The function allows string values in an object, but in this case Flow protects the original object: In the function you would be able to mutate the object so that the property `a` would have number in it which means that the type of original object would not be true anymore. You can get rid of this by making the property covariant (read-only) `{ +a: string | number }`. This prevents following code to change the property which makes it safe to pass stricter types to the function.
+
+This would not work:
+
+```js
+// @flow
+
+const fn = (obj: {| a: string | number |}) => {
+	// obj.a = 123 // NOTE! {| a: string |} passed in and after this a would be number if allowed
+	return obj;
+};
+
+const object: {| a: string |} = {a: 'str' };
+
+fn(object); // Error!
+```
+
+but with covariant property you can achieve what you were looking for:
+
+```js
+// @flow
+const fn = (obj: {| +a: string | number |}) => {
+  	// obj.a = 123 // NOTE! Since you are using covariant {| +a: string | number |}, you can't mutate it
+	return obj;
+};
+
+const object: {| a: string |} = { a: 'str' };
+
+fn(object);
+```
+
+Example ([https://flow.org/try](https://flow.org/try/#0PTAEAEDMBsHsHcBQiSgOoEsAuALWBXLUAJwFMBDAE1gDtoBPALmQGNaBnIyGgRlAF5QAClgAjAFaNQAbwA+oclM7EMNAOahZAApr4AtqNLEtsgL4BKAQD4ZiAJCox4gHTkBoHgCYAzKBAA5AHkAFQBRAEIZbUVQZVUNM1AAB3J2dlJKUFUFGkzySCwjUFwMdiyieAJoTMNQXQMijEgFaDh4DPsyLHxiGlAnAG5EU1YOIidSFiweKTktGLj1TVN3aRiAcmV10FMhlDBuHhEJSenzAb8wAB4AWjvQfBo2PT1SGiJsyFhiUCNib-Y4XCyFQdzB4IhkKh0JhILAACUKNQ6PQbgA3IzsDC0ZiINg0TigbiedzHSRRUAAagWWBUS209UMPzMln4NmkiFAoAcYCcrncXl8ARCEVAAGVVCxSKB6AQFGQHlilmw0eQVOR3lEtNSlLT4podPomcsADQyuUsDXrIh6QjkQrlTqkbq9foSIYjPFjN3iU6eWbyGl0hIrQTSBRSTa07a7ZDEsl+85AA))
+
 ### I got a "Missing type annotation" error. Where does it come from? <a class="toc" id="toc-i-got-a-missing-type-annotation-error-where-does-it-come-from" href="#toc-i-got-a-missing-type-annotation-error-where-does-it-come-from"></a>
 
 Flow requires type annotations at module boundaries to make sure it can scale. To read more about that, check out our [blog post](https://medium.com/flow-type/asking-for-required-annotations-64d4f9c1edf8) about that.


### PR DESCRIPTION
Common misconception is that you should be able to pass an array of "stricter" types to an array that accepts wider range of types. This is not true, and oftentimes it causes confusion why it's not possible. It's fairly easy to fix by changing types to be read-only.

Other thing often causing confusion is destructuring object unions. 

Feel free to fix potential grammar errors and enhance the explanation!