### PR TITLE
Make Function.prototype.apply arity strictly two

### DIFF
--- a/src/typing/flow_js.ml
+++ b/src/typing/flow_js.ml
@@ -5542,7 +5542,7 @@ let rec __flow cx ((l: Type.t), (u: Type.use_t)) trace =
     (*******************************************)
 
     (* resolves the arguments... *)
-    | FunProtoApplyT _,
+    | FunProtoApplyT lreason,
         CallT (use_op, reason_op, ({call_this_t = func; call_args_tlist; _} as funtype)) ->
       (* Drop the specific AST derived argument reasons. Our new arguments come
        * from arbitrary positions in the array. *)
@@ -5552,6 +5552,14 @@ let rec __flow cx ((l: Type.t), (u: Type.use_t)) trace =
           Op (FunCallMethod {op; fn; prop; args = []; local})
       | _ -> use_op
       in
+      if (List.length call_args_tlist) > 2 then begin
+        add_output cx ~trace Error_message.(ECallTypeArity {
+          call_loc = aloc_of_reason reason_op;
+          is_new = false;
+          reason_arity = lreason;
+          expected_arity = 2;
+        });
+      end;
       begin match call_args_tlist with
       (* func.apply() *)
       | [] ->

--- a/src/typing/flow_js.ml
+++ b/src/typing/flow_js.ml
@@ -5552,13 +5552,17 @@ let rec __flow cx ((l: Type.t), (u: Type.use_t)) trace =
           Op (FunCallMethod {op; fn; prop; args = []; local})
       | _ -> use_op
       in
-      if (List.length call_args_tlist) > 2 then begin
-        add_output cx ~trace Error_message.(ECallTypeArity {
-          call_loc = aloc_of_reason reason_op;
-          is_new = false;
-          reason_arity = lreason;
-          expected_arity = 2;
-        });
+      begin match call_args_tlist with
+      | [] -> ()
+      | _::_::(Arg t | SpreadArg t)::_ ->
+        Error_message.EFunctionCallExtraArg (
+          mk_reason RFunctionUnusedArgument (loc_of_t t),
+          lreason,
+          2,
+          use_op
+        )
+        |> add_output cx ~trace
+      | _ -> ()
       end;
       begin match call_args_tlist with
       (* func.apply() *)

--- a/tests/function/apply.js
+++ b/tests/function/apply.js
@@ -2,6 +2,9 @@ function test(a: string, b: number): number {
   return this.length; // expect []/"" this
 }
 
+// arity is strictly two arguments
+test.apply("", ["", 0], 'error')
+
 // tuples flow correctly into params
 test.apply("", ["", 0]);
 

--- a/tests/function/function.exp
+++ b/tests/function/function.exp
@@ -10,23 +10,37 @@ Cannot get `this.length` because:
                 ^^^^^^^^^^^
 
 References:
-   apply.js:9:12
-    9| test.apply(0, ["", 0]); // error: lookup `length` on Number
+   apply.js:12:12
+   12| test.apply(0, ["", 0]); // error: lookup `length` on Number
                   ^ [1]
-   apply.js:32:25
-   32| (test.call.apply(test, [0, 123, 'foo']): void);
+   apply.js:35:25
+   35| (test.call.apply(test, [0, 123, 'foo']): void);
                                ^ [2]
-   apply.js:37:25
-   37| (test.bind.apply(test, [0, 123]): (b: number) => number);
+   apply.js:40:25
+   40| (test.bind.apply(test, [0, 123]): (b: number) => number);
                                ^ [3]
 
 
-Error ---------------------------------------------------------------------------------------------------- apply.js:12:1
+Error ----------------------------------------------------------------------------------------------------- apply.js:6:1
+
+Cannot call function type [1] without exactly 2 type arguments.
+
+   apply.js:6:1
+     6| test.apply("", ["", 0], 'error')
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+References:
+   <BUILTINS>/core.js:120:18
+   120|     proto apply: Function$Prototype$Apply; // (thisArg: any, argArray?: any) => any
+                         ^^^^^^^^^^^^^^^^^^^^^^^^ [1]
+
+
+Error ---------------------------------------------------------------------------------------------------- apply.js:15:1
 
 Cannot call `test.apply` because function [1] requires another argument.
 
-   apply.js:12:1
-   12| test.apply("", [""]); // error: void ~> number
+   apply.js:15:1
+   15| test.apply("", [""]); // error: void ~> number
        ^^^^^^^^^^^^^^^^^^^^
 
 References:
@@ -35,12 +49,12 @@ References:
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 
-Error --------------------------------------------------------------------------------------------------- apply.js:15:21
+Error --------------------------------------------------------------------------------------------------- apply.js:18:21
 
 Cannot call `test.apply` with string bound to `b` because string [1] is incompatible with number [2].
 
-   apply.js:15:21
-   15| test.apply("", ["", ""]); // error: string ~> number (2nd arg)
+   apply.js:18:21
+   18| test.apply("", ["", ""]); // error: string ~> number (2nd arg)
                            ^^ [1]
 
 References:
@@ -49,12 +63,12 @@ References:
                                    ^^^^^^ [2]
 
 
-Error --------------------------------------------------------------------------------------------------- apply.js:16:17
+Error --------------------------------------------------------------------------------------------------- apply.js:19:17
 
 Cannot call `test.apply` with number bound to `a` because number [1] is incompatible with string [2].
 
-   apply.js:16:17
-   16| test.apply("", [0, 0]); // error: number ~> string (1st arg)
+   apply.js:19:17
+   19| test.apply("", [0, 0]); // error: number ~> string (1st arg)
                        ^ [1]
 
 References:
@@ -63,12 +77,12 @@ References:
                         ^^^^^^ [2]
 
 
-Error ---------------------------------------------------------------------------------------------------- apply.js:21:8
+Error ---------------------------------------------------------------------------------------------------- apply.js:24:8
 
 Cannot call `test.apply` with string bound to `b` because string [1] is incompatible with number [2].
 
-   apply.js:21:8
-   21| f(["", ""]); // error: string ~> number (2nd arg)
+   apply.js:24:8
+   24| f(["", ""]); // error: string ~> number (2nd arg)
               ^^ [1]
 
 References:
@@ -77,12 +91,12 @@ References:
                                    ^^^^^^ [2]
 
 
-Error ---------------------------------------------------------------------------------------------------- apply.js:22:4
+Error ---------------------------------------------------------------------------------------------------- apply.js:25:4
 
 Cannot call `test.apply` with number bound to `a` because number [1] is incompatible with string [2].
 
-   apply.js:22:4
-   22| f([0, 0]); // error: number ~> string (1st arg)
+   apply.js:25:4
+   25| f([0, 0]); // error: number ~> string (1st arg)
           ^ [1]
 
 References:
@@ -91,12 +105,12 @@ References:
                         ^^^^^^ [2]
 
 
-Error ---------------------------------------------------------------------------------------------------- apply.js:25:1
+Error ---------------------------------------------------------------------------------------------------- apply.js:28:1
 
 Cannot call `test.apply` because string [1] is incompatible with number [2].
 
-   apply.js:25:1
-    25| test.apply("", "not array"); // error: expect array of args
+   apply.js:28:1
+    28| test.apply("", "not array"); // error: expect array of args
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
@@ -108,29 +122,29 @@ References:
                                     ^^^^^^ [2]
 
 
-Error ---------------------------------------------------------------------------------------------------- apply.js:32:2
+Error ---------------------------------------------------------------------------------------------------- apply.js:35:2
 
 Cannot cast `test.call.apply(...)` to undefined because number [1] is incompatible with undefined [2].
 
-   apply.js:32:2
-   32| (test.call.apply(test, [0, 123, 'foo']): void);
+   apply.js:35:2
+   35| (test.call.apply(test, [0, 123, 'foo']): void);
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
    apply.js:1:38
     1| function test(a: string, b: number): number {
                                             ^^^^^^ [1]
-   apply.js:32:42
-   32| (test.call.apply(test, [0, 123, 'foo']): void);
+   apply.js:35:42
+   35| (test.call.apply(test, [0, 123, 'foo']): void);
                                                 ^^^^ [2]
 
 
-Error --------------------------------------------------------------------------------------------------- apply.js:32:28
+Error --------------------------------------------------------------------------------------------------- apply.js:35:28
 
 Cannot call `test.call.apply` with number bound to `a` because number [1] is incompatible with string [2].
 
-   apply.js:32:28
-   32| (test.call.apply(test, [0, 123, 'foo']): void);
+   apply.js:35:28
+   35| (test.call.apply(test, [0, 123, 'foo']): void);
                                   ^^^ [1]
 
 References:
@@ -139,12 +153,12 @@ References:
                         ^^^^^^ [2]
 
 
-Error --------------------------------------------------------------------------------------------------- apply.js:32:33
+Error --------------------------------------------------------------------------------------------------- apply.js:35:33
 
 Cannot call `test.call.apply` with string bound to `b` because string [1] is incompatible with number [2].
 
-   apply.js:32:33
-   32| (test.call.apply(test, [0, 123, 'foo']): void);
+   apply.js:35:33
+   35| (test.call.apply(test, [0, 123, 'foo']): void);
                                        ^^^^^ [1]
 
 References:
@@ -153,12 +167,12 @@ References:
                                    ^^^^^^ [2]
 
 
-Error --------------------------------------------------------------------------------------------------- apply.js:37:28
+Error --------------------------------------------------------------------------------------------------- apply.js:40:28
 
 Cannot call `test.bind.apply` with number bound to `a` because number [1] is incompatible with string [2].
 
-   apply.js:37:28
-   37| (test.bind.apply(test, [0, 123]): (b: number) => number);
+   apply.js:40:28
+   40| (test.bind.apply(test, [0, 123]): (b: number) => number);
                                   ^^^ [1]
 
 References:
@@ -167,17 +181,17 @@ References:
                         ^^^^^^ [2]
 
 
-Error --------------------------------------------------------------------------------------------------- apply.js:47:22
+Error --------------------------------------------------------------------------------------------------- apply.js:50:22
 
 Cannot call `x.apply` with number bound to `b` because number [1] is incompatible with string [2].
 
-   apply.js:47:22
-   47|   x.apply(x, ['foo', 123]); // error, number !~> string
+   apply.js:50:22
+   50|   x.apply(x, ['foo', 123]); // error, number !~> string
                             ^^^ [1]
 
 References:
-   apply.js:45:36
-   45| function test3(x: { (a: string, b: string): void }) {
+   apply.js:48:36
+   48| function test3(x: { (a: string, b: string): void }) {
                                           ^^^^^^ [2]
 
 
@@ -703,4 +717,4 @@ References:
 
 
 
-Found 51 errors
+Found 52 errors

--- a/tests/function/function.exp
+++ b/tests/function/function.exp
@@ -23,7 +23,7 @@ References:
 
 Error ----------------------------------------------------------------------------------------------------- apply.js:6:1
 
-Cannot call function type [1] without exactly 2 type arguments.
+Cannot call `test.apply` because no more than 2 arguments are expected by function type [1].
 
    apply.js:6:1
      6| test.apply("", ["", 0], 'error')


### PR DESCRIPTION
<!--
  If this is a change to library defintions, please include links to relevant documentation.
  If this is a documentation change, please prefix the title with [DOCS].

  If this is neither, ensure you opened a discussion issue and link it in the PR description.
-->

Fixes #7791, but maybe it is worth rewriting whole thing? I'm dissapointed that this isn't in core.js libdef