### PR TITLE
Add ounit to opam file

### DIFF
--- a/opam
+++ b/opam
@@ -14,6 +14,7 @@ depends: [
   "dtoa" {>= "0.3.1"}
   "ocamlbuild" {build}
   "ocamlfind" {build}
+  "ounit" {with-test}
   "core_kernel" {= "v0.11.1"}
   "sedlex" {= "1.99.4"}
   "lwt" {>= "3.3.0"}


### PR DESCRIPTION
`make ounit-tests` runs tests via ounit, so we need to install it.

`opam install . --deps-only --with-test` will install it; leaving off `--with-test` will not (if you were just installing flow,  not developing it)