### PR TITLE
Add $TupleReduce destructor

### DIFF
--- a/src/common/reason.ml
+++ b/src/common/reason.ml
@@ -132,7 +132,8 @@ type 'loc virtual_reason_desc =
   | RNoSuper
   | RDummyPrototype
   | RDummyThis
-  | RReduce
+  | RTupleReduce
+  | RUnionReduce
   | RObjectReduce
   | RTupleMap
   | RObjectMap
@@ -292,7 +293,7 @@ let rec map_desc_locs f = function
   | RNoSuper
   | RDummyPrototype
   | RDummyThis
-  | RReduce
+  | RTupleReduce
   | RObjectReduce
   | RTupleMap
   | RObjectMap
@@ -654,7 +655,7 @@ let rec string_of_desc = function
   | RNoSuper -> "empty super object"
   | RDummyPrototype -> "empty prototype object"
   | RDummyThis -> "bound `this` in method"
-  | RReduce -> "`$Reduce`"
+  | RTupleReduce -> "`$TupleReduce`"
   | RObjectReduce -> "`$ObjReduce`"
   | RTupleMap -> "`$TupleMap`"
   | RObjectMap -> "`$ObjMap`"
@@ -857,7 +858,7 @@ let is_constant_reason r =
 
 let is_typemap_reason r =
   match desc_of_reason r with
-  | RReduce
+  | RTupleReduce
   | RTupleMap
   | RObjectMap
   | RObjectMapi -> true
@@ -865,7 +866,7 @@ let is_typemap_reason r =
 
 let is_calltype_reason r =
   match desc_of_reason r with
-  | RReduce
+  | RTupleReduce
   | RTupleMap
   | RObjectMap
   | RObjectMapi
@@ -1332,7 +1333,7 @@ let classification_of_reason r = match desc_of_reason ~unwrap:true r with
 | RNoSuper
 | RDummyPrototype
 | RDummyThis
-| RReduce
+| RTupleReduce
 | RObjectReduce
 | RTupleMap
 | RObjectMap

--- a/src/common/reason.ml
+++ b/src/common/reason.ml
@@ -133,6 +133,7 @@ type 'loc virtual_reason_desc =
   | RDummyPrototype
   | RDummyThis
   | RReduce
+  | RObjectReduce
   | RTupleMap
   | RObjectMap
   | RObjectMapi
@@ -292,6 +293,7 @@ let rec map_desc_locs f = function
   | RDummyPrototype
   | RDummyThis
   | RReduce
+  | RObjectReduce
   | RTupleMap
   | RObjectMap
   | RType _
@@ -653,6 +655,7 @@ let rec string_of_desc = function
   | RDummyPrototype -> "empty prototype object"
   | RDummyThis -> "bound `this` in method"
   | RReduce -> "`$Reduce`"
+  | RObjectReduce -> "`$ObjReduce`"
   | RTupleMap -> "`$TupleMap`"
   | RObjectMap -> "`$ObjMap`"
   | RObjectMapi -> "`$ObjMapi`"
@@ -1330,6 +1333,7 @@ let classification_of_reason r = match desc_of_reason ~unwrap:true r with
 | RDummyPrototype
 | RDummyThis
 | RReduce
+| RObjectReduce
 | RTupleMap
 | RObjectMap
 | RObjectMapi

--- a/src/common/reason.ml
+++ b/src/common/reason.ml
@@ -133,8 +133,6 @@ type 'loc virtual_reason_desc =
   | RDummyPrototype
   | RDummyThis
   | RTupleReduce
-  | RUnionReduce
-  | RObjectReduce
   | RTupleMap
   | RObjectMap
   | RObjectMapi
@@ -294,7 +292,6 @@ let rec map_desc_locs f = function
   | RDummyPrototype
   | RDummyThis
   | RTupleReduce
-  | RObjectReduce
   | RTupleMap
   | RObjectMap
   | RType _
@@ -656,7 +653,6 @@ let rec string_of_desc = function
   | RDummyPrototype -> "empty prototype object"
   | RDummyThis -> "bound `this` in method"
   | RTupleReduce -> "`$TupleReduce`"
-  | RObjectReduce -> "`$ObjReduce`"
   | RTupleMap -> "`$TupleMap`"
   | RObjectMap -> "`$ObjMap`"
   | RObjectMapi -> "`$ObjMapi`"
@@ -1334,7 +1330,6 @@ let classification_of_reason r = match desc_of_reason ~unwrap:true r with
 | RDummyPrototype
 | RDummyThis
 | RTupleReduce
-| RObjectReduce
 | RTupleMap
 | RObjectMap
 | RObjectMapi

--- a/src/common/reason.ml
+++ b/src/common/reason.ml
@@ -132,6 +132,7 @@ type 'loc virtual_reason_desc =
   | RNoSuper
   | RDummyPrototype
   | RDummyThis
+  | RReduce
   | RTupleMap
   | RObjectMap
   | RObjectMapi
@@ -290,6 +291,7 @@ let rec map_desc_locs f = function
   | RNoSuper
   | RDummyPrototype
   | RDummyThis
+  | RReduce
   | RTupleMap
   | RObjectMap
   | RType _
@@ -650,6 +652,7 @@ let rec string_of_desc = function
   | RNoSuper -> "empty super object"
   | RDummyPrototype -> "empty prototype object"
   | RDummyThis -> "bound `this` in method"
+  | RReduce -> "`$Reduce`"
   | RTupleMap -> "`$TupleMap`"
   | RObjectMap -> "`$ObjMap`"
   | RObjectMapi -> "`$ObjMapi`"
@@ -851,6 +854,7 @@ let is_constant_reason r =
 
 let is_typemap_reason r =
   match desc_of_reason r with
+  | RReduce
   | RTupleMap
   | RObjectMap
   | RObjectMapi -> true
@@ -858,6 +862,7 @@ let is_typemap_reason r =
 
 let is_calltype_reason r =
   match desc_of_reason r with
+  | RReduce
   | RTupleMap
   | RObjectMap
   | RObjectMapi
