### PR TITLE
Fix: IDBDatabase.objectStoreNames should be of type DOMStringList

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -96,6 +96,13 @@ declare class DataTransferItem {
 
 declare type DOMStringMap = { [key:string]: string, ... }
 
+declare class DOMStringList {
+  +[key:number]: string;
+  +length: number;
+  item: (number) => string | null;
+  contains: (string) => boolean;
+}
+
 declare class DOMError {
   name: string;
 }

--- a/lib/indexeddb.js
+++ b/lib/indexeddb.js
@@ -38,7 +38,7 @@ declare interface IDBDatabase extends EventTarget {
   transaction(storeNames: string|string[], mode?: 'readonly'|'readwrite'|'versionchange'): IDBTransaction;
   name: string;
   version: number;
-  objectStoreNames: string[];
+  objectStoreNames: DOMStringList;
   onabort: (e: any) => mixed;
   onclose: (e: any) => mixed;
   onerror: (e: any) => mixed;


### PR DESCRIPTION
I was working with IDBDatabases and found that this object property has the wrong type. It should have the type DOMStringList instead of string[].

So I have added an interface for DOMStringList and the appropriate type definition for the property  IDBDatabase.objectStoreNames. 

The documentation for DOMStringList can be found here: https://developer.mozilla.org/en-US/docs/Web/API/DOMStringList

And the documentation for IDBDatabase.objectStoreNames can be found here: https://developer.mozilla.org/en-US/docs/Web/API/IDBDatabase/objectStoreNames