### PR TITLE
Add read-only tuple

### DIFF
--- a/src/common/reason.ml
+++ b/src/common/reason.ml
@@ -90,6 +90,7 @@ type 'loc virtual_reason_desc =
   | RArrayType
   | RROArrayType
   | RTupleType
+  | RROTupleType
   | RTupleElement
   | RTupleOutOfBoundsAccess
   | RFunction of reason_desc_function
@@ -240,7 +241,7 @@ let rec map_desc_locs f = function
     | RVoid | RNull | RSymbol | RExports | RNullOrVoid | RLongStringLit _ | RStringLit _
     | RNumberLit _ | RBigIntLit _ | RBooleanLit _ | RObject | RObjectLit | RObjectType
     | RObjectClassName | RInterfaceType | RArray | RArrayLit | REmptyArrayLit | RArrayType
-    | RROArrayType | RTupleType | RTupleElement | RTupleOutOfBoundsAccess | RFunction _
+    | RROArrayType | RTupleType | RROTupleType | RTupleElement | RTupleOutOfBoundsAccess | RFunction _
     | RFunctionType | RFunctionBody | RFunctionCallType | RFunctionUnusedArgument
     | RJSXFunctionCall _ | RJSXIdentifier _ | RJSXElementProps _ | RJSXElement _ | RJSXText | RFbt
       ) as r ->
@@ -537,6 +538,7 @@ let rec string_of_desc = function
   | RArrayType -> "array type"
   | RROArrayType -> "read-only array type"
   | RTupleType -> "tuple type"
+  | RROTupleType -> "read-only tuple type"
   | RTupleElement -> "tuple element"
   | RTupleOutOfBoundsAccess -> "undefined (out of bounds tuple access)"
   | RFunction func -> spf "%sfunction" (function_desc_prefix func)
@@ -1279,6 +1281,7 @@ let classification_of_reason r =
   | RArrayType
   | RROArrayType
   | RTupleType
