### PR TITLE
Add Element and Window scroll methods

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -121,6 +121,12 @@ declare type ShadowRootInit = {
        ...
 }
 
+declare type ScrollToOptions = {
+  top?: number;
+  left?: number;
+  behavior?: 'auto' | 'smooth';
+}
+
 type EventHandler = (event: Event) => mixed
 type EventListener = { handleEvent: EventHandler, ... } | EventHandler
 type MouseEventHandler = (event: MouseEvent) => mixed
@@ -1478,6 +1484,12 @@ declare class Element extends Node implements Animatable {
          inline?: ('start' | 'center' | 'end' | 'nearest'),
          ...
   })): void;
+  scroll(x: number, y: number): void;
+  scroll(options: ScrollToOptions): void;
+  scrollTo(x: number, y: number): void;
+  scrollTo(options: ScrollToOptions): void;
+  scrollBy(x: number, y: number): void;
+  scrollBy(options: ScrollToOptions): void;
   setAttribute(name?: string, value?: string): void;
   toggleAttribute(name?: string, force?: boolean): void;
   setAttributeNS(namespaceURI: string | null, qualifiedName: string, value: string): void;
@@ -3957,6 +3969,12 @@ declare var status: string;
 declare var top: WindowProxy;
 declare function getSelection(): Selection | null;
 declare var customElements: CustomElementRegistry;
+declare function scroll(x: number, y: number): void;
+declare function scroll(options: ScrollToOptions): void;
+declare function scrollTo(x: number, y: number): void;
+declare function scrollTo(options: ScrollToOptions): void;
+declare function scrollBy(x: number, y: number): void;
+declare function scrollBy(options: ScrollToOptions): void;
 
 /* Notification */
 type NotificationPermission = 'default' | 'denied' | 'granted';


### PR DESCRIPTION
All of this is just copied from https://github.com/facebook/flow/pull/7462, it's unclear why that PR was closed.

>`(Window|Element).scroll(To|By)?` are a set of functions for managing browser window and element scroll.
>
>MDN documentation -
>
>ScrollToOptions interface - https://developer.mozilla.org/en-US/docs/Web/API/ScrollToOptions
>`Window.scroll()` - https://developer.mozilla.org/en-US/docs/Web/API/Window/scroll
>`Window.scrollBy()` - https://developer.mozilla.org/en-US/docs/Web/API/Window/scrollBy
>`Element.scroll()` - https://developer.mozilla.org/en-US/docs/Web/API/Element/scroll
>`Element.scrollBy()` - https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollBy
>From testing -
>
>With `(x: number, y: number)`, both params are required.
>With `(options: ScrollToOptions)`, none of the properties are required.
>Any number in both cases can be null or undefined or even a string, in which case the browser will attempt to cast it to a number, although I don't think typing it that way is a good idea