### PR TITLE
Support length refinement of tuples

### DIFF
--- a/newtests/tuples/test.js
+++ b/newtests/tuples/test.js
@@ -75,10 +75,10 @@ export default suite(({addFile, addFiles, addCode}) => [
        `
          test.js:3
            3: function foo(x: [1,2]): string { return x.length; }
-                                                      ^^^^^^^^ Cannot return \`x.length\` because number [1] is incompatible with string [2].
+                                                      ^ Cannot return \`x.length\` because tuple length of 2 [1] is incompatible with string [2].
            References:
-           255:     +length: number;
-                             ^^^^^^ [1]. See lib: [LIB] core.js:255
+             3: function foo(x: [1,2]): string { return x.length; }
+                                ^^^^^ [1]
              3: function foo(x: [1,2]): string { return x.length; }
                                         ^^^^^^ [2]
        `,

--- a/src/common/reason.ml
+++ b/src/common/reason.ml
@@ -91,6 +91,7 @@ type 'loc virtual_reason_desc =
   | RROArrayType
   | RTupleType
   | RTupleElement
+  | RTupleLength of int
   | RTupleOutOfBoundsAccess
   | RFunction of reason_desc_function
   | RFunctionType
@@ -240,8 +241,8 @@ let rec map_desc_locs f = function
     | RVoid | RNull | RSymbol | RExports | RNullOrVoid | RLongStringLit _ | RStringLit _
     | RNumberLit _ | RBigIntLit _ | RBooleanLit _ | RObject | RObjectLit | RObjectType
     | RObjectClassName | RInterfaceType | RArray | RArrayLit | REmptyArrayLit | RArrayType
-    | RROArrayType | RTupleType | RTupleElement | RTupleOutOfBoundsAccess | RFunction _
-    | RFunctionType | RFunctionBody | RFunctionCallType | RFunctionUnusedArgument
+    | RROArrayType | RTupleType | RTupleElement | RTupleLength _ | RTupleOutOfBoundsAccess
+    | RFunction _ | RFunctionType | RFunctionBody | RFunctionCallType | RFunctionUnusedArgument
     | RJSXFunctionCall _ | RJSXIdentifier _ | RJSXElementProps _ | RJSXElement _ | RJSXText | RFbt
       ) as r ->
     r
@@ -539,6 +540,7 @@ let rec string_of_desc = function
   | RTupleType -> "tuple type"
   | RTupleElement -> "tuple element"
   | RTupleOutOfBoundsAccess -> "undefined (out of bounds tuple access)"
+  | RTupleLength i -> spf "tuple length of %d" i
   | RFunction func -> spf "%sfunction" (function_desc_prefix func)
   | RFunctionType -> "function type"
   | RFunctionBody -> "function body"
@@ -1295,6 +1297,7 @@ let classification_of_reason r =
   | RObjectClassName
   | RInterfaceType
   | RTupleElement
+  | RTupleLength _
   | RTupleOutOfBoundsAccess
   | RFunction _
   | RFunctionType

--- a/src/common/reason.mli
+++ b/src/common/reason.mli
@@ -41,6 +41,7 @@ type 'loc virtual_reason_desc =
   | RROArrayType
   | RTupleType
   | RTupleElement
+  | RTupleLength of int
   | RTupleOutOfBoundsAccess
   | RFunction of reason_desc_function
   | RFunctionType

--- a/src/typing/type.ml
+++ b/src/typing/type.ml
@@ -3698,6 +3698,19 @@ and extract_getter_type = function
   | DefT (_, _, FunT (_, _, { return_t; _ })) -> return_t
   | _ -> failwith "Getter property with unexpected type"
 
+and tuple_length reason trust ts =
+  let r =
+    let desc = RTupleLength (List.length ts) in
+    replace_desc_reason desc reason
+  in
+  let t =
+    let n = List.length ts in
+    let float = Pervasives.float_of_int n in
+    let string = Pervasives.string_of_int n in
+    SingletonNumT (float, string)
+  in
+  DefT (r, trust, t)
+
 and elemt_of_arrtype = function
   | ArrayAT (elemt, _)
   | ROArrayAT elemt

--- a/tests/refinements/refinements.exp
+++ b/tests/refinements/refinements.exp
@@ -3131,6 +3131,20 @@ References:
                       ^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 
+Error ---------------------------------------------------------------------------------------------------- tuple.js:32:6
+
+Cannot get `a[2]` because tuple type [1] only has 2 elements, so index 2 is out of bounds.
+
+   tuple.js:32:6
+   32|     (a[2]: number); // Error: one of the variants has only 2 elements.
+            ^^^^
+
+References:
+   tuple.js:25:17
+   25|   a: [string] | [number, number] | [number, number, number]
+                       ^^^^^^^^^^^^^^^^ [1]
+
+
 Error ---------------------------------------------------------------------------------------------------- typeof.js:5:5
 
 Cannot get `x[0]` because an index signature declaring the expected key / value type is missing in `Boolean` [1].
@@ -3533,4 +3547,4 @@ Cannot perform arithmetic operation because undefined [1] is not a number.
 
 
 
-Found 256 errors
+Found 257 errors

--- a/tests/refinements/tuple.js
+++ b/tests/refinements/tuple.js
@@ -1,0 +1,69 @@
+// @flow
+
+function length_refinement(a: [string] | [number, string]): void {
+  if (a.length === 1) {
+    (a[0]: string);
+  } else {
+
+    (a[0]: number);
+    (a[1]: string);
+  }
+}
+
+function partial_length_refinement(
+  a: [string] | [number, number] | [number, number, number]
+): void {
+  if (a.length === 1) {
+    (a[0]: string);
+  } else {
+    (a[0]: number);
+    (a[1]: number);
+  }
+}
+
+function partial_length_refinement_not_specific_enough(
+  a: [string] | [number, number] | [number, number, number]
+): void {
+  if (a.length === 1) {
+    (a[0]: string);
+  } else {
+    (a[0]: number);
+    (a[1]: number);
+    (a[2]: number); // Error: one of the variants has only 2 elements.
+  }
+}
+
+function refine_on_negative_length(a: [number] | [string, number]): void {
+  if (a.length === -1) {
+    (a: empty);
+  }
+}
+
+function refine_on_length_that_is_too_large(a: [number] | [string, number]): void {
+  if (a.length === 7) {
+    (a: empty);
+  }
+}
+
+function check_no_rounding(a: [number] | [string, number]): void {
+  if (a.length === 0.9) {
+    (a: empty);
+  }
+  if (a.length === 1.1) {
+    (a: empty);
+  }
+  if (a.length === 1.9) {
+    (a: empty);
+  }
+}
+
+function length_refinement_with_switch(a: [string] | [number, string]): void {
+  switch (a.length) {
+  case 1:
+    (a[0]: string);
+    break;
+  default:
+    (a[0]: number);
+    (a[1]: string);
+  }
+}

--- a/tests/tuples/tuples.exp
+++ b/tests/tuples/tuples.exp
@@ -237,5 +237,39 @@ References:
                      ^^^ [1]
 
 
+Error -------------------------------------------------------------------------------------------------- tuples.js:40:44
 
-Found 16 errors
+Cannot return `x.length` because tuple length of 2 [1] is incompatible with string [2].
+
+   tuples.js:40:44
+   40|     function a(x: [1, 2]): string { return x.length; }
+                                                  ^^^^^^^^
+
+References:
+   tuples.js:40:19
+   40|     function a(x: [1, 2]): string { return x.length; }
+                         ^^^^^^ [1]
+   tuples.js:40:28
+   40|     function a(x: [1, 2]): string { return x.length; }
+                                  ^^^^^^ [2]
+
+
+Error --------------------------------------------------------------------------------------------------- tuples.js:46:6
+
+Cannot cast `a_len` to number literal `2` because tuple length of 1 [1] is incompatible with number literal `2` [2].
+
+   tuples.js:46:6
+   46|     (a_len: 2);
+            ^^^^^
+
+References:
+   tuples.js:43:16
+   43|   function (a: [number]) {
+                      ^^^^^^^^ [1]
+   tuples.js:46:13
+   46|     (a_len: 2);
+                   ^ [2]
+
+
+
+Found 18 errors

--- a/tests/tuples/tuples.js
+++ b/tests/tuples/tuples.js
@@ -29,4 +29,20 @@ let tests = [
     const x = 0.5;
     t[x]; // error, not an integer
   },
+  // Make sure tuple length is a singleton.
+  function (a: [number]) {
+    const a_len = a.length;
+    (a_len: 1);
+  },
+  // Return length from a function with mismatched return type.
+  function () {
+    // error: tuple length 2 !~> string
+    function a(x: [1, 2]): string { return x.length; }
+  },
+  // Fail for a mismatched tuple length type.
+  function (a: [number]) {
+    const a_len = a.length;
+    // error: tuple length of 1 !~> number literal `2`
+    (a_len: 2);
+  }
 ];


### PR DESCRIPTION
I have rebased changes from https://github.com/facebook/flow/pull/5048 on top of the current master branch. (It was ~4000 changes behind %)
Addressed the only comment that the review had.

I must admit that I do not understand the flow source code as well as the original author.
But I will do my best to make sure this gets in.

I can see the original pull request was marked "interesting" here: https://github.com/facebook/flow/projects/4#card-20788575

It also feels that the test coverage is incomplete.  There are no tests that cover error messages.
Only the happy path is tested.  I did not figure out yet how to add this kind of tests.  Any kind of guidance is very welcome.