### PR TITLE
[LSP] fix range in completion response

### DIFF
--- a/newtests/lsp/completion/test.js
+++ b/newtests/lsp/completion/test.js
@@ -130,9 +130,9 @@ export default suite(
                 },
                 {
                   label: 'aUnion',
-                  kind: 6,
-                  detail: 'number',
-                  inlineDetail: 'number',
+                  kind: 13,
+                  detail: 'type aUnion = "a" | "b"',
+                  inlineDetail: 'type aUnion = "a" | "b"',
                   insertTextFormat: 1,
                 },
                 {
@@ -223,8 +223,8 @@ export default suite(
                   insertTextFormat: 2,
                   textEdit: {
                     range: {
-                      start: {line: 9, character: 14},
-                      end: {line: 9, character: 16},
+                      start: { line: 9, character: 15 },
+                      end: { line: 9, character: 15 }
                     },
                     newText: 'foo()',
                   },
@@ -245,8 +245,8 @@ export default suite(
                   insertTextFormat: 2,
                   textEdit: {
                     range: {
-                      start: {line: 9, character: 14},
-                      end: {line: 9, character: 16},
+                      start: { line: 9, character: 15 },
+                      end: { line: 9, character: 15 }
                     },
                     newText: 'aFunction(${1:arg1}, ${2:arg2})',
                   },

--- a/src/commands/autocompleteCommand.ml
+++ b/src/commands/autocompleteCommand.ml
@@ -95,7 +95,7 @@ let main base_flags option_values json pretty root strip_root wait_for_recheck a
     | Ok completions ->
       List.iter (fun res ->
         let name = res.ServerProt.Response.res_name in
-        let ty = res.ServerProt.Response.res_ty in
+        let (_ty_loc, ty) = res.ServerProt.Response.res_ty in
         print_endline (Printf.sprintf "%s %s" name ty)
       ) completions
   )

--- a/src/server/command_handler/commandHandler.ml
+++ b/src/server/command_handler/commandHandler.ml
@@ -1072,7 +1072,7 @@ let handle_persistent_autocomplete_lsp ~options ~id ~params ~loc ~metadata ~clie
       let metadata = with_data ~extra_data metadata in
       begin match result with
         | Ok items ->
-          let items = Core_list.map ~f: (Flow_lsp_conversions.flow_completion_to_lsp line char is_snippet_supported) items in
+          let items = Core_list.map ~f: (Flow_lsp_conversions.flow_completion_to_lsp is_snippet_supported) items in
           let r = CompletionResult { Lsp.Completion.isIncomplete = false; items; } in
           let response = ResponseMessage (id, r) in
           Lwt.return (LspResponse (Ok ((), Some response, metadata)))

--- a/src/server/protocol/serverProt.ml
+++ b/src/server/protocol/serverProt.ml
@@ -148,7 +148,7 @@ module Response = struct
   (* Results ready to be displayed to the user *)
   type complete_autocomplete_result = {
       res_loc      : Loc.t;
-      res_ty       : string;
+      res_ty       : Loc.t * string;
       res_kind     : Lsp.Completion.completionItemKind option;
       res_name     : string;
       func_details : func_details_result option;

--- a/src/services/autocomplete/autocompleteService_js.ml
+++ b/src/services/autocomplete/autocompleteService_js.ml
@@ -21,6 +21,17 @@ let add_autocomplete_token contents line column =
     ) else line_str
   )
 
+(* the autocomplete token inserts `suffix_len` characters, which are included
+ * in `ac_loc` returned by `Autocomplete_js`. They need to be removed before
+ * showing `ac_loc` to the client. *)
+let remove_autocomplete_token_from_loc loc =
+    let open Loc in
+    { loc with
+      _end = { loc._end with
+        column = loc._end.column - Autocomplete_js.suffix_len;
+      };
+    }
+
 let autocomplete_result_to_json ~strip_root result =
   let func_param_to_json param =
     Hh_json.JSON_Object [
@@ -37,12 +48,26 @@ let autocomplete_result_to_json ~strip_root result =
      | None -> Hh_json.JSON_Null
   in
   let name = result.res_name in
-  let ty = result.res_ty in
+  let (ty_loc, ty) = result.res_ty in
+
+  (* This is deprecated for two reasons:
+   *   1) The props are still our legacy, flat format rather than grouped into
+   *      "loc" and "range" properties.
+   *   2) It's the location of the definition of the type (the "type loc"),
+   *      which may be interesting but should be its own field. The loc should
+   *      instead be the range to replace (usually but not always the token
+   *      being completed; perhaps we also want to replace the whole member
+   *      expression, for example). That's `result.res_loc`, but we're not
+   *      exposing it in the legacy `flow autocomplete` or `flow ide` APIs; use
+   *      LSP instead.
+   *)
+  let deprecated_loc = Errors.deprecated_json_props_of_loc ~strip_root ty_loc in
+
   Hh_json.JSON_Object (
     ("name", Hh_json.JSON_String name) ::
     ("type", Hh_json.JSON_String ty) ::
     ("func_details", func_details_to_json result.func_details) ::
-    (Errors.deprecated_json_props_of_loc ~strip_root result.res_loc)
+    deprecated_loc
   )
 
 let autocomplete_response_to_json ~strip_root response =
