### PR TITLE
Add explicit `this` annotation syntax for function types

### DIFF
--- a/src/common/ty/ty.ml
+++ b/src/common/ty/ty.ml
@@ -78,6 +78,7 @@ and gen_kind =
 
 and fun_t = {
   fun_params: (string option * t * fun_param) list;
+  fun_this_param: (string option * t * fun_param) option;
   fun_rest_param: (string option * t) option;
   fun_return: t;
   fun_type_params: type_param list option;

--- a/src/common/ty/ty_printer.ml
+++ b/src/common/ty/ty_printer.ml
@@ -156,7 +156,7 @@ let type_ ?(size=5000) ?(with_comments=true) t =
         ]))
 
   and type_function ~depth ~sep
-    { fun_params; fun_rest_param; fun_return; fun_type_params } =
+    { fun_params; fun_rest_param; fun_this_param; fun_return; fun_type_params } =
     let params = counted_map (type_function_param ~depth) fun_params in
     let params = match fun_rest_param with
     | Some (name, t) -> params @ [ fuse [
@@ -164,6 +164,14 @@ let type_ ?(size=5000) ?(with_comments=true) t =
           type_function_param ~depth (name, t, { prm_optional = false })
         ]
       ]
+    | None -> params
+    in
+    let params = match fun_this_param with
+    | Some p -> [
+      fuse [
+        type_function_param ~depth p
+      ]
+    ] @ params
     | None -> params
     in
     fuse [

--- a/src/common/ty/ty_serializer.ml
+++ b/src/common/ty/ty_serializer.ml
@@ -131,6 +131,7 @@ and fun_params params rest_param =
     T.Function.Params.
     params;
     rest;
+    this = None;
   })
 
 and fun_param (name, t, {prm_optional}) =
@@ -282,6 +283,7 @@ and num_lit lit = {
 and getter t = function_ {
   fun_params = [];
   fun_rest_param = None;
+  fun_this_param = None;
   fun_return = t;
   fun_type_params = None;
 }
@@ -289,6 +291,7 @@ and getter t = function_ {
 and setter t = function_ {
   fun_params = [(None, t, {prm_optional = false})];
   fun_rest_param = None;
+  fun_this_param = None;
   fun_return = Void;
   fun_type_params = None;
 }

--- a/src/parser/estree_translator.ml
+++ b/src/parser/estree_translator.ml
@@ -1101,7 +1101,7 @@ end with type t = Impl.t) = struct
       ]
 
     and function_type (loc, { Type.Function.
-      params = (_, { Type.Function.Params.params; rest });
+      params = (_, { Type.Function.Params.params; rest; this });
       return;
       tparams;
     }) =
@@ -1109,6 +1109,7 @@ end with type t = Impl.t) = struct
         "params", array_of_list function_type_param params;
         "returnType", _type return;
         "rest", option function_type_rest rest;
+        "this", option function_type_param this;
         "typeParameters", option type_parameter_declaration tparams;
       ]
 

--- a/src/parser/flow_ast.ml
+++ b/src/parser/flow_ast.ml
@@ -111,6 +111,7 @@ and Type : sig
       type ('M, 'T) t = 'M * ('M, 'T) t'
       and ('M, 'T) t' = {
         params: ('M, 'T) Param.t list;
+        this: ('M, 'T) Param.t option;
         rest: ('M, 'T) RestParam.t option;
       }
       [@@deriving show]

