### PR TITLE
[docs] Update HOC injecting props example in docs to use spread

### DIFF
--- a/website/en/docs/react/hoc.md
+++ b/website/en/docs/react/hoc.md
@@ -50,28 +50,31 @@ that prop. For example, consider a navigation prop, or in the case of
 
 [`react-redux` a `store` prop]: https://github.com/reactjs/react-redux/blob/master/docs/api.md#connectmapstatetoprops-mapdispatchtoprops-mergeprops-options
 
-To remove a prop from the config, we can use `$Diff`. Let's make some small
-adjustments to our `trivialHoc`:
+To remove a prop from the config, we can take a component that includes the
+prop and return a component that does not. It's best to construct these
+types using object type spread.
 
 ```js
 //@flow
 import * as React from 'react';
 
-function injectProp<Config: {}>(
-  Component: React.AbstractComponent<Config>
-): React.AbstractComponent<$Diff<Config, {foo: number | void}>> {
+type InjectedProps = {| foo: number |}
+
+function injectProp<Config>(
+  Component: React.AbstractComponent<{| ...Config, ...InjectedProps |}>
+): React.AbstractComponent<Config> {
   return function WrapperComponent(
-    props: $Diff<Config, {foo: number | void}>,
+    props: Config,
   ) {
     return <Component {...props} foo={42} />;
   };
 }
 
-class MyComponent extends React.Component<{
+class MyComponent extends React.Component<{|
   a: number,
   b: number,
-  foo: number,
-}> {}
+  ...InjectedProps,
+|}> {}
 
 const MyEnhancedComponent = injectProp(MyComponent);
 
@@ -89,21 +92,23 @@ type `void`.
 //@flow
 import * as React from 'react';
 
-function injectProp<Config: {}>(
-  Component: React.AbstractComponent<Config>
-): React.AbstractComponent<$Diff<Config, {foo: number | void}>> {
+type InjectedProps = {| foo: number |}
+
+function injectProp<Config>(
+  Component: React.AbstractComponent<{| ...Config, ...InjectedProps |}>
+): React.AbstractComponent<Config> {
   return function WrapperComponent(
-    props: $Diff<Config, {foo: number | void}>,
+    props: Config,
   ) {
     return <Component {...props} foo={42} />;
   };
 }
 
-class MyComponent extends React.Component<{
+class MyComponent extends React.Component<{|
   a: number,
   b: number,
-  foo: number,
-}> {}
+  ...InjectedProps,
+|}> {}
 
 const MyEnhancedComponent = injectProp(MyComponent);
 
@@ -123,15 +128,21 @@ of the component, we can use [`React.forwardRef`](https://reactjs.org/docs/forwa
 //@flow
 import * as React from 'react';
 
-function injectAndPreserveInstance<Config: {}, Instance>(
-  Component: React.AbstractComponent<Config, Instance>,
+type InjectedProps = {| foo: number |}
+
+function injectAndPreserveInstance<Config, Instance>(
+  Component: React.AbstractComponent<{| ...Config, ...InjectedProps |}, Instance>
 ): React.AbstractComponent<Config, Instance> {
   return React.forwardRef<Config, Instance>((props, ref) =>
-      <Component ref={ref} {...props} />
+      <Component ref={ref} foo={3} {...props} />
   );
 }
 
-class MyComponent extends React.Component<{}> {}
+class MyComponent extends React.Component<{
+  a: number,
+  b: number,
+  ...InjectedProps,
+}> {}
 
 const MyEnhancedComponent = injectAndPreserveInstance(MyComponent);
 


### PR DESCRIPTION
There is still room for improvement here that the type spread work will unlock. For example, `mixed` (introduced by polymorphic type checking) will use `{}` instead of `{[string]: mixed}` in the spread computation. We can't use `{}` as an upper bound right now because [spreading an inexact object type inside an exact object type is not allowed](https://flow.org/try/#0JYWwDg9gTgLgBAKjgQwM5wEoFNkGN4BmUEIcA5FDvmQNwBQdMAnmFnAJIB2AVlvlgBMACsTDoAvHADeAHzgEIEAFxxOAVxAAjLFDgyAvgwJrO+YBE5xgPPjBEQwAHgDCFgsADmKqfoB8ACjo4OFdwCyxOGBVsPBgAOgBBTVQYKFjQyE4ImEdZODiC1053DwAafIKuXn5hUXQDXzoASmiqeKSUtPwM8MiXN09faSC4Shg1KEtjUxhzSwB1NLBWKB6syMDg4LA6lSKS0pGm4a3RrHHJuH6w9fgpAridh1R9eUVxKQAWACZXgHpfPRgvp6PogA).

Test Plan:
<img width="1009" alt="Screen Shot 2019-07-06 at 5 41 05 PM" src="https://user-images.githubusercontent.com/8551887/60761393-602f9800-a015-11e9-9b34-eee6a5bbd598.png">
<img width="972" alt="Screen Shot 2019-07-06 at 5 40 54 PM" src="https://user-images.githubusercontent.com/8551887/60761394-60c82e80-a015-11e9-84db-769b7deffa2c.png">
