### PR TITLE
Improve lib def for async act use case in react-dom/test-utils

### DIFF
--- a/lib/react-dom.js
+++ b/lib/react-dom.js
@@ -61,7 +61,7 @@ declare module 'react-dom/server' {
   declare var version: string;
 }
 
-type Thenable = { then(resolve: () => mixed, reject?: () => mixed): mixed, ... };
+type Thenable = { then(resolve: () => mixed, reject?: () => mixed): Thenable | void, ... };
 
 declare module 'react-dom/test-utils' {
   declare var Simulate: { [eventName: string]: (element: Element, eventData?: Object) => void, ... };


### PR DESCRIPTION
After attempting to upgrade to react 16.9, I noticed some flow errors when trying to use act (from `react-dom/test-utils`) with an async callback result. After some digging I noticed the type definition in https://github.com/facebook/flow/blob/master/lib/react-dom.js#L64 does not directly match https://github.com/facebook/react/blob/master/packages/react-reconciler/src/ReactFiberWorkLoop.js#L205. This PR aims to rectify this.

Is there a test suite for these lib defs somewhere where I can confirm this is working correctly.

<!--
  If this is a change to library defintions, please include links to relevant documentation.
  If this is a documentation change, please prefix the title with [DOCS].

  If this is neither, ensure you opened a discussion issue and link it in the PR description.
-->
