### PR TITLE
Fix $ElementType union property key

### DIFF
--- a/tests/type-destructors/element_type.js
+++ b/tests/type-destructors/element_type.js
@@ -1,3 +1,5 @@
+// @flow
+
 type BadArity = $ElementType<number, number, number>;
 
 type Arr = Array<number>;
@@ -21,3 +23,7 @@ function bar(o: Obj): $ElementType<Obj, string> {
   if (false) return o['buz'];
   else return 0;
 }
+
+declare var x: $ElementType<{a: ''}, 'a' | 'b'>;
+
+const y: string = x

--- a/tests/type-destructors/issue_4211.js
+++ b/tests/type-destructors/issue_4211.js
@@ -31,10 +31,11 @@ const data: Fields = {
 };
 
 function getField<K: $Keys<Fields>>(key: K): $ElementType<Fields, K> {
+  (data[key]: number | string); // OK
   return data[key];
 }
 
 const aValue = getField("a");
 const bValue = getField("b");
-(aValue: string);
-(bValue: number);
+(aValue: string); // OK
+(bValue: number); // OK

--- a/tests/type-destructors/issue_4211.js
+++ b/tests/type-destructors/issue_4211.js
@@ -11,11 +11,29 @@ declare var v1: T1;
 
 (1: T); // works
 (2: T1); // works
-('foo': T); // works
-('foo': T1); // works
-({a: 1}: T); // error
+("foo": T); // works
+("foo": T1); // works
+({ a: 1 }: T); // error
 
 declare var x: string & number;
 
 (x: T); // works
 (x: T1); // works
+
+type Fields = {|
+  a: string,
+  b: number
+|};
+
+const data: Fields = {
+  a: "foo",
+  b: 42
+};
+
+function getField<K: $Keys<Fields>>(key: K): $ElementType<Fields, K> {
+  return data[key];
+}
+
+const aValue = getField("a");
+const bValue = getField("b");
+

