### PR TITLE
$ObjMap property modifiers

### DIFF
--- a/src/common/ty/ty.ml
+++ b/src/common/ty/ty.ml
@@ -150,8 +150,8 @@ and utility =
   | PropertyType of t * t
   | ElementType of t * t
   | NonMaybeType of t
-  | ObjMap of t * t
-  | ObjMapi of t * t
+  | ObjMap of t * t * t option
+  | ObjMapi of t * t * t option
   | TupleMap of t * t
   | Call of t * t list
   | Class of t
@@ -314,8 +314,10 @@ let types_of_utility = function
   | PropertyType (t1, t2) -> Some [t1; t2]
   | ElementType (t1, t2) -> Some [t1; t2]
   | NonMaybeType t -> Some [t]
-  | ObjMap (t1, t2) -> Some [t1; t2]
-  | ObjMapi (t1, t2) -> Some [t1; t2]
+  | ObjMap (t1, t2, None) -> Some [t1; t2]
+  | ObjMapi (t1, t2, None) -> Some [t1; t2]
+  | ObjMap (t1, t2, Some t3) -> Some [t1; t2; t3]
+  | ObjMapi (t1, t2, Some t3) -> Some [t1; t2; t3]
   | TupleMap (t1, t2) -> Some [t1; t2]
   | Call (t, ts) -> Some (t::ts)
   | Class t -> Some [t]

