### PR TITLE
Better error messages for invalid bigints

### DIFF
--- a/newtests/bigint/test.js
+++ b/newtests/bigint/test.js
@@ -10,12 +10,12 @@ export default suite(({ addFile, addFiles, addCode }) => [
     addCode(`
       type InvalidDecimal = 1.0n;
     `).newErrors(
-      `
+        `
           test.js:4
             4:       type InvalidDecimal = 1.0n;
-                                           ^^^^ Invalid bigint literal
-        `
-    )
+                                           ^^^^ A bigint literal must be an integer
+        `,
+      )
   ]),
 
   test("BigInt invalid negative decimal type literal", [
@@ -25,7 +25,7 @@ export default suite(({ addFile, addFiles, addCode }) => [
         `
           test.js:4
             4:       type InvalidNegDecimal = -1.0n;
-                                              ^^^^^ Invalid bigint literal
+                                              ^^^^^ A bigint literal must be an integer
         `,
       )
   ]),
@@ -34,12 +34,12 @@ export default suite(({ addFile, addFiles, addCode }) => [
     addCode(`
       const invalid_decimal = 1.0n;
     `).newErrors(
-      `
+        `
           test.js:4
             4:       const invalid_decimal = 1.0n;
-                                             ^^^^ Invalid bigint literal
-        `
-    )
+                                             ^^^^ A bigint literal must be an integer
+        `,
+      )
   ]),
 
   test("BigInt invalid negative decimal literal", [
@@ -49,7 +49,7 @@ export default suite(({ addFile, addFiles, addCode }) => [
         `
           test.js:4
             4:       const invalid_neg_decimal = -1.0n;
-                                                  ^^^^ Invalid bigint literal
+                                                  ^^^^ A bigint literal must be an integer
         `,
       )
   ]),
@@ -58,12 +58,12 @@ export default suite(({ addFile, addFiles, addCode }) => [
     addCode(`
       type InvalidE = 2e9n;
     `).newErrors(
-      `
+        `
           test.js:4
             4:       type InvalidE = 2e9n;
-                                     ^^^^ Invalid bigint literal
-        `
-    )
+                                     ^^^^ A bigint literal cannot use exponential notation
+        `,
+      )
   ]),
 
   test("BigInt invalid negative scientific type literal", [
@@ -73,7 +73,7 @@ export default suite(({ addFile, addFiles, addCode }) => [
         `
           test.js:4
             4:       type InvalidNegE = -2e9n;
-                                        ^^^^^ Invalid bigint literal
+                                        ^^^^^ A bigint literal cannot use exponential notation
         `,
       )
   ]),
@@ -85,7 +85,7 @@ export default suite(({ addFile, addFiles, addCode }) => [
         `
           test.js:4
             4:       type InvalidNegDecimalE = 2.0e9n;
-                                               ^^^^^^ Invalid bigint literal
+                                               ^^^^^^ A bigint literal cannot use exponential notation
         `,
       )
   ]),
@@ -97,7 +97,7 @@ export default suite(({ addFile, addFiles, addCode }) => [
         `
           test.js:4
             4:       type InvalidNegDecimalE = -2.0e9n;
-                                               ^^^^^^^ Invalid bigint literal
+                                               ^^^^^^^ A bigint literal cannot use exponential notation
         `,
       )
   ]),
@@ -106,12 +106,12 @@ export default suite(({ addFile, addFiles, addCode }) => [
     addCode(`
       const invalid_e = 2e9n;
     `).newErrors(
-      `
+        `
           test.js:4
             4:       const invalid_e = 2e9n;
-                                       ^^^^ Invalid bigint literal
-        `
-    )
+                                       ^^^^ A bigint literal cannot use exponential notation
+        `,
+      )
   ]),
 
   test("BigInt invalid negative scientific literal", [
@@ -121,7 +121,7 @@ export default suite(({ addFile, addFiles, addCode }) => [
         `
           test.js:4
             4:       const invalid_neg_e = -2e9n;
-                                            ^^^^ Invalid bigint literal
+                                            ^^^^ A bigint literal cannot use exponential notation
         `,
       )
   ]),

--- a/src/parser/flow_lexer.ml
+++ b/src/parser/flow_lexer.ml
@@ -739,13 +739,13 @@ let token (env: Lex_env.t) lexbuf : result =
     recover env lexbuf ~f:(fun env lexbuf -> match%sedlex lexbuf with
     | scibigint ->
       let loc = loc_of_lexbuf env lexbuf in
-      let env = lex_error env loc Parse_error.InvalidBigInt in
+      let env = lex_error env loc Parse_error.InvalidSciBigInt in
       Token (env, T_BIGINT { kind = BIG_NORMAL; raw = lexeme lexbuf })
     | _ -> failwith "unreachable"
     )
   | scibigint ->
     let loc = loc_of_lexbuf env lexbuf in
-    let env = lex_error env loc Parse_error.InvalidBigInt in
+    let env = lex_error env loc Parse_error.InvalidSciBigInt in
     Token (env, T_BIGINT { kind = BIG_NORMAL; raw = lexeme lexbuf })
   | scinumber, word ->
     (* Numbers cannot be immediately followed by words *)
@@ -761,7 +761,7 @@ let token (env: Lex_env.t) lexbuf : result =
     recover env lexbuf ~f:(fun env lexbuf -> match%sedlex lexbuf with
     | floatbigint ->
       let loc = loc_of_lexbuf env lexbuf in
-      let env = lex_error env loc Parse_error.InvalidBigInt in
+      let env = lex_error env loc Parse_error.InvalidFloatBigInt in
       Token (env, T_BIGINT { kind = BIG_NORMAL; raw = lexeme lexbuf })
     | _ -> failwith "unreachable"
     )
@@ -774,7 +774,7 @@ let token (env: Lex_env.t) lexbuf : result =
     )
   | floatbigint ->
     let loc = loc_of_lexbuf env lexbuf in
-    let env = lex_error env loc Parse_error.InvalidBigInt in
+    let env = lex_error env loc Parse_error.InvalidFloatBigInt in
     Token (env, T_BIGINT { kind = BIG_NORMAL; raw = lexeme lexbuf })
   | wholebigint ->
     Token (env, T_BIGINT { kind = BIG_NORMAL; raw = lexeme lexbuf })
@@ -1668,14 +1668,14 @@ let type_token env lexbuf =
     | Opt neg, scibigint ->
       let num = lexeme lexbuf in
       let loc = loc_of_lexbuf env lexbuf in
-      let env = lex_error env loc Parse_error.InvalidBigInt in
+      let env = lex_error env loc Parse_error.InvalidSciBigInt in
       Token (env, mk_bignum_singleton BIG_NORMAL num)
     | _ -> failwith "unreachable"
     )
   | Opt neg, scibigint ->
     let num = lexeme lexbuf in
     let loc = loc_of_lexbuf env lexbuf in
