### PR TITLE
[type-definition] Proper overload for assert.fail

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -2435,12 +2435,14 @@ declare module "zlib" {
 
 declare module "assert" {
   declare class AssertionError extends Error {}
+  declare interface AssertFailFn {
+    (message?: string | Error): void;
+    (actual: any, expected: any, message: string, operator: string): void; // deprecated since v10.15
+  }
   declare module.exports: {
     (value: any, message?: string): void,
     ok(value: any, message?: string): void,
-    fail(message?: string | Error): void,
-    // deprecated since v10.15
-    fail(actual: any, expected: any, message: string, operator: string): void,
+    fail: AssertFailFn,
     equal(actual: any, expected: any, message?: string): void,
     notEqual(actual: any, expected: any, message?: string): void,
     deepEqual(actual: any, expected: any, message?: string): void,

--- a/lib/node.js
+++ b/lib/node.js
@@ -2437,7 +2437,7 @@ declare module "assert" {
   declare class AssertionError extends Error {}
   declare interface AssertFailFn {
     (message?: string | Error): void;
-    (actual: any, expected: any, message: string, operator: string): void; // deprecated since v10.15
+    (actual: any, expected: any, message?: string | Error, operator?: string, stackStartFn?: Function): void; // deprecated since v10.15
   }
   declare module.exports: {
     (value: any, message?: string): void,


### PR DESCRIPTION
Currently I get the following error when I have `assert.fail` with one argument:

```
Cannot call assert.fail because function [1] requires another argument.
     src/index.spec.js
       35│         assert.fail('message');

     /private/tmp/flow/flowlib_2209bba7/node.js
 [1] 2443│     fail(actual: any, expected: any, message: string, operator: string): void,
```

Fixes https://github.com/facebook/flow/issues/6799

Redo the work being merged in https://github.com/facebook/flow/pull/7482/files

Related docs: 
Single argument method overload - https://nodejs.org/docs/latest-v10.x/api/assert.html#assert_assert_fail_message

Deprecated method - https://nodejs.org/docs/latest-v10.x/api/assert.html#assert_assert_fail_actual_expected_message_operator_stackstartfn