### PR TITLE
MessagePort::onmessage can be null

### DIFF
--- a/lib/bom.js
+++ b/lib/bom.js
@@ -1344,7 +1344,7 @@ declare class MessagePort extends EventTarget {
   start(): void;
   close(): void;
 
-  onmessage: (ev: MessageEvent) => any;
+  onmessage: null | (ev: MessageEvent) => any;
 }
 
 declare class MessageChannel {


### PR DESCRIPTION
When creating a new `MessagePort`, by default its events are set to null. Moreover, setting them back to null causes no error.

This PR implements said behaviour. It's not the first interface to be like this either— workers have a similar `onmessage: null | (ev: MessageEvent) => any`. 

```
// Confirmed they initialize as null
var c = new MessageChannel(); 
c.port1.onmessage;

// Confirmed they can be set back to their default value with no issue
c.onmessage = console.log;
c.onmessage = null;
```

Couldn't find documentation of this in MDN. On the spec it's [defined in WebIDL as an `EventHandler`](https://html.spec.whatwg.org/multipage/web-messaging.html#message-ports), which is a [nullable `EventHandlerNonNull`](https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler).