### PR TITLE
[hack] include header for gettimeofday on Windows

### DIFF
--- a/hack/heap/hh_shared.c
+++ b/hack/heap/hh_shared.c
@@ -102,12 +102,12 @@
 #include <sys/resource.h>
 #include <sys/stat.h>
 #include <sys/syscall.h>
-#include <sys/time.h>
 #include <sys/types.h>
 #include <unistd.h>
 #endif
 
 #include <lz4.h>
+#include <sys/time.h>
 #include <time.h>
 
 #ifndef NO_SQLITE3


### PR DESCRIPTION
building under mingw on windows, we have to include sys/time.h for gettimeofday. it doesn't even exist according to MSDN.