--- a/src/parser/parser_env.ml
+++ b/src/parser/parser_env.ml
@@ -178,6 +178,7 @@ type env = {
   no_in                 : bool;
   no_call               : bool;
   no_let                : bool;
+  no_this               : bool;
   no_anon_function_type : bool;
   no_new                : bool;
   allow_yield           : bool;
@@ -230,6 +231,7 @@ let init_env ?(token_sink=None) ?(parse_options=None) source content =
     no_in = false;
     no_call = false;
     no_let = false;
+    no_this = true;
     no_anon_function_type = false;
     no_new = false;
     allow_yield = false;
@@ -263,6 +265,7 @@ let allow_super env = env.allow_super
 let no_in env = env.no_in
 let no_call env = env.no_call
 let no_let env = env.no_let
+let no_this env = env.no_this
 let no_anon_function_type env = env.no_anon_function_type
 let no_new env = env.no_new
 let errors env = !(env.errors)
@@ -336,6 +339,7 @@ let with_allow_yield allow_yield env = { env with allow_yield }
 let with_allow_await allow_await env = { env with allow_await }
 let with_allow_directive allow_directive env = { env with allow_directive }
 let with_allow_super allow_super env = { env with allow_super }
+let with_no_this no_this env = { env with no_this }
 let with_no_let no_let env = { env with no_let }
 let with_in_loop in_loop env = { env with in_loop }
 let with_no_in no_in env = { env with no_in }

--- a/src/parser/parser_env.mli
+++ b/src/parser/parser_env.mli
@@ -72,6 +72,7 @@ val allow_super : env -> allowed_super
 val no_in : env -> bool
 val no_call : env -> bool
 val no_let : env -> bool
+val no_this : env -> bool
 val no_anon_function_type : env -> bool
 val no_new : env -> bool
 val errors : env -> (Loc.t * Parse_error.t) list
@@ -104,6 +105,7 @@ val with_allow_await : bool -> env -> env
 val with_allow_directive : bool -> env -> env
 val with_allow_super : allowed_super -> env -> env
 val with_no_let : bool -> env -> env
+val with_no_this : bool -> env -> env
 val with_in_loop : bool -> env -> env
 val with_no_in : bool -> env -> env
 val with_no_anon_function_type : bool -> env -> env

--- a/src/parser/parser_flow.ml
+++ b/src/parser/parser_flow.ml
@@ -275,6 +275,8 @@ module rec Parse : PARSER = struct
          https://tc39.github.io/ecma262/#sec-identifiers-static-semantics-early-errors *)
       if allow_yield env then error_at env (loc, Error.UnexpectedReserved)
       else strict_error_at env (loc, Error.StrictReservedWord)
+    | "this" ->
+      if no_this env then error_at env (loc, Error.UnexpectedToken name)
     | _ when is_strict_reserved name ->
       strict_error_at env (loc, Error.StrictReservedWord)
     | _ when is_reserved name ->

--- a/src/parser_utils/flow_ast_differ.ml
+++ b/src/parser_utils/flow_ast_differ.ml
@@ -1832,18 +1832,19 @@ let program (algo : diff_algorithm)
       : node change list option =
     let open Ast.Type.Function in
     let {
-      params = (_params_loc1, { Params.params = params1; rest = rest1});
+      params = (_params_loc1, { Params.params = params1; rest = rest1; this = this1});
       return = return1; tparams = tparams1;
     } = ft1 in
     let {
-      params = (_params_loc2, { Params.params = params2; rest = rest2});
+      params = (_params_loc2, { Params.params = params2; rest = rest2; this = this2});
       return = return2; tparams = tparams2;
     } = ft2 in
     let tparams_diff = diff_if_changed_opt type_parameter_declaration tparams1 tparams2 in
     let params_diff = diff_and_recurse_no_trivial function_param_type params1 params2 in
     let rest_diff = diff_if_changed_opt function_rest_param_type rest1 rest2 in
+    let this_diff = diff_if_changed_opt function_param_type this1 this2 in
     let return_diff = diff_if_changed type_ return1 return2 |> Option.return in
-    join_diff_list [tparams_diff; params_diff; rest_diff; return_diff]
+    join_diff_list [tparams_diff; params_diff; rest_diff; this_diff; return_diff]
 
   and type_alias
       (t_alias1: (Loc.t, Loc.t) Ast.Statement.TypeAlias.t)

--- a/src/parser_utils/flow_ast_mapper.ml
+++ b/src/parser_utils/flow_ast_mapper.ml
@@ -542,17 +542,18 @@ class ['loc] mapper = object(this)
   method function_type _loc (ft: ('loc, 'loc) Ast.Type.Function.t) =
     let open Ast.Type.Function in
     let {
-      params = (params_loc, { Params.params = ps; rest = rpo });
+      params = (params_loc, { Params.params = ps; rest = rpo; this = tpo });
       return;
       tparams;
     } = ft in
     let ps' = ListUtils.ident_map this#function_param_type ps in
     let rpo' = map_opt this#function_rest_param_type rpo in
+    let tpo' = map_opt this#function_param_type tpo in
     let return' = this#type_ return in
     let tparams' = map_opt this#type_parameter_declaration tparams in
-    if ps' == ps && rpo' == rpo && return' == return && tparams' == tparams then ft
+    if ps' == ps && rpo' == rpo && tpo' == tpo && return' == return && tparams' == tparams then ft
     else {
-      params = (params_loc, { Params.params = ps'; rest = rpo' });
+      params = (params_loc, { Params.params = ps'; rest = rpo'; this = tpo' });
       return = return';
       tparams = tparams'
     }

--- a/src/parser_utils/flow_polymorphic_ast_mapper.ml
+++ b/src/parser_utils/flow_polymorphic_ast_mapper.ml
@@ -580,16 +580,17 @@ class virtual ['M, 'T, 'N, 'U] mapper = object(this)
   method function_type (ft: ('M, 'T) Ast.Type.Function.t) : ('N, 'U) Ast.Type.Function.t =
     let open Ast.Type.Function in
     let {
-      params = (params_annot, { Params.params = ps; rest = rpo });
+      params = (params_annot, { Params.params = ps; rest = rpo; this = tpo });
       return;
       tparams;
     } = ft in
     this#type_parameter_declaration_opt tparams (fun tparams' ->
       let ps' = Core_list.map ~f:this#function_param_type ps in
       let rpo' = Option.map ~f:this#function_rest_param_type rpo in
+      let tpo' = Option.map ~f:this#function_param_type tpo in
       let return' = this#type_ return in
       {
-        params = (this#on_loc_annot params_annot, { Params.params = ps'; rest = rpo' });
+        params = (this#on_loc_annot params_annot, { Params.params = ps'; rest = rpo'; this = tpo' });
         return = return';
         tparams = tparams';
       }

--- a/src/parser_utils/output/js_layout_generator.ml
+++ b/src/parser_utils/output/js_layout_generator.ml
@@ -2212,7 +2212,7 @@ and type_function_param (loc, { Ast.Type.Function.Param.
   ])
 
 and type_function ~sep { Ast.Type.Function.
-  params = (_, { Ast.Type.Function.Params.params; rest = restParams});
+  params = (_, { Ast.Type.Function.Params.params; rest = restParams; _});
   return;
   tparams;
 } =

--- a/src/parser_utils/signature_builder_generate.ml
+++ b/src/parser_utils/signature_builder_generate.ml
@@ -492,15 +492,18 @@ module T = struct
         return: little_annotation;
       } ->
       let params_loc, params, rest = params in
+      let rest = match rest with
+        | None -> None
+        | Some (loc, rest) -> Some (loc, {
+            Ast.Type.Function.RestParam.argument = param_of_type rest
+          })
+      in
       loc, {
         Ast.Type.Function.tparams;
         params = params_loc, {
           Ast.Type.Function.Params.params = Core_list.map ~f:param_of_type params;
-          rest = match rest with
-            | None -> None
-            | Some (loc, rest) -> Some (loc, {
-                Ast.Type.Function.RestParam.argument = param_of_type rest
-              })
+          rest;
+          this = None;
         };
         return = type_of_little_annotation outlined return;
       }

--- a/src/parser_utils/signature_builder_verify.ml
+++ b/src/parser_utils/signature_builder_verify.ml
@@ -189,7 +189,7 @@ module Eval(Env: EvalEnv) = struct
       let open Ast.Type.Function in
       let { tparams; params; return } = ft in
       let tps, deps = type_params tps tparams in
-      let _, { Params.params; rest; } = params in
+      let _, { Params.params; rest; _ } = params in
       let deps = List.fold_left (Deps.reduce_join (function_type_param tps)) deps params in
       let deps = match rest with
       | None -> deps

--- a/src/typing/debug_js.ml
+++ b/src/typing/debug_js.ml
@@ -1070,6 +1070,7 @@ and json_of_changeset_impl _json_cx = Hh_json.(
 and json_of_funtype json_cx = check_depth json_of_funtype_impl json_cx
 and json_of_funtype_impl json_cx {
   this_t;
+  has_explicit_this;
   params;
   rest_param;
   return_t;
@@ -1102,6 +1103,7 @@ and json_of_funtype_impl json_cx {
         | None -> []
         | Some name -> ["restParamName", JSON_String name])));
     "returnType", _json_of_t json_cx return_t;
+    "hasExplicitThis", JSON_Bool has_explicit_this;
     "isPredicate", JSON_Bool is_predicate;
     "closureIndex", int_ closure_t;
     "changeset", json_of_changeset json_cx changeset;

--- a/src/typing/flow_js.ml
+++ b/src/typing/flow_js.ml
@@ -2210,6 +2210,7 @@ let rec __flow cx ((l: Type.t), (u: Type.use_t)) trace =
         mk_reason RPrototype fun_loc |> Unsoundness.function_proto_any,
         {
           this_t = mk_reason RThis fun_loc |> MixedT.make |> with_trust bogus_trust;
+          has_explicit_this = false;
           params = [(Some "value", MixedT.at fun_loc |> with_trust bogus_trust)];
           rest_param = None;
           return_t = return_t;
@@ -7012,7 +7013,7 @@ and expand_any _cx any t =
       failwith "no any expansion defined for this case"
 
 and any_prop_to_function use_op {this_t; params; rest_param; return_t;
-    closure_t = _; is_predicate = _; changeset = _; def_reason = _;} covariant contravariant =
+    closure_t = _; is_predicate = _; changeset = _; def_reason = _; has_explicit_this = _;} covariant contravariant =
   List.iter (snd %> contravariant ~use_op) params;
   Option.iter ~f:(fun (_, _, t) -> contravariant ~use_op t) rest_param;
   contravariant ~use_op this_t;

--- a/src/typing/func_params_intf.ml
+++ b/src/typing/func_params_intf.ml
@@ -17,10 +17,12 @@ module type S = sig
   type reconstruct =
     (ALoc.t * Type.t) param_ast list ->
     (ALoc.t * Type.t) rest_ast option ->
+    (ALoc.t * Type.t) param_ast option ->
     (ALoc.t * Type.t) ast option
 
   val empty: reconstruct -> t
   val add_param: param -> t -> t
+  val add_this: param -> t -> t
   val add_rest: rest -> t -> t
 
   val value: t -> Type.fun_param list

--- a/src/typing/func_sig.ml
+++ b/src/typing/func_sig.ml
@@ -33,7 +33,7 @@ let default_constructor reason = {
   kind = Ctor;
   tparams = None;
   tparams_map = SMap.empty;
-  fparams = F.empty (fun _ _ -> None);
+  fparams = F.empty (fun _ _ _ -> None);
   body = None;
   return_t = VoidT.why reason |> with_trust bogus_trust;
   (* This can't be directly recursively called. In case this type is accidentally used downstream,
@@ -46,7 +46,7 @@ let field_initializer tparams_map reason expr return_t = {
   kind = FieldInit expr;
   tparams = None;
   tparams_map;
-  fparams = F.empty (fun _ _ -> None);
+  fparams = F.empty (fun _ _ _ -> None);
   body = None;
   return_t;
   (* This can't be recursively called. In case this type is accidentally used downstream, stub it
@@ -99,6 +99,7 @@ let functiontype cx this_t {reason; kind; tparams; fparams; return_t; knot; _} =
     closure_t = Env.peek_frame ();
     changeset = Env.retrieve_closure_changeset ();
     def_reason = reason;
+    has_explicit_this = false;
   } in
   let t = DefT (reason, make_trust (), FunT (static, prototype, funtype)) in
   let t = poly_type_of_tparams (Context.make_nominal cx) tparams t in

--- a/src/typing/resolvableTypeJob.ml
+++ b/src/typing/resolvableTypeJob.ml
@@ -157,8 +157,8 @@ and collect_of_type ?log_unresolved cx reason acc = function
     | Some id -> (Context.find_call cx id)::ts
     in
     collect_of_types ?log_unresolved cx reason acc ts
-  | DefT (_, _, FunT (_, _, { params; return_t; _ })) ->
-    let ts = List.fold_left (fun acc (_, t) -> t::acc) [return_t] params in
+  | DefT (_, _, FunT (_, _, { params; return_t; this_t; _ })) ->
+    let ts = List.fold_left (fun acc (_, t) -> t::acc) [return_t; this_t] params in
     collect_of_types ?log_unresolved cx reason acc ts
   | DefT (_, _, ArrT (ArrayAT (elemt, tuple_types))) ->
     let ts = Option.value ~default:[] tuple_types in
@@ -311,7 +311,7 @@ and collect_of_use ?log_unresolved cx reason acc = function
 | CallT (_, _, fct) ->
   let arg_types =
     Core_list.map ~f:(function Arg t | SpreadArg t -> t) fct.call_args_tlist in
-  collect_of_types ?log_unresolved cx reason acc (arg_types @ [fct.call_tout])
+  collect_of_types ?log_unresolved cx reason acc (arg_types @ [fct.call_tout; fct.call_this_t])
 | GetPropT (_, _, _, t_out) ->
   collect_of_type ?log_unresolved cx reason acc t_out
 | _ -> acc

--- a/src/typing/statement.ml
+++ b/src/typing/statement.ml
@@ -6727,7 +6727,7 @@ and mk_func_sig =
   in
 
   let mk_params cx tparams_map (loc, { Ast.Function.Params.params; rest })  =
-    let fparams = Func_stmt_params.empty (fun params rest ->
+    let fparams = Func_stmt_params.empty (fun params rest _ ->
       Some (loc, { Ast.Function.Params.params; rest })
     ) in
     let fparams = List.fold_left (fun acc param ->
@@ -6874,7 +6874,7 @@ and declare_function_to_function_declaration cx declare_loc func_decl =
   | Some (loc, Ast.Type.Predicate.Declared e) -> begin
       match annot with
       | (annot_loc, (func_annot_loc, Ast.Type.Function
-        { Ast.Type.Function.params = (params_loc, { Ast.Type.Function.Params.params; rest });
+        { Ast.Type.Function.params = (params_loc, { Ast.Type.Function.Params.params; rest; _ });
           Ast.Type.Function.return;
           Ast.Type.Function.tparams;
         })) ->
@@ -6960,7 +6960,7 @@ and declare_function_to_function_declaration cx declare_loc func_decl =
                 annot_loc, (
                   (func_annot_loc, fun_type),
                   Ast.Type.Function { Ast.Type.Function.
-                    params = params_loc, { Ast.Type.Function.Params.params; rest; };
+                    params = params_loc, { Ast.Type.Function.Params.params; rest; this = None };
                     return;
                     tparams;
                   }

--- a/src/typing/type.ml
+++ b/src/typing/type.ml
@@ -804,6 +804,7 @@ module rec TypeTerm : sig
     rest_param: fun_rest_param option;
     return_t: t;
     closure_t: int;
+    has_explicit_this: bool;
     is_predicate: bool;
     changeset: Changeset.t;
     def_reason: Reason.t;
@@ -3523,6 +3524,7 @@ let mk_methodtype
     this tins ~rest_param ~def_reason
     ?(frame=0) ?params_names ?(is_predicate=false) tout = {
   this_t = this;
+  has_explicit_this = false;
   params = (
     match params_names with
     | None -> Core_list.map ~f:(fun t -> None, t) tins

--- a/src/typing/type_mapper.ml
+++ b/src/typing/type_mapper.ml
@@ -287,6 +287,7 @@ class virtual ['a] t = object(self)
     else {exports_tmap = exports_tmap'; cjs_export = cjs_export'; has_every_named_export}
 
   method fun_type cx map_cx ({ this_t;
+                       has_explicit_this;
                        params;
                        rest_param;
                        return_t;
@@ -315,7 +316,7 @@ class virtual ['a] t = object(self)
       let return_t = return_t' in
       let params = params' in
       let rest_param = rest_param' in
-      {this_t; params; rest_param; return_t;
+      {this_t; has_explicit_this; params; rest_param; return_t;
        closure_t; is_predicate; changeset; def_reason}
 
   method inst_type cx map_cx i =

--- a/src/typing/type_visitor.ml
+++ b/src/typing/type_visitor.ml
@@ -744,6 +744,7 @@ class ['a] t = object(self)
       is_predicate = _;
       changeset = _;
       def_reason = _;
+      has_explicit_this = _;
     } = ft in
     let acc = self#type_ cx pole acc this_t in
     let acc = self#list (fun acc (_, t) -> self#type_ cx (P.inv pole) acc t) acc params in

--- a/tests/function/function.exp
+++ b/tests/function/function.exp
@@ -702,5 +702,84 @@ References:
                                  ^^^^^ [2]
 
 
+Error ------------------------------------------------------------------------------------------ this_annot_type.js:11:4
 
-Found 51 errors
+Cannot cast `this.foo` to string because number [1] is incompatible with string [2].
+
+   this_annot_type.js:11:4
+   11|   (this.foo: string); // error
+          ^^^^^^^^
+
+References:
+   this_annot_type.js:4:8
+    4|   foo: number
+              ^^^^^^ [1]
+   this_annot_type.js:11:14
+   11|   (this.foo: string); // error
+                    ^^^^^^ [2]
+
+
+Error ------------------------------------------------------------------------------------------ this_annot_type.js:17:4
+
+Cannot cast `this` to string because `T` [1] is incompatible with string [2].
+
+   this_annot_type.js:17:4
+   17|   (this: string); // error
+          ^^^^
+
+References:
+   this_annot_type.js:14:18
+   14| type F1 = (this: T, foo: number) => void
+                        ^ [1]
+   this_annot_type.js:17:10
+   17|   (this: string); // error
+                ^^^^^^ [2]
+
+
+Error ------------------------------------------------------------------------------------------ this_annot_type.js:19:4
+
+Cannot cast `foo` to string because number [1] is incompatible with string [2].
+
+   this_annot_type.js:19:4
+   19|   (foo: string); // error
+          ^^^
+
+References:
+   this_annot_type.js:14:26
+   14| type F1 = (this: T, foo: number) => void
+                                ^^^^^^ [1]
+   this_annot_type.js:19:9
+   19|   (foo: string); // error
+               ^^^^^^ [2]
+
+
+Error ------------------------------------------------------------------------------------------ this_annot_type.js:24:1
+
+Cannot call `f2` because property `foo` is missing in global object [1] but exists in `T` [2].
+
+   this_annot_type.js:24:1
+   24| f2(); // error
+       ^^^^ [1]
+
+References:
+   this_annot_type.js:22:27
+   22| declare function f2(this: T): void;
+                                 ^ [2]
+
+
+Error ------------------------------------------------------------------------------------------ this_annot_type.js:25:9
+
+null [1] is incompatible with `T` [2].
+
+   this_annot_type.js:25:9
+   25| f2.bind(null) // error
+               ^^^^ [1]
+
+References:
+   this_annot_type.js:22:27
+   22| declare function f2(this: T): void;
+                                 ^ [2]
+
+
+
+Found 56 errors

--- a/tests/function/function.exp
+++ b/tests/function/function.exp
@@ -560,6 +560,31 @@ References:
                   ^^^^^^ [2]
 
 
+Error ----------------------------------------------------------------------------------------------- issue-2812.js:14:1
+
+Cannot call `bar.join` because in type argument `T` [1]:
+ - Either object type [2] is incompatible with number [3].
+ - Or object type [2] is incompatible with string [4].
+
+   issue-2812.js:14:1
+   14| bar.join(',') // should error, nothing happens
+       ^^^^^^^^^^^^^
+
+References:
+   issue-2812.js:3:23
+    3| declare class MyArray<T> {
+                             ^ [1]
+   issue-2812.js:12:26
+   12| declare var bar: MyArray<{| a: number |}>;
+                                ^^^^^^^^^^^^^^^ [2]
+   issue-2812.js:5:14
+    5|   +join: <U: number | string>(this: MyArray<U>, separator?: string) => string;
+                    ^^^^^^ [3]
+   issue-2812.js:5:23
+    5|   +join: <U: number | string>(this: MyArray<U>, separator?: string) => string;
+                             ^^^^^^ [4]
+
+
 Error ------------------------------------------------------------------------------------------------ issue-7529.js:4:7
 
 Cannot call `foo` with `123` bound to `x` because number [1] is incompatible with string [2].
@@ -782,4 +807,4 @@ References:
 
 
 
-Found 56 errors
+Found 57 errors

--- a/tests/function/issue-1086.js
+++ b/tests/function/issue-1086.js
@@ -1,0 +1,15 @@
+// @flow
+
+declare class MyArray<T> {
+  // TODO: support methods
+  // this one is actually works better if implemented with $Call
+  +sort:
+    & ((this: MyArray<number>, compareFn: (a: T, b: T) => number) => Array<T>)
+    & ((compareFn?: (a: T, b: T) => number) => Array<T>);
+}
+
+declare var foo: MyArray<number>;
+foo.sort(); // should error, nothing happens
+
+declare var bar: MyArray<string>;
+bar.sort(); // ok

--- a/tests/function/issue-2812.js
+++ b/tests/function/issue-2812.js
@@ -1,0 +1,14 @@
+// @flow
+
+declare class MyArray<T> {
+  // TODO: support methods
+  +join: <U: number | string>(this: MyArray<U>, separator?: string) => string;
+}
+
+declare var foo: MyArray<number>;
+
+foo.join(',') // ok
+
+declare var bar: MyArray<{| a: number |}>;
+
+bar.join(',') // should error, nothing happens

--- a/tests/function/issue-2812.js
+++ b/tests/function/issue-2812.js
@@ -11,4 +11,4 @@ foo.join(',') // ok
 
 declare var bar: MyArray<{| a: number |}>;
 
-bar.join(',') // should error, nothing happens
+bar.join(',') // error, object ~> number | string

--- a/tests/function/this_annot_type.js
+++ b/tests/function/this_annot_type.js
@@ -1,0 +1,27 @@
+// @flow
+
+type T = {
+  foo: number
+}
+
+type F = (this: T) => void
+
+const f: F = function () {
+  (this.foo: number); // ok
+  (this.foo: string); // error
+}
+
+type F1 = (this: T, foo: number) => void
+
+const f1: F1 = function (foo) {
+  (this: string); // error
+  (foo: number); // ok
+  (foo: string); // error
+}
+
+declare function f2(this: T): void;
+
+f2(); // error
+f2.bind(null) // error
+f2.call({foo: 1}) // ok
+f2.apply({foo: 1}, []) // ok


### PR DESCRIPTION
<!--
  If this is a change to library defintions, please include links to relevant documentation.
  If this is a documentation change, please prefix the title with [DOCS].

  If this is neither, ensure you opened a discussion issue and link it in the PR description.
-->

Fixes #452 
This implements it only for types and declares, doesn't work on statements and expressions