### PR TITLE
Fix appveyor opam2 build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,6 +8,7 @@ environment:
       FORK_USER: ocaml
       FORK_BRANCH: master
       CYG_ROOT: C:\cygwin64
+      PACKAGE: flowtype-ci
       TESTS: false
       INSTALL: false
       DEPOPTS: false

--- a/resources/appveyor/build.sh
+++ b/resources/appveyor/build.sh
@@ -9,14 +9,11 @@ pwd
 # print opam config
 opam config list
 
-eval $(opam config env)
+eval $(opam env)
 
 # print ocaml config
 ocamlc -config
 
 cd "${APPVEYOR_BUILD_FOLDER}"
-opam pin add flowtype-ci . -n
-opam depext -u flowtype-ci
-opam install flowtype-ci --deps-only
 make all
 make -C src/parser/ ../../_build/src/parser/test/run_tests.native


### PR DESCRIPTION
the appveyor setup script automatically pins `.` and installs its deps, so we don't need to do it again. further, doing it ourselves was failing because it seemed to think that `.` was a git repo instead of a directory:

```
[00:14:56] Package flowtype-ci does not exist, create as a NEW package? [Y/n] y
[00:14:56] [flowtype-ci.~dev: git]
[00:14:56] [flowtype-ci.~dev: git]
[00:14:56] [flowtype-ci.~dev: git]
[00:14:56] [flowtype-ci.~dev: git]
[00:14:56] [flowtype-ci.~dev: git]
[00:14:56] [flowtype-ci.~dev: git]
[00:14:57] [flowtype-ci.~dev: git]
[00:14:57] [ERROR] Could not synchronize C:/cygwin64/home/appveyor/.opam/ocaml-variants.4.05.0+mingw64c/.opam-switch/sources/flowtype-ci from "git+file://C:/projects/flow#HEAD":
[00:14:57]         "C:\\cygwin64\\bin\\git.exe fetch -q" exited with code 128
[00:14:57] [ERROR] Error getting source from git+file://C:/projects/flow#HEAD:
[00:14:57]           - git+file://C:/projects/flow#HEAD
```