### PR TITLE
Add missing type definitions from the Fullscreen API

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -1463,7 +1463,7 @@ declare class Element extends Node {
   removeAttribute(name?: string): void;
   removeAttributeNode(attributeNode: Attr): Attr;
   removeAttributeNS(namespaceURI: string | null, localName: string): void;
-  requestFullscreen(): Promise<void>;
+  requestFullscreen(options?: { navigationUI: 'auto' | 'show' | 'hide' }): Promise<void>;
   requestPointerLock(): void;
   scrollIntoView(arg?: (boolean | { behavior?: ('auto' | 'instant' | 'smooth'), block?: ('start' | 'center' | 'end' | 'nearest'), inline?: ('start' | 'center' | 'end' | 'nearest')  })): void;
   setAttribute(name?: string, value?: string): void;

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -791,9 +791,12 @@ declare class Document extends Node {
   documentMode: number;
   domain: string | null;
   embeds: HTMLCollection<HTMLEmbedElement>;
+  exitFullscreen(): Promise<void>,
   queryCommandSupported(cmdID: string): boolean;
   execCommand(cmdID: string, showUI?: boolean, value?: any): boolean;
   forms: HTMLCollection<HTMLFormElement>;
+  fullscreenElement: Element | null;
+  fullscreenEnabled: boolean;
   getElementById(elementId: string): HTMLElement | null;
   getElementsByClassName(classNames: string): HTMLCollection<HTMLElement>;
   getElementsByName(elementName: string): HTMLCollection<HTMLElement>;
@@ -1460,7 +1463,7 @@ declare class Element extends Node {
   removeAttribute(name?: string): void;
   removeAttributeNode(attributeNode: Attr): Attr;
   removeAttributeNS(namespaceURI: string | null, localName: string): void;
-  requestFullscreen(): void;
+  requestFullscreen(): Promise<void>;
   requestPointerLock(): void;
   scrollIntoView(arg?: (boolean | { behavior?: ('auto' | 'instant' | 'smooth'), block?: ('start' | 'center' | 'end' | 'nearest'), inline?: ('start' | 'center' | 'end' | 'nearest')  })): void;
   setAttribute(name?: string, value?: string): void;
@@ -1659,6 +1662,8 @@ declare class HTMLElement extends Element {
   onended: ?Function;
   onerror: ?Function;
   onfocus: ?Function;
+  onfullscreenchange: ?Function;
+  onfullscreenerror: ?Function;
   ongotpointercapture: ?Function,
   oninput: ?Function;
   oninvalid: ?Function;


### PR DESCRIPTION
See #3031

The API spec: https://fullscreen.spec.whatwg.org/#api
The MDN guide: https://developer.mozilla.org/en-US/docs/Web/API/Fullscreen_API