### PR TITLE
Fix stack overflow in definite property init check

### DIFF
--- a/tests/uninitialized_instance_property/test.js
+++ b/tests/uninitialized_instance_property/test.js
@@ -1277,3 +1277,9 @@ class P64 {
   }
   p = 0;
 }
+
+// https://github.com/facebook/flow/issues/8037
+declare function P65_a<F>(b: F): F & {};
+class P65 {
+  b = P65_a(this.b);
+}

--- a/tests/uninitialized_instance_property/uninitialized_instance_property.exp
+++ b/tests/uninitialized_instance_property/uninitialized_instance_property.exp
@@ -1057,5 +1057,13 @@ It is unsafe to call a method in the constructor before all class properties are
              ^^^^^^^^
 
 
+Error -------------------------------------------------------------------------------------------------- test.js:1284:13
 
-Found 119 errors
+It is unsafe to read from a class property before it is definitely initialized. (`uninitialized-instance-property`)
+
+   1284|   b = P65_a(this.b);
+                     ^^^^^^
+
+
+
+Found 120 errors


### PR DESCRIPTION
Initializing an instance property to an intersection containing itself seems to cause a tvar cycle, which wasn't being handled by `is_voidable`, leading to a stack overflow.

Huge thanks to @lukeapage for the repro

Fixes https://github.com/facebook/flow/issues/8037