### PR TITLE
Fix code formatting on web site

### DIFF
--- a/website/_plugins/highlighter.rb
+++ b/website/_plugins/highlighter.rb
@@ -200,7 +200,7 @@ module Jekyll
             printed += before[index]
           end
 
-          printed += char
+          printed += CGI.escapeHTML(char)
 
           if after[index + 1] != nil
             printed += after[index + 1]

--- a/website/en/docs/faq/index.md
+++ b/website/en/docs/faq/index.md
@@ -143,7 +143,7 @@ const isNumber = (valueToRefine: ?number): %checks => typeof valueToRefine === '
 if (isNumber(val)) add(val, 2);
 ```
 
-### Why can't I pass an `Array<string>` to a function that takes an `Array<string | number>` <a class="toc" id="fun"></a>
+### Why can't I pass an `Array<string>` to a function that takes an `Array<string | number>` <a class="toc" id="toc-why-can-t-i-pass-an-array-to-a-function-that-takes-an-array" href="#toc-why-can-t-i-pass-an-array-to-a-function-that-takes-an-array"></a>
 
 The function's argument allows `string` values in its array, but in this case Flow prevents the original array from receiving a `number`. Inside the function, you would be able to push a `number` to the argument array, causing the type of the original array to no longer be accurate. You can fix this error by changing the type of the argument to `$ReadOnlyArray<string | number>`. This prevents the function body from pushing anything to the array, allowing it to accept narrower types.
 
@@ -178,7 +178,7 @@ fn(arr);
 
 Example ([https://flow.org/try](https://flow.org/try/#0PTAEAEDMBsHsHcBQiSgOoEsAuALWBXLUAJwFMBDAE1gDtoBPALmQGNaBnIyGgRlAF5QACnLFijUAEEx5egB5OxDDQDmoAD4ACmvgC2AI1LEAfAEoBx0AG9EASFSjiAOgAO+djiE8ATAGZzqAByAPIAKgCiAIRSMvKKyiqWLuTs7KSUoMqg5DQZ5JBYRqC4GOyZRPAE0HnQ7LCZNCzQ+JSkoDoGRmUYkNnQcPDpdmRY+MQ02WIA3IgAvqwcRI48EtLEsgpYSqqWggDaAOTk+iwHALozKGDcPCJiplOgqHIAtG+g+I2wurqkNFywYigIzEQHsSKRZCoN4w2Fw+EIxFIqFgABKFGodHoLwAbl0MLRmIg2DROKBuN4BMJHBIACToqjBLFrDbxVQabR6Qwmcz8Sw2UCCp5gRyudyeXzeHgBMAhCLRADKyhYbXoBEmbXcCVA9IxTIYLPkTmNljV+FALByNFgRDcHmyNHoJXZWHq2GGpFG40mxDmC1JSzE3lWsU220SVMOx1OF2QFLuxG8DyAA))
 
-### Why can't I pass `{ a: string }` to a function that takes `{ a: string | number }` <a class="toc"></a>
+### Why can't I pass `{ a: string }` to a function that takes `{ a: string | number }` <a class="toc" id="toc-why-can-t-i-pass-a-string-to-a-function-that-takes-a-string-number" href="#toc-why-can-t-i-pass-a-string-to-a-function-that-takes-a-string-number"></a>
 
 The function argument allows `string` values in its field, but in this case Flow prevents the original object from having a `number` written to it. Within the body of the function you would be able to mutate the object so that the property `a` would receive a `number`, causing the type of the original object to no longer be accurate. You can fix this error by making the property covariant (read-only): `{ +a: string | number }`. This prevents the function body from writing to the property, making it safe to pass more restricted types to the function.
 
@@ -213,7 +213,7 @@ fn(object);
 
 Example ([https://flow.org/try](https://flow.org/try/#0PTAEAEDMBsHsHcBQiSgOoEsAuALWBXLUAJwFMBDAE1gDtoBPALmQGNaBnIyGgRlAF5QAClgAjAFaNQAbwA+oclM7EMNAOahZAApr4AtqNLEtsgL4BKAQD4ZiAJCox4gHTkBoHgCYAzKBAA5AHkAFQBRAEIZbUVQZVUNM1AAB3J2dlJKUFUFGkzySCwjUFwMdiyieAJoTMNQXQMijEgFaDh4DPsyLHxiGlAnAG5EU1YOIidSFiweKTktGLj1TVN3aRiAcmV10FMhlDBuHhEJSenzAb8wAB4AWjvQfBo2PT1SGiJsyFhiUCNib-Y4XCyFQdzB4IhkKh0JhILAACUKNQ6PQbgA3IzsDC0ZiINg0TigbiedzHSRRUAAagWWBUS209UMPzMln4NmkiFAoAcYCcrncXl8ARCEVAAGVVCxSKB6AQFGQHlilmw0eQVOR3lEtNSlLT4podPomcsADQyuUsDXrIh6QjkQrlTqkbq9foSIYjPFjN3iU6eWbyGl0hIrQTSBRSTa07a7ZDEsl+85AA))
 
-### Why can't I refine a union of objects? <a class="toc"></a>
+### Why can't I refine a union of objects? <a class="toc" id="toc-why-can-t-i-refine-a-union-of-objects" href="#toc-why-can-t-i-refine-a-union-of-objects"></a>
 
 There are two potential reasons:
 1. You are using inexact objects.

--- a/website/en/docs/faq/index.md
+++ b/website/en/docs/faq/index.md
@@ -149,10 +149,10 @@ The function's argument allows `string` values in its array, but in this case Fl
 
 As an example, this would not work:
 
-```
+```js
 // @flow
 
-const fn = (arr: Array<string | number>) => {
+const fn = (arr: Array<string | number>) => {
   // arr.push(123) NOTE! Array<string> passed in and after this it would also include numbers if allowed
   return arr;
 };
@@ -164,9 +164,9 @@ fn(arr); // Error!
 
 but with `$ReadOnlyArray` you can achieve what you were looking for:
 
-```
+```js
 // @flow
-const fn = (arr: $ReadOnlyArray<string | number>) => {
+const fn = (arr: $ReadOnlyArray<string | number>) => {
   // arr.push(321) NOTE! Since you are using $ReadOnlyArray<...> you cannot push anything to it
   return arr;
 };
@@ -184,25 +184,25 @@ The function argument allows `string` values in its field, but in this case Flow
 
 As an example, this would not work:
 
-```
+```js
 // @flow
 
-const fn = (obj: {| a: string | number |}) => {
+const fn = (obj: {| a: string | number |}) => {
   // obj.a = 123;
   return obj;
 };
 
-const object: {| a: string |} = {a: 'str' };
+const object: {| a: string |} = {a: 'str' };
 
 fn(object); // Error!
 ```
 
 but with a covariant property you can achieve what you were looking for:
 
-```
+```js
 // @flow
-const fn = (obj: {| +a: string | number |}) => {
-  // obj.a = 123 NOTE! Since you are using covariant {| +a: string | number |}, you can't mutate it
+const fn = (obj: {| +a: string | number |}) => {
+  // obj.a = 123 NOTE! Since you are using covariant {| +a: string | number |}, you can't mutate it
   return obj;
 };
 
@@ -221,7 +221,7 @@ There are two potential reasons:
 
 Broken example:
 
-```
+```js
 /* @flow */
 
 type Action =
@@ -239,7 +239,7 @@ const fn = ({type, payload}: Action) => {
 
 Fixed example:
 
-```
+```js
 /* @flow */
 
 type Action =


### PR DESCRIPTION
There were two issues that caused FAQ to fail rendering:
1. The code highlighter didn't escape the code, and some comments have valid html in them (like `// Array<string>` where `<string>` is considered html element)
2. some of the code blocks had irregular whitespaces that caused the highlighting to fail

Also adds missing links.