@@ -1324,6 +1329,7 @@ let classification_of_reason r = match desc_of_reason ~unwrap:true r with
 | RNoSuper
 | RDummyPrototype
 | RDummyThis
+| RReduce
 | RTupleMap
 | RObjectMap
 | RObjectMapi

--- a/src/common/reason.mli
+++ b/src/common/reason.mli
@@ -81,7 +81,6 @@ type 'loc virtual_reason_desc =
   | RDummyPrototype
   | RDummyThis
   | RTupleReduce
-  | RObjectReduce
   | RTupleMap
   | RObjectMap
   | RObjectMapi

--- a/src/common/reason.mli
+++ b/src/common/reason.mli
@@ -81,6 +81,7 @@ type 'loc virtual_reason_desc =
   | RDummyPrototype
   | RDummyThis
   | RReduce
+  | RObjectReduce
   | RTupleMap
   | RObjectMap
   | RObjectMapi

--- a/src/common/reason.mli
+++ b/src/common/reason.mli
@@ -80,6 +80,7 @@ type 'loc virtual_reason_desc =
   | RNoSuper
   | RDummyPrototype
   | RDummyThis
+  | RReduce
   | RTupleMap
   | RObjectMap
   | RObjectMapi

--- a/src/common/reason.mli
+++ b/src/common/reason.mli
@@ -80,7 +80,7 @@ type 'loc virtual_reason_desc =
   | RNoSuper
   | RDummyPrototype
   | RDummyThis
-  | RReduce
+  | RTupleReduce
   | RObjectReduce
   | RTupleMap
   | RObjectMap

--- a/src/common/ty/ty.ml
+++ b/src/common/ty/ty.ml
@@ -153,7 +153,6 @@ and utility =
   | ObjMap of t * t
   | ObjMapi of t * t
   | TupleReduce of t * t * t option
-  | ObjReduce of t * t
   | TupleMap of t * t
   | Call of t * t list
   | Class of t
@@ -304,7 +303,6 @@ let string_of_utility_ctor = function
   | ObjMap _ -> "$ObjMap"
   | ObjMapi _ -> "$ObjMapi"
   | TupleReduce _ -> "$TupleReduce"
-  | ObjReduce _ -> "$ObjReduce"
   | TupleMap _ -> "$TupleMap"
   | Call _ -> "$Call"
   | Class _ -> "Class"
@@ -331,7 +329,6 @@ let types_of_utility = function
   | ObjMapi (t1, t2) -> Some [t1; t2]
   | TupleReduce (t1, t2, Some t3) -> Some [t1; t2; t3]
   | TupleReduce (t1, t2, None) -> Some [t1; t2]
-  | ObjReduce (t1, t2) -> Some [t1; t2]
   | TupleMap (t1, t2) -> Some [t1; t2]
   | Call (t, ts) -> Some (t::ts)
   | Class t -> Some [t]

--- a/src/common/ty/ty.ml
+++ b/src/common/ty/ty.ml
@@ -149,10 +149,12 @@ and utility =
   | Rest of t * t
   | PropertyType of t * t
   | ElementType of t * t
+  | ElementWrite of t * t * t
   | NonMaybeType of t
   | ObjMap of t * t
   | ObjMapi of t * t
-  | Reduce of t * t
+  | Reduce of t * t * t option
+  | ObjReduce of t * t
   | TupleMap of t * t
   | Call of t * t list
   | Class of t
@@ -299,10 +301,12 @@ let string_of_utility_ctor = function
   | Rest _ -> "$Rest"
   | PropertyType _ -> "$PropertyType"
   | ElementType _ -> "$ElementType"
+  | ElementWrite _ -> "$ElementWrite"
   | NonMaybeType _ -> "$NonMaybeType"
   | ObjMap _ -> "$ObjMap"
   | ObjMapi _ -> "$ObjMapi"
   | Reduce _ -> "$Reduce"
+  | ObjReduce _ -> "$ObjReduce"
   | TupleMap _ -> "$TupleMap"
   | Call _ -> "$Call"
   | Class _ -> "Class"
@@ -324,10 +328,13 @@ let types_of_utility = function
   | Rest (t1, t2) -> Some [t1; t2]
   | PropertyType (t1, t2) -> Some [t1; t2]
   | ElementType (t1, t2) -> Some [t1; t2]
+  | ElementWrite (t1, t2, t3) -> Some [t1; t2; t3]
   | NonMaybeType t -> Some [t]
   | ObjMap (t1, t2) -> Some [t1; t2]
   | ObjMapi (t1, t2) -> Some [t1; t2]
-  | Reduce (t1, t2) -> Some [t1; t2]
+  | Reduce (t1, t2, Some t3) -> Some [t1; t2; t3]
+  | Reduce (t1, t2, None) -> Some [t1; t2]
+  | ObjReduce (t1, t2) -> Some [t1; t2]
   | TupleMap (t1, t2) -> Some [t1; t2]
   | Call (t, ts) -> Some (t::ts)
   | Class t -> Some [t]

--- a/src/common/ty/ty.ml
+++ b/src/common/ty/ty.ml
@@ -153,7 +153,7 @@ and utility =
   | NonMaybeType of t
   | ObjMap of t * t
   | ObjMapi of t * t
-  | Reduce of t * t * t option
+  | TupleReduce of t * t * t option
   | ObjReduce of t * t
   | TupleMap of t * t
   | Call of t * t list
@@ -305,7 +305,7 @@ let string_of_utility_ctor = function
   | NonMaybeType _ -> "$NonMaybeType"
   | ObjMap _ -> "$ObjMap"
   | ObjMapi _ -> "$ObjMapi"
-  | Reduce _ -> "$Reduce"
+  | TupleReduce _ -> "$TupleReduce"
   | ObjReduce _ -> "$ObjReduce"
   | TupleMap _ -> "$TupleMap"
   | Call _ -> "$Call"
@@ -332,8 +332,8 @@ let types_of_utility = function
   | NonMaybeType t -> Some [t]
   | ObjMap (t1, t2) -> Some [t1; t2]
   | ObjMapi (t1, t2) -> Some [t1; t2]
