### PR TITLE
Symbol.iterator as class

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -86,6 +86,7 @@ declare class Object {
 }
 
 // Well known Symbols.
+declare class $SymbolIterator mixins Symbol {}
 declare class $SymbolHasInstance mixins Symbol {}
 declare class $SymboIsConcatSpreadable mixins Symbol {}
 declare class $SymbolIterator mixins Symbol {}
@@ -104,7 +105,7 @@ declare class Symbol {
   +description: string | void;
   static hasInstance: $SymbolHasInstance;
   static isConcatSpreadable: $SymboIsConcatSpreadable;
-  static iterator: string; // polyfill '@@iterator'
+  static iterator: $SymbolIterator;
   static keyFor(sym: Symbol): ?string;
   static length: 0;
   static match: $SymbolMatch;

--- a/src/flow_dot_js.ml
+++ b/src/flow_dot_js.ml
@@ -336,21 +336,21 @@ let types_to_json types ~strip_root =
   ) in
   JSON_Array types_json
 
-let coverage_to_json ~strip_root ~trust (types : (Loc.t * Coverage.expression_coverage) list) content =
+let coverage_to_json ~strip_root ~trust (types : (Loc.t * Coverage_response.expression_coverage) list) content =
   let accum_coverage (untainted, tainted, empty, total) (_loc, cov) =
   match cov with
-  | Coverage.Uncovered -> (untainted, tainted, empty, total + 1)
-  | Coverage.Empty     -> (untainted, tainted, empty + 1, total + 1)
-  | Coverage.Untainted -> (untainted + 1, tainted, empty, total + 1)
-  | Coverage.Tainted   -> (untainted, tainted + 1, empty, total + 1)
+  | Coverage_response.Uncovered -> (untainted, tainted, empty, total + 1)
+  | Coverage_response.Empty     -> (untainted, tainted, empty + 1, total + 1)
+  | Coverage_response.Untainted -> (untainted + 1, tainted, empty, total + 1)
+  | Coverage_response.Tainted   -> (untainted, tainted + 1, empty, total + 1)
   in
 
   let accum_coverage_locs (untainted, tainted, empty, uncovered) (loc, cov) =
   match cov with
-  | Coverage.Uncovered -> (untainted, tainted, empty, loc::uncovered)
-  | Coverage.Empty     -> (untainted, tainted, loc::empty, loc::uncovered)
-  | Coverage.Untainted -> (loc::untainted, tainted, empty, uncovered)
-  | Coverage.Tainted   -> (untainted, loc::tainted, empty, uncovered)
+  | Coverage_response.Uncovered -> (untainted, tainted, empty, loc::uncovered)
+  | Coverage_response.Empty     -> (untainted, tainted, loc::empty, loc::uncovered)
+  | Coverage_response.Untainted -> (loc::untainted, tainted, empty, uncovered)
+  | Coverage_response.Tainted   -> (untainted, loc::tainted, empty, uncovered)
   in
 
   let offset_table = lazy (Offset_utils.make content) in

--- a/src/typing/flow_js.ml
+++ b/src/typing/flow_js.ml
@@ -5367,9 +5367,13 @@ let rec __flow cx ((l: Type.t), (u: Type.use_t)) trace =
     | _, ElemT (use_op, reason_op, (DefT (_, _, ObjT _) as obj), action) ->
       let propref = match l with
       | DefT (reason_x, _, StrT (Literal (_, x))) ->
