### PR TITLE
add "value" property to DOMTokenList

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -1302,6 +1302,7 @@ declare class DOMTokenList {
   forEach(callbackfn: (value: string, index: number, list: DOMTokenList) => any, thisArg?: any): void;
   entries(): Iterator<[number, string]>;
   keys(): Iterator<number>;
+  value: string;
   values(): Iterator<string>;
 }
 


### PR DESCRIPTION
The [DOMTokenList](https://developer.mozilla.org/en-US/docs/Web/API/DOMTokenList) `value` property has [broad browser support](https://developer.mozilla.org/en-US/docs/Web/API/DOMTokenList/value#Browser_compatibility), and should be included in Flow's type definition.