### PR TITLE
Fix undefined return in TypedArray sort function

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -761,7 +761,7 @@ declare class $TypedArray {
     set(array: Array<number> | $TypedArray, offset?: number): void;
     slice(begin?: number, end?: number): this;
     some(callback: (value: number, index: number, array: this) => mixed, thisArg?: any): boolean;
-    sort(compare?: (a: number, b: number) => number): void;
+    sort(compare?: (a: number, b: number) => number): this;
     subarray(begin?: number, end?: number): this;
     values(): Iterator<number>;
 }


### PR DESCRIPTION
<!--
  If this is a change to library defintions, please include links to relevant documentation.
  If this is a documentation change, please prefix the title with [DOCS].

  If this is neither, ensure you opened a discussion issue and link it in the PR description.
-->

Fixes #6021

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/sort