### PR TITLE
[DOCS] bug in explicit createContext type example

### DIFF
--- a/website/en/docs/react/context.md
+++ b/website/en/docs/react/context.md
@@ -13,7 +13,7 @@ Flow will infer types from the way you use a context's `{ Provider, Consumer }`
 pair:
 
 ```js
-import React from "react";
+import * as React from "react";
 
 const Theme = React.createContext();
 
@@ -34,7 +34,7 @@ If your context has a default value, Flow will type your consumer component
 accordingly:
 
 ```js
-import React from "react";
+import * as React from "react";
 
 const Theme = React.createContext("light");
 
@@ -45,9 +45,9 @@ To explicitly specify the type of a context value, pass a type parameter to
 `createContext`:
 
 ```js
-import React from "react";
+import * as React from "react";
 
-const Theme = React.createContext<"light" | "dark">("light");
+const Theme: React.Context<"light" | "dark"> = React.createContext("light");
 
 <Theme.Provider value="blue" />; // Error! "blue" is not one of the allowed values.
 ```


### PR DESCRIPTION
<!--
  If this is a change to library definitions, please include links to relevant documentation.
  If this is a documentation change, please prefix the title with [DOCS].

  If this is neither, ensure you opened a discussion issue and link it in the PR description.
-->

I ran into a syntax error with the current docs' suggestion of:

```
const Theme = React.createContext<"light" | "dark">("light");
```

I was able to fix it by instead doing:

```
const Theme: React.Context<"light" | "dark"> = React.createContext("light");
```

Also, it seems to recommend [here](https://flow.org/en/docs/react/types/) to use `import * as React` instead of `import React` (especially if you're going to use some types) so I changed that here as well.