### PR TITLE
Implement `delete` operator write semantics, but without refinements

### DIFF
--- a/src/common/reason.ml
+++ b/src/common/reason.ml
@@ -149,6 +149,7 @@ type 'loc virtual_reason_desc =
   | RRestParameter of string option
   | RIdentifier of string
   | RIdentifierAssignment of string
+  | RPropertyDelete of string option
   | RPropertyAssignment of string option
   | RProperty of string option
   | RPrivateProperty of string
@@ -305,6 +306,7 @@ let rec map_desc_locs f = function
   | RRestParameter _
   | RIdentifier _
   | RIdentifierAssignment _
+  | RPropertyDelete _
   | RPropertyAssignment _
   | RProperty _
   | RPrivateProperty _
@@ -682,6 +684,8 @@ let rec string_of_desc = function
   | RProperty None -> "computed property"
   | RPrivateProperty x -> spf "property `#%s`" x
   | RMember { object_; property } -> spf "`%s%s`" object_ property
+  | RPropertyDelete (Some x) -> spf "delete of property `%s`" x
+  | RPropertyDelete None -> "delete of computed property/element"
   | RPropertyAssignment (Some x) -> spf "assignment of property `%s`" x
   | RPropertyAssignment None -> "assignment of computed property/element"
   | RShadowProperty x -> spf ".%s" x
@@ -1348,6 +1352,7 @@ let classification_of_reason r = match desc_of_reason ~unwrap:true r with
 | RRestParameter _
 | RIdentifier _
 | RIdentifierAssignment _
+| RPropertyDelete _
 | RPropertyAssignment _
 | RProperty _
 | RPrivateProperty _

--- a/src/common/reason.mli
+++ b/src/common/reason.mli
@@ -96,6 +96,7 @@ type 'loc virtual_reason_desc =
   | RRestParameter of string option
   | RIdentifier of string
   | RIdentifierAssignment of string
+  | RPropertyDelete of string option
   | RPropertyAssignment of string option
   | RProperty of string option
   | RPrivateProperty of string

--- a/src/typing/debug_js.ml
+++ b/src/typing/debug_js.ml
@@ -2988,6 +2988,8 @@ let dump_error_message =
         (dump_reason cx key_reason)
         (dump_reason cx value_reason)
         (dump_reason cx object2_reason)
+    | EDeleteOperand reason ->
+      spf "EDeleteOperand (%s)" (dump_reason cx reason)
 
 module Verbose = struct
   let print_if_verbose_lazy cx trace

--- a/src/typing/debug_js.ml
+++ b/src/typing/debug_js.ml
@@ -3000,8 +3000,8 @@ let dump_error_message =
         (dump_reason cx key_reason)
         (dump_reason cx value_reason)
         (dump_reason cx object2_reason)
-    | EDeleteSuperReference reason ->
-      spf "EDeleteSuperReference (%s)" (dump_reason cx reason)
+    | EDeleteUnsupportedReference reason ->
+      spf "EDeleteUnsupportedReference (%s)" (dump_reason cx reason)
     | EDeleteOperand reason ->
       spf "EDeleteOperand (%s)" (dump_reason cx reason)
 

--- a/src/typing/errors/error_message.ml
+++ b/src/typing/errors/error_message.ml
@@ -871,7 +871,7 @@ let aloc_of_msg : t -> ALoc.t option = function
   | EImportTypeAsTypeof (reason, _)
   | EExportValueAsType (reason, _)
   | EImportValueAsType (reason, _)
-  | ENonArraySpread reason ->
+  | ENonArraySpread reason
   | EDeleteSuperReference reason
   | EDeleteOperand reason
   | EDebugPrint (reason, _) ->

--- a/src/typing/errors/error_message.ml
+++ b/src/typing/errors/error_message.ml
@@ -231,7 +231,7 @@ and 'loc t' =
   | EInexactSpread of 'loc virtual_reason * 'loc virtual_reason
   | EUnexpectedTemporaryBaseType of 'loc
   | EBigIntNotYetSupported of 'loc virtual_reason
-  | EDeleteSuperReference of 'loc virtual_reason
+  | EDeleteUnsupportedReference of 'loc virtual_reason
   | EDeleteOperand of 'loc virtual_reason
   (* These are unused when calculating locations so we can leave this as Aloc *)
   | ESignatureVerification of Signature_builder_deps.With_ALoc.Error.t
@@ -634,7 +634,7 @@ let map_loc_of_error_message (f : 'a -> 'b) : 'a t' -> 'b t' =
   | EInexactSpread (r1, r2) -> EInexactSpread (map_reason r1, map_reason r2)
   | EUnexpectedTemporaryBaseType loc -> EUnexpectedTemporaryBaseType (f loc)
   | EBigIntNotYetSupported r -> EBigIntNotYetSupported (map_reason r)
