### PR TITLE
Fix $ObjMap and $ObjMapi exactness

### DIFF
--- a/src/typing/flow_js.ml
+++ b/src/typing/flow_js.ml
@@ -5431,7 +5431,7 @@ let rec __flow cx ((l: Type.t), (u: Type.use_t)) trace =
       let t = DefT (reason, bogus_trust (), ArrT (ROArrayAT elemt)) in
       rec_flow cx trace (t, MapTypeT (reason, TupleMap funt, tout))
 
-    | DefT (_, _, ObjT o), MapTypeT (reason_op, ObjectMap funt, tout) ->
+    | DefT (_, trust, ObjT o), MapTypeT (reason_op, ObjectMap funt, tout) ->
       let map_t t =
         let t, opt = match t with
         | OptionalT (_, t) -> t, true
@@ -5454,7 +5454,8 @@ let rec __flow cx ((l: Type.t), (u: Type.use_t)) trace =
       ) o.dict_t in
       let mapped_t =
         let reason = replace_reason_const RObjectType reason_op in
-        DefT (reason, bogus_trust (), ObjT {o with props_tmap; dict_t})
+        let t = DefT (reason, trust, ObjT {o with props_tmap; dict_t}) in
+        if o.flags.exact then ExactT (reason, t) else t
       in
       rec_flow_t cx trace (mapped_t, tout)
 
@@ -5485,7 +5486,8 @@ let rec __flow cx ((l: Type.t), (u: Type.use_t)) trace =
       ) o.dict_t in
       let mapped_t =
         let reason = replace_reason_const RObjectType reason_op in
-        DefT (reason, trust, ObjT {o with props_tmap; dict_t})
+        let t = DefT (reason, trust, ObjT {o with props_tmap; dict_t}) in
+        if o.flags.exact then ExactT (reason, t) else t
       in
       rec_flow_t cx trace (mapped_t, tout)
 

--- a/tests/objmap/objmap.exp
+++ b/tests/objmap/objmap.exp
@@ -317,6 +317,24 @@ References:
                  ^^^^^^ [2]
 
 
+Error --------------------------------------------------------------------------------------------------- objmap.js:23:5
+
+Cannot assign object literal to `foo` because inexact object literal [1] is incompatible with exact object type [2].
+
+   objmap.js:23:5
+   23| > = {} // error, {| a: number |} ~> {} 
+           ^^ [1]
+
+References:
+   objmap.js:20:10
+                v-------
+   20| var foo: $ObjMap<
+   21|   {|a: number|},
+   22|   <T>(t:T) => T
+   23| > = {} // error, {| a: number |} ~> {} 
+       ^ [2]
+
+
 Error ------------------------------------------------------------------------------------------------- optional.js:13:2
 
 Cannot cast `o3.b` to array type because undefined [1] is incompatible with array type [2].
@@ -352,4 +370,4 @@ References:
 
 
 
-Found 23 errors
+Found 24 errors

--- a/tests/objmap/objmap.js
+++ b/tests/objmap/objmap.js
@@ -16,3 +16,13 @@ promiseAllByKey({
   (o.foo: string); // error, number ~> string
   (o.bar: 'bar'); // ok
 });
+
+var foo: $ObjMap<
+  {|a: number|},
+  <T>(t:T) => T
+> = {} // error, {| a: number |} ~> {} 
+
+var bar: $ObjMap<
+  {a: number},
+  <T>(t:T) => T
+> = {} // ok


### PR DESCRIPTION
<!--
  If this is a change to library defintions, please include links to relevant documentation.
  If this is a documentation change, please prefix the title with [DOCS].

  If this is neither, ensure you opened a discussion issue and link it in the PR description.
-->

Does similar behaviour as `$ReadOnly` type, tho I'm not sure why flags.exact is different from ExactT.
Also added `trust`
