### PR TITLE
Drop Hack_caml.Sort module, no longer exists in 4.08

### DIFF
--- a/hack/third-party/core/hack_caml.ml
+++ b/hack/third-party/core/hack_caml.ml
@@ -36,7 +36,6 @@ module Queue = Queue
 module Random = Random
 module Scanf = Scanf
 module Set = Set
-module Sort = Sort
 module Stack = Stack
 module StdLabels = StdLabels
 module Stream = Stream


### PR DESCRIPTION
<!--
  If this is a change to library defintions, please include links to relevant documentation.
  If this is a documentation change, please prefix the title with [DOCS].

  If this is neither, ensure you opened a discussion issue and link it in the PR description.
-->
Hi!

I was trying to use `flow_parser` on a project with OCaml 4.08 and realized that the `Hack_caml` module re-exports the now removed `Sort` module.

Figured I'd open a PR instead of keep the change in a fork indefinitely.

Thanks for the good work 🙌 