### PR TITLE
docs: label user reported bugs with "needs triage" label

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,7 @@
 ---
 name: "Bug report"
 about: You want to report a reproducible bug or regression in Flow.
-labels: bug
+labels: bug, needs triage
 ---
 
 <!--


### PR DESCRIPTION
This change will help to identify verified/triaged bugs. Right now anyone can create a new issue labelled as bug and it's difficult to help triaging issues.