-    let env = lex_error env loc Parse_error.InvalidBigInt in
+    let env = lex_error env loc Parse_error.InvalidSciBigInt in
     Token (env, mk_bignum_singleton BIG_NORMAL num)
   | Opt neg, scinumber, word ->
     (* Numbers cannot be immediately followed by words *)
@@ -1695,7 +1695,7 @@ let type_token env lexbuf =
     | Opt neg, floatbigint ->
       let num = lexeme lexbuf in
       let loc = loc_of_lexbuf env lexbuf in
-      let env = lex_error env loc Parse_error.InvalidBigInt in
+      let env = lex_error env loc Parse_error.InvalidFloatBigInt in
       Token (env, mk_bignum_singleton BIG_NORMAL num)
     | _ -> failwith "unreachable"
     )
@@ -1710,7 +1710,7 @@ let type_token env lexbuf =
   | Opt neg, floatbigint ->
     let num = lexeme lexbuf in
     let loc = loc_of_lexbuf env lexbuf in
-    let env = lex_error env loc Parse_error.InvalidBigInt in
+    let env = lex_error env loc Parse_error.InvalidFloatBigInt in
     Token (env, mk_bignum_singleton BIG_NORMAL num)
   | Opt neg, wholebigint ->
     let num = lexeme lexbuf in

