### PR TITLE
Re-sync with internal repository

### DIFF
--- a/hack/fsnotify/dune
+++ b/hack/fsnotify/dune
@@ -1,0 +1,16 @@
+(* -*- tuareg -*- *)
+
+let () =
+  let system = List.assoc "system" Jbuild_plugin.V1.ocamlc_config in
+  let fsnotify_impl= match system with
+  | "macosx" -> "fsnotify_Darwin"
+  | "linux" -> "fsnotify_Linux"
+  | x -> "fsnotify_"^x
+  in
+  Printf.ksprintf Jbuild_plugin.V1.send "\
+
+(library
+  (name fsnotify)
+  (wrapped false)
+  (libraries %s))
+" fsnotify_impl

--- a/hack/injection/dune
+++ b/hack/injection/dune
@@ -1,0 +1,4 @@
+(library
+  (name injector_config)
+  (wrapped false)
+  (virtual_modules injector_config))


### PR DESCRIPTION
The internal and external repositories are out of sync. This attempts to brings them back in sync by patching the GitHub repository. Please carefully review this patch. You must disable ShipIt for your project in order to merge this pull request. DO NOT IMPORT this pull request. Instead, merge it directly on GitHub using the MERGE BUTTON. Re-enable ShipIt after merging.