### PR TITLE
Change return type of 'process.exit' from 'void' to 'empty'

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -2337,7 +2337,7 @@ declare class Process extends events$EventEmitter {
   ): void;
   execArgv : Array<string>;
   execPath : string;
-  exit(code? : number) : void;
+  exit(code? : number) : empty;
   exitCode? : number;
   getegid? : () => number;
   geteuid? : () => number;


### PR DESCRIPTION
`process.exit` never returns, therefore it is safe.

https://nodejs.org/docs/latest-v10.x/api/process.html#process_process_exit_code