### PR TITLE
Fix return type for _write

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -1728,7 +1728,7 @@ declare class stream$Duplex extends stream$Readable mixins stream$Writable {
     chunk: Buffer | string,
     encoding: string,
     callback: (error: ?Error, data?: Buffer | string) => void
-  ): boolean;
+  ): void;
 }
 declare class stream$Transform extends stream$Duplex {
   _transform(

--- a/lib/node.js
+++ b/lib/node.js
@@ -1696,7 +1696,7 @@ declare class stream$Writable extends stream$Stream {
     chunk: Buffer | string,
     encoding: string,
     callback: (error: ?Error, data?: Buffer | string) => void
-  ): boolean;
+  ): void;
   destroy(error?: Error): this;
 }
 


### PR DESCRIPTION
The documentation doesn't say anything about what it should return, so I assume it should return void.

https://nodejs.org/dist/latest-v10.x/docs/api/stream.html#stream_writable_write_chunk_encoding_callback_1