### PR TITLE
Add crash handling to Try Flow

### DIFF
--- a/website/_assets/js/tryFlow.js.es6.liquid
+++ b/website/_assets/js/tryFlow.js.es6.liquid
@@ -101,6 +101,19 @@ function printErrors(errors, editor) {
   return list;
 }
 
+function printCrash(error, editor) {
+  const div = document.createElement('div');
+  switch (error[1].c) {
+    case 'Stack_overflow':
+      div.appendChild(document.createTextNode('A stack overflow error has occured. Flow stopped working'));
+      break;
+    default:
+      div.appendChild(document.createTextNode('An unknown internal error has occured. Flow stopped working'));
+      break;
+  }
+  return div;
+}
+
 function removeChildren(node) {
   while (node.lastChild) node.removeChild(node.lastChild);
 }
@@ -128,7 +141,10 @@ function getAnnotations(text, callback, options, editor) {
       };
     });
     callback(lint);
-  });
+  }).catch(error => {
+    CodeMirror.signal(editor, 'flowCrash', error);
+    return [];
+  })
 }
 getAnnotations.async = true;
 
@@ -441,6 +457,14 @@ function createEditor(
         });
       }
     });
+
+    editor.on('flowCrash', error => {
+      console.error(error)
+      if (errorsNode) {
+        removeChildren(errorsNode);
+        errorsNode.appendChild(printCrash(error, editor));
+      }
+    })
 
     versionTabNode.addEventListener('change', function(evt) {
       const version = evt.target.value;

--- a/website/_assets/js/tryFlow.js.es6.liquid
+++ b/website/_assets/js/tryFlow.js.es6.liquid
@@ -103,13 +103,24 @@ function printErrors(errors, editor) {
 
 function printCrash(error, editor) {
   const div = document.createElement('div');
-  switch (error[1].c) {
-    case 'Stack_overflow':
-      div.appendChild(document.createTextNode('A stack overflow error has occured. Flow stopped working'));
-      break;
-    default:
-      div.appendChild(document.createTextNode('An unknown internal error has occured. Flow stopped working'));
-      break;
+  if (error[0] === 248) {
+    switch (error[1].c) {
+      case 'Stack_overflow':
+        div.appendChild(document.createTextNode('A stack overflow error has occured. Flow stopped working'));
+        break;
+      default:
+        div.appendChild(document.createTextNode('An unknown internal error has occured. Flow stopped working'));
+        break;
+    }
+  } else if (error[0] === 0) {
+    switch (error[1][1].c) {
+      case 'Flow_js.Not_expect_bound':
+        div.appendChild(document.createTextNode(`An internal error occured: ${error[2].c}`));
+        break;
+      default:
+        div.appendChild(document.createTextNode('An unknown internal error has occured. Flow stopped working'));
+        break;
+    }
   }
   return div;
 }


### PR DESCRIPTION
<!--
  If this is a change to library defintions, please include links to relevant documentation.
  If this is a documentation change, please prefix the title with [DOCS].

  If this is neither, ensure you opened a discussion issue and link it in the PR description.
-->

![image](https://user-images.githubusercontent.com/3275424/60399755-fd587f80-9b82-11e9-9e3a-0d34f26bc8cb.png)
This looks very error-prone itself... maybe something can be done from js_of_ocaml side to convert errors to more convenient structure