### PR TITLE
Ignore opam switch folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *TAGS
 _build
+_opam
 /dist
 /_obuild
 /.ocp

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 *TAGS
 _build
-_opam
+/_opam
 /dist
 /_obuild
 /.ocp


### PR DESCRIPTION
<!--
  If this is a change to library defintions, please include links to relevant documentation.
  If this is a documentation change, please prefix the title with [DOCS].

  If this is neither, ensure you opened a discussion issue and link it in the PR description.
-->

This ignores `_opam` folder