### PR TITLE
Fix ability to extend built-in classes

### DIFF
--- a/lib/bom.js
+++ b/lib/bom.js
@@ -585,7 +585,7 @@ declare class DOMRectReadOnly {
     height: number,
     ...
   }): DOMRectReadOnly;
-  constructor(x: number, y: number, width: number, height: number): DOMRectReadOnly;
+  constructor(x: number, y: number, width: number, height: number): void;
   +bottom: number;
   +height: number;
   +left: number;
@@ -1282,7 +1282,7 @@ declare class ChannelSplitterNode extends AudioNode {}
 
 type ConstantSourceOptions = { offset?: number, ... }
 declare class ConstantSourceNode extends AudioNode {
-  constructor(context: BaseAudioContext, options?: ConstantSourceOptions): ConstantSourceNode;
+  constructor(context: BaseAudioContext, options?: ConstantSourceOptions): void;
   offset: AudioParam;
   onended: (ev: any) => mixed;
   start(when?: number): void;
@@ -1492,7 +1492,7 @@ declare function fetch(input: RequestInfo, init?: RequestOptions): Promise<Respo
 type TextEncoder$availableEncodings = 'utf-8' | 'utf8' | 'unicode-1-1-utf-8' | 'utf-16be' | 'utf-16' | 'utf-16le';
 
 declare class TextEncoder {
-  constructor(encoding?: TextEncoder$availableEncodings): TextEncoder;
+  constructor(encoding?: TextEncoder$availableEncodings): void;
   encode(buffer: string, options?: { stream: bool, ... }): Uint8Array;
   encoding: TextEncoder$availableEncodings;
 }
@@ -1716,7 +1716,7 @@ type TextDecoder$availableEncodings =
 
 
 declare class TextDecoder {
-  constructor(encoding?: TextDecoder$availableEncodings, options?: { fatal: bool, ... }): TextDecoder;
+  constructor(encoding?: TextDecoder$availableEncodings, options?: { fatal: bool, ... }): void;
   encoding: TextDecoder$availableEncodings;
   fatal: bool;
   ignoreBOM: bool;
@@ -1817,10 +1817,9 @@ type VRDisplayEventInit = {
 };
 
 declare class VRDisplayEvent extends Event {
+  constructor(type: string, eventInitDict: VRDisplayEventInit): void;
   display: VRDisplay;
   reason?: VRDisplayEventReason;
-
-  constructor(type: string, eventInitDict: VRDisplayEventInit): VRDisplayEvent;
 }
 
 declare class MediaQueryListEvent {
@@ -1898,7 +1897,7 @@ declare class SpeechSynthesis extends EventTarget {
 declare var speechSynthesis: SpeechSynthesis;
 
 declare class SpeechSynthesisUtterance extends EventTarget {
-  constructor(text?: string): SpeechSynthesisUtterance;
+  constructor(text?: string): void;
 
   text: string;
   lang: string;
@@ -1926,7 +1925,8 @@ type SpeechSynthesisEvent$Init = Event$Init & {
 }
 
 declare class SpeechSynthesisEvent extends Event {
-  constructor(type: string, eventInitDict?: SpeechSynthesisEvent$Init): SpeechSynthesisEvent;
+  constructor(type: string, eventInitDict?: SpeechSynthesisEvent$Init): void;
+
   +utterance: SpeechSynthesisUtterance;
   charIndex: number;
   charLength: number;
@@ -1940,7 +1940,7 @@ type SpeechSynthesisErrorEvent$Init = SpeechSynthesisEvent$Init & {
 }
 
 declare class SpeechSynthesisErrorEvent extends SpeechSynthesisEvent {
-  constructor(type: string, eventInitDict?: SpeechSynthesisErrorEvent$Init): SpeechSynthesisErrorEvent;
+  constructor(type: string, eventInitDict?: SpeechSynthesisErrorEvent$Init): void;
   +error: SpeechSynthesisErrorCode;
 }
 

--- a/lib/core.js
+++ b/lib/core.js
@@ -364,7 +364,7 @@ declare class String {
 declare class RegExp {
     static (pattern: string | RegExp, flags?: RegExp$flags): RegExp;
     compile(): RegExp;
-    constructor(pattern: string | RegExp, flags?: RegExp$flags): RegExp;
+    constructor(pattern: string | RegExp, flags?: RegExp$flags): void;
     exec(string: string): RegExp$matchResult | null;
     flags: string;
     global: boolean;

--- a/lib/cssom.js
+++ b/lib/cssom.js
@@ -418,7 +418,7 @@ type DocumentTimelineOptions = {
 }
 
 declare class DocumentTimeline extends AnimationTimeline {
-  constructor(options?: DocumentTimelineOptions): DocumentTimeline;
+  constructor(options?: DocumentTimelineOptions): void;
 }
 
 type EffectTiming = {
@@ -486,8 +486,8 @@ declare class KeyframeEffect extends AnimationEffect {
     target: Element | null,
     keyframes: Keyframe[] | PropertyIndexedKeyframes | null,
     options?: number | KeyframeEffectOptions,
-  ): KeyframeEffect;
-  constructor(source: KeyframeEffect): KeyframeEffect;
+  ): void;
+  constructor(source: KeyframeEffect): void;
 
   target: Element | null;
   iterationComposite: IterationCompositeOperation;
@@ -497,7 +497,7 @@ declare class KeyframeEffect extends AnimationEffect {
 }
 
 declare class Animation extends EventTarget {
-  constructor(effect?: AnimationEffect | null, timeline?: AnimationTimeline | null): Animation;
+  constructor(effect?: AnimationEffect | null, timeline?: AnimationTimeline | null): void;
 
   id: string;
   effect: AnimationEffect | null;
@@ -545,7 +545,7 @@ type AnimationPlaybackEvent$Init = Event$Init & {
 }
 
 declare class AnimationPlaybackEvent extends Event {
-  constructor(type: string, animationEventInitDict?: AnimationPlaybackEvent$Init): AnimationPlaybackEvent;
+  constructor(type: string, animationEventInitDict?: AnimationPlaybackEvent$Init): void;
   +currentTime: number | null;
   +timelineTime: number | null;
 }

--- a/lib/node.js
+++ b/lib/node.js
@@ -2554,7 +2554,7 @@ declare module 'repl' {
   }): REPLServer;
 
   declare class Recoverable extends SyntaxError {
-    constructor(err: Error): Recoverable;
+    constructor(err: Error): void;
   }
 }
 


### PR DESCRIPTION
<!--
  If this is a change to library defintions, please include links to relevant documentation.
  If this is a documentation change, please prefix the title with [DOCS].

  If this is neither, ensure you opened a discussion issue and link it in the PR description.
-->

Change `constructor` return types to `void`

This allows using `class B extends A` without forcing constructor return type as `A`