### PR TITLE
lib/node: Add util.TextDecoder/TextEncoder

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -2023,6 +2023,25 @@ declare module "util" {
   declare function deprecate(f: Function, string: string): Function;
   declare function promisify(f: Function): Function;
   declare function callbackify(f: Function): Function;
+
+  declare class TextDecoder {
+    constructor(encoding?: string, options: {
+      fatal?: boolean,
+      ignoreBOM?: boolean,
+    }): void;
+    decode(input?: ArrayBuffer | DataView | $TypedArray, options?: {
+      stream?: boolean,
+    }): string;
+    encoding: string;
+    fatal: boolean;
+    ignoreBOM: boolean;
+  }
+
+  declare class TextEncoder {
+    constructor(): void;
+    encode(input?: string): Uint8Array;
+    encoding: string;
+  }
 }
 
 type vm$ScriptOptions = {


### PR DESCRIPTION
Library docs:
- [TextDecoder](https://nodejs.org/api/util.html#util_class_util_textdecoder)
- [TextEncoder](https://nodejs.org/api/util.html#util_class_util_textencoder)

Node 8.3 added them to 'util'.

Node 11.0 added them to the global object, but I didn't do that part.