### PR TITLE
Add performance-timeline type defs

### DIFF
--- a/lib/bom.js
+++ b/lib/bom.js
@@ -458,6 +458,31 @@ declare class Performance {
 
 declare var performance: Performance;
 
+type PerformanceEntryList = PerformanceEntry[];
+
+declare interface PerformanceObserverEntryList {
+  getEntries(): PerformanceEntryList;
+  getEntriesByType(type: string): PerformanceEntryList;
+  getEntriesByName(name: string, type: ?string): PerformanceEntryList;
+}
+
+type PerformanceObserverInit = {
+  entryTypes?: string[];
+  type?: string;
+  buffered?: boolean;
+  ...
+}
+
+declare class PerformanceObserver {
+  constructor(callback: (entries: PerformanceObserverEntryList, observer: PerformanceObserver) => void): void;
+
+  observe(options: ?PerformanceObserverInit): void;
+  disconnect(): void;
+  takeRecords(): PerformanceEntryList;
+
+  static supportedEntryTypes: string[];
+}
+
 declare class History {
     length: number;
     scrollRestoration: 'auto' | 'manual';


### PR DESCRIPTION
# Why

So that flow users may immediately use the type definitions for
[performance-timeline](https://www.w3.org/TR/performance-timeline-2/).

# What

Add the type definitions.
