### PR TITLE
Add crypto create(De)cipher options parameter

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -551,26 +551,41 @@ type crypto$key = string | {
   ...
 };
 
+type cryptoCipherOptions = duplexStreamOptions & {
+  authTagLength?: number,
+  ...
+};
+
 declare module "crypto" {
   declare var DEFAULT_ENCODING: string;
 
   declare class Sign extends crypto$Sign {}
   declare class Verify extends crypto$Verify {}
 
-  declare function createCipher(algorithm: string, password: string | Buffer): crypto$Cipher;
+  declare function createCipher(
+    algorithm: string,
+    password: string | Buffer,
+    options?: cryptoCipherOptions
+  ): crypto$Cipher;
   declare function createCipheriv(
     algorithm: string,
     key: string | Buffer,
-    iv: string | Buffer
+    iv: string | Buffer | null,
+    options?: cryptoCipherOptions
   ): crypto$Cipher;
   declare function createCredentials(
     details?: crypto$createCredentialsDetails
   ): crypto$Credentials
-  declare function createDecipher(algorithm: string, password: string | Buffer): crypto$Decipher;
+  declare function createDecipher(
+    algorithm: string,
+    password: string | Buffer,
+    options?: cryptoCipherOptions
+  ): crypto$Decipher;
   declare function createDecipheriv(
     algorithm: string,
     key: string | Buffer,
-    iv: string | Buffer
+    iv: string | Buffer | null,
+    options?: cryptoCipherOptions
   ): crypto$Decipher;
   declare function createDiffieHellman(prime_length: number): crypto$DiffieHellman;
   declare function createDiffieHellman(prime: number, encoding?: string): crypto$DiffieHellman;


### PR DESCRIPTION
See [`crypto.createCipher`](https://nodejs.org/docs/latest-v10.x/api/crypto.html#crypto_crypto_createcipher_algorithm_password_options), [`crypto.createCipheriv`](https://nodejs.org/docs/latest-v10.x/api/crypto.html#crypto_crypto_createcipheriv_algorithm_key_iv_options), [`crypto.createDecipher`](https://nodejs.org/docs/latest-v10.x/api/crypto.html#crypto_crypto_createdecipher_algorithm_password_options) and [`crypto.createDecipheriv`](https://nodejs.org/docs/latest-v10.x/api/crypto.html#crypto_crypto_createdecipheriv_algorithm_key_iv_options) documentation. These functions supported a `duplexStreamOption` as recently as Node 8, and supported an additional `authTagLength` as recently as Node 10.

Another approach could use overloading to avoid unexpected issues with `iv`s being `null` when the `algorithm` needs an IV.