-          let reason_prop = replace_reason_const (RProperty (Some x)) reason_x in
-          Named (reason_prop, x)
-      | _ -> Computed l
+        let reason_prop = replace_reason_const (RProperty (Some x)) reason_x in
+        Named (reason_prop, x)
+      | DefT (reason_x, _, InstanceT _) when DescFormat.name_of_instance_reason reason_x = "$SymbolIterator" ->
+        let reason_prop = replace_reason_const (RProperty (Some "@@iterator")) reason_x in
+        Named (reason_prop, "@@iterator")
+      | _ ->
+        Computed l
       in
       (match action with
       | ReadElem t ->

--- a/website/_assets/css/_try.scss
+++ b/website/_assets/css/_try.scss
@@ -12,6 +12,23 @@ html.site-fullscreen .content {
   position: relative;
   height: 100%;
 
+  .options {
+    position: absolute;
+    right: 50%;
+    z-index: 3;
+
+    label {
+      cursor: pointer;
+      float: left;
+      font-size: 14px;
+      padding: 7px 15px;
+
+      input {
+        margin-right: 8px;
+      }
+    }
+  }
+
   .code,
   .results {
     position: absolute;

--- a/website/_assets/css/_try.scss
+++ b/website/_assets/css/_try.scss
@@ -163,17 +163,26 @@ html.site-fullscreen .content {
 }
 
 @-webkit-keyframes sk-bouncedelay {
-  0%, 80%, 100% { -webkit-transform: scale(0) }
-  40% { -webkit-transform: scale(1.0) }
+  0%,
+  80%,
+  100% {
+    -webkit-transform: scale(0);
+  }
+  40% {
+    -webkit-transform: scale(1);
+  }
 }
 
 @keyframes sk-bouncedelay {
-  0%, 80%, 100% {
+  0%,
+  80%,
+  100% {
     -webkit-transform: scale(0);
     transform: scale(0);
-  } 40% {
-    -webkit-transform: scale(1.0);
-    transform: scale(1.0);
+  }
+  40% {
+    -webkit-transform: scale(1);
+    transform: scale(1);
   }
 }
 
@@ -204,4 +213,91 @@ html.site-fullscreen .content {
     text-overflow: ellipsis;
     width: 100%;
   }
+}
+
+/* New images */
+
+.CodeMirror-lint-mark-error {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%20viewBox%3D'0%200%206%203'%20enable-background%3D'new%200%200%206%203'%20height%3D'3'%20width%3D'6'%3E%3Cg%20fill%3D'%23d60a0a'%3E%3Cpolygon%20points%3D'5.5%2C0%202.5%2C3%201.1%2C3%204.1%2C0'%2F%3E%3Cpolygon%20points%3D'4%2C0%206%2C2%206%2C0.6%205.4%2C0'%2F%3E%3Cpolygon%20points%3D'0%2C2%201%2C3%202.4%2C3%200%2C0.6'%2F%3E%3C%2Fg%3E%3C%2Fsvg%3E");
+}
+
+.CodeMirror-lint-mark-warning {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%20viewBox%3D'0%200%206%203'%20enable-background%3D'new%200%200%206%203'%20height%3D'3'%20width%3D'6'%3E%3Cg%20fill%3D'%23117711'%3E%3Cpolygon%20points%3D'5.5%2C0%202.5%2C3%201.1%2C3%204.1%2C0'%2F%3E%3Cpolygon%20points%3D'4%2C0%206%2C2%206%2C0.6%205.4%2C0'%2F%3E%3Cpolygon%20points%3D'0%2C2%201%2C3%202.4%2C3%200%2C0.6'%2F%3E%3C%2Fg%3E%3C%2Fsvg%3E");
+}
+
+.CodeMirror-lint-mark-info {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%20viewBox%3D'0%200%206%203'%20enable-background%3D'new%200%200%206%203'%20height%3D'3'%20width%3D'6'%3E%3Cg%20fill%3D'%23008000'%3E%3Cpolygon%20points%3D'5.5%2C0%202.5%2C3%201.1%2C3%204.1%2C0'%2F%3E%3Cpolygon%20points%3D'4%2C0%206%2C2%206%2C0.6%205.4%2C0'%2F%3E%3Cpolygon%20points%3D'0%2C2%201%2C3%202.4%2C3%200%2C0.6'%2F%3E%3C%2Fg%3E%3C%2Fsvg%3E");
+}
+
+/* The lint marker gutter */
+
+.CodeMirror-lint-markers {
+  width: 16px;
+}
+
+.CodeMirror-lint-tooltip {
+  background-color: #ffd;
+  border: 1px solid black;
+  border-radius: 4px 4px 4px 4px;
+  color: black;
+  font-family: monospace;
+  font-size: 10pt;
+  overflow: hidden;
+  padding: 2px 5px;
+  position: fixed;
+  white-space: pre;
+  white-space: pre-wrap;
+  z-index: 100;
+  max-width: 600px;
+  opacity: 0;
+  transition: opacity 0.4s;
+  -moz-transition: opacity 0.4s;
+  -webkit-transition: opacity 0.4s;
+  -o-transition: opacity 0.4s;
+  -ms-transition: opacity 0.4s;
+}
+
+.CodeMirror-lint-mark-error,
+.CodeMirror-lint-mark-warning,
+.CodeMirror-lint-mark-info {
+  display: inline-block;
+  background-position: left bottom;
+  background-repeat: repeat-x;
+}
+
+.CodeMirror-lint-marker-error,
+.CodeMirror-lint-marker-warning {
+  background-position: center center;
+  background-repeat: no-repeat;
+  cursor: pointer;
+  display: inline-block;
+  height: 16px;
+  width: 16px;
+  vertical-align: middle;
+  position: relative;
+}
+
+.CodeMirror-lint-message-error,
+.CodeMirror-lint-message-warning {
+  padding-left: 18px;
+  background-position: top left;
+  background-repeat: no-repeat;
+}
+
+.CodeMirror-lint-marker-error,
+.CodeMirror-lint-message-error {
+  background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAMAAAAoLQ9TAAAAHlBMVEW7AAC7AACxAAC7AAC7AAAAAAC4AAC5AAD///+7AAAUdclpAAAABnRSTlMXnORSiwCK0ZKSAAAATUlEQVR42mWPOQ7AQAgDuQLx/z8csYRmPRIFIwRGnosRrpamvkKi0FTIiMASR3hhKW+hAN6/tIWhu9PDWiTGNEkTtIOucA5Oyr9ckPgAWm0GPBog6v4AAAAASUVORK5CYII=");
+}
+
+.CodeMirror-lint-marker-warning,
+.CodeMirror-lint-message-warning {
+  background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAMAAAAoLQ9TAAAANlBMVEX/uwDvrwD/uwD/uwD/uwD/uwD/uwD/uwD/uwD6twD/uwAAAADurwD2tQD7uAD+ugAAAAD/uwDhmeTRAAAADHRSTlMJ8mN1EYcbmiixgACm7WbuAAAAVklEQVR42n3PUQqAIBBFUU1LLc3u/jdbOJoW1P08DA9Gba8+YWJ6gNJoNYIBzAA2chBth5kLmG9YUoG0NHAUwFXwO9LuBQL1giCQb8gC9Oro2vp5rncCIY8L8uEx5ZkAAAAASUVORK5CYII=");
+}
+
+.CodeMirror-lint-marker-multiple {
+  background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAcAAAAHCAMAAADzjKfhAAAACVBMVEUAAAAAAAC/v7914kyHAAAAAXRSTlMAQObYZgAAACNJREFUeNo1ioEJAAAIwmz/H90iFFSGJgFMe3gaLZ0od+9/AQZ0ADosbYraAAAAAElFTkSuQmCC");
+  background-repeat: no-repeat;
+  background-position: right bottom;
+  width: 100%;
+  height: 100%;
 }

--- a/website/_assets/js/tryFlow.js.es6.liquid
+++ b/website/_assets/js/tryFlow.js.es6.liquid
@@ -106,12 +106,25 @@ function removeChildren(node) {
 }
 
 function getAnnotations(text, callback, options, editor) {
-  Promise.resolve(editor.getOption('flow'))
-  .then(flowProxy => flowProxy.checkContent('-', text))
-  .then(errors => {
-    CodeMirror.signal(editor, 'flowErrors', errors);
+  const flow = Promise.resolve(editor.getOption('flow'));
+  const sources = Promise.all([
+    flow
+      .then(flowProxy => flowProxy.coverage('-', text))
+      .then(coverage => {
+        CodeMirror.signal(editor, 'flowCoverage', coverage);
+        return coverage.expressions.uncovered_locs
+      })
+      .catch(() => []),
+    flow
+      .then(flowProxy => flowProxy.checkContent('-', text))
+      .then(errors => {
+        CodeMirror.signal(editor, 'flowErrors', errors);
+        return errors
+      })
+  ]);
 
-    var lint = errors.map(function(err) {
+  sources.then(([coverage, errors]) => {
+    const errorsLint = errors.map(function(err) {
       var messages = err.message;
       var firstLoc = messages[0].loc;
       var message = messages.map(function(msg) {
@@ -127,7 +140,21 @@ function getAnnotations(text, callback, options, editor) {
         message: message
       };
     });
-    callback(lint);
+    const coverageLint = coverage.map(function (loc) {
+      return {
+        from: CodeMirror.Pos(
+          loc.start.line - 1,
+          loc.start.column - 1,
+        ),
+        to: CodeMirror.Pos(loc.end.line - 1, loc.end.column),
+        severity: 'info',
+        message: 'Not covered by flow'
+      }
+    });
+    callback([
+      ...errorsLint,
+      ...coverageLint,
+    ]);
   });
 }
 getAnnotations.async = true;
@@ -217,6 +244,14 @@ class AsyncLocalFlow {
     return Promise.resolve(this._flow.checkContent(filename, body));
   }
 
+  coverage(filename, body) {
+    return Promise.resolve(this._flow.coverage(filename, body))
+  }
+
+  dumpTypes(filename, body) {
+    return Promise.resolve(this._flow.dumpTypes(filename, body))
+  }
+
   typeAtPos(filename, body, line, col) {
     return Promise.resolve(this._flow.typeAtPos(filename, body, line, col));
   }
@@ -237,6 +272,14 @@ class AsyncWorkerFlow {
 
   checkContent(filename, body) {
     return this._worker.send({ type: 'checkContent', filename, body });
+  }
+
+  coverage(filename, body) {
+    return this._worker.send({ type: 'coverage', filename, body })
+  }
+
+  dumpTypes(filename, body) {
+    return this._worker.send({ type: 'dumpTypes', filename, body })
   }
 
   typeAtPos(filename, body, line, col) {

--- a/website/_assets/js/tryFlow.js.es6.liquid
+++ b/website/_assets/js/tryFlow.js.es6.liquid
@@ -8,9 +8,7 @@ import 'codemirror/mode/jsx/jsx';
 import * as LZString from 'lz-string';
 import {load as initFlowLocally} from 'flow-loader';
 
-CodeMirror.defineOption('flow', null, function(editor) {
-  editor.performLint();
-});
+CodeMirror.defineOption('flow', null);
 
 function appendMsg(container, msg, editor) {
   const clickHandler = (msg) => {
@@ -105,10 +103,10 @@ function removeChildren(node) {
   while (node.lastChild) node.removeChild(node.lastChild);
 }
 
-function getAnnotations(text, callback, options, editor) {
-  const flow = Promise.resolve(editor.getOption('flow'));
-  const sources = Promise.all([
-    flow
+function coverage(text, flow, isCoverageEnabled, editor) {
+  const isCoverageEnabled = editor.getOption('coverageEnabled');
+  if (isCoverageEnabled) {
+    return flow
       .then(flowProxy => flowProxy.coverage('-', text))
       .then(coverage => {
         CodeMirror.signal(editor, 'flowCoverage', coverage);
@@ -117,13 +115,26 @@ function getAnnotations(text, callback, options, editor) {
       .catch(err => {
         console.error(err)
         return []
-      }),
-    flow
-      .then(flowProxy => flowProxy.checkContent('-', text))
-      .then(errors => {
-        CodeMirror.signal(editor, 'flowErrors', errors);
-        return errors
       })
+  }
+  return Promise.resolve([])
+}
+
+function checkContent(text, flow, editor) {
+  return flow
+    .then(flowProxy => flowProxy.checkContent('-', text))
+    .then(errors => {
+      CodeMirror.signal(editor, 'flowErrors', errors);
+      return errors
+    })
+}
+
+function getAnnotations(text, callback, options, editor) {
+  const flow = Promise.resolve(editor.getOption('flow'));
+
+  const sources = Promise.all([
+    coverage(text, flow, editor),
+    checkContent(text, flow, editor),
   ]);
 
   sources.then(([coverage, errors]) => {
@@ -312,6 +323,7 @@ function initFlow(version) {
 
 function createEditor(
   flowVersion,
+  optionsNode,
   domNode,
   resultsNode,
   flowVersions
@@ -397,6 +409,14 @@ function createEditor(
 
     resultsNode.className += " show-errors";
 
+    const coverageOption = document.createElement('label');
+    const coverageCheckbox = document.createElement('input');
+    coverageCheckbox.type = 'checkbox';
+    coverageOption.appendChild(coverageCheckbox);
+    coverageOption.appendChild(document.createTextNode(' coverage'));
+
+    optionsNode.appendChild(coverageOption);
+
     const cursorPositionNode = document.querySelector('footer .cursor-position');
     const typeAtPosNode = document.querySelector('footer .type-at-pos');
 
@@ -432,7 +452,8 @@ function createEditor(
         typeAtPosNode.title = typeAtPos ? typeAtPos.c : '';
         typeAtPosNode.textContent = typeAtPos ? typeAtPos.c : '';
       })
-      .catch(() => {
+      .catch((err) => {
+        console.error(err);
         typeAtPosNode.title = '';
         typeAtPosNode.textContent = '';
       });
@@ -499,6 +520,12 @@ function createEditor(
         removeClass(resultsNode, 'show-loading');
       });
       editor.setOption('flow', flowProxy);
+    });
+
+    coverageCheckbox.addEventListener('change', function(evt) {
+      const checked = evt.target.checked;
+      editor.setOption('coverageEnabled', checked);
+      editor.performLint();
     });
   });
 }

--- a/website/_assets/js/tryFlow.js.es6.liquid
+++ b/website/_assets/js/tryFlow.js.es6.liquid
@@ -114,7 +114,10 @@ function getAnnotations(text, callback, options, editor) {
         CodeMirror.signal(editor, 'flowCoverage', coverage);
         return coverage.expressions.uncovered_locs
       })
-      .catch(() => []),
+      .catch(err => {
+        console.error(err)
+        return []
+      }),
     flow
       .then(flowProxy => flowProxy.checkContent('-', text))
       .then(errors => {
@@ -245,7 +248,10 @@ class AsyncLocalFlow {
   }
 
   coverage(filename, body) {
-    return Promise.resolve(this._flow.coverage(filename, body))
+    if (this._flow.coverage) {
+      return Promise.resolve(this._flow.coverage(filename, body))
+    }
+    return Promise.reject(Error('coverage method is missing'))
   }
 
   dumpTypes(filename, body) {

--- a/website/_assets/js/tryFlowWorker.js
+++ b/website/_assets/js/tryFlowWorker.js
@@ -19,11 +19,26 @@ this.onmessage = function(e) {
     case "checkContent":
       getFlow(data.version).then(function(flow) {
         var result = flow.checkContent(data.filename, data.body);
-        postMessage({id: data.id, type: "checkContent", result: result });
+        postMessage({id: data.id, type: "checkContent", result: result});
       })["catch"](function (e) {
         postMessage({id: data.id, type: "checkContent", err: e});
       });
       return;
+    case "dumpTypes":
+      getFlow(data.version).then(function(flow) {
+        var result = flow.dumpTypes(data.filename, data.body);
+        postMessage({id: data.id, type: "dumpTypes", result: result});
+      })["catch"](function (e) {
+        postMessage({id: data.id, type: "dumpTypes", err: e});
+      });
+      return;
+    case "coverage":
+      getFlow(data.version).then(function(flow) {
+        var result = flow.coverage(data.filename, data.body);
+        postMessage({id: data.id, type: "coverage", result: result});
+      })["catch"](function (e) {
+        postMessage({id: data.id, type: "coverage", err: e});
+      })
     case "typeAtPos":
       getFlow(data.version).then(function(flow) {
         var result = flow.typeAtPos(

--- a/website/_assets/js/tryFlowWorker.js
+++ b/website/_assets/js/tryFlowWorker.js
@@ -34,8 +34,12 @@ this.onmessage = function(e) {
       return;
     case "coverage":
       getFlow(data.version).then(function(flow) {
-        var result = flow.coverage(data.filename, data.body);
-        postMessage({id: data.id, type: "coverage", result: result});
+        if (flow.coverage) {
+          var result = flow.coverage(data.filename, data.body);
+          postMessage({id: data.id, type: "coverage", result: result});
+        } else {
+          postMessage({id: data.id, type: "coverage", err: Error('coverage method is missing')});
+        }
       })["catch"](function (e) {
         postMessage({id: data.id, type: "coverage", err: e});
       })

--- a/website/_layouts/default.html
+++ b/website/_layouts/default.html
@@ -26,7 +26,6 @@
     {% endif %}
     {% if page.codemirror or layout.codemirror %}
       <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.20.2/codemirror.min.css" integrity="sha256-MdzaXfGXzZdeHw/XEV2LNNycipsLk4uZ0FYzO3hbuvI=" crossorigin="anonymous"/>
-      <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.20.2/addon/lint/lint.min.css" integrity="sha256-EYLrIw6E5tjVEIS+bAgP0iR6uTreFdhzLmIGueibEDM=" crossorigin="anonymous"/>
     {% endif %}
     <script type="text/javascript" src="{% asset_path 'require_2_3_3.js' %}"></script>
     <script type="text/javascript">

--- a/website/try.html
+++ b/website/try.html
@@ -9,6 +9,8 @@ scripts:
 ---
 
 <div class="try-editor">
+  <div class="options" id="options">
+  </div>
   <div class="code" id="code">
   </div>
   <div class="results show-loading" id="results">
@@ -26,6 +28,7 @@ scripts:
   requirejs(['{% asset_name "tryFlow" %}'], function(tryFlow) {
     tryFlow.createEditor(
       '{{ site.flow.version }}',
+      document.getElementById("options"),
       document.getElementById("code"),
       document.getElementById("results"),
       {{ site.flow.versions | jsonify }}


### PR DESCRIPTION
<!--
  If this is a change to library defintions, please include links to relevant documentation.
  If this is a documentation change, please prefix the title with [DOCS].

  If this is neither, ensure you opened a discussion issue and link it in the PR description.
-->

Makes `Symbol.iterator` real symbol instead of `string`

Doesn't work with computed keys on interfaces or classes (they have weird $key, $value thing with many bugs)