### PR TITLE
Method predicates

### DIFF
--- a/src/parser/object_parser.ml
+++ b/src/parser/object_parser.ml
@@ -553,7 +553,7 @@ module Object
             env |> with_allow_super Super_prop
         in
         let value = with_loc (fun env ->
-          let sig_loc, (tparams, params, return) = with_loc (fun env ->
+          let sig_loc, (tparams, params, return, predicate) = with_loc (fun env ->
             let tparams = Type.type_parameter_declaration env in
             let params =
               let yield, await = match async, generator with
@@ -564,8 +564,8 @@ module Object
               in
               Declaration.function_params ~await ~yield env
             in
-            let return = Type.annotation_opt env in
-            (tparams, params, return)
+            let (return, predicate) = Type.annotation_and_predicate_opt env in
+            (tparams, params, return, predicate)
           ) env in
           let body, strict = Declaration.function_body env ~async ~generator in
           let simple = Declaration.is_simple_function_params params in
@@ -577,7 +577,7 @@ module Object
             generator;
             async;
             (* TODO: add support for method predicates *)
-            predicate = None;
+            predicate;
             return;
             tparams;
             sig_loc;

--- a/src/typing/func_sig.ml
+++ b/src/typing/func_sig.ml
@@ -105,7 +105,7 @@ let functiontype cx this_t {reason; kind; tparams; fparams; return_t; knot; _} =
   Flow.unify cx t knot;
   t
 
-let methodtype cx {reason; tparams; fparams; return_t; _} =
+let methodtype cx {reason; kind; tparams; fparams; return_t; _} =
   let params = F.value fparams in
   let params_names, params_tlist = List.split params in
   let rest_param = F.rest fparams in
@@ -114,7 +114,7 @@ let methodtype cx {reason; tparams; fparams; return_t; _} =
     dummy_static reason,
     dummy_prototype,
     mk_boundfunctiontype
-      params_tlist ~rest_param ~def_reason ~params_names return_t
+      params_tlist ~rest_param ~def_reason ~params_names ~is_predicate:(kind = Predicate) return_t
   )) in
   poly_type_of_tparams (Context.make_nominal cx) tparams t
 

--- a/tests/predicates-declared/class-static-predicate-lib.js
+++ b/tests/predicates-declared/class-static-predicate-lib.js
@@ -1,0 +1,23 @@
+// @flow
+
+// Part from immutable.js
+
+declare export class Seq<K, +V> {
+  static isSeq: typeof isSeq;
+  size: number | void;
+}
+
+declare function isSeq(
+  maybeSeq: mixed
+): boolean /*::%checks(maybeSeq instanceof Seq)*/;
+
+declare export class KeyedCollection<K, +V> {
+  flatten(depth?: number): KeyedCollection<V, K>;
+  flatten(shallow?: boolean): KeyedCollection<any, any>;
+}
+
+// If you remove `mixins` clause it works
+declare export class KeyedSeq<K, +V> extends Seq<K, V> mixins KeyedCollection<K, V> {
+  flatten(depth?: number): KeyedSeq<any, any>;
+  flatten(shallow?: boolean): KeyedSeq<any, any>;
+}

--- a/tests/predicates-declared/class-static-predicate-lib.js
+++ b/tests/predicates-declared/class-static-predicate-lib.js
@@ -7,7 +7,7 @@ declare export class Seq<K, +V> {
   size: number | void;
 }
 
