### PR TITLE
[DOCS] Update creation.md

### DIFF
--- a/website/en/docs/libdefs/creation.md
+++ b/website/en/docs/libdefs/creation.md
@@ -89,8 +89,7 @@ declare module "some-third-party-library" {
 The name specified in quotes after `declare module` can be any string, but it
 should correspond to the same string you'd use to `require` or `import` the
 third-party module into your project. For defining modules that are accessed via
-a relative `require`/`import` path, check out the docs on
-[`.js.flow`](javascript:alert("TODO")) files.
+a relative `require`/`import` path, please see the docs on the `.js.flow` files which will be available soon.
 
 Within the body of a `declare module` block, you can specify the set of exports
 for that module. However, before we start talking about exports we have to talk


### PR DESCRIPTION
I've replaced the alert TODO with a clear indication that the documentation is simply not ready yet. Defining modules that are accessed via a relative require/import path is not a well covered area and to find some mention of it in the docs but be presented with an alert box isn't great.

<!--
  If this is a change to library defintions, please include links to relevant documentation.
  If this is a documentation change, please prefix the title with [DOCS].

  If this is neither, ensure you opened a discussion issue and link it in the PR description.
-->
