### PR TITLE
Support all options in `flow init --options`

### DIFF
--- a/_tags
+++ b/_tags
@@ -1,4 +1,4 @@
-true: package(core_kernel), package(ppx_deriving), package(dtoa), package(wtf8)
+true: package(core_kernel), package(ppx_fields_conv), package(ppx_deriving), package(dtoa), package(wtf8)
 <**/*.ml*>: ocaml, warn_A, warn(-4-6-29-35-44-48-50), warn_error_A, safe_string
 <**/__tests__/**>: package(oUnit)
 <hack/fsnotify_win/fsnotify.ml>: unsafe_string

--- a/opam
+++ b/opam
@@ -19,6 +19,7 @@ depends: [
   "lwt" { >= "3.3.0" }
   "lwt_log" { = "1.0.0" }
   "lwt_ppx" { >= "1.1.0" }
+  "ppx_fields_conv" {build}
   "ppx_deriving" {build}
   "ppx_gen_rec" {build}
   "ppx_tools_versioned" { = "5.2" }

--- a/src/commands/config/flowConfig.ml
+++ b/src/commands/config/flowConfig.ml
@@ -652,9 +652,6 @@ module Opts = struct
       warn_on_unknown_opts
 end
 
-(* Suppress unused Direct module warning *)
-(* let _ = Opts.Direct.fold *)
-
 type config = {
   (* completely ignored files (both module resolving and typing) *)
   ignores: string list;

--- a/src/common/options.ml
+++ b/src/common/options.ml
@@ -181,3 +181,32 @@ let lazy_mode_to_string lazy_mode =
   | LAZY_MODE_IDE -> "ide"
   | LAZY_MODE_WATCHMAN -> "watchman"
   | NON_LAZY_MODE -> "none"
+
+let esproposal_feature_mode_to_string esproposal_feature_mode =
+  match esproposal_feature_mode with
+  | ESPROPOSAL_ENABLE -> "enable"
+  | ESPROPOSAL_IGNORE -> "ignore"
+  | ESPROPOSAL_WARN -> "warn"
+
+let file_watcher_to_string file_watcher =
+  match file_watcher with
+  | NoFileWatcher -> "none"
+  | DFind -> "dfind"
+  | Watchman -> "watchman"
+
+let module_system_to_string module_system =
+  match module_system with
+  | Node -> "node"
+  | Haste -> "haste"
+
+let saved_state_fetcher_to_string saved_state_fetcher =
+  match saved_state_fetcher with
+  | Dummy_fetcher -> "none"
+  | Local_fetcher -> "local"
+  | Fb_fetcher -> "fb"
+
+let trust_mode_to_string trust_mode =
+  match trust_mode with
+  | NoTrust -> "none"
+  | SilentTrust -> "silent"
+  | CheckTrust -> "check" 


### PR DESCRIPTION
<!--
  If this is a change to library defintions, please include links to relevant documentation.
  If this is a documentation change, please prefix the title with [DOCS].

  If this is neither, ensure you opened a discussion issue and link it in the PR description.
-->

Fixes #7769

Doesn't support `module.name_mappers`