-  | EDeleteSuperReference r -> EDeleteSuperReference (map_reason r)
+  | EDeleteUnsupportedReference r -> EDeleteUnsupportedReference (map_reason r)
   | EDeleteOperand r -> EDeleteOperand (map_reason r)
   | ESignatureVerification _ as e -> e
   | ENonArraySpread r -> ENonArraySpread (map_reason r)
@@ -822,7 +822,7 @@ let util_use_op_of_msg nope util = function
 | EInexactSpread _
 | EUnexpectedTemporaryBaseType _
 | EBigIntNotYetSupported _
-| EDeleteSuperReference (_)
+| EDeleteUnsupportedReference (_)
 | EDeleteOperand (_)
 | ESignatureVerification _
 | ENonArraySpread _
@@ -872,7 +872,7 @@ let aloc_of_msg : t -> ALoc.t option = function
   | EExportValueAsType (reason, _)
   | EImportValueAsType (reason, _)
   | ENonArraySpread reason
-  | EDeleteSuperReference reason
+  | EDeleteUnsupportedReference reason
   | EDeleteOperand reason
   | EDebugPrint (reason, _) ->
         Some (aloc_of_reason reason)
@@ -2187,7 +2187,7 @@ let friendly_message_of_msg : Loc.t t' -> Loc.t friendly_message_recipe =
         text " or a property value that conflicts with "; ref value_reason;
         text ". Can you make "; ref object2_reason; text " exact?";
       ]
-    | EDeleteSuperReference reason ->
+    | EDeleteUnsupportedReference reason ->
       Normal [
         text "Cannot perform delete operation because "; ref reason; text " ";
         text "is unsupported reference.";

--- a/src/typing/errors/error_message.ml
+++ b/src/typing/errors/error_message.ml
@@ -2181,7 +2181,7 @@ let friendly_message_of_msg : Loc.t t' -> Loc.t friendly_message_recipe =
       ]
     | EDeleteOperand reason ->
       Normal [
-        text "Cannot perform delete operation because"; ref reason; text " ";
+        text "Cannot perform delete operation because "; ref reason; text " ";
         text "is not a property reference.";
       ]
 )

