### PR TITLE
Make Vibrate in Notification optional

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -3958,7 +3958,7 @@ type NotificationOptions = {
   icon: string,
   badge: string,
   sound: string,
-  vibrate: VibratePattern,
+  vibrate?: VibratePattern,
   timestamp: number,
   renotify: boolean,
   silent: boolean,
@@ -3985,7 +3985,7 @@ declare class Notification extends EventTarget {
   icon: string;
   badge: string;
   sound: string;
-  vibrate: Array<number>;
+  vibrate?: Array<number>;
   timestamp: number;
   renotify: boolean;
   silent: boolean;


### PR DESCRIPTION
Per: https://notifications.spec.whatwg.org/#ref-for-vibration-pattern

`A notification can have a vibration pattern.`
Key word is can.

Also, further down:
`If options’s silent is true and options’s vibrate is present, throw a TypeError exception.`

Vibrate needs to be optional.

<!--
  If this is a change to library defintions, please include links to relevant documentation.
  If this is a documentation change, please prefix the title with [DOCS].

  If this is neither, ensure you opened a discussion issue and link it in the PR description.
-->