-declare function isSeq(
+declare export function isSeq(
   maybeSeq: mixed
 ): boolean /*::%checks(maybeSeq instanceof Seq)*/;
 

--- a/tests/predicates-declared/class-static-predicate.js
+++ b/tests/predicates-declared/class-static-predicate.js
@@ -1,0 +1,12 @@
+// @flow
+
+import {Seq} from './class-static-predicate-lib'
+
+declare var m: string | Seq<number, string>;
+
+// TODO: should refine
+if (Seq.isSeq(m)) {
+  m.size // Cannot get `m.size` because property `size` is missing in  `String` 
+} else {
+  ;(m: string);
+}

--- a/tests/predicates-declared/class-static-predicate.js
+++ b/tests/predicates-declared/class-static-predicate.js
@@ -1,12 +1,19 @@
 // @flow
 
-import {Seq} from './class-static-predicate-lib'
+import {Seq, isSeq} from './class-static-predicate-lib'
 
-declare var m: string | Seq<number, string>;
+declare var foo: string | Seq<number, string>;
 
 // TODO: should refine
-if (Seq.isSeq(m)) {
-  m.size // Cannot get `m.size` because property `size` is missing in  `String` 
+if (Seq.isSeq(foo)) {
+  foo.size // Cannot get `m.size` because property `size` is missing in  `String` 
 } else {
-  ;(m: string);
+  ;(foo: string);
+}
+
+// TODO: should refine
+if (isSeq(foo)) {
+  foo.size // Cannot get `m.size` because property `size` is missing in  `String` 
+} else {
+  ;(foo: string);
 }

--- a/tests/predicates-declared/issue-7920-lib.js
+++ b/tests/predicates-declared/issue-7920-lib.js
@@ -1,0 +1,9 @@
+// @flow
+
+declare function lodash_isNil(value: mixed): boolean %checks(value == null)
+
+declare class Lodash {
+  +isNil: typeof lodash_isNil;
+}
+
+declare export var _: Lodash;

--- a/tests/predicates-declared/issue-7920.js
+++ b/tests/predicates-declared/issue-7920.js
@@ -1,0 +1,10 @@
+// @flow
+
+import { _ } from "./issue-7920-lib";
+
+const test: ?string = "foo";
+
+if (!_.isNil(test)) {
+  (test: string); // ok
+  (null: typeof test); // error
+}

--- a/tests/predicates-declared/predicates-declared.exp
+++ b/tests/predicates-declared/predicates-declared.exp
@@ -1,3 +1,65 @@
+Error ------------------------------------------------------------------------------------ class-static-predicate.js:9:3
+
+Cannot get `foo.size` because property `size` is missing in `String` [1].
+
+   class-static-predicate.js:9:3
+   9|   foo.size // Cannot get `m.size` because property `size` is missing in  `String` 
+        ^^^^^^^^
+
+References:
+   class-static-predicate.js:5:18
+   5| declare var foo: string | Seq<number, string>;
+                       ^^^^^^ [1]
+
+
+Error ----------------------------------------------------------------------------------- class-static-predicate.js:11:5
+
+Cannot cast `foo` to string because `Seq` [1] is incompatible with string [2].
+
+   class-static-predicate.js:11:5
+   11|   ;(foo: string);
+           ^^^
+
+References:
+   class-static-predicate.js:5:27
+    5| declare var foo: string | Seq<number, string>;
+                                 ^^^^^^^^^^^^^^^^^^^ [1]
+   class-static-predicate.js:11:10
+   11|   ;(foo: string);
+                ^^^^^^ [2]
+
+
+Error ----------------------------------------------------------------------------------- class-static-predicate.js:16:3
+
+Cannot get `foo.size` because property `size` is missing in `String` [1].
+
+   class-static-predicate.js:16:3
+   16|   foo.size // Cannot get `m.size` because property `size` is missing in  `String` 
+         ^^^^^^^^
+
+References:
+   class-static-predicate.js:5:18
+    5| declare var foo: string | Seq<number, string>;
+                        ^^^^^^ [1]
+
+
+Error ----------------------------------------------------------------------------------- class-static-predicate.js:18:5
+
+Cannot cast `foo` to string because `Seq` [1] is incompatible with string [2].
+
+   class-static-predicate.js:18:5
+   18|   ;(foo: string);
+           ^^^
+
+References:
+   class-static-predicate.js:5:27
+    5| declare var foo: string | Seq<number, string>;
+                                 ^^^^^^^^^^^^^^^^^^^ [1]
+   class-static-predicate.js:18:10
+   18|   ;(foo: string);
+                ^^^^^^ [2]
+
+
 Error --------------------------------------------------------------------------------------- sanity-conditional.js:5:50
 
 Unexpected token =
@@ -116,7 +178,7 @@ References:
 
 
 
-Found 9 errors
+Found 13 errors
 
 Only showing the most relevant union/intersection branches.
 To see all branches, re-run Flow with --show-all-branches

--- a/tests/predicates-declared/predicates-declared.exp
+++ b/tests/predicates-declared/predicates-declared.exp
@@ -60,6 +60,20 @@ References:
                 ^^^^^^ [2]
 
 
+Error ------------------------------------------------------------------------------------------------ issue-7920.js:9:4
+
+Cannot cast `null` to `typeof test` because null [1] is incompatible with string [2].
+
+   issue-7920.js:9:4
+   9|   (null: typeof test); // error
+         ^^^^ [1]
+
+References:
+   issue-7920.js:9:10
+   9|   (null: typeof test); // error
+               ^^^^^^^^^^^ [2]
+
+
 Error --------------------------------------------------------------------------------------- sanity-conditional.js:5:50
 
 Unexpected token =
@@ -178,7 +192,7 @@ References:
 
 
 
-Found 13 errors
+Found 14 errors
 
 Only showing the most relevant union/intersection branches.
 To see all branches, re-run Flow with --show-all-branches


### PR DESCRIPTION
<!--
  If this is a change to library defintions, please include links to relevant documentation.
  If this is a documentation change, please prefix the title with [DOCS].

  If this is neither, ensure you opened a discussion issue and link it in the PR description.
-->

Enables parsing and typechecking stuff like this

```js
class Hello {
  test(x: mixed): boolean %checks { return typeof x === 'string' }
}
const m = new Hello()
const foo: string | number = ''
if (m.test(foo)) {
  foo // string
}
```

```js
declare function isString(x: mixed): boolean %checks(typeof x === 'string')
declare var is: {|
   string: typeof isString
|}
const foo: string | number = ''
if (is.string(foo)) {
  foo // string
}
```