--- a/src/typing/debug_js.ml
+++ b/src/typing/debug_js.ml
@@ -1222,11 +1222,19 @@ and json_of_type_map_impl json_cx = Hh_json.(function
   | TupleMap t -> JSON_Object [
       "tupleMap", _json_of_t json_cx t;
     ]
-  | ObjectMap (t, _) -> JSON_Object [
+  | ObjectMap (t, None) -> JSON_Object [
       "objectMap", _json_of_t json_cx t;
     ]
-  | ObjectMapi (t, _) -> JSON_Object [
+  | ObjectMap (t, Some t2) -> JSON_Object [
+      "objectMap", _json_of_t json_cx t;
+      "objectMapParams", _json_of_t json_cx t2;
+    ]
+  | ObjectMapi (t, None) -> JSON_Object [
       "objectMapi", _json_of_t json_cx t;
+    ]
+  | ObjectMapi (t, Some t2) -> JSON_Object [
+      "objectMapi", _json_of_t json_cx t;
+      "objectMapiParams", _json_of_t json_cx t2;
     ]
 )
 

--- a/src/typing/debug_js.ml
+++ b/src/typing/debug_js.ml
@@ -1222,10 +1222,10 @@ and json_of_type_map_impl json_cx = Hh_json.(function
   | TupleMap t -> JSON_Object [
       "tupleMap", _json_of_t json_cx t;
     ]
-  | ObjectMap t -> JSON_Object [
+  | ObjectMap (t, _) -> JSON_Object [
       "objectMap", _json_of_t json_cx t;
     ]
-  | ObjectMapi t -> JSON_Object [
+  | ObjectMapi (t, _) -> JSON_Object [
       "objectMapi", _json_of_t json_cx t;
     ]
 )

--- a/src/typing/resolvableTypeJob.ml
+++ b/src/typing/resolvableTypeJob.ml
@@ -298,7 +298,9 @@ and collect_of_destructor ?log_unresolved cx reason acc = function
     -> acc
 
 and collect_of_type_map ?log_unresolved cx reason acc = function
-  | TupleMap t | ObjectMap t | ObjectMapi t ->
+  | TupleMap t 
+  | ObjectMap (t, _)
+  | ObjectMapi (t, _) ->
     collect_of_type ?log_unresolved cx reason acc t
 
 (* TODO: Support for use types is currently sketchy. Full resolution of use

--- a/src/typing/resolvableTypeJob.ml
+++ b/src/typing/resolvableTypeJob.ml
@@ -298,10 +298,13 @@ and collect_of_destructor ?log_unresolved cx reason acc = function
     -> acc
 
 and collect_of_type_map ?log_unresolved cx reason acc = function
-  | TupleMap t 
-  | ObjectMap (t, _)
-  | ObjectMapi (t, _) ->
+  | ObjectMap (t, None)
+  | ObjectMapi (t, None)
+  | TupleMap t ->
     collect_of_type ?log_unresolved cx reason acc t
+  | ObjectMap (t, Some t2)
+  | ObjectMapi (t, Some t2) ->
+    collect_of_types ?log_unresolved cx reason acc [t; t2]
 
 (* TODO: Support for use types is currently sketchy. Full resolution of use
    types are only needed for choice-making on intersections. We care about

--- a/src/typing/ty_normalizer.ml
+++ b/src/typing/ty_normalizer.ml
@@ -1510,10 +1510,14 @@ end = struct
       type__ ~env t' >>| fun ty' -> Ty.Utility (Ty.ElementType (ty, ty'))
     | T.CallType ts ->
       mapM (type__ ~env) ts >>| fun tys -> Ty.Utility (Ty.Call (ty, tys))
-    | T.TypeMap (T.ObjectMap t') ->
-      type__ ~env t' >>| fun ty' -> Ty.Utility (Ty.ObjMap (ty, ty'))
-    | T.TypeMap (T.ObjectMapi t') ->
-      type__ ~env t' >>| fun ty' -> Ty.Utility (Ty.ObjMapi (ty, ty'))
+    | T.TypeMap (T.ObjectMap (t', Some t2')) ->
+      mapM (type__ ~env) [t'; t2'] >>| fun tys -> Ty.Utility (Ty.ObjMap (ty, Core_list.nth_exn tys 0, Core_list.nth tys 1))
+    | T.TypeMap (T.ObjectMapi (t', Some t2')) ->
+      mapM (type__ ~env) [t'; t2'] >>| fun tys -> Ty.Utility (Ty.ObjMapi (ty, Core_list.nth_exn tys 0, Core_list.nth tys 1))
+    | T.TypeMap (T.ObjectMap (t', _)) ->
+      type__ ~env t' >>| fun ty' -> Ty.Utility (Ty.ObjMap (ty, ty', None))
+    | T.TypeMap (T.ObjectMapi (t', _)) ->
+      type__ ~env t' >>| fun ty' -> Ty.Utility (Ty.ObjMapi (ty, ty', None))
     | T.PropertyType k ->
       return (Ty.Utility (Ty.PropertyType (ty, Ty.StrLit k)))
     | T.TypeMap (T.TupleMap t') ->

--- a/src/typing/type.ml
+++ b/src/typing/type.ml
@@ -1060,9 +1060,9 @@ module rec TypeTerm : sig
 
   and type_map =
   | TupleMap of t
-  | ObjectMap of t
-  | ObjectMapi of t
-
+  | ObjectMap of t * t option
+  | ObjectMapi of t * t option
+ 
   and prototype = t
 
   and super = t

--- a/src/typing/type_annotation.ml
+++ b/src/typing/type_annotation.ml
@@ -532,25 +532,31 @@ let rec convert cx tparams_map = Ast.Type.(function
     )
 
   | "$ObjMap" ->
-    check_type_arg_arity cx loc t_ast targs 2 (fun () ->
-      let t1, t2, targs = match convert_type_params () with
-      | [t1; t2], targs -> t1, t2, targs
-      | _ -> assert false in
-      let reason = mk_reason RObjectMap loc in
-      reconstruct_ast
-        (EvalT (t1, TypeDestructorT (use_op reason, reason, TypeMap (ObjectMap t2)), mk_id ()))
-        targs
+    let reason = mk_reason RObjectMap loc in
+    (match convert_type_params () with
+      | ([t1; t2; t3], targs) ->
+        reconstruct_ast
+          (EvalT (t1, TypeDestructorT (use_op reason, reason, TypeMap (ObjectMap (t2, Some t3))), mk_id ()))
+          targs
+      | ([t1; t2], targs) ->
+        reconstruct_ast
+          (EvalT (t1, TypeDestructorT (use_op reason, reason, TypeMap (ObjectMap (t2, None))), mk_id ()))
+          targs
+      | _ -> error_type cx loc (Error_message.ETypeParamMinArity (loc, 2)) t_ast
     )
 
   | "$ObjMapi" ->
-    check_type_arg_arity cx loc t_ast targs 2 (fun () ->
-      let t1, t2, targs = match convert_type_params () with
-      | [t1; t2], targs -> t1, t2, targs
-      | _ -> assert false in
-      let reason = mk_reason RObjectMapi loc in
-      reconstruct_ast
-        (EvalT (t1, TypeDestructorT (use_op reason, reason, TypeMap (ObjectMapi t2)), mk_id ()))
-        targs
+    let reason = mk_reason RObjectMapi loc in
+    (match convert_type_params () with
+      | ([t1; t2; t3], targs) ->
+        reconstruct_ast
+          (EvalT (t1, TypeDestructorT (use_op reason, reason, TypeMap (ObjectMapi (t2, Some t3))), mk_id ()))
+          targs
+      | ([t1; t2], targs) ->
+        reconstruct_ast
+          (EvalT (t1, TypeDestructorT (use_op reason, reason, TypeMap (ObjectMapi (t2, None))), mk_id ()))
+          targs
+      | _ -> error_type cx loc (Error_message.ETypeParamMinArity (loc, 2)) t_ast
     )
 
   | "$CharSet" ->

--- a/src/typing/type_mapper.ml
+++ b/src/typing/type_mapper.ml
@@ -548,14 +548,14 @@ class virtual ['a] t = object(self)
       let t'' = self#type_ cx map_cx t' in
       if t'' == t' then t
       else TupleMap t''
-    | ObjectMap t' ->
+    | ObjectMap (t', t2') ->
       let t'' = self#type_ cx map_cx t' in
       if t'' == t' then t
-      else ObjectMap t''
-    | ObjectMapi t' ->
+      else ObjectMap (t'', t2')
+    | ObjectMapi (t', t2') ->
       let t'' = self#type_ cx map_cx t' in
       if t'' == t' then t
-      else ObjectMapi t''
+      else ObjectMapi (t'', t2')
 
   method virtual props: Context.t -> 'a -> Properties.id -> Properties.id
 

--- a/src/typing/type_visitor.ml
+++ b/src/typing/type_visitor.ml
@@ -867,8 +867,8 @@ class ['a] t = object(self)
 
   method private type_map cx acc = function
   | TupleMap t
-  | ObjectMap t
-  | ObjectMapi t -> self#type_ cx pole_TODO acc t
+  | ObjectMap (t, _)
+  | ObjectMapi (t, _) -> self#type_ cx pole_TODO acc t
 
   method private choice_use_tool cx acc = function
   | FullyResolveType id ->

--- a/tests/objmap/modifiers.js
+++ b/tests/objmap/modifiers.js
@@ -5,16 +5,16 @@ type Id = <T>(T) => T;
 type Partial<T: {}> = $ObjMap<T, Id, { optional: true }>;
 type Required<T: {}> = $ObjMap<T, Id, { optional: false }>;
 
-type Readonly<T: {}> = $ObjMap<T, Id, { polarity: '+' }>;
-type Writeonly<T: {}> = $ObjMap<T, Id, { polarity: '-' }>;
-type ReadWrite<T: {}> = $ObjMap<T, Id, { polarity: 'N' }>;
+type Readonly<T: {}> = $ObjMap<T, Id, { polarity: "+" }>;
+type Writeonly<T: {}> = $ObjMap<T, Id, { polarity: "-" }>;
+type ReadWrite<T: {}> = $ObjMap<T, Id, { polarity: "N" }>;
 
 type T = {| a: number, b: string |};
-type TP = {| a?: number, b ?: string |};
+type TP = {| a?: number, b?: string |};
 type TR = {| +a: number, +b: string |};
 type TW = {| -a: number, -b: string |};
-type TPR = {| +a ?: number, +b ?: string |};
-type TPW = {| -a ?: number, -b ?: string |};
+type TPR = {| +a?: number, +b?: string |};
+type TPW = {| -a?: number, -b?: string |};
 
 var v02: TP;
 var v02: $ObjMap<T, Id, { optional: true }>;
@@ -22,17 +22,17 @@ var v02: Partial<T>;
 var v02: $ObjMap<TP, Id>;
 
 var v03: TR;
-var v03: $ObjMap<T, Id, { polarity: '+' }>;
+var v03: $ObjMap<T, Id, { polarity: "+" }>;
 var v03: Readonly<T>;
 var v03: $ObjMap<TR, Id>;
 
 var v04: TW;
-var v04: $ObjMap<T, Id, { polarity: '-' }>;
+var v04: $ObjMap<T, Id, { polarity: "-" }>;
 var v04: Writeonly<T>;
 var v04: $ObjMap<TW, Id>;
 
 var v05: TPR;
-var v05: $ObjMap<T, Id, { optional: true, polarity: '+' }>;
+var v05: $ObjMap<T, Id, { optional: true, polarity: "+" }>;
 var v05: Partial<TR>;
 var v05: Readonly<TP>;
 var v05: Partial<Readonly<T>>;
@@ -40,7 +40,7 @@ var v05: Readonly<Partial<T>>;
 var v05: $ObjMap<TPR, Id>;
 
 var v06: TPW;
-var v06: $ObjMap<T, Id, { optional: true, polarity: '-' }>;
+var v06: $ObjMap<T, Id, { optional: true, polarity: "-" }>;
 var v06: Partial<TW>;
 var v06: Writeonly<TP>;
 var v06: Partial<Writeonly<T>>;
@@ -53,8 +53,8 @@ type B = { a: { x: number }, b: { x: string } };
 type BP = { a?: { x: number }, b?: { x: string } };
 type BR = { +a: { x: number }, +b: { x: string } };
 type BW = { -a: { x: number }, -b: { x: string } };
-type BPR = { +a ?: { x: number }, +b ?: { x: string } };
-type BPW = { -a ?: { x: number }, -b ?: { x: string } };
+type BPR = { +a?: { x: number }, +b?: { x: string } };
+type BPW = { -a?: { x: number }, -b?: { x: string } };
 
 var b01: B;
 var b01: $ObjMap<B, Id>;
@@ -65,17 +65,17 @@ var b02: Partial<B>;
 var b02: $ObjMap<BP, Id>;
 
 var b03: BR;
-var b03: $ObjMap<B, Id, { polarity: '+' }>;
+var b03: $ObjMap<B, Id, { polarity: "+" }>;
 var b03: Readonly<B>;
 var b03: $ObjMap<BR, Id>;
 
 var b04: BW;
-var b04: $ObjMap<B, Id, { polarity: '-' }>;
+var b04: $ObjMap<B, Id, { polarity: "-" }>;
 var b04: Writeonly<B>;
 var b04: $ObjMap<BW, Id>;
 
 var b05: BPR;
-var b05: $ObjMap<B, Id, { optional: true, polarity: '+' }>;
+var b05: $ObjMap<B, Id, { optional: true, polarity: "+" }>;
 var b05: Partial<BR>;
 var b05: Readonly<BP>;
 var b05: Partial<Readonly<B>>;
@@ -83,7 +83,7 @@ var b05: Readonly<Partial<B>>;
 var b05: $ObjMap<BPR, Id>;
 
 var b06: BPW;
-var b06: $ObjMap<B, Id, { optional: true, polarity: '-' }>;
+var b06: $ObjMap<B, Id, { optional: true, polarity: "-" }>;
 var b06: Partial<BW>;
 var b06: Writeonly<BP>;
 var b06: Partial<Writeonly<B>>;
@@ -119,22 +119,22 @@ var foo1: $ObjMap<T, Id, boolean>;
 var foo1: $ObjMap<T, Id, string>;
 var foo1: $ObjMap<T, Id, string>;
 
-type Config = { polarity: '+' }
+type Config = { polarity: "+" };
 var foo2: { +a: string }; // not ok
-var foo2: $ObjMap<{ a: string }, Id, Config>; // TODO: doesn't support aliases / generics
+var foo2: $ObjMap<{ a: string }, Id, Config>;
 
-type Polarity<T: {}, K: '-' | '+' | 'N' > = $ObjMap<T, Id, { polarity: K }>;
+type Polarity<T: {}, K: "-" | "+" | "N"> = $ObjMap<T, Id, { polarity: K }>;
 var foo3: { +a: string }; // not ok
-var foo3: Polarity<{ a: string }, '+'>; // TODO: doesn't support aliases / generics
+var foo3: Polarity<{ a: string }, "+">;
 
-var foo4: {+a: 'a', +b: 'b'}
-var foo4: $ObjMapi<{ a: string, b: string }, <K>(K) => K, { polarity: '+' }>
+var foo4: { +a: "a", +b: "b" };
+var foo4: $ObjMapi<{ a: string, b: string }, <K>(K) => K, { polarity: "+" }>;
 
 var foo5: { a: string, b: string };
-var foo5: ReadWrite<{+a: string, +b: string}>;
-var foo5: ReadWrite<{-a: string, +b: string}>;
-var foo5: ReadWrite<{+a: string, -b: string}>;
-var foo5: ReadWrite<{-a: string, -b: string}>;
+var foo5: ReadWrite<{ +a: string, +b: string }>;
+var foo5: ReadWrite<{ -a: string, +b: string }>;
+var foo5: ReadWrite<{ +a: string, -b: string }>;
+var foo5: ReadWrite<{ -a: string, -b: string }>;
 
 var foo6: { a: string, b: string };
 var foo6: Required<{ a?: string, b?: string }>;

--- a/tests/objmap/modifiers.js
+++ b/tests/objmap/modifiers.js
@@ -1,0 +1,140 @@
+//@flow
+
+type Id = <T>(T) => T;
+
+type Partial<T: {}> = $ObjMap<T, Id, { optional: true }>;
+type Required<T: {}> = $ObjMap<T, Id, { optional: false }>;
+
+type Readonly<T: {}> = $ObjMap<T, Id, { polarity: '+' }>;
+type Writeonly<T: {}> = $ObjMap<T, Id, { polarity: '-' }>;
+type ReadWrite<T: {}> = $ObjMap<T, Id, { polarity: 'N' }>;
+
+type T = {| a: number, b: string |};
+type TP = {| a?: number, b ?: string |};
+type TR = {| +a: number, +b: string |};
+type TW = {| -a: number, -b: string |};
+type TPR = {| +a ?: number, +b ?: string |};
+type TPW = {| -a ?: number, -b ?: string |};
+
+var v02: TP;
+var v02: $ObjMap<T, Id, { optional: true }>;
+var v02: Partial<T>;
+var v02: $ObjMap<TP, Id>;
+
+var v03: TR;
+var v03: $ObjMap<T, Id, { polarity: '+' }>;
+var v03: Readonly<T>;
+var v03: $ObjMap<TR, Id>;
+
+var v04: TW;
+var v04: $ObjMap<T, Id, { polarity: '-' }>;
+var v04: Writeonly<T>;
+var v04: $ObjMap<TW, Id>;
+
+var v05: TPR;
+var v05: $ObjMap<T, Id, { optional: true, polarity: '+' }>;
+var v05: Partial<TR>;
+var v05: Readonly<TP>;
+var v05: Partial<Readonly<T>>;
+var v05: Readonly<Partial<T>>;
+var v05: $ObjMap<TPR, Id>;
+
+var v06: TPW;
+var v06: $ObjMap<T, Id, { optional: true, polarity: '-' }>;
+var v06: Partial<TW>;
+var v06: Writeonly<TP>;
+var v06: Partial<Writeonly<T>>;
+var v06: Writeonly<Partial<T>>;
+var v06: $ObjMap<TPW, Id>;
+
+type Boxified<T> = $ObjMap<T, <P>(P) => { x: P }>;
+
+type B = { a: { x: number }, b: { x: string } };
+type BP = { a?: { x: number }, b?: { x: string } };
+type BR = { +a: { x: number }, +b: { x: string } };
+type BW = { -a: { x: number }, -b: { x: string } };
+type BPR = { +a ?: { x: number }, +b ?: { x: string } };
+type BPW = { -a ?: { x: number }, -b ?: { x: string } };
+
+var b01: B;
+var b01: $ObjMap<B, Id>;
+
+var b02: BP;
+var b02: $ObjMap<B, Id, { optional: true }>;
+var b02: Partial<B>;
+var b02: $ObjMap<BP, Id>;
+
+var b03: BR;
+var b03: $ObjMap<B, Id, { polarity: '+' }>;
+var b03: Readonly<B>;
+var b03: $ObjMap<BR, Id>;
+
+var b04: BW;
+var b04: $ObjMap<B, Id, { polarity: '-' }>;
+var b04: Writeonly<B>;
+var b04: $ObjMap<BW, Id>;
+
+var b05: BPR;
+var b05: $ObjMap<B, Id, { optional: true, polarity: '+' }>;
+var b05: Partial<BR>;
+var b05: Readonly<BP>;
+var b05: Partial<Readonly<B>>;
+var b05: Readonly<Partial<B>>;
+var b05: $ObjMap<BPR, Id>;
+
+var b06: BPW;
+var b06: $ObjMap<B, Id, { optional: true, polarity: '-' }>;
+var b06: Partial<BW>;
+var b06: Writeonly<BP>;
+var b06: Partial<Writeonly<B>>;
+var b06: Writeonly<Partial<B>>;
+var b06: $ObjMap<BPW, Id>;
+
+type Foo = { prop: number, [x: string]: number };
+
+function f1(x: Partial<Foo>) {
+  x.prop; // ok
+  (x["other"] || 0).toFixed();
+}
+
+function f2(x: Readonly<Foo>) {
+  x.prop; // ok
+  x["other"].toFixed();
+}
+
+function f3(x: Boxified<Foo>) {
+  x.prop; // ok
+  x["other"].x.toFixed();
+}
+
+function f4(x: $ObjMap<Foo, Id>) {
+  x.prop; // ok
+  x["other"].toFixed();
+}
+
+var foo1: T;
+var foo1: $ObjMap<T, Id, {}>;
+var foo1: $ObjMap<T, Id, null>; // TODO: should error
+var foo1: $ObjMap<T, Id, boolean>; // TODO: should error
+var foo1: $ObjMap<T, Id, string>; // TODO: should error
+var foo1: $ObjMap<T, Id, string>; // TODO: should error
+
+type Config = { polarity: '+' }
+var foo2: {+a: string}; // not ok
+var foo2: $ObjMap<{ a: string }, Id, Config>; // TODO: doesn't support aliases / generics
+
+type Polarity<T: {}, K: '-' | '+' | 'N' > = $ObjMap<T, Id, { polarity: K }>;
+var foo3: {+a: string}; // not ok
+var foo3: Polarity<{ a: string }, '+'>; // TODO: doesn't support aliases / generics
+
+var foo4: {+a: 'a', +b: 'b'}
+var foo4: $ObjMapi<{ a: string, b: string }, <K>(K) => K, { polarity: '+' }>
+
+var foo5: { a: string, b: string };
+var foo5: ReadWrite<{+a: string, +b: string}>;
+var foo5: ReadWrite<{-a: string, +b: string}>;
+var foo5: ReadWrite<{+a: string, -b: string}>;
+var foo5: ReadWrite<{-a: string, -b: string}>;
+
+var foo6: { a: string, b: string };
+var foo6: Required<{ a?: string, b?: string }>;

--- a/tests/objmap/modifiers.js
+++ b/tests/objmap/modifiers.js
@@ -114,17 +114,17 @@ function f4(x: $ObjMap<Foo, Id>) {
 
 var foo1: T;
 var foo1: $ObjMap<T, Id, {}>;
-var foo1: $ObjMap<T, Id, null>; // TODO: should error
-var foo1: $ObjMap<T, Id, boolean>; // TODO: should error
-var foo1: $ObjMap<T, Id, string>; // TODO: should error
-var foo1: $ObjMap<T, Id, string>; // TODO: should error
+var foo1: $ObjMap<T, Id, null>;
+var foo1: $ObjMap<T, Id, boolean>;
+var foo1: $ObjMap<T, Id, string>;
+var foo1: $ObjMap<T, Id, string>;
 
 type Config = { polarity: '+' }
-var foo2: {+a: string}; // not ok
+var foo2: { +a: string }; // not ok
 var foo2: $ObjMap<{ a: string }, Id, Config>; // TODO: doesn't support aliases / generics
 
 type Polarity<T: {}, K: '-' | '+' | 'N' > = $ObjMap<T, Id, { polarity: K }>;
-var foo3: {+a: string}; // not ok
+var foo3: { +a: string }; // not ok
 var foo3: Polarity<{ a: string }, '+'>; // TODO: doesn't support aliases / generics
 
 var foo4: {+a: 'a', +b: 'b'}
@@ -138,3 +138,15 @@ var foo5: ReadWrite<{-a: string, -b: string}>;
 
 var foo6: { a: string, b: string };
 var foo6: Required<{ a?: string, b?: string }>;
+
+var dict0: { +[key: string]: number };
+var dict0: Readonly<{ [key: string]: number }>;
+
+var dict1: { -[key: string]: number };
+var dict1: Writeonly<{ [key: string]: number }>;
+
+var dict2: { [key: string]: number };
+var dict2: Partial<{ [key: string]: number }>;
+
+var dict3: { [key: string]: number };
+var dict3: Required<{ [key: string]: number }>;

--- a/tests/objmap/objmap.exp
+++ b/tests/objmap/objmap.exp
@@ -282,6 +282,34 @@ References:
                                                        ^^^^^ [2]
 
 
+Error ---------------------------------------------------------------------------------------------- modifiers.js:123:11
+
+Property `a` is read-only in object type [1] but writable in object type [2].
+
+   modifiers.js:123:11
+   123| var foo2: {+a: string}; // not ok
+                  ^^^^^^^^^^^^ [1]
+
+References:
+   modifiers.js:124:11
+   124| var foo2: $ObjMap<{ a: string }, Id, Config>; // TODO: doesn't support aliases / generics
+                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [2]
+
+
+Error ---------------------------------------------------------------------------------------------- modifiers.js:127:11
+
+Property `a` is read-only in object type [1] but writable in object type [2].
+
+   modifiers.js:127:11
+   127| var foo3: {+a: string}; // not ok
+                  ^^^^^^^^^^^^ [1]
+
+References:
+   modifiers.js:128:11
+   128| var foo3: Polarity<{ a: string }, '+'>; // TODO: doesn't support aliases / generics
+                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [2]
+
+
 Error --------------------------------------------------------------------------------------------------- objmap.js:10:2
 
 Cannot cast `o.FOO` to string literal `BAR` because string literal `FOO` [1] is incompatible with string literal
@@ -352,4 +380,4 @@ References:
 
 
 
-Found 23 errors
+Found 25 errors

--- a/tests/objmap/objmap.exp
+++ b/tests/objmap/objmap.exp
@@ -324,7 +324,7 @@ Property `a` is read-only in object type [1] but writable in object type [2].
 
 References:
    modifiers.js:124:11
-   124| var foo2: $ObjMap<{ a: string }, Id, Config>; // TODO: doesn't support aliases / generics
+   124| var foo2: $ObjMap<{ a: string }, Id, Config>;
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [2]
 
 
@@ -338,7 +338,7 @@ Property `a` is read-only in object type [1] but writable in object type [2].
 
 References:
    modifiers.js:128:11
-   128| var foo3: Polarity<{ a: string }, '+'>; // TODO: doesn't support aliases / generics
+   128| var foo3: Polarity<{ a: string }, "+">;
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [2]
 
 

--- a/tests/objmap/objmap.exp
+++ b/tests/objmap/objmap.exp
@@ -282,13 +282,45 @@ References:
                                                        ^^^^^ [2]
 
 
+Error ---------------------------------------------------------------------------------------------- modifiers.js:117:26
+
+null [1] is not an object.
+
+   117| var foo1: $ObjMap<T, Id, null>;
+                                 ^^^^ [1]
+
+
+Error ---------------------------------------------------------------------------------------------- modifiers.js:118:26
+
+boolean [1] is not an object.
+
+   118| var foo1: $ObjMap<T, Id, boolean>;
+                                 ^^^^^^^ [1]
+
+
+Error ---------------------------------------------------------------------------------------------- modifiers.js:119:26
+
+string [1] is not an object.
+
+   119| var foo1: $ObjMap<T, Id, string>;
+                                 ^^^^^^ [1]
+
+
+Error ---------------------------------------------------------------------------------------------- modifiers.js:120:26
+
+string [1] is not an object.
+
+   120| var foo1: $ObjMap<T, Id, string>;
+                                 ^^^^^^ [1]
+
+
 Error ---------------------------------------------------------------------------------------------- modifiers.js:123:11
 
 Property `a` is read-only in object type [1] but writable in object type [2].
 
    modifiers.js:123:11
-   123| var foo2: {+a: string}; // not ok
-                  ^^^^^^^^^^^^ [1]
+   123| var foo2: { +a: string }; // not ok
+                  ^^^^^^^^^^^^^^ [1]
 
 References:
    modifiers.js:124:11
@@ -301,8 +333,8 @@ Error --------------------------------------------------------------------------
 Property `a` is read-only in object type [1] but writable in object type [2].
 
    modifiers.js:127:11
-   127| var foo3: {+a: string}; // not ok
-                  ^^^^^^^^^^^^ [1]
+   127| var foo3: { +a: string }; // not ok
+                  ^^^^^^^^^^^^^^ [1]
 
 References:
    modifiers.js:128:11
@@ -380,4 +412,4 @@ References:
 
 
 
-Found 25 errors
+Found 29 errors


### PR DESCRIPTION
<!--
  If this is a change to library defintions, please include links to relevant documentation.
  If this is a documentation change, please prefix the title with [DOCS].

  If this is neither, ensure you opened a discussion issue and link it in the PR description.
-->

Related: https://github.com/facebook/flow/issues/7639, https://github.com/facebook/flow/pull/7571

## Summary

Adds third argument to `$ObjMap`

## Example

```js
type Id = <T>(T) => T;

type Partial<T: {}> = $ObjMap<T, Id, { optional: true }>;
type Required<T: {}> = $ObjMap<T, Id, { optional: false }>;

type Readonly<T: {}> = $ObjMap<T, Id, { polarity: '+' }>;
type Writeonly<T: {}> = $ObjMap<T, Id, { polarity: '-' }>;
type ReadWrite<T: {}> = $ObjMap<T, Id, { polarity: 'N' }>;

// Regular $ObjMap still works

type Foo = $ObjMap<{|a: string|}, () => number>
```