@@ -79,8 +104,8 @@ let lsp_completion_of_type (ty: Ty.t) =
       Utility _ | Mu _
     ) ->  Some Variable
 
-let autocomplete_create_result ((name, loc), ty) =
-  let res_ty = Ty_printer.string_of_t ~with_comments:false ty in
+let autocomplete_create_result ((name, loc), (ty, ty_loc)) =
+  let res_ty = ty_loc, Ty_printer.string_of_t ~with_comments:false ty in
   let res_kind = lsp_completion_of_type ty in
   Ty.(match ty with
   | Fun {fun_params; fun_rest_param; fun_return; _} ->
@@ -125,7 +150,7 @@ let autocomplete_filter_members members =
 let autocomplete_member
     ~exclude_proto_members ~ac_type
     cx file_sig typed_ast this ac_name ac_loc docblock =
-  let ac_loc = ALoc.to_loc_exn ac_loc in
+  let ac_loc = ALoc.to_loc_exn ac_loc |> remove_autocomplete_token_from_loc in
   let this_t = Members.resolve_type cx this in
   (* Resolve primitive types to their internal class type. We do this to allow
      autocompletion on these too. *)
@@ -175,7 +200,7 @@ let autocomplete_member
     |> SMap.values
     |> Ty_normalizer.from_types ~options ~genv
     |> Core_list.filter_map ~f:(function
-     | l, Ok s -> Some (l, s)
+     | (name, ty_loc), Ok ty -> Some ((name, ac_loc), (ty, ty_loc))
      | _ -> None
      )
     |> Core_list.map ~f:autocomplete_create_result
@@ -184,7 +209,8 @@ let autocomplete_member
 
 
 (* env is all visible bound names at cursor *)
-let autocomplete_id cx file_sig env typed_ast =
+let autocomplete_id cx ac_loc file_sig env typed_ast =
+  let ac_loc = ALoc.to_loc_exn ac_loc |> remove_autocomplete_token_from_loc in
   let result = SMap.fold (fun name entry acc ->
     (* Filter out internal environment variables except for this and
        super. *)
@@ -193,7 +219,7 @@ let autocomplete_id cx file_sig env typed_ast =
     if not (is_this || is_super) && Reason.is_internal_name name
     then acc
     else (
-      let (loc, name) =
+      let (ty_loc, name) =
         (* renaming of this/super *)
         if is_this
         then (Loc.none, "this")
@@ -217,7 +243,7 @@ let autocomplete_id cx file_sig env typed_ast =
       let genv = Ty_normalizer_env.mk_genv ~full_cx:cx ~file ~typed_ast ~file_sig in
       let type_ = Scope.Entry.actual_type entry in
       match Ty_normalizer.from_type ~options ~genv type_ with
-      | Ok t -> autocomplete_create_result ((name, loc), t) :: acc
+      | Ok ty -> autocomplete_create_result ((name, ac_loc), (ty, ty_loc)) :: acc
       | Error _ -> acc
     )
   ) env [] in
@@ -245,8 +271,8 @@ let autocomplete_jsx cx file_sig typed_ast cls ac_name ac_loc docblock = Flow_js
 let autocomplete_get_results cx file_sig typed_ast state docblock =
   let file_sig = File_sig.abstractify_locs file_sig in
   match !state with
-  | Some { ac_type = Acid (env); _; } ->
-    autocomplete_id cx file_sig env typed_ast
+  | Some { ac_loc; ac_type = Acid (env); _; } ->
+    autocomplete_id cx ac_loc file_sig env typed_ast
   | Some { ac_name; ac_loc; ac_type = Acmem (this); } ->
     autocomplete_member ~exclude_proto_members:false ~ac_type:"Acmem"
       cx file_sig typed_ast this ac_name ac_loc docblock


### PR DESCRIPTION
the range in a TextEdit needs to point to the whole range to replace. when we send back a TextEdit in a completion response, it was just the cursor position (ish?). So if you're completing `foo.ba|` and we return `bar()`, the range needs to cover all of `ba` so that it gets replaced.