### PR TITLE
Change flow-upgrade to use https over git protocol

### DIFF
--- a/packages/flow-upgrade/package.json
+++ b/packages/flow-upgrade/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "chalk": "^2.0.1",
     "graceful-fs": "^4.1.11",
-    "jscodeshift": "git://github.com/jbrown215/jscodeshift.git",
+    "jscodeshift": "https://github.com/jbrown215/jscodeshift.git",
     "ora": "^1.3.0",
     "prompt-confirm": "^1.2.0",
     "semver": "^5.3.0",


### PR DESCRIPTION
https is more likely to work in all environments (the binary git protocol often doesn't work well with corporate proxies)