### PR TITLE
Avoid using `Object` in server options

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -1331,7 +1331,16 @@ declare class http$Server extends net$Server {
   listen(port?: number, hostname?: string, callback?: Function): this;
   listen(port?: number, callback?: Function): this;
   listen(path: string, callback?: Function): this;
-  listen(handle: Object, callback?: Function): this;
+  listen(handle: {
+    port?: number,
+    host?: string,
+    path?: string,
+    backlog?: number,
+    exclusive?: boolean,
+    readableAll?: boolean,
+    writableAll?: boolean,
+    ipv6Only?: boolean,
+  }, callback?: Function): this;
   listening: boolean;
   close(callback?: (error: ?Error) => mixed): this;
   maxHeadersCount: number;
@@ -1347,7 +1356,16 @@ declare class https$Server extends tls$Server {
   listen(port?: number, hostname?: string, callback?: Function): this;
   listen(port?: number, callback?: Function): this;
   listen(path: string, callback?: Function): this;
-  listen(handle: Object, callback?: Function): this;
+  listen(handle: {
+    port?: number,
+    host?: string,
+    path?: string,
+    backlog?: number,
+    exclusive?: boolean,
+    readableAll?: boolean,
+    writableAll?: boolean,
+    ipv6Only?: boolean,
+  }, callback?: Function): this;
   close(callback?: (error: ?Error) => mixed): this;
   keepAliveTimeout: number;
   setTimeout(msecs: number, callback: Function): this;


### PR DESCRIPTION
<!--
  If this is a change to library defintions, please include links to relevant documentation.
  If this is a documentation change, please prefix the title with [DOCS].

  If this is neither, ensure you opened a discussion issue and link it in the PR description.
-->

If `handle` is `Object`, this will cause this error:

```js
server.listen(true); // true is considered as Object.
```

Docs: [net_server_listen_options_callback](https://nodejs.org/api/net.html#net_server_listen_options_callback).