### PR TITLE
Make flow-dev-tools public

### DIFF
--- a/packages/flow-dev-tools/package.json
+++ b/packages/flow-dev-tools/package.json
@@ -1,8 +1,12 @@
 {
   "name": "flow-dev-tools",
-  "private": true,
   "license": "MIT",
   "version": "0.1.0",
+  "bin": "./bin/tool",
+  "files": [
+    "bin",
+    "src"
+  ],
   "dependencies": {
     "babel-jest": "^21.0.2",
     "babel-plugin-syntax-async-functions": "^6.8.0",


### PR DESCRIPTION
<!--
  If this is a change to library defintions, please include links to relevant documentation.
  If this is a documentation change, please prefix the title with [DOCS].

  If this is neither, ensure you opened a discussion issue and link it in the PR description.
-->

Inspired from: https://twitter.com/threepointone/status/1118442563046989824

This PR makes `flow-dev-tools` public which allows devs to use this tool easily.

Previously:

- Clone flow repo
- install deps
- cd into product repo
- Use the tool like so: `../../<flow-repo>/packages/bin/tool ...`

Now:

- `npx flow-dev-tools ...`

I removed the `private: true` from the `package.json`. I'm unsure if I need to do anything more in order to allow this to be published to npm.