### PR TITLE
fix native event annotations for mouse based events

### DIFF
--- a/lib/react-dom.js
+++ b/lib/react-dom.js
@@ -198,7 +198,7 @@ declare class SyntheticKeyboardEvent<
   which: number;
 }
 
-type $SyntheticMouseEvent = {|
+class $SyntheticMouseEvent {
   altKey: boolean;
   button: number;
   buttons: number;
@@ -213,25 +213,22 @@ type $SyntheticMouseEvent = {|
   screenX: number;
   screenY: number;
   shiftKey: boolean;
-|}
+}
 
 declare class SyntheticMouseEvent<
   +T: EventTarget = EventTarget,
-> extends SyntheticUIEvent<T, MouseEvent> {
-  ...$SyntheticMouseEvent,
+> extends SyntheticUIEvent<T, MouseEvent> mixins $SyntheticMouseEvent {
 }
 
 declare class SyntheticDragEvent<
   +T: EventTarget = EventTarget,
-> extends SyntheticUIEvent<T, DragEvent> {
-  ...$SyntheticMouseEvent,
+> extends SyntheticUIEvent<T, DragEvent> mixins $SyntheticMouseEvent {
   dataTransfer: any;
 }
 
 declare class SyntheticWheelEvent<
   +T: EventTarget = EventTarget,
-> extends SyntheticUIEvent<T, WheelEvent> {
-  ...$SyntheticMouseEvent,
+> extends SyntheticUIEvent<T, WheelEvent> mixins $SyntheticMouseEvent  {
   deltaMode: number;
   deltaX: number;
   deltaY: number;
@@ -240,8 +237,7 @@ declare class SyntheticWheelEvent<
 
 declare class SyntheticPointerEvent<
   +T: EventTarget = EventTarget,
-> extends SyntheticUIEvent<T, PointerEvent> {
-  ...$SyntheticMouseEvent,
+> extends SyntheticUIEvent<T, PointerEvent> mixins $SyntheticMouseEvent {
   pointerId: number;
   width: number;
   height: number;

--- a/lib/react-dom.js
+++ b/lib/react-dom.js
@@ -198,7 +198,10 @@ declare class SyntheticKeyboardEvent<
   which: number;
 }
 
-class $SyntheticMouseEvent {
+declare class SyntheticMouseEvent<
+  +T: EventTarget = EventTarget,
+  +E: Event = MouseEvent,
+> extends SyntheticUIEvent<T, E> {
   altKey: boolean;
   button: number;
   buttons: number;
@@ -215,20 +218,15 @@ class $SyntheticMouseEvent {
   shiftKey: boolean;
 }
 
-declare class SyntheticMouseEvent<
-  +T: EventTarget = EventTarget,
-> extends SyntheticUIEvent<T, MouseEvent> mixins $SyntheticMouseEvent {
-}
-
 declare class SyntheticDragEvent<
   +T: EventTarget = EventTarget,
-> extends SyntheticUIEvent<T, DragEvent> mixins $SyntheticMouseEvent {
+> extends SyntheticMouseEvent<T, DragEvent> {
   dataTransfer: any;
 }
 
 declare class SyntheticWheelEvent<
   +T: EventTarget = EventTarget,
-> extends SyntheticUIEvent<T, WheelEvent> mixins $SyntheticMouseEvent  {
+> extends SyntheticMouseEvent<T, WheelEvent>  {
   deltaMode: number;
   deltaX: number;
   deltaY: number;
@@ -237,7 +235,7 @@ declare class SyntheticWheelEvent<
 
 declare class SyntheticPointerEvent<
   +T: EventTarget = EventTarget,
-> extends SyntheticUIEvent<T, PointerEvent> mixins $SyntheticMouseEvent {
+> extends SyntheticMouseEvent<T, PointerEvent> {
   pointerId: number;
   width: number;
   height: number;

--- a/lib/react-dom.js
+++ b/lib/react-dom.js
@@ -198,9 +198,7 @@ declare class SyntheticKeyboardEvent<
   which: number;
 }
 
-declare class SyntheticMouseEvent<
-  +T: EventTarget = EventTarget,
-> extends SyntheticUIEvent<T, MouseEvent> {
+type $SyntheticMouseEvent = {|
   altKey: boolean;
   button: number;
   buttons: number;
@@ -215,17 +213,25 @@ declare class SyntheticMouseEvent<
   screenX: number;
   screenY: number;
   shiftKey: boolean;
+|}
+
+declare class SyntheticMouseEvent<
+  +T: EventTarget = EventTarget,
+> extends SyntheticUIEvent<T, MouseEvent> {
+  ...$SyntheticMouseEvent,
 }
 
 declare class SyntheticDragEvent<
   +T: EventTarget = EventTarget,
-> extends SyntheticMouseEvent<T> {
+> extends SyntheticUIEvent<T, DragEvent> {
+  ...$SyntheticMouseEvent,
   dataTransfer: any;
 }
 
 declare class SyntheticWheelEvent<
   +T: EventTarget = EventTarget,
-> extends SyntheticMouseEvent<T> {
+> extends SyntheticUIEvent<T, WheelEvent> {
+  ...$SyntheticMouseEvent,
   deltaMode: number;
   deltaX: number;
   deltaY: number;
@@ -234,7 +240,8 @@ declare class SyntheticWheelEvent<
 
 declare class SyntheticPointerEvent<
   +T: EventTarget = EventTarget,
-> extends SyntheticMouseEvent<T> {
+> extends SyntheticUIEvent<T, PointerEvent> {
+  ...$SyntheticMouseEvent,
   pointerId: number;
   width: number;
   height: number;


### PR DESCRIPTION
Current annotation of the `SyntheticDragEvent`, `SyntheticWheelEvent`, `SyntheticPointerEvent` leads to wrong annotations for the nativeEvents (in all these three events annotation for native event will be having type `MouseEvent`). 

Flow docs themselves contain information, how SyntheticEvent<T> types that React provides and the DOM event are relate for 2 of 3 changed annotations: https://flow.org/en/docs/react/events/