--- a/src/parser/parse_error.ml
+++ b/src/parser/parse_error.ml
@@ -32,7 +32,8 @@ type t =
   | InexactInsideExact
   | InexactInsideNonObject
   | NewlineAfterThrow
-  | InvalidBigInt
+  | InvalidFloatBigInt
+  | InvalidSciBigInt
   | InvalidRegExp
   | InvalidRegExpFlags of string
   | UnterminatedRegExp
@@ -161,7 +162,8 @@ module PP =
       | InexactInsideNonObject ->
           "Explicit inexact syntax can only appear inside an object type"
       | NewlineAfterThrow ->  "Illegal newline after throw"
-      | InvalidBigInt -> "Invalid bigint literal"
+      | InvalidFloatBigInt -> "A bigint literal must be an integer"
+      | InvalidSciBigInt -> "A bigint literal cannot use exponential notation"
       | InvalidRegExp -> "Invalid regular expression"
       | InvalidRegExpFlags flags -> "Invalid flags supplied to RegExp constructor '"^flags^"'"
       | UnterminatedRegExp ->  "Invalid regular expression: missing /"

--- a/src/parser/test/flow/bigint/exponent-part.tree.json
+++ b/src/parser/test/flow/bigint/exponent-part.tree.json
@@ -2,7 +2,7 @@
   "errors":[
     {
       "loc":{"source":null,"start":{"line":1,"column":0},"end":{"line":1,"column":4}},
-      "message":"Invalid bigint literal"
+      "message":"A bigint literal cannot use exponential notation"
     }
   ],
   "type":"Program",

--- a/src/parser/test/flow/bigint/float-invalid-dot.tree.json
+++ b/src/parser/test/flow/bigint/float-invalid-dot.tree.json
@@ -2,7 +2,7 @@
   "errors":[
     {
       "loc":{"source":null,"start":{"line":1,"column":0},"end":{"line":1,"column":3}},
-      "message":"Invalid bigint literal"
+      "message":"A bigint literal must be an integer"
     }
   ],
   "type":"Program",

--- a/src/parser/test/flow/bigint/float-invalid-without-fractional-digits.tree.json
+++ b/src/parser/test/flow/bigint/float-invalid-without-fractional-digits.tree.json
@@ -2,7 +2,7 @@
   "errors":[
     {
       "loc":{"source":null,"start":{"line":1,"column":0},"end":{"line":1,"column":3}},
-      "message":"Invalid bigint literal"
+      "message":"A bigint literal must be an integer"
     }
   ],
   "type":"Program",

--- a/src/parser/test/flow/bigint/float-invalid.tree.json
+++ b/src/parser/test/flow/bigint/float-invalid.tree.json
@@ -2,7 +2,7 @@
   "errors":[
     {
       "loc":{"source":null,"start":{"line":1,"column":0},"end":{"line":1,"column":4}},
-      "message":"Invalid bigint literal"
+      "message":"A bigint literal must be an integer"
     }
   ],
   "type":"Program",

--- a/src/parser/test/flow/types/bigint_literal_invalid/migrated_0001.tree.json
+++ b/src/parser/test/flow/types/bigint_literal_invalid/migrated_0001.tree.json
@@ -2,7 +2,7 @@
   "errors":[
     {
       "loc":{"source":null,"start":{"line":1,"column":7},"end":{"line":1,"column":13}},
-      "message":"Invalid bigint literal"
+      "message":"A bigint literal must be an integer"
     }
   ],
   "type":"Program",

--- a/src/parser/test/flow/types/bigint_literal_invalid/migrated_0010.tree.json
+++ b/src/parser/test/flow/types/bigint_literal_invalid/migrated_0010.tree.json
@@ -2,7 +2,7 @@
   "errors":[
     {
       "loc":{"source":null,"start":{"line":1,"column":7},"end":{"line":1,"column":11}},
-      "message":"Invalid bigint literal"
+      "message":"A bigint literal cannot use exponential notation"
     }
   ],
   "type":"Program",


### PR DESCRIPTION
<!--
  If this is a change to library defintions, please include links to relevant documentation.
  If this is a documentation change, please prefix the title with [DOCS].

  If this is neither, ensure you opened a discussion issue and link it in the PR description.
-->
This was shamelessly copied from TypeScript