### PR TITLE
Bump required ocaml version to 4.07.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,14 +25,14 @@ aliases:
     name: Install deps from opam
     command: |
       eval $(opam env)
-      opam switch create . 4.05.0 --deps-only | cat
+      opam switch create . 4.07.1 --deps-only | cat
 
   - &restore_opam_cache
     keys:
-      - opam-cache-{{ arch }}-opam_{{ checksum ".circleci/opamversion" }}-ocaml_4_05_0-{{ checksum "opam" }}
+      - opam-cache-{{ arch }}-opam_{{ checksum ".circleci/opamversion" }}-ocaml_4_07_1-{{ checksum "opam" }}
 
   - &save_opam_cache
-    key: opam-cache-{{ arch }}-opam_{{ checksum ".circleci/opamversion" }}-ocaml_4_05_0-{{ checksum "opam" }}
+    key: opam-cache-{{ arch }}-opam_{{ checksum ".circleci/opamversion" }}-ocaml_4_07_1-{{ checksum "opam" }}
     paths:
       - ~/.opam
 
@@ -154,9 +154,9 @@ jobs:
       - restore_cache: *restore_opam_cache
       - run:
           name: Install ocaml
-          command: opam init --comp 4.05.0 -yn | cat
+          command: opam init --comp 4.07.1 -yn | cat
       - save_cache:
-          key: opam-cache-{{ arch }}-opam_{{ checksum ".circleci/opamversion" }}-ocaml_4_05_0
+          key: opam-cache-{{ arch }}-opam_{{ checksum ".circleci/opamversion" }}-ocaml_4_07_1
           paths:
             - ~/.opam
       - run:

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ opam depext --install flowtype
 If you don't have a new enough version of OCaml to compile Flow, you can also use OPAM to bootstrap a modern version.  Install OPAM via the [binary packages](http://opam.ocaml.org/doc/Install.html#InstallOPAMin2minutes) for your operating system and run:
 
 ```
-opam init --comp=4.05.0
+opam init --comp=4.07.1
 opam install flowtype
 eval `opam config env`
 flow --help
@@ -111,20 +111,20 @@ More thorough documentation and many examples can be found at [flow.org](https:/
 
 ## Building Flow
 
-Flow is written in OCaml (OCaml 4.05.0 or higher is required). You can install OCaml on macOS and Linux by following the instructions at [ocaml.org](https://ocaml.org/docs/install.html).
+Flow is written in OCaml (OCaml 4.07.1 or higher is required). You can install OCaml on macOS and Linux by following the instructions at [ocaml.org](https://ocaml.org/docs/install.html).
 
 For example, on Ubuntu 16.04 and similar systems:
 
 ```
 sudo apt-get install opam
-opam init --comp 4.05.0
+opam init --comp 4.07.1
 ```
 
 On macOS, using the [brew package manager](http://brew.sh/):
 
 ```
 brew install opam
-opam init --comp 4.05.0
+opam init --comp 4.07.1
 ```
 
 Then, restart your shell and install these additional libraries:
@@ -173,11 +173,11 @@ The general idea is that we build in Cygwin, targeting mingw. This gives us a bi
 
 ### Install Opam
 1. Open the cygwin64 terminal
-2. Download opam with `curl -fsSL -o opam64.tar.xz https://github.com/fdopen/opam-repository-mingw/releases/download/0.0.0.1/opam64.tar.xz`
+2. Download opam with `curl -fsSL -o opam64.tar.xz https://github.com/fdopen/opam-repository-mingw/releases/download/0.0.0.2/opam64.tar.xz`
 3. `tar -xf opam64.tar.xz`
 4. `cd opam64`
 5. Install opam `./install.sh`
-6. Initialize opam to point to a mingw fork: `opam init -a default "https://github.com/fdopen/opam-repository-mingw.git" --comp "4.05.0+mingw64c" --switch "4.05.0+mingw64c"`
+6. Initialize opam to point to a mingw fork: `opam init default "https://github.com/fdopen/opam-repository-mingw.git#opam2" -c "ocaml-variants.4.07.1+mingw64c" --disable-sandboxing`
 7. Make sure opam stuff is in your path: ```eval `opam config env` ```
 
 ### Install Flow

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ os: Visual Studio 2015
 platform: x64
 environment:
   matrix:
-    - OPAM_SWITCH: 4.05.0+mingw64c
+    - OPAM_SWITCH: 4.07.1+mingw64c
       FORK_USER: ocaml
       FORK_BRANCH: master
       CYG_ROOT: C:\cygwin64

--- a/opam
+++ b/opam
@@ -8,7 +8,7 @@ homepage: "https://flow.org"
 doc: "https://flow.org/en/docs/getting-started/"
 bug-reports: "https://github.com/facebook/flow/issues"
 depends: [
-  "ocaml" {>= "4.05.0"}
+  "ocaml" {>= "4.07.1"}
   "base-unix"
   "base-bytes"
   "dtoa" {>= "0.3.1"}

--- a/src/parser/opam
+++ b/src/parser/opam
@@ -10,7 +10,7 @@ license: "MIT"
 build: [ make "-C" "src/parser" "build-parser" ]
 install: [ make "-C" "src/parser" "ocamlfind-install"]
 depends: [
-  "ocaml" {>= "4.05.0"}
+  "ocaml" {>= "4.07.1"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "ppx_deriving" {build}


### PR DESCRIPTION
We're bumping the required ocaml version to 4.07.1, in order to stay up to date. There's no internal testing against other versions, so although at this moment we're currently technically compatible with 4.05.0, we are bumping the minimum "required" version to 4.07.1. It may work on older versions but it is not supported.