### PR TITLE
[DOCS] deprecate `*`  (existential) type

### DIFF
--- a/website/en/docs/linting/rule-reference.md
+++ b/website/en/docs/linting/rule-reference.md
@@ -216,6 +216,11 @@ Triggers when you use the `$Supertype` or `$Subtype` utility types, as these typ
 unsafe and usually just equivalent to `any`. If the utilities were being used in a sound manner, the
 desired behavior can usually be recovered through the [`$Shape`](../../types/utilities/#toc-shape) utility or [bounded generics](../../types/generics/#toc-generic-types-act-as-bounds).
 
+#### `deprecated-type` <a class="toc" id="toc-deprecated-type" href="#toc-deprecated-type"></a>
+Triggers when you use the `*` (existential) utility type, as this type is
+unsafe and usually just equivalent to `any`.
+The effect of `*` can generally be achieved by simply not providing a type annotation.
+
 #### `dynamic-export` <a class="toc" id="toc-dynamic-export" href="#toc-dynamic-export"></a>
 Triggers when a dynamic type (usually `any`) appears in a position exported from a file. Note that this is a very noisy lint, and can be triggered even
 when exporting types that are defined in our library definitions to include `any` types. For this reason we recommend turning it on on a per-file or even

--- a/website/en/docs/types/utilities.md
+++ b/website/en/docs/types/utilities.md
@@ -638,42 +638,5 @@ This utility has been deprecated and should be avoided. See [here](../../linting
 
 ## Existential Type (`*`) <a class="toc" id="toc-existential-type" href="#toc-existential-type"></a>
 
-`*` is known as the existential type.
+This utility has been deprecated and should be avoided. See [here](../../linting/rule-reference/#toc-deprecated-type) for details.
 
-An existential type is used as a placeholder to tell Flow to infer the type.
-
-For example, in the `Class<ParamStore<T>>` example, we could have used an existential type for the return:
-
-```js
-// @flow
-function makeParamStore<T>(storeClass: Class<ParamStore<T>>, data: T): * {
-  return new storeClass(data);
-}
-(makeParamStore(ParamStore, 1): ParamStore<number>);
-(makeParamStore(ParamStore, 1): ParamStore<boolean>); // failed because of the second parameter
-```
-
-The `*` can be thought of as an "auto" instruction to Flow, telling it to fill in the type from context.
-
-In comparison to `any`, `*` may allow you to avoid losing type safety.
-
-The existential operator is also useful for automatically filling in types without unnecessary verbosity:
-
-```js
-// @flow
-class DataStore {
-  data: *; // If this property weren't defined, you'd get an error just trying to assign `data`
-  constructor() {
-    this.data = {
-      name: 'DataStore',
-      isOffline: true
-    };
-  }
-  goOnline() {
-    this.data.isOffline = false;
-  }
-  changeName() {
-    this.data.isOffline = 'SomeStore'; // oops, wrong key!
-  }
-}
-```


### PR DESCRIPTION
According to discussion in discord, `*` has been deprecated and added to the `deprecated-utility` lint. This changes the docs correspondingly.