### PR TITLE
Avoid using `any`'s in common Date class

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -393,7 +393,7 @@ declare class Date {
     setUTCSeconds(sec: number, ms?: number): number;
     toDateString(): string;
     toISOString(): string;
-    toJSON(key?: any): string;
+    toJSON(key?: mixed): string;
     toLocaleDateString(locales?: string | Array<string>, options?: Intl$DateTimeFormatOptions): string;
     toLocaleString(locales?: string | Array<string>, options?: Intl$DateTimeFormatOptions): string;
     toLocaleTimeString(locales?: string | Array<string>, options?: Intl$DateTimeFormatOptions): string;


### PR DESCRIPTION
This causes any JS library exporting `Date` instances to blow up on the `dynamic-export` linter flag. Disabling the flag is not an option for library authors, since any project using that library will also have to disable that linter flag in turn.
