### PR TITLE
Add $Distribute destructor

### DIFF
--- a/src/common/reason.ml
+++ b/src/common/reason.ml
@@ -133,6 +133,7 @@ type 'loc virtual_reason_desc =
   | RNoSuper
   | RDummyPrototype
   | RDummyThis
+  | RDistribute
   | RTupleMap
   | RObjectMap
   | RObjectMapi
@@ -292,6 +293,7 @@ let rec map_desc_locs f = function
   | RNoSuper
   | RDummyPrototype
   | RDummyThis
+  | RDistribute
   | RTupleMap
   | RObjectMap
   | RType _
@@ -654,6 +656,7 @@ let rec string_of_desc = function
   | RNoSuper -> "empty super object"
   | RDummyPrototype -> "empty prototype object"
   | RDummyThis -> "bound `this` in method"
+  | RDistribute -> "`$Distribute`"
   | RTupleMap -> "`$TupleMap`"
   | RObjectMap -> "`$ObjMap`"
   | RObjectMapi -> "`$ObjMapi`"
@@ -855,6 +858,7 @@ let is_constant_reason r =
 
 let is_typemap_reason r =
   match desc_of_reason r with
+  | RDistribute
   | RTupleMap
   | RObjectMap
   | RObjectMapi -> true
@@ -862,6 +866,7 @@ let is_typemap_reason r =
 
 let is_calltype_reason r =
   match desc_of_reason r with
+  | RDistribute
   | RTupleMap
   | RObjectMap
   | RObjectMapi
@@ -1328,6 +1333,7 @@ let classification_of_reason r = match desc_of_reason ~unwrap:true r with
 | RNoSuper
 | RDummyPrototype
 | RDummyThis
+| RDistribute
 | RTupleMap
 | RObjectMap
 | RObjectMapi

--- a/src/common/reason.mli
+++ b/src/common/reason.mli
@@ -81,6 +81,7 @@ type 'loc virtual_reason_desc =
   | RNoSuper
   | RDummyPrototype
   | RDummyThis
+  | RDistribute
   | RTupleMap
   | RObjectMap
   | RObjectMapi

--- a/src/common/ty/ty.ml
+++ b/src/common/ty/ty.ml
@@ -150,6 +150,7 @@ and utility =
   | PropertyType of t * t
   | ElementType of t * t
   | NonMaybeType of t
+  | Distribute of t * t
   | ObjMap of t * t
   | ObjMapi of t * t
   | TupleMap of t * t
@@ -299,6 +300,7 @@ let string_of_utility_ctor = function
   | PropertyType _ -> "$PropertyType"
   | ElementType _ -> "$ElementType"
   | NonMaybeType _ -> "$NonMaybeType"
+  | Distribute _ -> "$Distribute"
   | ObjMap _ -> "$ObjMap"
   | ObjMapi _ -> "$ObjMapi"
   | TupleMap _ -> "$TupleMap"
@@ -323,6 +325,7 @@ let types_of_utility = function
   | PropertyType (t1, t2) -> Some [t1; t2]
   | ElementType (t1, t2) -> Some [t1; t2]
   | NonMaybeType t -> Some [t]
+  | Distribute (t1, t2) -> Some [t1; t2]
   | ObjMap (t1, t2) -> Some [t1; t2]
   | ObjMapi (t1, t2) -> Some [t1; t2]
   | TupleMap (t1, t2) -> Some [t1; t2]

--- a/src/typing/debug_js.ml
+++ b/src/typing/debug_js.ml
@@ -37,6 +37,7 @@ let string_of_binary_test_ctor = function
   | SentinelProp _ -> "SentinelProp"
 
 let string_of_type_map = function
+  | Distribute _ -> "Distribute"
   | TupleMap _ -> "TupleMap"
   | ObjectMap _ -> "ObjectMap"
   | ObjectMapi _ -> "ObjectMapi"
@@ -74,6 +75,7 @@ let string_of_destructor = function
   | RestType _ -> "Rest"
   | ValuesType -> "Values"
   | CallType _ -> "CallType"
+  | TypeMap (Distribute _) -> "Distribute"
   | TypeMap (TupleMap _) -> "TupleMap"
   | TypeMap (ObjectMap _) -> "ObjectMap"
   | TypeMap (ObjectMapi _) -> "ObjectMapi"
