### PR TITLE
Add generic to Object.entries

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -45,7 +45,7 @@ declare class Object {
     static create(o: any, properties?: PropertyDescriptorMap): any; // compiler magic
     static defineProperties(o: any, properties: PropertyDescriptorMap): any;
     static defineProperty<T>(o: any, p: any, attributes: PropertyDescriptor<T>): any;
-    static entries(object: mixed): Array<[string, mixed]>;
+    static entries<T>(object: { [key: string]: T }): Array<[string, T]>;
     static freeze<T>(o: T): T;
     static fromEntries<K, V>(entries: Iterable<[K, V] | {'0': K, '1': V}>): {[K]: V};
 


### PR DESCRIPTION
In my humble opinion there is one strong problem, in ```Object.entries()``` typings .
Me and many other developers cannot use this perfect API because we should "fight" with this ```mixed``` Tuple second value type, and as the result, flow wins, this method keeps being unused.

[Here is simple implementation of the problem](https://flow.org/try/#0PQKgBAAgZgNg9gdzCYAoAlgOwC4FMBOUAhgMa5gDKAFnLgM5gDeqYYd6AXrgFxiYCuAWwBGBADQswJOPHy862fFgDmEgL4BuVKmwBPAA7kACvlxQCpgCbVadCp3pgAvGACC+fEV0AeANoKlTFU+IVF8AF0APh0DcgBhfgU4QQIAESJsImcmXwBrXF1uAJVw3gERAjVtPUNKGno4mRhcEmx0OExs908fG3pomNq+ugBZIn1DfGyACjp6ul5hgEpnSJCK-GrYsAA1Ihh0SwzcYdcANyJ0GCJhK-Q9GckSROxktIyiXj2Do7xTi6uNzuegkrCSJFyw0aMGarXamEW82hsLaHQkKyca2EcBkuCImG00kwCjYSKaLVRCLqtmRFPh2V8kmYrDBDl4AEYAAyglnSWS8ABEwmuEIFPLUPOZLPYXA5ACYeaw+XA5GABQgqPdcGLJBKmZJWbKwABORVSGQqwW6XAwxA61h61hSw08MBcgB0AFYzcrVUKRbl7WA9eEtKgiSTBLoAGJEQRXXQmMwWXDWeb2LgLMAJJIpfDpTLZKUCkbofICjncyQCgBCVxgFbd7J5Atcc2aukbAA51GGI9hSbYxhMCIih+NJjNGGwHMGMWsZbgw8BgObiQOLj9jv9Ltdbgc9F99odt-NzrugQfdDNnrn3pkxGxXhCoeS4R150xwx0SZuT38zwBPdgWvFxplvV48wLIhH3BSEyRhOkP1WL8lR-AciCAm5mgzeheG6LxvHKMI1hcODX0Q99MHdQRxlmeZh0mJYtDQ9cwH0UxzA8VNcLoAAVfh9GaWkqN4JMuKsYZeOyAB5YQACsKXdXAcCUehwJeN58w+ZjtFYFcwFMbB+HwToOOTbjrAcfjBOEt9KXdKx+DIaZZkyYys2xXF8UfXwwEfcyJJ42dwk-KUDNYdAoDAaYAEIFAyRIViMkzOgSjyWLAFdJAisAopizCL2FE5rPdLASBgfhLHUwKUysrglhWcLVxZQzcGM0ywEUfhcBylrgz64NH263AllQTRtAMiNcXdeBlGmP9fhOQCipA6Yo1jeMYETTi6qk6zYIQlF4UarQgA)