### PR TITLE
ReadableStream pipeTo returns a promise

### DIFF
--- a/lib/streams.js
+++ b/lib/streams.js
@@ -97,7 +97,7 @@ declare class ReadableStream {
   cancel(reason: string): void,
   getReader(): ReadableStreamReader,
   pipeThrough(transform: TransformStream, options: ?any): void,
-  pipeTo(dest: WritableStream, options: ?PipeToOptions): void,
+  pipeTo(dest: WritableStream, options: ?PipeToOptions): Promise<void>,
   tee(): [ReadableStream, ReadableStream],
 };
 


### PR DESCRIPTION
<!--
  If this is a change to library defintions, please include links to relevant documentation.
  If this is a documentation change, please prefix the title with [DOCS].

  If this is neither, ensure you opened a discussion issue and link it in the PR description.
-->

Updates the return signature of `pipeTo` method on `ReadableStream`, which should return a promise.

https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream/pipeTo


