### PR TITLE
[DOCS] Updated compiler-babel.md

### DIFF
--- a/website/en/docs/_install/compiler-babel.md
+++ b/website/en/docs/_install/compiler-babel.md
@@ -2,7 +2,7 @@
 support for Flow. Babel will take your Flow code and strip out any type
 annotations.
 
-First install `babel-cli` and `babel-preset-flow` with either
+First install `babel-cli` and `@babel/preset-flow` with either
 [Yarn](https://yarnpkg.com/) or [npm](https://www.npmjs.com/).
 
 ```sh
@@ -14,7 +14,7 @@ Next you need to create a `.babelrc` file at the root of your project with
 
 ```json
 {
-  "presets": ["flow"]
+  "presets": ["@babel/preset-flow"]
 }
 ```
 


### PR DESCRIPTION
updated how to install babel presets to use the newer namespace conventions.
my react application kept crashing due to the conflict in my babel version `"@babel/core": "^7.4.0"`

<!--
  If this is a change to library defintions, please include links to relevant documentation.
  If this is a documentation change, please prefix the title with [DOCS].

  If this is neither, ensure you opened a discussion issue and link it in the PR description.
-->