--- a/src/typing/errors/flow_error.ml
+++ b/src/typing/errors/flow_error.ml
@@ -465,6 +465,10 @@ let rec make_error_printable lazy_table_of_aloc (error : Loc.t t) : Loc.t Errors
         `Root (loc_reason, None,
           [text "Cannot assign "; desc value; text " to "; desc prop])
 
+      | Op (DeleteProperty {prop; lhs; _}) ->
+        `Root (lhs, None,
+          [text "Cannot delete "; desc prop])
+
       | Frame (ArrayElementCompatibility {lower; _}, use_op) ->
         `Frame (lower, use_op,
           [text "array element"])
@@ -815,11 +819,13 @@ let rec make_error_printable lazy_table_of_aloc (error : Loc.t t) : Loc.t Errors
     | IncompatibleGetPropT (prop_loc, prop)
     | IncompatibleSetPropT (prop_loc, prop)
     | IncompatibleMatchPropT (prop_loc, prop)
+    | IncompatibleDeletePropT (prop_loc, prop)
     | IncompatibleHasOwnPropT (prop_loc, prop)
     | IncompatibleMethodT (prop_loc, prop)
       -> mk_prop_missing_error prop_loc prop lower use_op
     | IncompatibleGetElemT prop_loc
     | IncompatibleSetElemT prop_loc
+    | IncompatibleDeleteElemT prop_loc
     | IncompatibleCallElemT prop_loc
       -> mk_prop_missing_error prop_loc None lower use_op
     | IncompatibleGetStaticsT

--- a/src/typing/sigHash.ml
+++ b/src/typing/sigHash.ml
@@ -89,11 +89,13 @@ type hash =
   | SetPrivatePropH
   | GetPropH
   | MatchPropH
+  | DeletePropH
   | GetPrivatePropH
   | TestPropH
   | SetElemH
   | GetElemH
   | CallElemH
+  | DeleteElemH
   | GetStaticsH
   | GetProtoH
   | SetProtoH
@@ -249,10 +251,12 @@ let hash_of_use_ctor = Type.(function
   | SetPrivatePropT _ -> SetPrivatePropH
   | GetPropT _ -> GetPropH
   | MatchPropT _ -> MatchPropH
+  | DeletePropT _ -> DeletePropH
   | GetPrivatePropT _ -> GetPrivatePropH
   | TestPropT _ -> TestPropH
   | SetElemT _ -> SetElemH
   | GetElemT _ -> GetElemH
+  | DeleteElemT _ -> DeleteElemH
   | CallElemT _ -> CallElemH
   | GetStaticsT _ -> GetStaticsH
   | GetProtoT _ -> GetProtoH

--- a/src/typing/statement.ml
+++ b/src/typing/statement.ml
@@ -4460,14 +4460,16 @@ and unary cx loc = Ast.Expression.Unary.(function
       | _, Identifier _
       | _, Member _ ->
         let (_, _), _ as argument = expression cx argument in
+        Flow.add_output cx (Error_message.EDeleteOperand op_prop_reason);
         argument
       | _, OptionalMember _ ->
         let (_, _), _ as argument = expression cx argument in
         (* TODO: support optional member *)
+        Flow.add_output cx (Error_message.EDeleteOperand op_prop_reason);
         argument
       | _ ->
-        Flow.add_output cx (Error_message.EDeleteOperand op_prop_reason);
         let (_, _), _ as argument = expression cx argument in
+        Flow.add_output cx (Error_message.EDeleteOperand op_prop_reason);
         argument
       in
       BoolT.at loc |> with_trust literal_trust, { operator = Delete; argument; comments }

--- a/src/typing/statement.ml
+++ b/src/typing/statement.ml
@@ -4384,13 +4384,14 @@ and unary cx loc = Ast.Expression.Unary.(function
       VoidT.at loc |> with_trust literal_trust, { operator = Void; argument; comments }
 
   | { operator = Delete; argument; comments } ->
-      let (rhs_loc, _), _ as argument = expression cx argument in
+      let reason = mk_expression_reason argument in
+      let (_, _), _ as argument = expression cx argument in
       (match argument with
       | _, Ast.Expression.Identifier _ -> ()
       | _, Ast.Expression.Member _ -> ()
       | _, Ast.Expression.OptionalMember _ -> ()
       | _ ->
-        Flow.add_output cx (Error_message.EInvalidLHSInAssignment rhs_loc);
+        Flow.add_output cx (Error_message.EDeleteOperand reason);
       );
       BoolT.at loc |> with_trust literal_trust, { operator = Delete; argument; comments }
 

--- a/src/typing/statement.ml
+++ b/src/typing/statement.ml
@@ -4458,9 +4458,12 @@ and unary cx loc = Ast.Expression.Unary.(function
           property = Member.PropertyExpression index;
         }
       | _, Identifier _
-      | _, Member _
+      | _, Member _ ->
+        let (_, _), _ as argument = expression cx argument in
+        argument
       | _, OptionalMember _ ->
         let (_, _), _ as argument = expression cx argument in
+        (* TODO: support optional member *)
         argument
       | _ ->
         Flow.add_output cx (Error_message.EDeleteOperand op_prop_reason);

--- a/src/typing/statement.ml
+++ b/src/typing/statement.ml
@@ -4384,7 +4384,14 @@ and unary cx loc = Ast.Expression.Unary.(function
       VoidT.at loc |> with_trust literal_trust, { operator = Void; argument; comments }
 
   | { operator = Delete; argument; comments } ->
-      let argument = expression cx argument in
+      let (rhs_loc, argt), _ as argument = expression cx argument in
+      (match argument with
+      | _, Ast.Expression.Identifier _ -> ()
+      | _, Ast.Expression.Member _ -> ()
+      | _, Ast.Expression.OptionalMember _ -> ()
+      | _ ->
+        Flow.add_output cx (Error_message.EInvalidLHSInAssignment rhs_loc);
+      );
       BoolT.at loc |> with_trust literal_trust, { operator = Delete; argument; comments }
 
   | { operator = Await; argument; comments } ->

--- a/src/typing/statement.ml
+++ b/src/typing/statement.ml
@@ -4396,7 +4396,7 @@ and unary cx loc = Ast.Expression.Unary.(function
         let prop_reason = mk_reason (RProperty (Some name)) prop_loc in
         let super = super_ cx rhs_loc in
         let prop_t = Tvar.mk cx prop_reason in
-        Flow.add_output cx (Error_message.EDeleteSuperReference op_prop_reason);
+        Flow.add_output cx (Error_message.EDeleteUnsupportedReference op_prop_reason);
         let property = Member.PropertyIdentifier ((prop_loc, prop_t), id) in
         (rhs_loc, prop_t), Member { Member.
           _object = (super_loc, super), Super;
@@ -4460,12 +4460,12 @@ and unary cx loc = Ast.Expression.Unary.(function
       | _, Identifier _
       | _, Member _ ->
         let (_, _), _ as argument = expression cx argument in
-        Flow.add_output cx (Error_message.EDeleteOperand op_prop_reason);
+        Flow.add_output cx (Error_message.EDeleteUnsupportedReference op_prop_reason);
         argument
       | _, OptionalMember _ ->
         let (_, _), _ as argument = expression cx argument in
         (* TODO: support optional member *)
-        Flow.add_output cx (Error_message.EDeleteOperand op_prop_reason);
+        Flow.add_output cx (Error_message.EDeleteUnsupportedReference op_prop_reason);
         argument
       | _ ->
         let (_, _), _ as argument = expression cx argument in

--- a/src/typing/statement.ml
+++ b/src/typing/statement.ml
@@ -4384,7 +4384,7 @@ and unary cx loc = Ast.Expression.Unary.(function
       VoidT.at loc |> with_trust literal_trust, { operator = Void; argument; comments }
 
   | { operator = Delete; argument; comments } ->
-      let (rhs_loc, argt), _ as argument = expression cx argument in
+      let (rhs_loc, _), _ as argument = expression cx argument in
       (match argument with
       | _, Ast.Expression.Identifier _ -> ()
       | _, Ast.Expression.Member _ -> ()

--- a/src/typing/type_mapper.ml
+++ b/src/typing/type_mapper.ml
@@ -656,6 +656,11 @@ class virtual ['a] t_with_uses = object(self)
           let t'' = self#type_ cx map_cx t' in
           if prop' == prop && t'' == t' then t
           else MatchPropT (use_op, r, prop', t'')
+      | DeletePropT (use_op, r, prop, t') ->
+          let prop' = self#prop_ref cx map_cx prop in
+          let t'' = self#type_ cx map_cx t' in
+          if prop' == prop && t'' == t' then t
+          else DeletePropT (use_op, r, prop', t'')
       | GetPrivatePropT (use_op, r, prop, scopes, static, t') ->
           let t'' = self#type_ cx map_cx t' in
           let scopes' = ListUtils.ident_map (self#class_binding cx map_cx) scopes in
@@ -677,6 +682,11 @@ class virtual ['a] t_with_uses = object(self)
           let t2' = self#type_ cx map_cx t2 in
           if t1' == t1 && t2' == t2 then t
           else GetElemT (use_op, r, t1', t2')
+      | DeleteElemT (use_op, r, t1, t2) ->
+          let t1' = self#type_ cx map_cx t1 in
+          let t2' = self#type_ cx map_cx t2 in
+          if t1' == t1 && t2' == t2 then t
+          else DeleteElemT (use_op, r, t1', t2')
       | CallElemT (r1, r2, t', funcall) ->
           let t'' = self#type_ cx map_cx t' in
           let funcall' = self#fun_call_type cx map_cx funcall in
@@ -1091,6 +1101,10 @@ class virtual ['a] t_with_uses = object(self)
         let tout' = OptionUtils.ident_map (self#type_ cx map_cx) tout in
         if tin' == tin && tout' == tout then t
         else WriteElem (tin', tout')
+    | DeleteElem t' ->
+        let t'' = self#type_ cx map_cx t' in
+        if t'' == t' then t
+        else DeleteElem t''
     | CallElem (r, funcall) ->
         let funcall' = self#fun_call_type cx map_cx funcall in
         if funcall' == funcall then t
@@ -1243,6 +1257,10 @@ class virtual ['a] t_with_uses = object(self)
       let t'' = self#type_ cx map_cx t' in
       if t'' == t' then t
       else MatchProp (use, t')
+    | DeleteProp (use, t') ->
+      let t'' = self#type_ cx map_cx t' in
+      if t'' == t' then t
+      else DeleteProp (use, t')
 
   method cont cx map_cx t =
     match t with

--- a/src/typing/type_visitor.ml
+++ b/src/typing/type_visitor.ml
@@ -288,7 +288,8 @@ class ['a] t = object(self)
     acc
 
   | GetPropT (_, _, p, t)
-  | MatchPropT(_, _, p, t)
+  | MatchPropT (_, _, p, t)
+  | DeletePropT (_, _, p, t)
   | TestPropT (_, _, p, t) ->
     let acc = self#propref cx acc p in
     let acc = self#type_ cx pole_TODO acc t in
@@ -312,6 +313,11 @@ class ['a] t = object(self)
     acc
 
   | GetElemT (_, _, e, t) ->
+    let acc = self#type_ cx pole_TODO acc e in
+    let acc = self#type_ cx pole_TODO acc t in
+    acc
+
+  | DeleteElemT (_, _, e, t) ->
     let acc = self#type_ cx pole_TODO acc e in
     let acc = self#type_ cx pole_TODO acc t in
     acc
@@ -857,6 +863,7 @@ class ['a] t = object(self)
   | LookupProp (_, prop)
   | SuperProp (_, prop) ->
     self#prop cx pole_TODO acc prop
+  | DeleteProp (_, t)
   | MatchProp (_, t) ->
     self#type_ cx pole_TODO acc t
 
@@ -867,6 +874,8 @@ class ['a] t = object(self)
     let acc = self#type_ cx pole_TODO acc tin in
     let acc = self#opt (self#type_ cx pole_TODO) acc tout in
     acc
+  | DeleteElem t ->
+    self#type_ cx pole_TODO acc t
   | CallElem (_, fn) ->
     self#fun_call_type cx acc fn
 

--- a/tests/unary/.flowconfig
+++ b/tests/unary/.flowconfig
@@ -1,0 +1,2 @@
+[options]
+esproposal.optional_chaining=enable

--- a/tests/unary/delete.js
+++ b/tests/unary/delete.js
@@ -1,0 +1,19 @@
+//@flow
+
+let tests = [
+  function (foo: { a: number }) {
+    delete foo.a; // ok
+  },
+  function () {
+    delete { a: 1 } // error
+  },
+  function () {
+    delete [1, 2, 3] // error
+  },
+  function (foo: number[]) {
+    delete foo[0] // ok
+  },
+  function (foo: { a?: number }) {
+    delete foo?.a // ok
+  },
+]

--- a/tests/unary/delete.js
+++ b/tests/unary/delete.js
@@ -4,16 +4,68 @@ let tests = [
   function (foo: { a: number }) {
     delete foo.a; // ok
   },
+  function (foo: { a: number }) {
+    delete foo['a']; // ok
+  },
+
+  function (foo: { +a: number }) {
+    delete foo.a; // error
+  },
+  function (foo: { +a: number }) {
+    delete foo['a']; // error
+  },
+  
+  function (foo: { -a: number }) {
+    delete foo.a; // ok
+  },
+  function (foo: { -a: number }) {
+    delete foo['a']; // ok
+  },
+
+  function (foo: number[]) {
+    delete foo[0] // ok
+  },
+  function (foo: [number]) {
+    delete foo[1] // error
+  },
+  function (foo: $ReadOnlyArray<number>) {
+    delete foo[0] // error
+  },
+
+  function (foo: { a?: number }) {
+    delete foo?.a // ok
+  },
+  function (foo: { +a?: number }) {
+    delete foo?.a // TODO
+  },
+  function (foo: { -a?: number }) {
+    delete foo?.a // TODO
+  },
+
+  function (foo: {[key: string]: number}) {
+    delete foo['bar'] // ok
+  },
+  function (foo: {+[key: string]: number}) {
+    delete foo['bar'] // error
+  },
+  function (foo: {-[key: string]: number}) {
+    delete foo['bar'] // ok
+  },
+
+  function (foo: {[key: number]: number}) {
+    delete foo[0] // ok
+  },
+  function (foo: {+[key: number]: number}) {
+    delete foo[1] // error
+  },
+  function (foo: {-[key: number]: number}) {
+    delete foo[1] // ok
+  },
+
   function () {
     delete { a: 1 } // error
   },
   function () {
     delete [1, 2, 3] // error
-  },
-  function (foo: number[]) {
-    delete foo[0] // ok
-  },
-  function (foo: { a?: number }) {
-    delete foo?.a // ok
   },
 ]

--- a/tests/unary/delete.js
+++ b/tests/unary/delete.js
@@ -1,11 +1,17 @@
 //@flow
 
 let tests = [
-  function (foo: { a: number }) {
+  function (foo: { a?: number }) {
     delete foo.a; // ok
   },
-  function (foo: { a: number }) {
+  function (foo: { a?: number }) {
     delete foo['a']; // ok
+  },
+  function (foo: { a: number }) {
+    delete foo.a; // error
+  },
+  function (foo: { a: number }) {
+    delete foo['a']; // error
   },
 
   function (foo: { +a: number }) {
@@ -14,16 +20,25 @@ let tests = [
   function (foo: { +a: number }) {
     delete foo['a']; // error
   },
-  
-  function (foo: { -a: number }) {
+
+  function (foo: { -a?: number }) {
     delete foo.a; // ok
   },
-  function (foo: { -a: number }) {
+  function (foo: { -a?: number }) {
     delete foo['a']; // ok
   },
+  function (foo: { -a: number }) {
+    delete foo.a; // error
+  },
+  function (foo: { -a: number }) {
+    delete foo['a']; // error
+  },
 
-  function (foo: number[]) {
+  function (foo: Array<number | void>) {
     delete foo[0] // ok
+  },
+  function (foo: number[]) {
+    delete foo[0] // error
   },
   function (foo: [number]) {
     delete foo[1] // error
@@ -33,7 +48,7 @@ let tests = [
   },
 
   function (foo: { a?: number }) {
-    delete foo?.a // ok
+    delete foo?.a // TODO
   },
   function (foo: { +a?: number }) {
     delete foo?.a // TODO
@@ -42,30 +57,52 @@ let tests = [
     delete foo?.a // TODO
   },
 
-  function (foo: {[key: string]: number}) {
+  function (foo: { [key: string]: number | void }) {
     delete foo['bar'] // ok
   },
-  function (foo: {+[key: string]: number}) {
+  function (foo: { -[key: string]: number | void }) {
+    delete foo['bar'] // ok
+  },
+  function (foo: { [key: string]: number }) {
     delete foo['bar'] // error
   },
-  function (foo: {-[key: string]: number}) {
-    delete foo['bar'] // ok
+  function (foo: { +[key: string]: number }) {
+    delete foo['bar'] // error
+  },
+  function (foo: { -[key: string]: number }) {
+    delete foo['bar'] // error
   },
 
-  function (foo: {[key: number]: number}) {
+  function (foo: { [key: number]: number | void }) {
     delete foo[0] // ok
+  },
+  function (foo: { [key: number]: number | void }) {
+    delete foo[0] // ok
+  },
+  function (foo: { [key: number]: number }) {
+    delete foo[0] // error
   },
   function (foo: {+[key: number]: number}) {
     delete foo[1] // error
   },
   function (foo: {-[key: number]: number}) {
-    delete foo[1] // ok
+    delete foo[1] // error
   },
 
+  function (a: number) {
+    delete a;
+  },
   function () {
     delete { a: 1 } // error
   },
   function () {
     delete [1, 2, 3] // error
   },
+  function() {
+    class Foo {
+      bar() {
+        delete super.name;
+      }
+    }
+  }
 ]

--- a/tests/unary/unary.exp
+++ b/tests/unary/unary.exp
@@ -1,17 +1,17 @@
 Error --------------------------------------------------------------------------------------------------- delete.js:8:12
 
-Invalid left-hand side in assignment expression.
+Cannot perform delete operation because object literal [1] is not a property reference.
 
    8|     delete { a: 1 } // error
-                 ^^^^^^^^
+                 ^^^^^^^^ [1]
 
 
 Error -------------------------------------------------------------------------------------------------- delete.js:11:12
 
-Invalid left-hand side in assignment expression.
+Cannot perform delete operation because array literal [1] is not a property reference.
 
    11|     delete [1, 2, 3] // error
-                  ^^^^^^^^^
+                  ^^^^^^^^^ [1]
 
 
 Error ---------------------------------------------------------------------------------------------------- unary.js:8:10

--- a/tests/unary/unary.exp
+++ b/tests/unary/unary.exp
@@ -1,16 +1,78 @@
-Error --------------------------------------------------------------------------------------------------- delete.js:8:12
+Error -------------------------------------------------------------------------------------------------- delete.js:12:12
+
+Cannot delete `foo.a` because property `a` is not writable.
+
+   12|     delete foo.a; // error
+                  ^^^^^
+
+
+Error -------------------------------------------------------------------------------------------------- delete.js:15:12
+
+Cannot delete `foo['a']` because property `a` is not writable.
+
+   15|     delete foo['a']; // error
+                  ^^^^^^^^
+
+
+Error -------------------------------------------------------------------------------------------------- delete.js:29:12
+
+Cannot delete `foo[1]` because tuple type [1] only has 1 element, so index 1 is out of bounds.
+
+   delete.js:29:12
+   29|     delete foo[1] // error
+                  ^^^^^^
+
+References:
+   delete.js:28:18
+   28|   function (foo: [number]) {
+                        ^^^^^^^^ [1]
+
+
+Error -------------------------------------------------------------------------------------------------- delete.js:32:12
+
+Cannot delete `foo[0]` because read-only arrays cannot be written to.
+
+   32|     delete foo[0] // error
+                  ^^^^^^
+
+
+Error -------------------------------------------------------------------------------------------------- delete.js:42:12
+
+Cannot get `foo?.a` because property `a` is not readable.
+
+   42|     delete foo?.a // TODO
+                  ^^^^^^
+
+
+Error -------------------------------------------------------------------------------------------------- delete.js:49:12
+
+Cannot delete `foo['bar']` because property `bar` is not writable.
+
+   49|     delete foo['bar'] // error
+                  ^^^^^^^^^^
+
+
+Error -------------------------------------------------------------------------------------------------- delete.js:59:12
+
+Cannot delete `foo[1]` because an index signature declaring the expected key / value type is not writable.
+
+   59|     delete foo[1] // error
+                  ^^^^^^
+
+
+Error -------------------------------------------------------------------------------------------------- delete.js:66:12
 
 Cannot perform delete operation because object literal [1] is not a property reference.
 
-   8|     delete { a: 1 } // error
-                 ^^^^^^^^ [1]
+   66|     delete { a: 1 } // error
+                  ^^^^^^^^ [1]
 
 
-Error -------------------------------------------------------------------------------------------------- delete.js:11:12
+Error -------------------------------------------------------------------------------------------------- delete.js:69:12
 
 Cannot perform delete operation because array literal [1] is not a property reference.
 
-   11|     delete [1, 2, 3] // error
+   69|     delete [1, 2, 3] // error
                   ^^^^^^^^^ [1]
 
 
@@ -214,4 +276,4 @@ References:
 
 
 
-Found 16 errors
+Found 23 errors

--- a/tests/unary/unary.exp
+++ b/tests/unary/unary.exp
@@ -1,3 +1,19 @@
+Error --------------------------------------------------------------------------------------------------- delete.js:8:12
+
+Invalid left-hand side in assignment expression.
+
+   8|     delete { a: 1 } // error
+                 ^^^^^^^^
+
+
+Error -------------------------------------------------------------------------------------------------- delete.js:11:12
+
+Invalid left-hand side in assignment expression.
+
+   11|     delete [1, 2, 3] // error
+                  ^^^^^^^^^
+
+
 Error ---------------------------------------------------------------------------------------------------- unary.js:8:10
 
 string [1] is not a number.
@@ -198,4 +214,4 @@ References:
 
 
 
-Found 14 errors
+Found 16 errors

--- a/tests/unary/unary.exp
+++ b/tests/unary/unary.exp
@@ -1,79 +1,259 @@
-Error -------------------------------------------------------------------------------------------------- delete.js:12:12
+Error -------------------------------------------------------------------------------------------------- delete.js:11:12
+
+Cannot delete `foo.a` because undefined [1] is incompatible with number [1].
+
+   delete.js:11:12
+   11|     delete foo.a; // error
+                  ^^^^^
+
+References:
+   delete.js:10:23
+   10|   function (foo: { a: number }) {
+                             ^^^^^^ [1]
+
+
+Error -------------------------------------------------------------------------------------------------- delete.js:14:12
+
+Cannot delete `foo['a']` because undefined [1] is incompatible with number [1].
+
+   delete.js:14:12
+   14|     delete foo['a']; // error
+                  ^^^^^^^^
+
+References:
+   delete.js:13:23
+   13|   function (foo: { a: number }) {
+                             ^^^^^^ [1]
+
+
+Error -------------------------------------------------------------------------------------------------- delete.js:18:12
 
 Cannot delete `foo.a` because property `a` is not writable.
 
-   12|     delete foo.a; // error
+   18|     delete foo.a; // error
                   ^^^^^
 
 
-Error -------------------------------------------------------------------------------------------------- delete.js:15:12
+Error -------------------------------------------------------------------------------------------------- delete.js:21:12
 
 Cannot delete `foo['a']` because property `a` is not writable.
 
-   15|     delete foo['a']; // error
+   21|     delete foo['a']; // error
                   ^^^^^^^^
 
 
-Error -------------------------------------------------------------------------------------------------- delete.js:29:12
+Error -------------------------------------------------------------------------------------------------- delete.js:31:12
 
-Cannot delete `foo[1]` because tuple type [1] only has 1 element, so index 1 is out of bounds.
+Cannot delete `foo.a` because undefined [1] is incompatible with number [1].
 
-   delete.js:29:12
-   29|     delete foo[1] // error
+   delete.js:31:12
+   31|     delete foo.a; // error
+                  ^^^^^
+
+References:
+   delete.js:30:24
+   30|   function (foo: { -a: number }) {
+                              ^^^^^^ [1]
+
+
+Error -------------------------------------------------------------------------------------------------- delete.js:34:12
+
+Cannot delete `foo['a']` because undefined [1] is incompatible with number [1].
+
+   delete.js:34:12
+   34|     delete foo['a']; // error
+                  ^^^^^^^^
+
+References:
+   delete.js:33:24
+   33|   function (foo: { -a: number }) {
+                              ^^^^^^ [1]
+
+
+Error -------------------------------------------------------------------------------------------------- delete.js:41:12
+
+Cannot delete `foo[0]` because undefined [1] is incompatible with number [2].
+
+   delete.js:41:12
+   41|     delete foo[0] // error
                   ^^^^^^
 
 References:
-   delete.js:28:18
-   28|   function (foo: [number]) {
+   delete.js:41:5
+   41|     delete foo[0] // error
+           ^^^^^^^^^^^^^ [1]
+   delete.js:40:18
+   40|   function (foo: number[]) {
+                        ^^^^^^ [2]
+
+
+Error -------------------------------------------------------------------------------------------------- delete.js:44:12
+
+Cannot delete `foo[1]` because tuple type [1] only has 1 element, so index 1 is out of bounds.
+
+   delete.js:44:12
+   44|     delete foo[1] // error
+                  ^^^^^^
+
+References:
+   delete.js:43:18
+   43|   function (foo: [number]) {
                         ^^^^^^^^ [1]
 
 
-Error -------------------------------------------------------------------------------------------------- delete.js:32:12
+Error -------------------------------------------------------------------------------------------------- delete.js:47:12
 
-Cannot delete `foo[0]` because read-only arrays cannot be written to.
+Cannot delete `foo[0]` because:
+ - undefined [1] is incompatible with number [2].
+ - read-only arrays cannot be written to.
 
-   32|     delete foo[0] // error
+   delete.js:47:12
+   47|     delete foo[0] // error
                   ^^^^^^
 
+References:
+   delete.js:47:5
+   47|     delete foo[0] // error
+           ^^^^^^^^^^^^^ [1]
+   delete.js:46:33
+   46|   function (foo: $ReadOnlyArray<number>) {
+                                       ^^^^^^ [2]
 
-Error -------------------------------------------------------------------------------------------------- delete.js:42:12
+
+Error -------------------------------------------------------------------------------------------------- delete.js:51:12
+
+Cannot perform delete operation because `foo?.a` [1] is unsupported reference.
+
+   51|     delete foo?.a // TODO
+                  ^^^^^^ [1]
+
+
+Error -------------------------------------------------------------------------------------------------- delete.js:54:12
+
+Cannot perform delete operation because `foo?.a` [1] is unsupported reference.
+
+   54|     delete foo?.a // TODO
+                  ^^^^^^ [1]
+
+
+Error -------------------------------------------------------------------------------------------------- delete.js:57:12
 
 Cannot get `foo?.a` because property `a` is not readable.
 
-   42|     delete foo?.a // TODO
+   57|     delete foo?.a // TODO
                   ^^^^^^
 
 
-Error -------------------------------------------------------------------------------------------------- delete.js:49:12
+Error -------------------------------------------------------------------------------------------------- delete.js:57:12
+
+Cannot perform delete operation because `foo?.a` [1] is unsupported reference.
+
+   57|     delete foo?.a // TODO
+                  ^^^^^^ [1]
+
+
+Error -------------------------------------------------------------------------------------------------- delete.js:67:12
+
+Cannot delete `foo['bar']` because undefined [1] is incompatible with number [1].
+
+   delete.js:67:12
+   67|     delete foo['bar'] // error
+                  ^^^^^^^^^^
+
+References:
+   delete.js:66:35
+   66|   function (foo: { [key: string]: number }) {
+                                         ^^^^^^ [1]
+
+
+Error -------------------------------------------------------------------------------------------------- delete.js:70:12
 
 Cannot delete `foo['bar']` because property `bar` is not writable.
 
-   49|     delete foo['bar'] // error
+   70|     delete foo['bar'] // error
                   ^^^^^^^^^^
 
 
-Error -------------------------------------------------------------------------------------------------- delete.js:59:12
+Error -------------------------------------------------------------------------------------------------- delete.js:73:12
+
+Cannot delete `foo['bar']` because undefined [1] is incompatible with number [1].
+
+   delete.js:73:12
+   73|     delete foo['bar'] // error
+                  ^^^^^^^^^^
+
+References:
+   delete.js:72:36
+   72|   function (foo: { -[key: string]: number }) {
+                                          ^^^^^^ [1]
+
+
+Error -------------------------------------------------------------------------------------------------- delete.js:83:12
+
+Cannot delete `foo[0]` because undefined [1] is incompatible with number [1].
+
+   delete.js:83:12
+   83|     delete foo[0] // error
+                  ^^^^^^
+
+References:
+   delete.js:82:35
+   82|   function (foo: { [key: number]: number }) {
+                                         ^^^^^^ [1]
+
+
+Error -------------------------------------------------------------------------------------------------- delete.js:86:12
 
 Cannot delete `foo[1]` because an index signature declaring the expected key / value type is not writable.
 
-   59|     delete foo[1] // error
+   86|     delete foo[1] // error
                   ^^^^^^
 
 
-Error -------------------------------------------------------------------------------------------------- delete.js:66:12
+Error -------------------------------------------------------------------------------------------------- delete.js:89:12
+
+Cannot delete `foo[1]` because undefined [1] is incompatible with number [1].
+
+   delete.js:89:12
+   89|     delete foo[1] // error
+                  ^^^^^^
+
+References:
+   delete.js:88:35
+   88|   function (foo: {-[key: number]: number}) {
+                                         ^^^^^^ [1]
+
+
+Error -------------------------------------------------------------------------------------------------- delete.js:93:12
+
+Cannot perform delete operation because `a` [1] is unsupported reference.
+
+   93|     delete a;
+                  ^ [1]
+
+
+Error -------------------------------------------------------------------------------------------------- delete.js:96:12
 
 Cannot perform delete operation because object literal [1] is not a property reference.
 
-   66|     delete { a: 1 } // error
+   96|     delete { a: 1 } // error
                   ^^^^^^^^ [1]
 
 
-Error -------------------------------------------------------------------------------------------------- delete.js:69:12
+Error -------------------------------------------------------------------------------------------------- delete.js:99:12
 
 Cannot perform delete operation because array literal [1] is not a property reference.
 
-   69|     delete [1, 2, 3] // error
+   99|     delete [1, 2, 3] // error
                   ^^^^^^^^^ [1]
+
+
+Error ------------------------------------------------------------------------------------------------- delete.js:104:16
+
+Cannot perform delete operation because `super.name` [1] is unsupported reference.
+
+   104|         delete super.name;
+                       ^^^^^^^^^^ [1]
 
 
 Error ---------------------------------------------------------------------------------------------------- unary.js:8:10
@@ -276,4 +456,4 @@ References:
 
 
 
-Found 23 errors
+Found 38 errors


### PR DESCRIPTION
<!--
  If this is a change to library defintions, please include links to relevant documentation.
  If this is a documentation change, please prefix the title with [DOCS].

  If this is neither, ensure you opened a discussion issue and link it in the PR description.
-->

Can't help with #2207, but disallows deleting read-only properties
Only allow `MemberExpression`, `Identifier`
