### PR TITLE
Fixed nodejs net$Socket.connect signatures

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -1432,7 +1432,9 @@ declare class net$Socket extends stream$Duplex {
   bufferSize: number;
   bytesRead: number;
   bytesWritten: number;
-  connect(options: Object, connectListener?: Function): void;
+  connect(options: Object, connectListener?: () => mixed): net$Socket;
+  connect(path: string, connectListener?: () => mixed): net$Socket;
+  connect(port: number, host?: string, connectListener?: () => mixed): net$Socket;
   destroyed: boolean;
   end(
     chunkOrEncodingOrCallback?: Buffer | Uint8Array | string | (data: any) => void,


### PR DESCRIPTION
According to node.js docs, net$Socket.connect has three signatures:
1. connect(options: Object, connectListener?: Function): https://nodejs.org/dist/latest-v10.x/docs/api/net.html#net_socket_connect_options_connectlistener
2. connect(path: string, connectListener?: Function): https://nodejs.org/dist/latest-v10.x/docs/api/net.html#net_socket_connect_path_connectlistener
3. connect(port: number, host?: string, connectListener?: Function): https://nodejs.org/dist/latest-v10.x/docs/api/net.html#net_socket_connect_port_host_connectlistener

All three are returning socket itself, instead of void
