### PR TITLE
Add String.prototype.matchAll

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -86,6 +86,7 @@ declare class $SymbolHasInstance mixins Symbol {}
 declare class $SymboIsConcatSpreadable mixins Symbol {}
 declare class $SymbolIterator mixins Symbol {}
 declare class $SymbolMatch mixins Symbol {}
+declare class $SymbolMatchAll mixins Symbol {}
 declare class $SymbolReplace mixins Symbol {}
 declare class $SymbolSearch mixins Symbol {}
 declare class $SymbolSpecies mixins Symbol {}
@@ -104,6 +105,7 @@ declare class Symbol {
   static keyFor(sym: Symbol): ?string;
   static length: 0;
   static match: $SymbolMatch;
+  static matchAll: $SymbolMatchAll;
   static replace: $SymbolReplace;
   static search: $SymbolSearch;
   static species: $SymbolSpecies;
@@ -322,6 +324,7 @@ declare class String {
     link(href: string): string;
     localeCompare(that: string, locales?: string | Array<string>, options?: Intl$CollatorOptions): number;
     match(regexp: string | RegExp): RegExp$matchResult | null;
+    matchAll(regexp: string | RegExp): Iterator<RegExp$matchResult>;
     normalize(format?: string): string;
     padEnd(targetLength: number, padString?: string): string;
     padStart(targetLength: number, padString?: string): string;
@@ -364,10 +367,12 @@ declare class RegExp {
     lastIndex: number;
     multiline: boolean;
     source: string;
-    sticky: bool;
-    unicode: bool;
+    sticky: boolean;
+    unicode: boolean;
+    dotAll: boolean;
     test(string: string): boolean;
     toString(): string;
+    +[key: $SymbolMatchAll]: (str: string) => Iterator<RegExp$matchResult>
 }
 
 declare class Date {


### PR DESCRIPTION
<!--
  If this is a change to library defintions, please include links to relevant documentation.
  If this is a documentation change, please prefix the title with [DOCS].

  If this is neither, ensure you opened a discussion issue and link it in the PR description.
-->

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/@@matchAll
https://developer.mozilla.org/ru/docs/Web/JavaScript/Reference/Global_Objects/String/matchAll
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/matchAll