### PR TITLE
Update/add HTML spec URLs in comments

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -424,9 +424,9 @@ declare class PromiseRejectionEvent extends Event {
 }
 
 // used for websockets and postMessage, for example. See:
-// http://www.w3.org/TR/2011/WD-websockets-20110419/
+// https://www.w3.org/TR/2011/WD-websockets-20110419/
 // and
-// http://www.w3.org/TR/2008/WD-html5-20080610/comms.html
+// https://www.w3.org/TR/2008/WD-html5-20080610/comms.html
 // and
 // https://html.spec.whatwg.org/multipage/comms.html#the-messageevent-interfaces
 declare class MessageEvent extends Event {
@@ -674,9 +674,11 @@ declare class HTMLCollection<+Elem: HTMLElement> {
 }
 
 // from https://www.w3.org/TR/custom-elements/#extensions-to-document-interface-to-register
+// See also https://github.com/w3c/webcomponents/
 type ElementRegistrationOptions = {
        +prototype?: {
               // from https://www.w3.org/TR/custom-elements/#types-of-callbacks
+              // See also https://github.com/w3c/webcomponents/
               +createdCallback?: () => mixed,
               +attachedCallback?: () => mixed,
               +detachedCallback?: () => mixed,
@@ -2915,7 +2917,7 @@ declare class WebGLContextEvent extends Event {
 // http://www.w3.org/TR/html5/scripting-1.html#renderingcontext
 type RenderingContext = CanvasRenderingContext2D | WebGLRenderingContext;
 
-// http://www.w3.org/TR/html5/scripting-1.html#htmlcanvaselement
+// https://www.w3.org/TR/html5/scripting-1.html#htmlcanvaselement
 declare class HTMLCanvasElement extends HTMLElement {
   width: number;
   height: number;
@@ -3248,7 +3250,7 @@ declare class ValidityState {
   valid: boolean;
 }
 
-// http://www.w3.org/TR/html5/forms.html#dom-textarea/input-setselectionrange
+// https://w3c.github.io/html/sec-forms.html#dom-selectionapielements-setselectionrange
 type SelectionDirection = 'backward' | 'forward' | 'none';
 type SelectionMode = 'select' | 'start' | 'end' | 'preserve';
 declare class HTMLInputElement extends HTMLElement {
@@ -3339,7 +3341,7 @@ declare class HTMLButtonElement extends HTMLElement {
   setCustomValidity(error: string): void;
 }
 
-// http://dev.w3.org/html5/spec-preview/the-textarea-element.html
+// https://w3c.github.io/html/sec-forms.html#the-textarea-element
 declare class HTMLTextAreaElement extends HTMLElement {
   autofocus: boolean;
   cols: number;
@@ -3450,7 +3452,7 @@ declare class HTMLAnchorElement extends HTMLElement {
   username: string;
 }
 
-// http://dev.w3.org/html5/spec-preview/the-label-element.html
+// https://w3c.github.io/html/sec-forms.html#the-label-element
 declare class HTMLLabelElement extends HTMLElement {
   form: HTMLFormElement | null;
   htmlFor: string;


### PR DESCRIPTION
I noticed some of the URLs in the comments of lib/dom.js were pointing to outdated or non-https URLs. Thought I'd help by updating them and adding a couple of other relevant ones. 