### PR TITLE
Change signature verification error message

### DIFF
--- a/src/typing/errors/error_message.ml
+++ b/src/typing/errors/error_message.ml
@@ -1650,8 +1650,8 @@ let friendly_message_of_msg : Loc.t t' -> Loc.t friendly_message_recipe =
           [text (spf "TODO: %s is not supported yet, try using a type cast." msg)]
       end in
       Normal
-        ((text "Failed to build a typed interface for this module. ")::
-         (text "The exports of this module must be annotated with types. ")::
+        ((text "Cannot build a typed interface for this module. ")::
+         (text "You should annotate the exports of this module with types. ")::
          msg)
 
     | EUnreachable _ ->


### PR DESCRIPTION
<!--
  If this is a change to library defintions, please include links to relevant documentation.
  If this is a documentation change, please prefix the title with [DOCS].

  If this is neither, ensure you opened a discussion issue and link it in the PR description.
-->

Avoids using passive voice and mirrors "Cannot" verb from every other error message, thus making it present tense