+  | RROTupleType
   | RRestArray _
   | RArrayPatternRestProp ->
     `Array

--- a/src/common/reason.mli
+++ b/src/common/reason.mli
@@ -40,6 +40,7 @@ type 'loc virtual_reason_desc =
   | RArrayType
   | RROArrayType
   | RTupleType
+  | RROTupleType
   | RTupleElement
   | RTupleOutOfBoundsAccess
   | RFunction of reason_desc_function

--- a/src/typing/debug_js.ml
+++ b/src/typing/debug_js.ml
@@ -204,6 +204,12 @@ and _json_of_t_impl json_cx t =
           ("elemType", _json_of_t json_cx elemt);
           ("tupleType", JSON_Array (Core_list.map ~f:(_json_of_t json_cx) tuple_types));
         ]
+      | DefT (_, _, ArrT (ROTupleAT (elemt, tuple_types))) ->
+        [
+          ("kind", JSON_String "ReadOnlyTuple");
+          ("elemType", _json_of_t json_cx elemt);
+          ("tupleType", JSON_Array (Core_list.map ~f:(_json_of_t json_cx) tuple_types));
+        ]
       | DefT (_, _, ArrT (ROArrayAT elemt)) ->
         [("kind", JSON_String "ReadOnlyArray"); ("elemType", _json_of_t json_cx elemt)]
       | DefT (_, _, CharSetT chars) ->
@@ -1661,6 +1667,11 @@ let rec dump_t_ (depth, tvars) cx t =
       p
         ~trust:(Some trust)
         ~extra:(spf "Tuple [%s]" (String.concat ", " (Core_list.map ~f:kid tup)))
+        t
+    | DefT (_, trust, ArrT (ROTupleAT (_, tup))) ->
+      p
+        ~trust:(Some trust)
+        ~extra:(spf "ReadOnlyTuple [%s]" (String.concat ", " (Core_list.map ~f:kid tup)))
         t
     | DefT (_, trust, ArrT (ROArrayAT elemt)) ->
       p ~trust:(Some trust) ~extra:(spf "ReadOnlyArray %s" (kid elemt)) t

--- a/src/typing/errors/error_message.ml
+++ b/src/typing/errors/error_message.ml
@@ -1204,7 +1204,7 @@ let friendly_message_of_msg : Loc.t t' -> Loc.t friendly_message_recipe =
           export;
           text " as a value. ";
             (* text "Use "; code "import type"; text " instead."; *)
-          
+
         ]
     | ENoDefaultExport (_, module_name, suggestion) ->
       Normal
@@ -1493,8 +1493,12 @@ let friendly_message_of_msg : Loc.t t' -> Loc.t friendly_message_recipe =
           [text "the index must be statically known to write a tuple element"],
           use_op )
     | EROArrayWrite (reasons, use_op) ->
-      let (lower, _) = reasons in
-      UseOp (loc_of_reason lower, [text "read-only arrays cannot be written to"], use_op)
+      let (lower, reason_tup) = reasons in
+      let desc = match (desc_of_reason reason_tup) with
+      | RROTupleType -> "read-only tuples"
+      | _ -> "read-only arrays"
+      in
+      UseOp (loc_of_reason lower, [text desc; text " cannot be written to"], use_op)
     | EUnionSpeculationFailed { use_op; reason; reason_op = _; branches } ->
       Speculation (loc_of_reason reason, use_op, branches)
     | ESpeculationAmbiguous

--- a/src/typing/flow_js.ml
+++ b/src/typing/flow_js.ml
@@ -7347,6 +7347,7 @@ struct
       true
     | UseT (use_op, DefT (_, _, ArrT (ROArrayAT t))) (* read-only arrays are covariant *)
     | UseT (use_op, DefT (_, _, ClassT t)) (* mk_instance ~for_type:false *)
+    | UseT (use_op, ExactT (_, t))
     | UseT (use_op, OpenPredT (_, t, _, _))
     | UseT (use_op, ShapeT t) ->
       covariant_flow ~use_op t;
@@ -7473,6 +7474,8 @@ struct
 
     | UseT (_, UnionT _)
     | UseT (_, IntersectionT _) (* Already handled in the wildcard case in __flow *)
+    | UseT (_, OpenT _) ->
+      false
     (* These types have no t_out, so can't propagate anything. Thus we short-circuit by returning
      true *)
     | AssertArithmeticOperandT _

--- a/src/typing/flow_js.ml
+++ b/src/typing/flow_js.ml
@@ -5645,11 +5645,13 @@ struct
         (**************)
         (* object kit *)
         (**************)
-        | (DefT (reason, trust, ArrT (TupleAT (elemt, tuple_types))), ObjKitT (use_op, _, _, Object.ReadOnly, tout)) ->
+        | (DefT (_, trust, ArrT (TupleAT (elemt, tuple_types))), ObjKitT (use_op, reason, _, Object.ReadOnly, tout)) ->
           rec_flow_t cx ~use_op trace (
             DefT (replace_desc_reason RROTupleType reason, trust, ArrT (ROTupleAT (elemt, tuple_types))),
             tout
           )
+        | (DefT (_, _, ArrT (ROTupleAT _)), ObjKitT (use_op, _, _, Object.ReadOnly, tout)) ->
+          rec_flow_t cx ~use_op trace (l, tout)
         | (_, ObjKitT (use_op, reason, resolve_tool, tool, tout)) ->
           ObjectKit.run cx trace ~use_op reason resolve_tool tool tout l
         (**************************************************)

--- a/src/typing/flow_js.ml
+++ b/src/typing/flow_js.ml
@@ -7343,8 +7343,7 @@ struct
     | SubstOnPredT (_, _, OpenPredT (_, t, _, _)) ->
       covariant_flow ~use_op:unknown_use t;
       true
-    | UseT (use_op, DefT (_, _, ArrT (ROArrayAT t)))
-    | UseT (use_op, DefT (_, _, ArrT (ROTupleAT (t, _)))) (* read-only arrays are covariant *)
+    | UseT (use_op, DefT (_, _, ArrT (ROArrayAT t))) (* read-only arrays are covariant *)
     | UseT (use_op, DefT (_, _, ClassT t)) (* mk_instance ~for_type:false *)
     | UseT (use_op, OpenPredT (_, t, _, _))
     | UseT (use_op, ShapeT t) ->
@@ -7353,6 +7352,10 @@ struct
     | UseT (use_op, DefT (_, _, ReactAbstractComponentT { config; instance })) ->
       contravariant_flow ~use_op config;
       covariant_flow ~use_op instance;
+      true
+    | UseT (use_op, DefT (_, _, ArrT (ROTupleAT (t, ts)))) ->
+      List.iter (covariant_flow ~use_op) ts;
+      covariant_flow ~use_op t;
       true
     (* Some types just need to be expanded and filled with any types *)
     | UseT (use_op, (DefT (_, _, ArrT (ArrayAT _)) as t))
@@ -7535,13 +7538,16 @@ struct
       true
     | DefT (_, _, ClassT t)
     | DefT (_, _, ArrT (ROArrayAT t))
-    | DefT (_, _, ArrT (ROTupleAT (t, _)))
     | DefT (_, _, TypeT (_, t)) ->
       covariant_flow ~use_op t;
       true
     | DefT (_, _, ReactAbstractComponentT { config; instance }) ->
       contravariant_flow ~use_op config;
       covariant_flow ~use_op instance;
+      true
+    | DefT (_, _, ArrT (ROTupleAT (t, ts))) ->
+      List.iter (covariant_flow ~use_op) ts;
+      covariant_flow ~use_op t;
       true
     (* These types have no negative positions in their lower bounds *)
     | ExistsT _

--- a/src/typing/react_kit.ml
+++ b/src/typing/react_kit.ml
@@ -305,7 +305,7 @@ module Kit (Flow : Flow_common.S) : REACT = struct
         Error reason
     in
     let coerce_array = function
-      | DefT (_, _, ArrT (ArrayAT (_, Some ts) | TupleAT (_, ts))) -> Ok ts
+      | DefT (_, _, ArrT (ArrayAT (_, Some ts) | TupleAT (_, ts) | ROTupleAT (_, ts))) -> Ok ts
       | DefT (reason, _, ArrT _)
       | AnyT (reason, _) ->
         Error reason
@@ -349,7 +349,7 @@ module Kit (Flow : Flow_common.S) : REACT = struct
       (* Stateless functional components. *)
       | DefT (_, _, FunT _)
       (* Stateless functional components, again. This time for callable `ObjT`s. *)
-      
+
       | DefT (_, _, ObjT { call_t = Some _; _ }) ->
         rec_flow cx trace (component, ReactInToProps (reason_op, tin))
       (* Abstract components. *)

--- a/src/typing/resolvableTypeJob.ml
+++ b/src/typing/resolvableTypeJob.ml
@@ -135,7 +135,7 @@ and collect_of_type ?log_unresolved cx acc = function
     let ts = Option.value ~default:[] tuple_types in
     let ts = elemt :: ts in
     collect_of_types ?log_unresolved cx acc ts
-  | DefT (_, _, ArrT (TupleAT (elemt, tuple_types))) ->
+  | DefT (_, _, ArrT (TupleAT (elemt, tuple_types) | ROTupleAT (elemt, tuple_types))) ->
     collect_of_types ?log_unresolved cx acc (elemt :: tuple_types)
   | DefT (_, _, ArrT (ROArrayAT elemt)) -> collect_of_type ?log_unresolved cx acc elemt
   | DefT

--- a/src/typing/sigHash.ml
+++ b/src/typing/sigHash.ml
@@ -63,6 +63,7 @@ type hash =
   | ArrATH
   | ArrTupleATH
   | ArrROArrayATH
+  | ArrROTupleATH
   | ClassH
   | OptionalH
   | EvalH
@@ -216,8 +217,9 @@ let hash_of_def_ctor =
     | PolyT _ -> failwith "undefined hash of PolyT"
     | IdxWrapper _ -> failwith "undefined hash of IdxWrapper"
     | ArrT (ArrayAT _) -> ArrATH
-    | ArrT (TupleAT _) -> ArrTupleATH
     | ArrT (ROArrayAT _) -> ArrROArrayATH
+    | ArrT (TupleAT _) -> ArrTupleATH
+    | ArrT (ROTupleAT _) -> ArrROTupleATH
     | BoolT _ -> BoolH
     | CharSetT _ -> CharSetH
     | ClassT _ -> ClassH

--- a/src/typing/ty_normalizer.ml
+++ b/src/typing/ty_normalizer.ml
@@ -912,6 +912,9 @@ end = struct
     | T.TupleAT (_, ts) ->
       let%map ts = mapM (type__ ~env) ts in
       Ty.Tup ts
+    | T.ROTupleAT (_, ts) ->
+      let%map ts = mapM (type__ ~env) ts in
+      Ty.Utility (Ty.ReadOnly (Ty.Tup ts))
 
   (* Used for instances of React.createClass(..) *)
   and react_component =

--- a/src/typing/type.ml
+++ b/src/typing/type.ml
@@ -867,6 +867,7 @@ module rec TypeTerm : sig
      * myTuple[expr]
      *)
     | TupleAT of t * t list
+    | ROTupleAT of t * t list
     (* ROArrayAT(elemt) is the super type for all tuples and arrays for which
      * elemt is a supertype of every element type *)
     | ROArrayAT of t
@@ -1770,13 +1771,13 @@ end = struct
         (* the only unresolved tvars at this point are those that instantiate polymorphic types *)
         | OpenT _
         (* some types may not be evaluated yet; TODO *)
-        
+
         | EvalT _
         | TypeAppT _
         | KeysT _
         | IntersectionT _
         (* other types might wrap parts that are accessible directly *)
-        
+
         | OpaqueT _
         | DefT (_, _, InstanceT _)
         | DefT (_, _, PolyT _) ->
@@ -3698,7 +3699,8 @@ and extract_getter_type = function
 and elemt_of_arrtype = function
   | ArrayAT (elemt, _)
   | ROArrayAT elemt
-  | TupleAT (elemt, _) ->
+  | TupleAT (elemt, _)
+  | ROTupleAT (elemt, _) ->
     elemt
 
 let optional ?annot_loc t =

--- a/src/typing/type_mapper.ml
+++ b/src/typing/type_mapper.ml
@@ -644,6 +644,13 @@ class virtual ['a] t =
           t
         else
           TupleAT (t'', tlist')
+      | ROTupleAT (t', tlist) ->
+        let t'' = self#type_ cx map_cx t' in
+        let tlist' = ListUtils.ident_map (self#type_ cx map_cx) tlist in
+        if t'' == t' && tlist' == tlist then
+          t
+        else
+          ROTupleAT (t'', tlist')
       | ROArrayAT t' ->
         let t'' = self#type_ cx map_cx t' in
         if t'' == t' then

--- a/src/typing/type_visitor.ml
+++ b/src/typing/type_visitor.ml
@@ -679,6 +679,10 @@ class ['a] t =
         let acc = self#type_ cx P.Neutral acc t in
         let acc = self#list (self#type_ cx P.Neutral) acc ts in
         acc
+      | ROTupleAT (t, ts) ->
+        let acc = self#type_ cx pole acc t in
+        let acc = self#list (self#type_ cx pole) acc ts in
+        acc
       | ROArrayAT t -> self#type_ cx pole acc t
 
     method private inst_type cx pole acc i =

--- a/tests/tuples/read-only.js
+++ b/tests/tuples/read-only.js
@@ -1,0 +1,9 @@
+// @flow
+
+declare var x: $ReadOnly<[number, string]>;
+
+x[0] = 1; // can't write
+
+const y: $ReadOnly<[number | string, string]> = x; // covariance
+
+declare var z: $ReadOnly<$ReadOnly<[number]>>; // nested $ReadOnly works

--- a/tests/tuples/tuples.exp
+++ b/tests/tuples/tuples.exp
@@ -53,6 +53,14 @@ References:
            ^^^^^^^^^^^^^^^^^ [2]
 
 
+Error ------------------------------------------------------------------------------------------------- read-only.js:5:1
+
+Cannot assign `1` to `x[0]` because read-only tuples cannot be written to.
+
+   5| x[0] = 1; // can't write
+      ^^^^
+
+
 Error --------------------------------------------------------------------------------------------------- too-few.js:5:5
 
 Cannot call `foo` with array literal bound to `a` because array literal [1] has an arity of 1 but tuple type [2] has an
@@ -238,4 +246,4 @@ References:
 
 
 
-Found 16 errors
+Found 17 errors


### PR DESCRIPTION
<!--
  If this is a change to library defintions, please include links to relevant documentation.
  If this is a documentation change, please prefix the title with [DOCS].

  If this is neither, ensure you opened a discussion issue and link it in the PR description.
-->

A regular tuple is still subtype of `$ReadOnlyArray` because of length-changing methods, but read-only tuple disables writing to elements

The syntax is just reusing `$ReadOnly` destructor

```js
declare var x: $ReadOnly<[number, string]>
```

Partial solution for https://github.com/facebook/flow/issues/4509

