### PR TITLE
Add defaultProps to AbstractComponent

### DIFF
--- a/lib/react.js
+++ b/lib/react.js
@@ -127,7 +127,8 @@ declare class LegacyReactComponent<Props, State>
   state: State;
 }
 
-declare type React$AbstractComponentStatics = {
+declare type React$AbstractComponentStatics<Config> = {
+  defaultProps: $Rest<Config, {}>,
   displayName?: ?string,
   // This is only on function components, but trying to access name when
   // displayName is undefined is a common pattern.

--- a/src/typing/flow_js.ml
+++ b/src/typing/flow_js.ml
@@ -3969,14 +3969,14 @@ let rec __flow cx ((l: Type.t), (u: Type.use_t)) trace =
     (* When looking at properties of an AbstractComponent, we delegate to a union of
      * function component and class component
      *)
-    | DefT (r, _, ReactAbstractComponentT _),(
+    | DefT (r, _, ReactAbstractComponentT {config; _}),(
         TestPropT _
       | GetPropT  _
       | SetPropT _
       | GetElemT _
       | SetElemT _
     ) ->
-      let statics = get_builtin_type cx ~trace r "React$AbstractComponentStatics" in
+      let statics = get_builtin_typeapp cx ~trace r "React$AbstractComponentStatics" [config] in
       rec_flow cx trace (statics, u)
 
     (******************)


### PR DESCRIPTION
<!--
  If this is a change to library defintions, please include links to relevant documentation.
  If this is a documentation change, please prefix the title with [DOCS].

  If this is neither, ensure you opened a discussion issue and link it in the PR description.
-->

Partial fix for https://github.com/facebook/flow/issues/7467

But I don't think it's faithful to how Flow models `defaultProps` ?

`$Rest<X, {}>` is basically better `$Shape` (makes fields really optional)