### PR TITLE
Add methods to Node HTTP ServerResponse typedef

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -1373,18 +1373,24 @@ declare class http$ClientRequest<+SocketT = net$Socket> extends stream$Writable 
 
 declare class http$ServerResponse extends stream$Writable {
   addTrailers(headers: { [key: string] : string, ... }): void;
+  connection: net$Socket;
   finished: boolean;
   getHeader(name: string): string;
+  getHeaderNames(): Array<string>;
+  getHeaders(): { [key: string] : string | Array<string> };
+  hasHeader(name: string): boolean;
   headersSent: boolean;
   removeHeader(name: string): void;
   sendDate: boolean;
   setHeader(name: string, value: string | Array<string>): void;
   setTimeout(msecs: number, callback?: Function): http$ServerResponse;
+  socket: net$Socket;
   statusCode: number;
   statusMessage: string;
   writeContinue(): void;
   writeHead(status: number, statusMessage?: string, headers?: { [key: string] : string, ... }): void;
   writeHead(status: number, headers?: { [key: string] : string, ... }): void;
+  writeProcessing(): void;
 }
 
 declare class http$Server extends net$Server {


### PR DESCRIPTION
I noticed that a few methods that are present in the [Node documentation](https://nodejs.org/api/http.html) don't exist in the current `lib/node.js` typedef.

Test plan: Manual

