### PR TITLE
[flowlib] Add MessagePort::onmessageerror

### DIFF
--- a/lib/bom.js
+++ b/lib/bom.js
@@ -1345,6 +1345,7 @@ declare class MessagePort extends EventTarget {
   close(): void;
 
   onmessage: null | (ev: MessageEvent) => any;
+  onmessageerror: null | (ev: MessageEvent) => any;
 }
 
 declare class MessageChannel {


### PR DESCRIPTION
`MessagePort`s have a second event listener. It's called when there's an error deserializing the message.

Documentation: https://developer.mozilla.org/en-US/docs/Web/API/MessagePort#Event_handlers