### PR TITLE
fix: use correct component for MemoComponentWithEqual tests

### DIFF
--- a/tests/react_16_6/memo.js
+++ b/tests/react_16_6/memo.js
@@ -15,9 +15,9 @@ const _d = <MemoComponent foo="string" />; // Error wrong type for foo
 
 const MemoComponentWithEqual = React.memo(Component, (props1, props2) => props1 === props2);
 
-const _e = <MemoComponent foo={3} />;
-const _f = <MemoComponent />; // Error missing foo
-const _g = <MemoComponent foo={3} bar={3} />; // Error extra bar
-const _h = <MemoComponent foo="string" />; // Error wrong type for foo
+const _e = <MemoComponentWithEqual foo={3} />;
+const _f = <MemoComponentWithEqual />; // Error missing foo
+const _g = <MemoComponentWithEqual foo={3} bar={3} />; // Error extra bar
+const _h = <MemoComponentWithEqual foo="string" />; // Error wrong type for foo
 
 const _i = React.memo(React.forwardRef(Component));

--- a/tests/react_16_6/react_16_6.exp
+++ b/tests/react_16_6/react_16_6.exp
@@ -271,16 +271,16 @@ References:
 
 Error ---------------------------------------------------------------------------------------------------- memo.js:19:12
 
-Cannot create `MemoComponent` element because property `foo` is missing in props [1] but exists in `Props` [2].
+Cannot create `MemoComponentWithEqual` element because property `foo` is missing in props [1] but exists in `Props` [2].
 
    memo.js:19:12
-   19| const _f = <MemoComponent />; // Error missing foo
-                  ^^^^^^^^^^^^^^^^^
+   19| const _f = <MemoComponentWithEqual />; // Error missing foo
+                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   memo.js:9:23
-    9| const MemoComponent = React.memo(Component);
-                             ^^^^^^^^^^^^^^^^^^^^^ [1]
+   memo.js:16:32
+   16| const MemoComponentWithEqual = React.memo(Component, (props1, props2) => props1 === props2);
+                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
    memo.js:7:23
     7| function Component(x: Props): React.Node { return null }
                              ^^^^^ [2]
@@ -288,33 +288,33 @@ References:
 
 Error ---------------------------------------------------------------------------------------------------- memo.js:20:12
 
-Cannot create `MemoComponent` element because property `bar` is missing in `Props` [1] but exists in props [2].
+Cannot create `MemoComponentWithEqual` element because property `bar` is missing in `Props` [1] but exists in props [2].
 
    memo.js:20:12
-   20| const _g = <MemoComponent foo={3} bar={3} />; // Error extra bar
-                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   20| const _g = <MemoComponentWithEqual foo={3} bar={3} />; // Error extra bar
+                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
    memo.js:7:23
     7| function Component(x: Props): React.Node { return null }
                              ^^^^^ [1]
-   memo.js:9:23
-    9| const MemoComponent = React.memo(Component);
-                             ^^^^^^^^^^^^^^^^^^^^^ [2]
+   memo.js:16:32
+   16| const MemoComponentWithEqual = React.memo(Component, (props1, props2) => props1 === props2);
+                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [2]
 
 
 Error ---------------------------------------------------------------------------------------------------- memo.js:21:12
 
-Cannot create `MemoComponent` element because string [1] is incompatible with number [2] in property `foo`.
+Cannot create `MemoComponentWithEqual` element because string [1] is incompatible with number [2] in property `foo`.
 
    memo.js:21:12
-   21| const _h = <MemoComponent foo="string" />; // Error wrong type for foo
-                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   21| const _h = <MemoComponentWithEqual foo="string" />; // Error wrong type for foo
+                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   memo.js:21:31
-   21| const _h = <MemoComponent foo="string" />; // Error wrong type for foo
-                                     ^^^^^^^^ [1]
+   memo.js:21:40
+   21| const _h = <MemoComponentWithEqual foo="string" />; // Error wrong type for foo
+                                              ^^^^^^^^ [1]
    memo.js:5:22
     5| type Props = {| foo: number |};
                             ^^^^^^ [2]


### PR DESCRIPTION
<!--
  If this is a change to library defintions, please include links to relevant documentation.
  If this is a documentation change, please prefix the title with [DOCS].

  If this is neither, ensure you opened a discussion issue and link it in the PR description.
-->

Addressing #7848, use the correct component for `MemoComponentWithEqual` test.

**Edit**: reference the correct issue