### PR TITLE
Fix error message z-index

### DIFF
--- a/website/_assets/css/_try.scss
+++ b/website/_assets/css/_try.scss
@@ -4,6 +4,10 @@ html.site-fullscreen .content {
   height: 100%;
 }
 
+.CodeMirror-lint-tooltip {
+  z-index: 1040 !important;
+}
+
 .try-editor {
   position: relative;
   height: 100%;


### PR DESCRIPTION
<!--
  If this is a change to library defintions, please include links to relevant documentation.
  If this is a documentation change, please prefix the title with [DOCS].

  If this is neither, ensure you opened a discussion issue and link it in the PR description.
-->

Change CodeMirror error message z-index, so that it always appear on top of navigation bar