-  | Reduce (t1, t2, Some t3) -> Some [t1; t2; t3]
-  | Reduce (t1, t2, None) -> Some [t1; t2]
+  | TupleReduce (t1, t2, Some t3) -> Some [t1; t2; t3]
+  | TupleReduce (t1, t2, None) -> Some [t1; t2]
   | ObjReduce (t1, t2) -> Some [t1; t2]
   | TupleMap (t1, t2) -> Some [t1; t2]
   | Call (t, ts) -> Some (t::ts)

--- a/src/common/ty/ty.ml
+++ b/src/common/ty/ty.ml
@@ -152,6 +152,7 @@ and utility =
   | NonMaybeType of t
   | ObjMap of t * t
   | ObjMapi of t * t
+  | Reduce of t * t
   | TupleMap of t * t
   | Call of t * t list
   | Class of t
@@ -301,6 +302,7 @@ let string_of_utility_ctor = function
   | NonMaybeType _ -> "$NonMaybeType"
   | ObjMap _ -> "$ObjMap"
   | ObjMapi _ -> "$ObjMapi"
+  | Reduce _ -> "$Reduce"
   | TupleMap _ -> "$TupleMap"
   | Call _ -> "$Call"
   | Class _ -> "Class"
@@ -325,6 +327,7 @@ let types_of_utility = function
   | NonMaybeType t -> Some [t]
   | ObjMap (t1, t2) -> Some [t1; t2]
   | ObjMapi (t1, t2) -> Some [t1; t2]
+  | Reduce (t1, t2) -> Some [t1; t2]
   | TupleMap (t1, t2) -> Some [t1; t2]
   | Call (t, ts) -> Some (t::ts)
   | Class t -> Some [t]

--- a/src/common/ty/ty.ml
+++ b/src/common/ty/ty.ml
@@ -149,7 +149,6 @@ and utility =
   | Rest of t * t
   | PropertyType of t * t
   | ElementType of t * t
-  | ElementWrite of t * t * t
   | NonMaybeType of t
   | ObjMap of t * t
   | ObjMapi of t * t
@@ -301,7 +300,6 @@ let string_of_utility_ctor = function
   | Rest _ -> "$Rest"
   | PropertyType _ -> "$PropertyType"
   | ElementType _ -> "$ElementType"
-  | ElementWrite _ -> "$ElementWrite"
   | NonMaybeType _ -> "$NonMaybeType"
   | ObjMap _ -> "$ObjMap"
   | ObjMapi _ -> "$ObjMapi"
@@ -328,7 +326,6 @@ let types_of_utility = function
   | Rest (t1, t2) -> Some [t1; t2]
   | PropertyType (t1, t2) -> Some [t1; t2]
   | ElementType (t1, t2) -> Some [t1; t2]
-  | ElementWrite (t1, t2, t3) -> Some [t1; t2; t3]
   | NonMaybeType t -> Some [t]
   | ObjMap (t1, t2) -> Some [t1; t2]
   | ObjMapi (t1, t2) -> Some [t1; t2]

--- a/src/typing/debug_js.ml
+++ b/src/typing/debug_js.ml
@@ -38,7 +38,6 @@ let string_of_binary_test_ctor = function
 
 let string_of_type_map = function
   | TupleReduce _ -> "TupleReduce"
-  | ObjectReduce _ -> "ObjectReduce"
   | TupleMap _ -> "TupleMap"
   | ObjectMap _ -> "ObjectMap"
   | ObjectMapi _ -> "ObjectMapi"
