### PR TITLE
HTMLImageElement class should have a decode method.

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -2977,6 +2977,7 @@ declare class HTMLImageElement extends HTMLElement {
   crossOrigin: ?string;
   currentSrc: string; // readonly
   height: number;
+  decode(): Promise<void>;
   isMap: boolean;
   naturalHeight: number; // readonly
   naturalWidth: number; // readonly


### PR DESCRIPTION
This is consistent with the TypeScript definition: https://github.com/Microsoft/TypeScript/blob/master/src/lib/dom.generated.d.ts#L6906

The MDN docs: https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/decode

And the spec: https://html.spec.whatwg.org/multipage/embedded-content.html#dom-img-decode