@@ -1264,6 +1266,9 @@ and json_of_destructor_impl json_cx = Hh_json.(function
 
 and json_of_type_map json_cx = check_depth json_of_type_map_impl json_cx
 and json_of_type_map_impl json_cx = Hh_json.(function
+  | Distribute t -> JSON_Object [
+      "distribute", _json_of_t json_cx t;
+    ]
   | TupleMap t -> JSON_Object [
       "tupleMap", _json_of_t json_cx t;
     ]

--- a/src/typing/resolvableTypeJob.ml
+++ b/src/typing/resolvableTypeJob.ml
@@ -276,7 +276,10 @@ and collect_of_destructor ?log_unresolved cx acc = function
     -> acc
 
 and collect_of_type_map ?log_unresolved cx acc = function
-  | TupleMap t | ObjectMap t | ObjectMapi t ->
+  | Distribute t
+  | TupleMap t
+  | ObjectMap t
+  | ObjectMapi t ->
     collect_of_type ?log_unresolved cx acc t
 
 (* In some positions, like annots, we trust that tvars are 0->1. *)

--- a/src/typing/ty_normalizer.ml
+++ b/src/typing/ty_normalizer.ml
@@ -1492,6 +1492,8 @@ end = struct
       type__ ~env t' >>| fun ty' -> Ty.Utility (Ty.ElementType (ty, ty'))
     | T.CallType ts ->
       mapM (type__ ~env) ts >>| fun tys -> Ty.Utility (Ty.Call (ty, tys))
+    | T.TypeMap (T.Distribute t') ->
+      type__ ~env t' >>| fun ty' -> Ty.Utility (Ty.Distribute (ty, ty'))
     | T.TypeMap (T.ObjectMap t') ->
       type__ ~env t' >>| fun ty' -> Ty.Utility (Ty.ObjMap (ty, ty'))
     | T.TypeMap (T.ObjectMapi t') ->

--- a/src/typing/type.ml
+++ b/src/typing/type.ml
@@ -1067,6 +1067,7 @@ module rec TypeTerm : sig
   | ReactConfigType of t
 
   and type_map =
+  | Distribute of t
   | TupleMap of t
   | ObjectMap of t
   | ObjectMapi of t

--- a/src/typing/type_annotation.ml
+++ b/src/typing/type_annotation.ml
@@ -757,6 +757,17 @@ let rec convert cx tparams_map = Ast.Type.(function
     | _ ->
       error_type cx loc (Error_message.ETypeParamMinArity (loc, 1)) t_ast)
 
+  | "$Distribute" ->
+    check_type_arg_arity cx loc t_ast targs 2 (fun () ->
+      let t1, t2, targs = match convert_type_params () with
+      | [t1; t2], targs -> t1, t2, targs
+      | _ -> assert false in
+      let reason = mk_reason RDistribute loc in
+      reconstruct_ast
+        (EvalT (t1, TypeDestructorT (use_op reason, reason, TypeMap (Distribute t2)), mk_id ()))
+        targs
+    )
+
   | "$TupleMap" ->
     check_type_arg_arity cx loc t_ast targs 2 (fun () ->
       let t1, t2, targs = match convert_type_params () with

--- a/src/typing/type_mapper.ml
+++ b/src/typing/type_mapper.ml
@@ -548,6 +548,10 @@ class virtual ['a] t = object(self)
 
   method type_map cx map_cx t =
     match t with
+    | Distribute t' ->
+      let t'' = self#type_ cx map_cx t' in
+      if t'' == t' then t
+      else Distribute t''
     | TupleMap t' ->
       let t'' = self#type_ cx map_cx t' in
       if t'' == t' then t

--- a/src/typing/type_visitor.ml
+++ b/src/typing/type_visitor.ml
@@ -876,6 +876,7 @@ class ['a] t = object(self)
   | Upper u -> self#use_type_ cx acc u
 
   method private type_map cx acc = function
+  | Distribute t
   | TupleMap t
   | ObjectMap t
   | ObjectMapi t -> self#type_ cx pole_TODO acc t


### PR DESCRIPTION
<!--
  If this is a change to library defintions, please include links to relevant documentation.
  If this is a documentation change, please prefix the title with [DOCS].

  If this is neither, ensure you opened a discussion issue and link it in the PR description.
-->

This enables doing something similar to Conditional Types from TypeScript (previous name `$UnionMap`)

```js
type TypeName<T> = $Distribute<
  T,
  & (<T: string>(T) => "string")
  & (<T: number>(T) => "number")
  & (<T: boolean>(T) => "boolean")
  & (<T: void>(T) => "undefined")
  & (<T: (...any) => mixed>(T) => "function")
  & (() => "object")
>;

type T1 = TypeName<string>;  // "string"
type T2 = TypeName<true>;  // "boolean"
type T3 = TypeName<() => void>;  // "function"
type T4 = TypeName<string[]>;  // "object"

type T10 = TypeName<string | (() => void)>;  // "string" | "function"
type T12 = TypeName<string | string[] | void>;  // "string" | "object" | "undefined"
type T11 = TypeName<string[] | number[]>;  // "object"
```

But there's soundness issue with deferred resolving of destructor

```js
type Foo = {
  propA: boolean,
  propB: boolean
};

function coerce<T>(
  x: T
): $Distribute<T, (<V: Foo>(V) => string) & (<V>(V) => number)> {
  return 1; // no error
}

const a: string = coerce({ propA: true, propB: false });
const b: number = coerce("");
```