--- a/tests/type-destructors/issue_4211.js
+++ b/tests/type-destructors/issue_4211.js
@@ -36,4 +36,5 @@ function getField<K: $Keys<Fields>>(key: K): $ElementType<Fields, K> {
 
 const aValue = getField("a");
 const bValue = getField("b");
-
+(aValue: string);
+(bValue: number);

--- a/tests/type-destructors/issue_4211.js
+++ b/tests/type-destructors/issue_4211.js
@@ -1,12 +1,21 @@
 // @flow
 
 declare var t: [number, string];
-type T = $ElementType<typeof t, 0 | 1>;
+declare var y: 0 | 1;
+type T = $ElementType<typeof t, typeof y>;
+type T1 = $ElementType<typeof t, 0 | 1>;
 declare var v: T;
+declare var v1: T1;
 (v: number | string); // OK, correct
+(v1: number | string);
 
+(1: T); // works
+(2: T1); // works
 ('foo': T); // works
+('foo': T1); // works
+({a: 1}: T); // error
 
 declare var x: string & number;
 
 (x: T); // works
+(x: T1); // works

--- a/tests/type-destructors/issue_4211.js
+++ b/tests/type-destructors/issue_4211.js
@@ -1,0 +1,12 @@
+// @flow
+
+declare var t: [number, string];
+type T = $ElementType<typeof t, 0 | 1>;
+declare var v: T;
+(v: number | string); // OK, correct
+
+('foo': T); // works
+
+declare var x: string & number;
+
+(x: T); // works

--- a/tests/type-destructors/property_type.js
+++ b/tests/type-destructors/property_type.js
@@ -1,3 +1,5 @@
+// @flow
+
 type Malformed = $PropertyType<any, number>;
 
 type Obj = { x: string };

--- a/tests/type-destructors/type-destructors.exp
+++ b/tests/type-destructors/type-destructors.exp
@@ -272,6 +272,25 @@ References:
                       ^^ [1]
 
 
+Error ----------------------------------------------------------------------------------------------- issue_4211.js:16:2
+
+Cannot cast object literal to `T` because:
+ - Either object literal [1] is incompatible with number [2].
+ - Or object literal [1] is incompatible with string [3].
+
+   issue_4211.js:16:2
+   16| ({a: 1}: T); // error
+        ^^^^^^ [1]
+
+References:
+   issue_4211.js:3:17
+    3| declare var t: [number, string];
+                       ^^^^^^ [2]
+   issue_4211.js:3:25
+    3| declare var t: [number, string];
+                               ^^^^^^ [3]
+
+
 Error ----------------------------------------------------------------------------------------------- merged/test.js:9:4
 
 Cannot call `fn` with object literal bound to the first parameter because property `foo` is missing in object type [1]
@@ -753,7 +772,7 @@ References:
 
 
 
-Found 50 errors
+Found 51 errors
 
 Only showing the most relevant union/intersection branches.
 To see all branches, re-run Flow with --show-all-branches

--- a/tests/type-destructors/type-destructors.exp
+++ b/tests/type-destructors/type-destructors.exp
@@ -1,37 +1,51 @@
-Error --------------------------------------------------------------------------------------------- element_type.js:1:17
+Error --------------------------------------------------------------------------------------------- element_type.js:3:17
 
 Cannot use type without exactly 2 type arguments.
 
-   1| type BadArity = $ElementType<number, number, number>;
+   3| type BadArity = $ElementType<number, number, number>;
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 
-Error ---------------------------------------------------------------------------------------------- element_type.js:7:2
+Error ---------------------------------------------------------------------------------------------- element_type.js:9:2
 
 Cannot cast `'hello world'` to `Arr_Elem` because string [1] is incompatible with number [2].
 
-   element_type.js:7:2
-   7| ('hello world': Arr_Elem);
+   element_type.js:9:2
+   9| ('hello world': Arr_Elem);
        ^^^^^^^^^^^^^ [1]
 
 References:
-   element_type.js:7:17
-   7| ('hello world': Arr_Elem);
+   element_type.js:9:17
+   9| ('hello world': Arr_Elem);
                       ^^^^^^^^ [2]
 
 
-Error --------------------------------------------------------------------------------------------- element_type.js:18:2
+Error --------------------------------------------------------------------------------------------- element_type.js:20:2
 
 Cannot cast `'hello world'` to `Obj_Elem` because string [1] is incompatible with number [2].
 
-   element_type.js:18:2
-   18| ('hello world': Obj_Elem);
+   element_type.js:20:2
+   20| ('hello world': Obj_Elem);
         ^^^^^^^^^^^^^ [1]
 
 References:
-   element_type.js:18:17
-   18| ('hello world': Obj_Elem);
+   element_type.js:20:17
+   20| ('hello world': Obj_Elem);
                        ^^^^^^^^ [2]
+
+
+Error -------------------------------------------------------------------------------------------- element_type.js:27:16
+
+Cannot instantiate `$ElementType` because property `b` is missing in object type [1].
+
+   element_type.js:27:16
+   27| declare var x: $ElementType<{a: ''}, 'a' | 'b'>;
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+References:
+   element_type.js:27:29
+   27| declare var x: $ElementType<{a: ''}, 'a' | 'b'>;
+                                   ^^^^^^^ [1]
 
 
 Error -------------------------------------------------------------------------------------------------- errors.js:12:10
@@ -334,39 +348,39 @@ References:
                          ^^^^ [2]
 
 
-Error -------------------------------------------------------------------------------------------- property_type.js:1:18
+Error -------------------------------------------------------------------------------------------- property_type.js:3:18
 
 Cannot use `$PropertyType` because the second type argument must be a string literal.
 
-   1| type Malformed = $PropertyType<any, number>;
+   3| type Malformed = $PropertyType<any, number>;
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 
-Error --------------------------------------------------------------------------------------------- property_type.js:6:2
+Error --------------------------------------------------------------------------------------------- property_type.js:8:2
 
 Cannot cast `42` to `Obj_Prop_x` because number [1] is incompatible with string [2].
 
-   property_type.js:6:2
-   6| (42: Obj_Prop_x);
+   property_type.js:8:2
+   8| (42: Obj_Prop_x);
        ^^ [1]
 
 References:
-   property_type.js:6:6
-   6| (42: Obj_Prop_x);
+   property_type.js:8:6
+   8| (42: Obj_Prop_x);
            ^^^^^^^^^^ [2]
 
 
-Error ------------------------------------------------------------------------------------------- property_type.js:10:15
+Error ------------------------------------------------------------------------------------------- property_type.js:12:15
 
 Cannot return `0` because number [1] is incompatible with string [2].
 
-   property_type.js:10:15
-   10|   else return 0;
+   property_type.js:12:15
+   12|   else return 0;
                      ^ [1]
 
 References:
-   property_type.js:3:17
-    3| type Obj = { x: string };
+   property_type.js:5:17
+    5| type Obj = { x: string };
                        ^^^^^^ [2]
 
 
@@ -714,65 +728,65 @@ References:
                ^^ [1]
 
 
-Error ---------------------------------------------------------------------------------------------------- union.js:2:40
+Error ---------------------------------------------------------------------------------------------------- union.js:4:40
 
 Cannot assign `true` to `x1` because:
  - Either boolean [1] is incompatible with number [2].
  - Or boolean [1] is incompatible with string [3].
 
-   union.js:2:40
-   2| var x1: $NonMaybeType<number|string> = true; // err, boolean ~> number|string
+   union.js:4:40
+   4| var x1: $NonMaybeType<number|string> = true; // err, boolean ~> number|string
                                              ^^^^ [1]
 
 References:
-   union.js:2:23
-   2| var x1: $NonMaybeType<number|string> = true; // err, boolean ~> number|string
+   union.js:4:23
+   4| var x1: $NonMaybeType<number|string> = true; // err, boolean ~> number|string
                             ^^^^^^ [2]
-   union.js:2:30
-   2| var x1: $NonMaybeType<number|string> = true; // err, boolean ~> number|string
+   union.js:4:30
+   4| var x1: $NonMaybeType<number|string> = true; // err, boolean ~> number|string
                                    ^^^^^^ [3]
 
 
-Error ---------------------------------------------------------------------------------------------------- union.js:4:52
+Error ---------------------------------------------------------------------------------------------------- union.js:6:52
 
 Cannot assign `true` to `x3` because:
  - Either boolean [1] is incompatible with number [2].
  - Or boolean [1] is incompatible with string [3].
 
-   union.js:4:52
-   4| var x3: $PropertyType<{p:number}|{p:string},'p'> = true; // err, boolean ~> number|string
+   union.js:6:52
+   6| var x3: $PropertyType<{p:number}|{p:string},'p'> = true; // err, boolean ~> number|string
                                                          ^^^^ [1]
 
 References:
-   union.js:4:26
-   4| var x3: $PropertyType<{p:number}|{p:string},'p'> = true; // err, boolean ~> number|string
+   union.js:6:26
+   6| var x3: $PropertyType<{p:number}|{p:string},'p'> = true; // err, boolean ~> number|string
                                ^^^^^^ [2]
-   union.js:4:37
-   4| var x3: $PropertyType<{p:number}|{p:string},'p'> = true; // err, boolean ~> number|string
+   union.js:6:37
+   6| var x3: $PropertyType<{p:number}|{p:string},'p'> = true; // err, boolean ~> number|string
                                           ^^^^^^ [3]
 
 
-Error ---------------------------------------------------------------------------------------------------- union.js:10:2
+Error ---------------------------------------------------------------------------------------------------- union.js:12:2
 
 Cannot cast `null` to `P2` because:
  - Either null [1] is incompatible with string [2].
  - Or null [1] is incompatible with number [3].
 
-   union.js:10:2
-   10| (null: P2); // err, null ~> string|number
+   union.js:12:2
+   12| (null: P2); // err, null ~> string|number
         ^^^^ [1]
 
 References:
-   union.js:11:14
-   11| type T = {p: string} | {p: number}; // NB: T resolved here
+   union.js:13:14
+   13| type T = {p: string} | {p: number}; // NB: T resolved here
                     ^^^^^^ [2]
-   union.js:11:28
-   11| type T = {p: string} | {p: number}; // NB: T resolved here
+   union.js:13:28
+   13| type T = {p: string} | {p: number}; // NB: T resolved here
                                   ^^^^^^ [3]
 
 
 
-Found 51 errors
+Found 52 errors
 
 Only showing the most relevant union/intersection branches.
 To see all branches, re-run Flow with --show-all-branches

--- a/tests/type-destructors/union.js
+++ b/tests/type-destructors/union.js
@@ -1,3 +1,5 @@
+// @flow
+
 var x0: $NonMaybeType<number|string> = 0; // ok, number ~> number|string
 var x1: $NonMaybeType<number|string> = true; // err, boolean ~> number|string
 var x2: $PropertyType<{p:number}|{p:string},'p'> = 0; // ok, number ~> number|string


### PR DESCRIPTION
Similar issue was fixed in de994b684b3b0561df4e596e0a46b63a93d70a33.

When union types are flowing into `ElemT` it splits into two different constraints. Consider the following example:

```js
type T = $ElementType<[number, string], 0 | 1>;
("string": T);
```

When evaluating this declaration, we emit the following constraints:

1. EvalT (ElementType, ...) -> ...
2. 0 | 1 -> ElemT ([number, string], ReadElem T)

Constraint (2) is processed by splitting, which turns into two
separate constraints `0 -> ElemT (...)` and `1 -> ElemT (...)` then we get two constraints for our result tvar after:

1. number -> T
2. string -> T

Since `AnnotT` can't hold tvars with multiple types (see comment below) we see a spurious error that `string` is
not compatible with `number`.

> Note on usage: AnnotT can be used as a general wrapper for tvars as long
        as the wrapped tvars are 0->1. If instead the possible types of a
        wrapped tvar are T1 and T2, then the current rules would flow T1 | T2 to
        upper bounds, and would flow lower bounds to T1 & T2.

This diff deals with the above by handling union types specially in the ElemT use type.

Fixes #4211