### PR TITLE
Make Symbol.iterator real symbol

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -104,7 +104,7 @@ declare class Symbol {
   +description: string | void;
   static hasInstance: $SymbolHasInstance;
   static isConcatSpreadable: $SymboIsConcatSpreadable;
-  static iterator: string; // polyfill '@@iterator'
+  static iterator: $SymbolIterator;
   static keyFor(sym: Symbol): ?string;
   static length: 0;
   static match: $SymbolMatch;

--- a/src/typing/flow_js.ml
+++ b/src/typing/flow_js.ml
@@ -5367,9 +5367,13 @@ let rec __flow cx ((l: Type.t), (u: Type.use_t)) trace =
     | _, ElemT (use_op, reason_op, (DefT (_, _, ObjT _) as obj), action) ->
       let propref = match l with
       | DefT (reason_x, _, StrT (Literal (_, x))) ->
-          let reason_prop = replace_reason_const (RProperty (Some x)) reason_x in
-          Named (reason_prop, x)
-      | _ -> Computed l
+        let reason_prop = replace_reason_const (RProperty (Some x)) reason_x in
+        Named (reason_prop, x)
+      | DefT (reason_x, _, InstanceT _) when DescFormat.name_of_instance_reason reason_x = "$SymbolIterator" ->
+        let reason_prop = replace_reason_const (RProperty (Some "@@iterator")) reason_x in
+        Named (reason_prop, "@@iterator")
+      | _ ->
+        Computed l
       in
       (match action with
       | ReadElem t ->


### PR DESCRIPTION
<!--
  If this is a change to library defintions, please include links to relevant documentation.
  If this is a documentation change, please prefix the title with [DOCS].

  If this is neither, ensure you opened a discussion issue and link it in the PR description.
-->

Makes `Symbol.iterator` real symbol instead of `string`

Doesn't work with computed keys on interfaces or classes (they have weird $key, $value thing instead of real indexers)