### PR TITLE
Fix typo in installation instructions

### DIFF
--- a/website/en/docs/_install/compiler-babel.md
+++ b/website/en/docs/_install/compiler-babel.md
@@ -2,15 +2,15 @@
 support for Flow. Babel will take your Flow code and strip out any type
 annotations.
 
-First install `babel-cli` and `@babel/preset-flow` with either
-[Yarn](https://yarnpkg.com/) or [npm](https://www.npmjs.com/).
+First install `@babel/core`, `@babel/cli`, and `@babel/preset-flow` with
+either [Yarn](https://yarnpkg.com/) or [npm](https://www.npmjs.com/).
 
 ```sh
-{{include.install_command}} babel-cli babel-preset-flow
+{{include.install_command}} @babel/core @babel/cli @babel/preset-flow
 ```
 
 Next you need to create a `.babelrc` file at the root of your project with
-`"flow"` in your `"presets"`.
+`"@babel/preset-flow"` in your `"presets"`.
 
 ```json
 {


### PR DESCRIPTION
Installation instructions for babel + NPM instructed installing the incorrect babel plugin.