### PR TITLE
Switch several properties to optional in Notification and Notificatio…

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -3971,21 +3971,21 @@ type NotificationAction = {
        ...
 };
 type NotificationOptions = {
-       dir: NotificationDirection,
-       lang: string,
-       body: string,
-       tag: string,
-       image: string,
-       icon: string,
-       badge: string,
-       sound: string,
+       dir?: NotificationDirection,
+       lang?: string,
+       body?: string,
+       tag?: string,
+       image?: string,
+       icon?: string,
+       badge?: string,
+       sound?: string,
        vibrate?: VibratePattern,
-       timestamp: number,
-       renotify: boolean,
-       silent: boolean,
-       requireInteraction: boolean,
-       data: ?any,
-       actions: Array<NotificationAction>,
+       timestamp?: number,
+       renotify?: boolean,
+       silent?: boolean,
+       requireInteraction?: boolean,
+       data?: ?any,
+       actions?: Array<NotificationAction>,
        ...
 };
 
@@ -3996,17 +3996,18 @@ declare class Notification extends EventTarget {
     callback?: (perm: NotificationPermission) => mixed
   ): Promise<NotificationPermission>;
   static maxActions: number;
-  onclick: (evt: Event) => any;
-  onerror: (evt: Event) => any;
+  onclick: ?(evt: Event) => mixed;
+  onclose: ?(evt: Event) => mixed;
+  onerror: ?(evt: Event) => mixed;
+  onshow: ?(evt: Event) => mixed;
   title: string;
   dir: NotificationDirection;
   lang: string;
   body: string;
   tag: string;
-  image: string;
-  icon: string;
-  badge: string;
-  sound: string;
+  image?: string;
+  icon?: string;
+  badge?: string;
   vibrate?: Array<number>;
   timestamp: number;
   renotify: boolean;


### PR DESCRIPTION
Per: https://notifications.spec.whatwg.org/#api

As far as I understand that spec, all properties from `NotificationOptions` are optional and some have a default value. We can see that in the example:

```javascript
var not = new Notification("Gebrünn Gebrünn by Paul Kalkbrenner", { icon: "newsong.svg", tag: "song" });
not.onclick = function() { displaySong(this); };
```

Where `image` is not specified in the constructor even its type is `USVString` in the spec api. This is reflected in this pull request by making all properties of `type NotificationOptions` optionals.


Another part of the spec:
> A notification _can_ have these associated graphics: an image URL, icon URL, and badge URL; and their corresponding image resource, icon resource, and badge resource.

I made those properties optional to reflect it.

I could not find any reference to the `sound` property so I removed it.

All event listeners are empty when creating the notification.