### PR TITLE
lib/node: Add type definition for TLS certificate objects.

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -1885,6 +1885,30 @@ type tls$connectOptions = {
   requestOCSP?: boolean,
 };
 
+type tls$Certificate$Subject = {
+  C?: string,
+  ST?: string,
+  L?: string,
+  O?: string,
+  OU?: string,
+  CN?: string,
+};
+
+type tls$Certificate = {
+  raw: Buffer,
+  subject: tls$Certificate$Subject,
+  issuer: tls$Certificate$Subject,
+  valid_from: string,
+  valid_to: string,
+  serialNumber: string,
+  fingerprint: string,
+  fingerprint256: string,
+  ext_key_usage?: Array<string>,
+  subjectaltname?: string,
+  infoAccess?: {[string]: Array<string>},
+  issuerCertificate?: tls$Certificate,
+};
+
 declare class tls$TLSSocket extends net$Socket {
   constructor(socket: net$Socket, options?: Object): void;
   authorized: boolean;
@@ -1892,7 +1916,7 @@ declare class tls$TLSSocket extends net$Socket {
   encrypted: true;
   getCipher(): { name: string, version: string } | null;
   getEphemeralKeyInfo(): { type: 'DH', size: number } | { type: 'EDHC', name: string, size: number } | null;
-  getPeerCertificate(detailed?: boolean): Object | null;
+  getPeerCertificate(detailed?: boolean): tls$Certificate | null;
   getSession(): ?Buffer;
   getTLSTicket(): Buffer | void;
   renegotiate(options: Object, callback: Function): boolean | void;


### PR DESCRIPTION
Node API documentation: https://nodejs.org/api/tls.html#tls_certificate_object

Note: the API docs for `subjectaltname` say "Array" but it's actually a string (https://github.com/nodejs/node/issues/27721).