### PR TITLE
Add $ObjReduce destructor

### DIFF
--- a/src/common/reason.ml
+++ b/src/common/reason.ml
@@ -133,6 +133,7 @@ type 'loc virtual_reason_desc =
   | RNoSuper
   | RDummyPrototype
   | RDummyThis
+  | RObjectReduce
   | RTupleMap
   | RObjectMap
   | RObjectMapi
@@ -292,6 +293,7 @@ let rec map_desc_locs f = function
   | RNoSuper
   | RDummyPrototype
   | RDummyThis
+  | RObjectReduce
   | RTupleMap
   | RObjectMap
   | RType _
@@ -654,6 +656,7 @@ let rec string_of_desc = function
   | RNoSuper -> "empty super object"
   | RDummyPrototype -> "empty prototype object"
   | RDummyThis -> "bound `this` in method"
+  | RObjectReduce -> "`$ObjReduce`"
   | RTupleMap -> "`$TupleMap`"
   | RObjectMap -> "`$ObjMap`"
   | RObjectMapi -> "`$ObjMapi`"
@@ -855,6 +858,7 @@ let is_constant_reason r =
 
 let is_typemap_reason r =
   match desc_of_reason r with
+  | RObjectReduce
   | RTupleMap
   | RObjectMap
   | RObjectMapi -> true
@@ -862,6 +866,7 @@ let is_typemap_reason r =
 
 let is_calltype_reason r =
   match desc_of_reason r with
+  | RObjectReduce
   | RTupleMap
   | RObjectMap
   | RObjectMapi
@@ -1328,6 +1333,7 @@ let classification_of_reason r = match desc_of_reason ~unwrap:true r with
 | RNoSuper
 | RDummyPrototype
 | RDummyThis
+| RObjectReduce
 | RTupleMap
 | RObjectMap
 | RObjectMapi

--- a/src/common/reason.mli
+++ b/src/common/reason.mli
@@ -81,6 +81,7 @@ type 'loc virtual_reason_desc =
   | RNoSuper
   | RDummyPrototype
   | RDummyThis
+  | RObjectReduce
   | RTupleMap
   | RObjectMap
   | RObjectMapi

--- a/src/common/ty/ty.ml
+++ b/src/common/ty/ty.ml
@@ -152,6 +152,7 @@ and utility =
   | NonMaybeType of t
   | ObjMap of t * t
   | ObjMapi of t * t
+  | ObjReduce of t * t * t
   | TupleMap of t * t
   | Call of t * t list
   | Class of t
@@ -301,6 +302,7 @@ let string_of_utility_ctor = function
   | NonMaybeType _ -> "$NonMaybeType"
   | ObjMap _ -> "$ObjMap"
   | ObjMapi _ -> "$ObjMapi"
+  | ObjReduce _ -> "$ObjReduce"
   | TupleMap _ -> "$TupleMap"
   | Call _ -> "$Call"
   | Class _ -> "Class"
@@ -325,6 +327,7 @@ let types_of_utility = function
   | NonMaybeType t -> Some [t]
   | ObjMap (t1, t2) -> Some [t1; t2]
   | ObjMapi (t1, t2) -> Some [t1; t2]
+  | ObjReduce (t1, t2, t3) -> Some [t1; t2; t3]
   | TupleMap (t1, t2) -> Some [t1; t2]
   | Call (t, ts) -> Some (t::ts)
   | Class t -> Some [t]

--- a/src/typing/debug_js.ml
+++ b/src/typing/debug_js.ml
@@ -37,6 +37,7 @@ let string_of_binary_test_ctor = function
   | SentinelProp _ -> "SentinelProp"
 
 let string_of_type_map = function
+  | ObjectReduce _ -> "ObjectReduce"
   | TupleMap _ -> "TupleMap"
   | ObjectMap _ -> "ObjectMap"
   | ObjectMapi _ -> "ObjectMapi"
@@ -77,6 +78,7 @@ let string_of_destructor = function
   | TypeMap (TupleMap _) -> "TupleMap"
   | TypeMap (ObjectMap _) -> "ObjectMap"
   | TypeMap (ObjectMapi _) -> "ObjectMapi"
+  | TypeMap (ObjectReduce _) -> "ObjectReduce"
   | ReactElementPropsType -> "ReactElementProps"
   | ReactElementConfigType -> "ReactElementConfig"
   | ReactElementRefType -> "ReactElementRef"
@@ -1264,6 +1266,10 @@ and json_of_destructor_impl json_cx = Hh_json.(function
 
 and json_of_type_map json_cx = check_depth json_of_type_map_impl json_cx
 and json_of_type_map_impl json_cx = Hh_json.(function
+  | ObjectReduce (t, t2) -> JSON_Object [
+      "reduce", _json_of_t json_cx t;
+      "reduceInit", _json_of_t json_cx t2;
+    ]
   | TupleMap t -> JSON_Object [
       "tupleMap", _json_of_t json_cx t;
     ]

--- a/src/typing/resolvableTypeJob.ml
+++ b/src/typing/resolvableTypeJob.ml
@@ -278,6 +278,8 @@ and collect_of_destructor ?log_unresolved cx acc = function
 and collect_of_type_map ?log_unresolved cx acc = function
   | TupleMap t | ObjectMap t | ObjectMapi t ->
     collect_of_type ?log_unresolved cx acc t
+  | ObjectReduce (t, t2) ->
+    collect_of_types ?log_unresolved cx acc [t; t2]
 
 (* In some positions, like annots, we trust that tvars are 0->1. *)
 and collect_of_binding ?log_unresolved cx acc = function

--- a/src/typing/ty_normalizer.ml
+++ b/src/typing/ty_normalizer.ml
@@ -1498,6 +1498,8 @@ end = struct
       type__ ~env t' >>| fun ty' -> Ty.Utility (Ty.ObjMapi (ty, ty'))
     | T.PropertyType k ->
       return (Ty.Utility (Ty.PropertyType (ty, Ty.StrLit k)))
+    | T.TypeMap (T.ObjectReduce (t', t2')) ->
+      mapM (type__ ~env) [t'; t2'] >>| fun tys -> Ty.Utility (Ty.ObjReduce (ty, Core_list.nth_exn tys 0, Core_list.nth_exn tys 1))
     | T.TypeMap (T.TupleMap t') ->
       type__ ~env t' >>| fun ty' -> Ty.Utility (Ty.TupleMap (ty, ty'))
     | T.RestType (T.Object.Rest.Sound, t') ->

--- a/src/typing/type.ml
+++ b/src/typing/type.ml
@@ -1067,6 +1067,7 @@ module rec TypeTerm : sig
   | ReactConfigType of t
 
   and type_map =
+  | ObjectReduce of t * t
   | TupleMap of t
   | ObjectMap of t
   | ObjectMapi of t

--- a/src/typing/type_annotation.ml
+++ b/src/typing/type_annotation.ml
@@ -768,6 +768,17 @@ let rec convert cx tparams_map = Ast.Type.(function
         targs
     )
 
+  | "$ObjReduce" ->
+    check_type_arg_arity cx loc t_ast targs 3 (fun () ->
+      let t1, t2, t3, targs = match convert_type_params () with
+      | [t1; t2; t3], targs -> t1, t2, t3, targs
+      | _ -> assert false in
+      let reason = mk_reason RObjectReduce loc in
+      reconstruct_ast
+        (EvalT (t1, TypeDestructorT (use_op reason, reason, TypeMap (ObjectReduce (t2, t3))), mk_id ()))
+        targs
+    )
+
   | "$ObjMap" ->
     check_type_arg_arity cx loc t_ast targs 2 (fun () ->
       let t1, t2, targs = match convert_type_params () with

--- a/src/typing/type_mapper.ml
+++ b/src/typing/type_mapper.ml
@@ -548,6 +548,11 @@ class virtual ['a] t = object(self)
 
   method type_map cx map_cx t =
     match t with
+    | ObjectReduce (t', t2') ->
+      let t'' = self#type_ cx map_cx t' in
+      let t2'' = self#type_ cx map_cx t2' in
+      if t'' == t' && t2'' == t2' then t
+      else ObjectReduce (t'', t2'')
     | TupleMap t' ->
       let t'' = self#type_ cx map_cx t' in
       if t'' == t' then t

--- a/src/typing/type_visitor.ml
+++ b/src/typing/type_visitor.ml
@@ -876,6 +876,7 @@ class ['a] t = object(self)
   | Upper u -> self#use_type_ cx acc u
 
   method private type_map cx acc = function
+  | ObjectReduce (t, _)
   | TupleMap t
   | ObjectMap t
   | ObjectMapi t -> self#type_ cx pole_TODO acc t


### PR DESCRIPTION
<!--
  If this is a change to library defintions, please include links to relevant documentation.
  If this is a documentation change, please prefix the title with [DOCS].

  If this is neither, ensure you opened a discussion issue and link it in the PR description.
-->

```js
$ObjReduce<
  {| a: 1, b: 2 |}, 
  <Acc, Key, Value>(Acc, Key, Value) => Acc | Key, 
  empty
> // 'a' | 'b'

$ObjReduce<
  {| a: 1, b: 2 |}, 
  <Acc, Key, Value>(Acc, Key, Value) => {| 
     ...Acc, 
     [K in Key]: Value // hypothetical computed key
  |},
  empty
> // {| a: 1, b: 2 |}
```