@@ -1267,9 +1266,6 @@ and json_of_type_map_impl json_cx = Hh_json.(function
     ]
   | TupleReduce (t, None) -> JSON_Object [
       "reduce", _json_of_t json_cx t;
-    ]
-  | ObjectReduce t -> JSON_Object [
-      "objectReduce", _json_of_t json_cx t;
     ]
   | TupleMap t -> JSON_Object [
       "tupleMap", _json_of_t json_cx t;

--- a/src/typing/debug_js.ml
+++ b/src/typing/debug_js.ml
@@ -1202,10 +1202,6 @@ and json_of_destructor_impl json_cx = Hh_json.(function
   | ElementType t -> JSON_Object [
       "elementType", _json_of_t json_cx t
     ]
-  | ElementWrite (t1, t2) -> JSON_Object [
-      "elementWrite", _json_of_t json_cx t1;
-      "elementWriteType", _json_of_t json_cx t2
-    ]
   | Bind t -> JSON_Object [
       "thisType", _json_of_t json_cx t
     ]

--- a/src/typing/debug_js.ml
+++ b/src/typing/debug_js.ml
@@ -38,6 +38,7 @@ let string_of_binary_test_ctor = function
 
 let string_of_type_map = function
   | Reduce _ -> "Reduce"
+  | ObjectReduce _ -> "ObjectReduce"
   | TupleMap _ -> "TupleMap"
   | ObjectMap _ -> "ObjectMap"
   | ObjectMapi _ -> "ObjectMapi"
@@ -1202,6 +1203,10 @@ and json_of_destructor_impl json_cx = Hh_json.(function
   | ElementType t -> JSON_Object [
       "elementType", _json_of_t json_cx t
     ]
+  | ElementWrite (t1, t2) -> JSON_Object [
+      "elementWrite", _json_of_t json_cx t1;
+      "elementWriteType", _json_of_t json_cx t2
+    ]
   | Bind t -> JSON_Object [
       "thisType", _json_of_t json_cx t
     ]
@@ -1256,8 +1261,15 @@ and json_of_destructor_impl json_cx = Hh_json.(function
 
 and json_of_type_map json_cx = check_depth json_of_type_map_impl json_cx
 and json_of_type_map_impl json_cx = Hh_json.(function
-  | Reduce t -> JSON_Object [
+  | Reduce (t, Some t2) -> JSON_Object [
       "reduce", _json_of_t json_cx t;
+      "reduceInit", _json_of_t json_cx t2;
+    ]
+  | Reduce (t, None) -> JSON_Object [
+      "reduce", _json_of_t json_cx t;
+    ]
+  | ObjectReduce t -> JSON_Object [
+      "objectReduce", _json_of_t json_cx t;
     ]
   | TupleMap t -> JSON_Object [
       "tupleMap", _json_of_t json_cx t;

--- a/src/typing/debug_js.ml
+++ b/src/typing/debug_js.ml
@@ -37,7 +37,7 @@ let string_of_binary_test_ctor = function
   | SentinelProp _ -> "SentinelProp"
 
 let string_of_type_map = function
-  | Reduce _ -> "Reduce"
+  | TupleReduce _ -> "TupleReduce"
   | ObjectReduce _ -> "ObjectReduce"
   | TupleMap _ -> "TupleMap"
   | ObjectMap _ -> "ObjectMap"
@@ -83,7 +83,7 @@ let string_of_destructor = function
   | TypeMap (TupleMap _) -> "TupleMap"
   | TypeMap (ObjectMap _) -> "ObjectMap"
   | TypeMap (ObjectMapi _) -> "ObjectMapi"
-  | TypeMap (Reduce _) -> "Reduce"
+  | TypeMap (TupleReduce _) -> "TupleReduce"
   | ReactElementPropsType -> "ReactElementProps"
   | ReactElementConfigType -> "ReactElementConfig"
   | ReactElementRefType -> "ReactElementRef"
@@ -1261,11 +1261,11 @@ and json_of_destructor_impl json_cx = Hh_json.(function
 
 and json_of_type_map json_cx = check_depth json_of_type_map_impl json_cx
 and json_of_type_map_impl json_cx = Hh_json.(function
-  | Reduce (t, Some t2) -> JSON_Object [
+  | TupleReduce (t, Some t2) -> JSON_Object [
       "reduce", _json_of_t json_cx t;
       "reduceInit", _json_of_t json_cx t2;
     ]
-  | Reduce (t, None) -> JSON_Object [
+  | TupleReduce (t, None) -> JSON_Object [
       "reduce", _json_of_t json_cx t;
     ]
   | ObjectReduce t -> JSON_Object [

--- a/src/typing/debug_js.ml
+++ b/src/typing/debug_js.ml
@@ -37,6 +37,7 @@ let string_of_binary_test_ctor = function
   | SentinelProp _ -> "SentinelProp"
 
 let string_of_type_map = function
+  | Reduce _ -> "Reduce"
   | TupleMap _ -> "TupleMap"
   | ObjectMap _ -> "ObjectMap"
   | ObjectMapi _ -> "ObjectMapi"
@@ -81,6 +82,7 @@ let string_of_destructor = function
   | TypeMap (TupleMap _) -> "TupleMap"
   | TypeMap (ObjectMap _) -> "ObjectMap"
   | TypeMap (ObjectMapi _) -> "ObjectMapi"
+  | TypeMap (Reduce _) -> "Reduce"
   | ReactElementPropsType -> "ReactElementProps"
   | ReactElementConfigType -> "ReactElementConfig"
   | ReactElementRefType -> "ReactElementRef"
@@ -1254,6 +1256,9 @@ and json_of_destructor_impl json_cx = Hh_json.(function
 
 and json_of_type_map json_cx = check_depth json_of_type_map_impl json_cx
 and json_of_type_map_impl json_cx = Hh_json.(function
+  | Reduce t -> JSON_Object [
+      "reduce", _json_of_t json_cx t;
+    ]
   | TupleMap t -> JSON_Object [
       "tupleMap", _json_of_t json_cx t;
     ]

--- a/src/typing/flow_js.ml
+++ b/src/typing/flow_js.ml
@@ -5427,6 +5427,33 @@ let rec __flow cx ((l: Type.t), (u: Type.use_t)) trace =
     | AnyT _, MapTypeT (_, reason_op, _, tout) ->
       rec_flow_t cx trace (AnyT.untyped reason_op, tout)
 
+    | DefT (_, _, ArrT arrtype), MapTypeT (use_op, reason_op, Reduce funt, tout) ->
+      let f x = EvalT (funt, TypeDestructorT (use_op, reason_op, CallType [x]), mk_id ()) in
+      let props = match arrtype with
+      | ArrayAT (_, opt) ->
+        (match opt with
+          | Some ts ->
+            Core_list.fold_left ts ~f:(fun acc value ->
+              match value with
+                | DefT (_, _, SingletonStrT str) -> SMap.add str (Field (None, (f value), Neutral)) acc
+                | _ -> acc
+            ) ~init:SMap.empty
+          | None -> SMap.empty)
+      | TupleAT (_, ts) ->
+        Core_list.fold_left ts ~f:(fun acc value ->
+          match value with
+            | DefT (_, _, SingletonStrT str) -> SMap.add str (Field (None, (f value), Neutral)) acc
+            | _ -> acc
+        ) ~init:SMap.empty
+      | ROArrayAT (_) -> SMap.empty in
+      let reason = replace_reason_const RObjectType reason_op in
+      let proto = ObjProtoT reason in
+      let t =
+        (* DefT (reason, trust, ObjT {props_tmap;}) *)
+        Obj_type.mk_with_proto cx reason ~sealed:true ~exact:true ~props proto
+      in
+      rec_flow_t cx trace (t, tout)
+
     | DefT (_, trust, ArrT arrtype), MapTypeT (use_op, reason_op, TupleMap funt, tout) ->
       let f x = EvalT (funt, TypeDestructorT (use_op, reason_op, CallType [x]), mk_id ()) in
       let arrtype = match arrtype with

--- a/src/typing/flow_js.ml
+++ b/src/typing/flow_js.ml
@@ -7608,7 +7608,6 @@ and eval_destructor cx ~trace use_op reason t d tout = match t with
     let reason_op = replace_reason_const (RProperty (Some x)) reason in
     GetPropT (use_op, reason, Named (reason_op, x), tout)
   | ElementType t -> GetElemT (use_op, reason, t, tout)
-  | ElementWrite (t, t2) -> SetElemT (use_op, reason, t, t2, Some tout)
   | Bind t -> BindT (use_op, reason, mk_methodcalltype t None [] tout, true)
   | SpreadType (options, todo_rev) ->
     let open Object in

--- a/src/typing/resolvableTypeJob.ml
+++ b/src/typing/resolvableTypeJob.ml
@@ -262,6 +262,7 @@ and collect_of_destructor ?log_unresolved cx acc = function
   | NonMaybeType -> acc
   | PropertyType _ -> acc
   | ElementType t -> collect_of_type ?log_unresolved cx acc t
+  | ElementWrite (_, t) -> collect_of_type ?log_unresolved cx acc t
   | Bind t -> collect_of_type ?log_unresolved cx acc t
   | ReadOnlyType -> acc
   | SpreadType (_, ts) -> collect_of_types ?log_unresolved cx acc ts
@@ -276,7 +277,7 @@ and collect_of_destructor ?log_unresolved cx acc = function
     -> acc
 
 and collect_of_type_map ?log_unresolved cx acc = function
-  | Reduce t | TupleMap t | ObjectMap t | ObjectMapi t ->
+  | Reduce (t, _) | ObjectReduce t | TupleMap t | ObjectMap t | ObjectMapi t ->
     collect_of_type ?log_unresolved cx acc t
 
 (* In some positions, like annots, we trust that tvars are 0->1. *)

--- a/src/typing/resolvableTypeJob.ml
+++ b/src/typing/resolvableTypeJob.ml
@@ -276,7 +276,7 @@ and collect_of_destructor ?log_unresolved cx acc = function
     -> acc
 
 and collect_of_type_map ?log_unresolved cx acc = function
-  | TupleMap t | ObjectMap t | ObjectMapi t ->
+  | Reduce t | TupleMap t | ObjectMap t | ObjectMapi t ->
     collect_of_type ?log_unresolved cx acc t
 
 (* In some positions, like annots, we trust that tvars are 0->1. *)

--- a/src/typing/resolvableTypeJob.ml
+++ b/src/typing/resolvableTypeJob.ml
@@ -277,8 +277,14 @@ and collect_of_destructor ?log_unresolved cx acc = function
     -> acc
 
 and collect_of_type_map ?log_unresolved cx acc = function
-  | Reduce (t, _) | ObjectReduce t | TupleMap t | ObjectMap t | ObjectMapi t ->
+  | TupleMap t
+  | ObjectReduce t
+  | ObjectMap t
+  | TupleReduce (t, None)
+  | ObjectMapi t ->
     collect_of_type ?log_unresolved cx acc t
+  | TupleReduce (t, Some t2) ->
+    collect_of_types ?log_unresolved cx acc [t; t2]
 
 (* In some positions, like annots, we trust that tvars are 0->1. *)
 and collect_of_binding ?log_unresolved cx acc = function

--- a/src/typing/resolvableTypeJob.ml
+++ b/src/typing/resolvableTypeJob.ml
@@ -278,7 +278,6 @@ and collect_of_destructor ?log_unresolved cx acc = function
 
 and collect_of_type_map ?log_unresolved cx acc = function
   | TupleMap t
-  | ObjectReduce t
   | ObjectMap t
   | TupleReduce (t, None)
   | ObjectMapi t ->

--- a/src/typing/resolvableTypeJob.ml
+++ b/src/typing/resolvableTypeJob.ml
@@ -262,7 +262,6 @@ and collect_of_destructor ?log_unresolved cx acc = function
   | NonMaybeType -> acc
   | PropertyType _ -> acc
   | ElementType t -> collect_of_type ?log_unresolved cx acc t
-  | ElementWrite (_, t) -> collect_of_type ?log_unresolved cx acc t
   | Bind t -> collect_of_type ?log_unresolved cx acc t
   | ReadOnlyType -> acc
   | SpreadType (_, ts) -> collect_of_types ?log_unresolved cx acc ts

--- a/src/typing/ty_normalizer.ml
+++ b/src/typing/ty_normalizer.ml
@@ -1490,6 +1490,8 @@ end = struct
     | T.ValuesType -> return (Ty.Utility (Ty.Values ty))
     | T.ElementType t' ->
       type__ ~env t' >>| fun ty' -> Ty.Utility (Ty.ElementType (ty, ty'))
+    | T.ElementWrite (t', _) ->
+       type__ ~env t' >>| fun ty' -> Ty.Utility (Ty.ElementWrite (ty, ty', ty'))
     | T.CallType ts ->
       mapM (type__ ~env) ts >>| fun tys -> Ty.Utility (Ty.Call (ty, tys))
     | T.TypeMap (T.ObjectMap t') ->
@@ -1498,8 +1500,12 @@ end = struct
       type__ ~env t' >>| fun ty' -> Ty.Utility (Ty.ObjMapi (ty, ty'))
     | T.PropertyType k ->
       return (Ty.Utility (Ty.PropertyType (ty, Ty.StrLit k)))
-    | T.TypeMap (T.Reduce t') ->
-      type__ ~env t' >>| fun ty' -> Ty.Utility (Ty.Reduce (ty, ty'))
+    | T.TypeMap (T.Reduce (t', Some t2')) ->
+      mapM (type__ ~env) [t'; t2'] >>| fun tys -> Ty.Utility (Ty.Reduce (ty, Core_list.nth_exn tys 0, Core_list.nth tys 1))
+    | T.TypeMap (T.Reduce (t', None)) ->
+      type__ ~env t' >>| fun ty' -> Ty.Utility (Ty.Reduce (ty, ty', None))
+    | T.TypeMap (T.ObjectReduce t') ->
+      type__ ~env t' >>| fun ty' -> Ty.Utility (Ty.ObjReduce (ty, ty'))
     | T.TypeMap (T.TupleMap t') ->
       type__ ~env t' >>| fun ty' -> Ty.Utility (Ty.TupleMap (ty, ty'))
     | T.RestType (T.Object.Rest.Sound, t') ->

--- a/src/typing/ty_normalizer.ml
+++ b/src/typing/ty_normalizer.ml
@@ -1498,6 +1498,8 @@ end = struct
       type__ ~env t' >>| fun ty' -> Ty.Utility (Ty.ObjMapi (ty, ty'))
     | T.PropertyType k ->
       return (Ty.Utility (Ty.PropertyType (ty, Ty.StrLit k)))
+    | T.TypeMap (T.Reduce t') ->
+      type__ ~env t' >>| fun ty' -> Ty.Utility (Ty.Reduce (ty, ty'))
     | T.TypeMap (T.TupleMap t') ->
       type__ ~env t' >>| fun ty' -> Ty.Utility (Ty.TupleMap (ty, ty'))
     | T.RestType (T.Object.Rest.Sound, t') ->

--- a/src/typing/ty_normalizer.ml
+++ b/src/typing/ty_normalizer.ml
@@ -1504,8 +1504,6 @@ end = struct
       mapM (type__ ~env) [t'; t2'] >>| fun tys -> Ty.Utility (Ty.TupleReduce (ty, Core_list.nth_exn tys 0, Core_list.nth tys 1))
     | T.TypeMap (T.TupleReduce (t', None)) ->
       type__ ~env t' >>| fun ty' -> Ty.Utility (Ty.TupleReduce (ty, ty', None))
-    | T.TypeMap (T.ObjectReduce t') ->
-      type__ ~env t' >>| fun ty' -> Ty.Utility (Ty.ObjReduce (ty, ty'))
     | T.TypeMap (T.TupleMap t') ->
       type__ ~env t' >>| fun ty' -> Ty.Utility (Ty.TupleMap (ty, ty'))
     | T.RestType (T.Object.Rest.Sound, t') ->

--- a/src/typing/ty_normalizer.ml
+++ b/src/typing/ty_normalizer.ml
@@ -1490,8 +1490,6 @@ end = struct
     | T.ValuesType -> return (Ty.Utility (Ty.Values ty))
     | T.ElementType t' ->
       type__ ~env t' >>| fun ty' -> Ty.Utility (Ty.ElementType (ty, ty'))
-    | T.ElementWrite (t', _) ->
-       type__ ~env t' >>| fun ty' -> Ty.Utility (Ty.ElementWrite (ty, ty', ty'))
     | T.CallType ts ->
       mapM (type__ ~env) ts >>| fun tys -> Ty.Utility (Ty.Call (ty, tys))
     | T.TypeMap (T.ObjectMap t') ->

--- a/src/typing/ty_normalizer.ml
+++ b/src/typing/ty_normalizer.ml
@@ -1500,10 +1500,10 @@ end = struct
       type__ ~env t' >>| fun ty' -> Ty.Utility (Ty.ObjMapi (ty, ty'))
     | T.PropertyType k ->
       return (Ty.Utility (Ty.PropertyType (ty, Ty.StrLit k)))
-    | T.TypeMap (T.Reduce (t', Some t2')) ->
-      mapM (type__ ~env) [t'; t2'] >>| fun tys -> Ty.Utility (Ty.Reduce (ty, Core_list.nth_exn tys 0, Core_list.nth tys 1))
-    | T.TypeMap (T.Reduce (t', None)) ->
-      type__ ~env t' >>| fun ty' -> Ty.Utility (Ty.Reduce (ty, ty', None))
+    | T.TypeMap (T.TupleReduce (t', Some t2')) ->
+      mapM (type__ ~env) [t'; t2'] >>| fun tys -> Ty.Utility (Ty.TupleReduce (ty, Core_list.nth_exn tys 0, Core_list.nth tys 1))
+    | T.TypeMap (T.TupleReduce (t', None)) ->
+      type__ ~env t' >>| fun ty' -> Ty.Utility (Ty.TupleReduce (ty, ty', None))
     | T.TypeMap (T.ObjectReduce t') ->
       type__ ~env t' >>| fun ty' -> Ty.Utility (Ty.ObjReduce (ty, ty'))
     | T.TypeMap (T.TupleMap t') ->

--- a/src/typing/type.ml
+++ b/src/typing/type.ml
@@ -1060,6 +1060,7 @@ module rec TypeTerm : sig
   | ReactConfigType of t
 
   and type_map =
+  | Reduce of t
   | TupleMap of t
   | ObjectMap of t
   | ObjectMapi of t

--- a/src/typing/type.ml
+++ b/src/typing/type.ml
@@ -1062,7 +1062,6 @@ module rec TypeTerm : sig
 
   and type_map =
   | TupleReduce of t * t option
-  | ObjectReduce of t
   | TupleMap of t
   | ObjectMap of t
   | ObjectMapi of t

--- a/src/typing/type.ml
+++ b/src/typing/type.ml
@@ -1061,7 +1061,7 @@ module rec TypeTerm : sig
   | ReactConfigType of t
 
   and type_map =
-  | Reduce of t * t option
+  | TupleReduce of t * t option
   | ObjectReduce of t
   | TupleMap of t
   | ObjectMap of t

--- a/src/typing/type.ml
+++ b/src/typing/type.ml
@@ -1047,7 +1047,6 @@ module rec TypeTerm : sig
   | NonMaybeType
   | PropertyType of string
   | ElementType of t
-  | ElementWrite of t * t
   | Bind of t
   | ReadOnlyType
   | SpreadType of Object.Spread.target * t list

--- a/src/typing/type.ml
+++ b/src/typing/type.ml
@@ -1047,6 +1047,7 @@ module rec TypeTerm : sig
   | NonMaybeType
   | PropertyType of string
   | ElementType of t
+  | ElementWrite of t * t
   | Bind of t
   | ReadOnlyType
   | SpreadType of Object.Spread.target * t list
@@ -1060,7 +1061,8 @@ module rec TypeTerm : sig
   | ReactConfigType of t
 
   and type_map =
-  | Reduce of t
+  | Reduce of t * t option
+  | ObjectReduce of t
   | TupleMap of t
   | ObjectMap of t
   | ObjectMapi of t

--- a/src/typing/type_annotation.ml
+++ b/src/typing/type_annotation.ml
@@ -768,6 +768,17 @@ let rec convert cx tparams_map = Ast.Type.(function
         targs
     )
 
+  | "$Reduce" ->
+    check_type_arg_arity cx loc t_ast targs 2 (fun () ->
+      let t1, t2, targs = match convert_type_params () with
+      | [t1; t2], targs -> t1, t2, targs
+      | _ -> assert false in
+      let reason = mk_reason RReduce loc in
+      reconstruct_ast
+        (EvalT (t1, TypeDestructorT (use_op reason, reason, TypeMap (Reduce t2)), mk_id ()))
+        targs
+    )
+
   | "$ObjMap" ->
     check_type_arg_arity cx loc t_ast targs 2 (fun () ->
       let t1, t2, targs = match convert_type_params () with

--- a/src/typing/type_annotation.ml
+++ b/src/typing/type_annotation.ml
@@ -626,20 +626,6 @@ let rec convert cx tparams_map = Ast.Type.(function
       | _ -> assert false
     )
 
-  (* $ElementWrite<T, string, T2> acts as the type of the string elements in object
-     type T *)
-  | "$ElementWrite" ->
-    check_type_arg_arity cx loc t_ast targs 3 (fun () ->
-      match convert_type_params () with
-      | ([t; e; e2], targs) ->
-        let reason = mk_reason (RType "$ElementWrite") loc in
-        reconstruct_ast
-          (EvalT (t, TypeDestructorT
-            (use_op reason, reason, ElementWrite (e, e2)), mk_id()))
-          targs
-      | _ -> assert false
-    )
-
   (* $NonMaybeType<T> acts as the type T without null and void *)
   | "$NonMaybeType" ->
     check_type_arg_arity cx loc t_ast targs 1 (fun () ->

--- a/src/typing/type_annotation.ml
+++ b/src/typing/type_annotation.ml
@@ -782,17 +782,6 @@ let rec convert cx tparams_map = Ast.Type.(function
         targs
     )
 
-  | "$ObjReduce" ->
-    check_type_arg_arity cx loc t_ast targs 2 (fun () ->
-      let t1, t2, targs = match convert_type_params () with
-      | [t1; t2], targs -> t1, t2, targs
-      | _ -> assert false in
-      let reason = mk_reason RObjectReduce loc in
-      reconstruct_ast
-        (EvalT (t1, TypeDestructorT (use_op reason, reason, TypeMap (ObjectReduce t2)), mk_id ()))
-        targs
-    )
-
   | "$TupleReduce" ->
     (match convert_type_params () with
       | ([t1; t2; t3], targs) ->
@@ -811,21 +800,6 @@ let rec convert cx tparams_map = Ast.Type.(function
           targs
       | _ -> error_type cx loc (Error_message.ETypeParamMinArity (loc, 2)) t_ast
     )
-
-    (match convert_type_params () with
-      | ([t1; t2; t3], targs) ->
-        let reason = mk_reason RReduce loc in
-        reconstruct_ast
-          (EvalT (t1, TypeDestructorT (use_op reason, reason, TypeMap (Reduce (t2, (Some t3)))), mk_id ()))
-          targs
-      | ([t1; t2], targs) ->
-        let reason = mk_reason RReduce loc in
-        reconstruct_ast
-          (EvalT (t1, TypeDestructorT (use_op reason, reason, TypeMap (Reduce (t2, None))), mk_id ()))
-          targs
-      | _ -> error_type cx loc (Error_message.ETypeParamMinArity (loc, 2)) t_ast
-    )
-
 
   | "$ObjMap" ->
     check_type_arg_arity cx loc t_ast targs 2 (fun () ->

--- a/src/typing/type_annotation.ml
+++ b/src/typing/type_annotation.ml
@@ -793,7 +793,25 @@ let rec convert cx tparams_map = Ast.Type.(function
         targs
     )
 
-  | "$Reduce" ->
+  | "$TupleReduce" ->
+    (match convert_type_params () with
+      | ([t1; t2; t3], targs) ->
+        let reason = mk_reason RTupleReduce loc in
+        reconstruct_ast
+          (EvalT (
+            t1,
+            TypeDestructorT (use_op reason, reason, TypeMap (TupleReduce (t2, Some t3))),
+            mk_id ()
+          ))
+          targs
+      | ([t1; t2], targs) ->
+        let reason = mk_reason RTupleReduce loc in
+        reconstruct_ast
+          (EvalT (t1, TypeDestructorT (use_op reason, reason, TypeMap (TupleReduce (t2, None))), mk_id ()))
+          targs
+      | _ -> error_type cx loc (Error_message.ETypeParamMinArity (loc, 2)) t_ast
+    )
+
     (match convert_type_params () with
       | ([t1; t2; t3], targs) ->
         let reason = mk_reason RReduce loc in

--- a/src/typing/type_mapper.ml
+++ b/src/typing/type_mapper.ml
@@ -385,10 +385,6 @@ class virtual ['a] t = object(self)
           let t'' = self#type_ cx map_cx t' in
           if t'' == t' then t
           else ElementType t''
-      | ElementWrite (t', t2') ->
-          let (t1, t2) as t'' = (self#type_ cx map_cx t', self#type_ cx map_cx t2') in
-          if t'' == (t', t2') then t
-          else ElementWrite (t1, t2)
       | Bind t' ->
           let t'' = self#type_ cx map_cx t' in
           if t'' == t' then t

--- a/src/typing/type_mapper.ml
+++ b/src/typing/type_mapper.ml
@@ -556,6 +556,10 @@ class virtual ['a] t = object(self)
 
   method type_map cx map_cx t =
     match t with
+    | Reduce t' ->
+      let t'' = self#type_ cx map_cx t' in
+      if t'' == t' then t
+      else Reduce t''
     | TupleMap t' ->
       let t'' = self#type_ cx map_cx t' in
       if t'' == t' then t

--- a/src/typing/type_mapper.ml
+++ b/src/typing/type_mapper.ml
@@ -560,15 +560,15 @@ class virtual ['a] t = object(self)
 
   method type_map cx map_cx t =
     match t with
-    | Reduce (t', Some t2') ->
+    | TupleReduce (t', Some t2') ->
       let t'' = self#type_ cx map_cx t' in
       let t2'' = self#type_ cx map_cx t2' in
-      if t'' == t' then t
-      else Reduce (t'', Some t2'')
-    | Reduce (t', None) ->
+      if t'' == t' && t2'' == t2' then t
+      else TupleReduce (t'', Some t2'')
+    | TupleReduce (t', None) ->
       let t'' = self#type_ cx map_cx t' in
       if t'' == t' then t
-      else Reduce (t'', None)
+      else TupleReduce (t'', None)
     | ObjectReduce t' ->
       let t'' = self#type_ cx map_cx t' in
       if t'' == t' then t

--- a/src/typing/type_mapper.ml
+++ b/src/typing/type_mapper.ml
@@ -385,6 +385,10 @@ class virtual ['a] t = object(self)
           let t'' = self#type_ cx map_cx t' in
           if t'' == t' then t
           else ElementType t''
+      | ElementWrite (t', t2') ->
+          let (t1, t2) as t'' = (self#type_ cx map_cx t', self#type_ cx map_cx t2') in
+          if t'' == (t', t2') then t
+          else ElementWrite (t1, t2)
       | Bind t' ->
           let t'' = self#type_ cx map_cx t' in
           if t'' == t' then t
@@ -556,10 +560,19 @@ class virtual ['a] t = object(self)
 
   method type_map cx map_cx t =
     match t with
-    | Reduce t' ->
+    | Reduce (t', Some t2') ->
+      let t'' = self#type_ cx map_cx t' in
+      let t2'' = self#type_ cx map_cx t2' in
+      if t'' == t' then t
+      else Reduce (t'', Some t2'')
+    | Reduce (t', None) ->
       let t'' = self#type_ cx map_cx t' in
       if t'' == t' then t
-      else Reduce t''
+      else Reduce (t'', None)
+    | ObjectReduce t' ->
+      let t'' = self#type_ cx map_cx t' in
+      if t'' == t' then t
+      else ObjectReduce t''
     | TupleMap t' ->
       let t'' = self#type_ cx map_cx t' in
       if t'' == t' then t

--- a/src/typing/type_mapper.ml
+++ b/src/typing/type_mapper.ml
@@ -569,10 +569,6 @@ class virtual ['a] t = object(self)
       let t'' = self#type_ cx map_cx t' in
       if t'' == t' then t
       else TupleReduce (t'', None)
-    | ObjectReduce t' ->
-      let t'' = self#type_ cx map_cx t' in
-      if t'' == t' then t
-      else ObjectReduce t''
     | TupleMap t' ->
       let t'' = self#type_ cx map_cx t' in
       if t'' == t' then t

--- a/src/typing/type_visitor.ml
+++ b/src/typing/type_visitor.ml
@@ -238,6 +238,7 @@ class ['a] t = object(self)
     -> acc
   | ReactConfigType default_props -> self#type_ cx pole_TODO acc default_props
   | ElementType t -> self#type_ cx pole_TODO acc t
+  | ElementWrite (_,t) -> self#type_ cx pole_TODO acc t
   | Bind t -> self#type_ cx pole_TODO acc t
   | SpreadType (_, ts) -> self#list (self#type_ cx pole_TODO) acc ts
   | RestType (_,t) -> self#type_ cx pole_TODO acc t
@@ -876,7 +877,8 @@ class ['a] t = object(self)
   | Upper u -> self#use_type_ cx acc u
 
   method private type_map cx acc = function
-  | Reduce t
+  | Reduce (t, _)
+  | ObjectReduce t
   | TupleMap t
   | ObjectMap t
   | ObjectMapi t -> self#type_ cx pole_TODO acc t

--- a/src/typing/type_visitor.ml
+++ b/src/typing/type_visitor.ml
@@ -877,7 +877,8 @@ class ['a] t = object(self)
   | Upper u -> self#use_type_ cx acc u
 
   method private type_map cx acc = function
-  | Reduce (t, _)
+  | TupleReduce (t, _)
+  | UnionReduce (t, _)
   | ObjectReduce t
   | TupleMap t
   | ObjectMap t

--- a/src/typing/type_visitor.ml
+++ b/src/typing/type_visitor.ml
@@ -238,7 +238,6 @@ class ['a] t = object(self)
     -> acc
   | ReactConfigType default_props -> self#type_ cx pole_TODO acc default_props
   | ElementType t -> self#type_ cx pole_TODO acc t
-  | ElementWrite (_,t) -> self#type_ cx pole_TODO acc t
   | Bind t -> self#type_ cx pole_TODO acc t
   | SpreadType (_, ts) -> self#list (self#type_ cx pole_TODO) acc ts
   | RestType (_,t) -> self#type_ cx pole_TODO acc t

--- a/src/typing/type_visitor.ml
+++ b/src/typing/type_visitor.ml
@@ -876,6 +876,7 @@ class ['a] t = object(self)
   | Upper u -> self#use_type_ cx acc u
 
   method private type_map cx acc = function
+  | Reduce t
   | TupleMap t
   | ObjectMap t
   | ObjectMapi t -> self#type_ cx pole_TODO acc t

--- a/src/typing/type_visitor.ml
+++ b/src/typing/type_visitor.ml
@@ -878,8 +878,6 @@ class ['a] t = object(self)
 
   method private type_map cx acc = function
   | TupleReduce (t, _)
-  | UnionReduce (t, _)
-  | ObjectReduce t
   | TupleMap t
   | ObjectMap t
   | ObjectMapi t -> self#type_ cx pole_TODO acc t


### PR DESCRIPTION
<!--
  If this is a change to library defintions, please include links to relevant documentation.
  If this is a documentation change, please prefix the title with [DOCS].

  If this is neither, ensure you opened a discussion issue and link it in the PR description.
-->

```js
// @flow

declare var union: $TupleReduce<
  [1, 2, 3],
  <Acc, Value, Key>(Acc, Value, Key) => Acc | Value
>;

declare var accumulate: $TupleReduce<
  [1, 2, 3],
  <Acc, Value, Key>(Acc, Value, Key) => [Acc, Value],
  []
>;

union; // 1 | 2 | 3
accumulate; // [[[[], 1], 2], 3]

```