### PR TITLE
[DOCS] Update tuples.md

### DIFF
--- a/website/en/docs/types/tuples.md
+++ b/website/en/docs/types/tuples.md
@@ -25,7 +25,7 @@ let bool : boolean = tuple[1]; // Works!
 let str  : string  = tuple[2]; // Works!
 ```
 
-If you try getting from an index that does not exist it will not type-check hence will result in a static error.
+If you try getting from an index that does not exist, it will not type-check hence will result in a static error.
 
 ```js
 // @flow

--- a/website/en/docs/types/tuples.md
+++ b/website/en/docs/types/tuples.md
@@ -25,8 +25,7 @@ let bool : boolean = tuple[1]; // Works!
 let str  : string  = tuple[2]; // Works!
 ```
 
-If you try getting from an index that does not exist it will return a type of
-`void`.
+If you try getting from an index that does not exist it will not type-check hence will result in a static error.
 
 ```js
 // @flow


### PR DESCRIPTION
If a tuple is defined as follows:

```js
let tuple: [number, boolean, string] = [1, true, "three"];
```

and an access to one of its elements is attempted like this:

```js
let none: void = tuple[3];
```

Access attempt will result in an error rather than returning a value of type `void`, so suggesting this change.