### PR TITLE
Remove literal reason on $Exact

### DIFF
--- a/src/typing/flow_js.ml
+++ b/src/typing/flow_js.ml
@@ -3498,7 +3498,6 @@ struct
 
         (* exactify incoming LB object type, flow to UB *)
         | (DefT (r, trust, ObjT obj), MakeExactT (_, Upper u)) ->
-          let r = if is_literal_object_reason r then replace_desc_reason RObjectType r else r in
           let exactobj = { obj with flags = { obj.flags with exact = true } } in
           rec_flow cx trace (DefT (r, trust, ObjT exactobj), u)
         (* exactify incoming UB object type, flow to LB *)


### PR DESCRIPTION
<!--
  If this is a change to library defintions, please include links to relevant documentation.
  If this is a documentation change, please prefix the title with [DOCS].

  If this is neither, ensure you opened a discussion issue and link it in the PR description.
-->

Partial fix for #7853 

Prevent leaking literal object reason to `$Exact`