### PR TITLE
Fix library definitions to pass 'implicit-inexact-object' lint

### DIFF
--- a/lib/bom.js
+++ b/lib/bom.js
@@ -1896,6 +1896,7 @@ type SpeechSynthesisEvent$Init = Event$Init & {
   charLength?: number;
   elapsedTime?: number;
   name?: string;
+  ...
 }
 
 declare class SpeechSynthesisEvent extends Event {
@@ -1909,6 +1910,7 @@ declare class SpeechSynthesisEvent extends Event {
 
 type SpeechSynthesisErrorEvent$Init = SpeechSynthesisEvent$Init & {
   error: SpeechSynthesisErrorCode;
+  ...
 }
 
 declare class SpeechSynthesisErrorEvent extends SpeechSynthesisEvent {

--- a/lib/core.js
+++ b/lib/core.js
@@ -75,7 +75,7 @@ declare class Object {
     static keys(o: $NotNullOrVoid): Array<string>;
     static preventExtensions<T>(o: T): T;
     static seal<T>(o: T): T;
-    static setPrototypeOf<T>(o: T, proto: ?{}): T;
+    static setPrototypeOf<T>(o: T, proto: ?{...}): T;
     static values(object: $NotNullOrVoid): Array<mixed>;
     hasOwnProperty(prop: mixed): boolean;
     isPrototypeOf(o: mixed): boolean;
@@ -475,7 +475,7 @@ declare class Error {
     columnNumber?: number;
 
     // note: v8 only (node/chrome)
-    static captureStackTrace(target: {[any] : any}, constructor?: any): void;
+    static captureStackTrace(target: { [any] : any, ... }, constructor?: any): void;
 
     static stackTraceLimit: number;
     static prepareStackTrace: (err: Error, stack: CallSite[]) => mixed;
@@ -842,8 +842,8 @@ declare var Reflect: {
 /* Proxy */
 
 type Proxy$traps<T> = {
-    getPrototypeOf?: (target: T) => {[any] : any} | null,
-    setPrototypeOf?: (target: T, prototype: {[any] : any} | null) => boolean,
+    getPrototypeOf?: (target: T) => { [any] : any, ... } | null,
+    setPrototypeOf?: (target: T, prototype: { [any] : any, ... } | null) => boolean,
     isExtensible?: (target: T) => boolean,
     preventExtensions?: (target: T) => boolean,
     getOwnPropertyDescriptor?: (target: T, property: string) => void | PropertyDescriptor<T>,
@@ -854,7 +854,7 @@ type Proxy$traps<T> = {
     deleteProperty?: (target: T, property: string) => boolean,
     ownKeys?: (target: T) => Array<string>,
     apply?: (target: T, context: any, args: Array<any>) => any,
-    construct?: (target: T, args: Array<any>, newTarget: (...any) => any) => {[any] : any},
+    construct?: (target: T, args: Array<any>, newTarget: (...any) => any) => { [any] : any, ... },
     ...
 };
 


### PR DESCRIPTION
In `graphql-js` we use `implicit-inexact-object` lint option that stop working in `0.103.0` so we can't update flow. Can you please merge this fix and release `0.103.1`?
Note: I didn't test these changes since I don't have a local environment to run flow.

Also, it would be great if you add CI test that checks that libary definitions pass all lint rules to prevent such regressions in the future.
Here is the error log:
```
> graphql@14.4.2 check /Users/ivang/dev/graphql-js
> flow check

Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ /private/tmp/flow/flowlib_19144060/bom.js:1564:47

Please add ... to the end of the list of properties to express an inexact object type.
(implicit-inexact-object)

     1561│   onboundary: ?((ev: SpeechSynthesisEvent) => mixed);
     1562│ }
     1563│
     1564│ type SpeechSynthesisEvent$Init = Event$Init & {
     1565│   utterance: SpeechSynthesisUtterance;
     1566│   charIndex?: number;
     1567│   charLength?: number;
     1568│   elapsedTime?: number;
     1569│   name?: string;
     1570│ }
     1571│
     1572│ declare class SpeechSynthesisEvent extends Event {
     1573│   constructor(type: string, eventInitDict?: SpeechSynthesisEvent$Init): SpeechSynthesisEvent;


Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ /private/tmp/flow/flowlib_19144060/bom.js:1581:67

Please add ... to the end of the list of properties to express an inexact object type.
(implicit-inexact-object)

     1578│   name: string;
     1579│ }
     1580│
     1581│ type SpeechSynthesisErrorEvent$Init = SpeechSynthesisEvent$Init & {
     1582│   error: SpeechSynthesisErrorCode;
     1583│ }
     1584│
     1585│ declare class SpeechSynthesisErrorEvent extends SpeechSynthesisEvent {
     1586│   constructor(type: string, eventInitDict?: SpeechSynthesisErrorEvent$Init): SpeechSynthesisErrorEvent;


Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ /private/tmp/flow/flowlib_19144060/core.js:74:44

Please add ... to the end of the list of properties to express an inexact object type.
(implicit-inexact-object)

     71│     static keys(o: $NotNullOrVoid): Array<string>;
     72│     static preventExtensions<T>(o: T): T;
     73│     static seal<T>(o: T): T;
     74│     static setPrototypeOf<T>(o: T, proto: ?{}): T;
     75│     static values(object: $NotNullOrVoid): Array<mixed>;
     76│     hasOwnProperty(prop: mixed): boolean;
     77│     isPrototypeOf(o: mixed): boolean;


Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ /private/tmp/flow/flowlib_19144060/core.js:468:38

Please add ... to the end of the list of properties to express an inexact object type.
(implicit-inexact-object)

     465│     columnNumber?: number;
     466│
     467│     // note: v8 only (node/chrome)
     468│     static captureStackTrace(target: {[any] : any}, constructor?: any): void;
     469│
     470│     static stackTraceLimit: number;
     471│     static prepareStackTrace: (err: Error, stack: CallSite[]) => mixed;


Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ /private/tmp/flow/flowlib_19144060/core.js:835:37

Please add ... to the end of the list of properties to express an inexact object type.
(implicit-inexact-object)

     832│ /* Proxy */
     833│
     834│ type Proxy$traps<T> = {
     835│     getPrototypeOf?: (target: T) => {[any] : any} | null,
     836│     setPrototypeOf?: (target: T, prototype: {[any] : any} | null) => boolean,
     837│     isExtensible?: (target: T) => boolean,
     838│     preventExtensions?: (target: T) => boolean,


Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ /private/tmp/flow/flowlib_19144060/core.js:836:45

Please add ... to the end of the list of properties to express an inexact object type.
(implicit-inexact-object)

     833│
     834│ type Proxy$traps<T> = {
     835│     getPrototypeOf?: (target: T) => {[any] : any} | null,
     836│     setPrototypeOf?: (target: T, prototype: {[any] : any} | null) => boolean,
     837│     isExtensible?: (target: T) => boolean,
     838│     preventExtensions?: (target: T) => boolean,
     839│     getOwnPropertyDescriptor?: (target: T, property: string) => void | PropertyDescriptor<T>,


Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ /private/tmp/flow/flowlib_19144060/core.js:847:78

Please add ... to the end of the list of properties to express an inexact object type.
(implicit-inexact-object)

     844│     deleteProperty?: (target: T, property: string) => boolean,
     845│     ownKeys?: (target: T) => Array<string>,
     846│     apply?: (target: T, context: any, args: Array<any>) => any,
     847│     construct?: (target: T, args: Array<any>, newTarget: (...any) => any) => {[any] : any},
     848│     ...
     849│ };
     850│
```
