### PR TITLE
Fix [declarations] not suppressing errors correctly & rename to [silence]

### DIFF
--- a/src/services/inference/init_js.ml
+++ b/src/services/inference/init_js.ml
@@ -64,7 +64,6 @@ let load_lib_files ~sig_cx ~options ~reader files =
          (fun (exclude_syms, results) file ->
            let lib_file = File_key.LibFile file in
            let lint_severities = options.Options.opt_lint_severities in
-           let file_options = Options.file_options options in
            let%lwt result = parse_lib_file ~reader options file in
            Lwt.return
              (match result with
@@ -95,7 +94,6 @@ let load_lib_files ~sig_cx ~options ~reader files =
                    ast
                    ~exclude_syms
                    ~lint_severities
-                   ~file_options:(Some file_options)
                    ~file_sig
                in
                let errors = Context.errors cx in

--- a/src/services/inference/merge_service.ml
+++ b/src/services/inference/merge_service.ml
@@ -125,7 +125,6 @@ let merge_context_generic ~options ~reader ~get_ast_unsafe ~get_file_sig_unsafe 
   let (master_cx, dep_cxs, file_reqs) = reqs_of_component ~reader component required in
   let metadata = Context.metadata_of_options options in
   let lint_severities = Options.lint_severities options in
-  let file_options = Some (Options.file_options options) in
   let strict_mode = Options.strict_mode options in
   let get_aloc_table_unsafe =
     Parsing_heaps.Reader_dispatcher.get_sig_ast_aloc_table_unsafe ~reader
@@ -134,7 +133,6 @@ let merge_context_generic ~options ~reader ~get_ast_unsafe ~get_file_sig_unsafe 
     Merge_js.merge_component
       ~metadata
       ~lint_severities
-      ~file_options
       ~strict_mode
       ~file_sigs
       ~phase
@@ -221,7 +219,6 @@ let merge_contents_context ~reader options file ast info file_sig =
   in
   let metadata = Context.metadata_of_options options in
   let lint_severities = Options.lint_severities options in
-  let file_options = Some (Options.file_options options) in
   let strict_mode = Options.strict_mode options in
   let get_aloc_table_unsafe =
     Parsing_heaps.Reader_dispatcher.get_sig_ast_aloc_table_unsafe ~reader
@@ -230,7 +227,6 @@ let merge_contents_context ~reader options file ast info file_sig =
     Merge_js.merge_component
       ~metadata
       ~lint_severities
-      ~file_options
       ~strict_mode
       ~file_sigs
       ~get_ast_unsafe:(fun _ -> (comments, aloc_ast))

--- a/src/typing/merge_js.ml
+++ b/src/typing/merge_js.ml
@@ -347,7 +347,6 @@ let detect_non_voidable_properties cx =
 let merge_component
     ~metadata
     ~lint_severities
-    ~file_options
     ~strict_mode
     ~file_sigs
     ~get_ast_unsafe
@@ -416,7 +415,6 @@ let merge_component
             comments
             ast
             ~lint_severities
-            ~file_options
             ~file_sig
         in
         (cx :: cxs, tast :: tasts, FilenameMap.add filename cx impl_cxs))

--- a/src/typing/merge_js.mli
+++ b/src/typing/merge_js.mli
@@ -26,7 +26,6 @@ end
 val merge_component :
   metadata:Context.metadata ->
   lint_severities:Severity.severity LintSettings.t ->
-  file_options:Files.options option ->
   strict_mode:StrictModeSettings.t ->
   file_sigs:File_sig.With_ALoc.t Utils_js.FilenameMap.t ->
   get_ast_unsafe:(File_key.t -> get_ast_return) ->

--- a/src/typing/type_inference_js.mli
+++ b/src/typing/type_inference_js.mli
@@ -8,7 +8,6 @@
 (* Lint suppressions are handled iff lint_severities is Some. *)
 val infer_ast :
   lint_severities:Severity.severity LintSettings.t ->
-  file_options:Files.options option ->
   file_sig:File_sig.With_ALoc.t ->
   Context.t ->
   File_key.t ->
@@ -20,7 +19,6 @@ val infer_ast :
 val infer_lib_file :
   exclude_syms:SSet.t ->
   lint_severities:Severity.severity LintSettings.t ->
-  file_options:Files.options option ->
   file_sig:File_sig.With_ALoc.t ->
   Context.t ->
   (Loc.t, Loc.t) Flow_ast.program ->

--- a/tests/config_declarations/config_declarations.exp
+++ b/tests/config_declarations/config_declarations.exp
@@ -20,5 +20,13 @@ Unused suppression comment.
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 
+Warning ------------------------------------------------------------------------------------------------------- B.js:1:1
 
-Found 1 error and 1 warning
+Unused suppression comment.
+
+   1| // $FlowFixMe
+      ^^^^^^^^^^^^^
+
+
+
+Found 1 error and 2 warnings

--- a/tests/config_declarations_react/.flowconfig
+++ b/tests/config_declarations_react/.flowconfig
@@ -1,0 +1,14 @@
+[ignore]
+
+[include]
+
+[libs]
+
+[declarations]
+<PROJECT_ROOT>/node_modules/react-native/.*
+
+[options]
+suppress_comment=.*\\$FlowFixMe
+suppress_comment=.*\\$FlowIssue
+suppress_comment=\\(.\\|\n\\)*\\$FlowNewLine
+include_warnings=true

--- a/tests/config_declarations_react/A.js
+++ b/tests/config_declarations_react/A.js
@@ -1,0 +1,14 @@
+// Due to [declarations], this won't error
+const str2str = require('react-native/str2str')
+
+// But this identical one will
+const str2str_loud = require('react-d3/str2str')
+
+// Calling str2str with a string is correct
+const foo: string = str2str(' bar ');
+
+// But not with a number
+const fooNum: number = str2str(39); // Would not error if using [untyped]!
+
+// trim2 should still error as well
+str2str(39);

--- a/tests/config_declarations_react/B.js
+++ b/tests/config_declarations_react/B.js
@@ -1,0 +1,5 @@
+const React = require('React');
+
+// Will error. Ensuring this still errors properly despite the react-native decl
+const AsyncMode: boolean = React.unstable_AsyncMode;
+

--- a/tests/config_declarations_react/config_declarations_react.exp
+++ b/tests/config_declarations_react/config_declarations_react.exp
@@ -1,0 +1,63 @@
+Error ------------------------------------------------------------------------------------------------------- A.js:11:24
+
+Cannot assign `str2str(...)` to `fooNum` because string [1] is incompatible with number [2].
+
+   A.js:11:24
+   11| const fooNum: number = str2str(39); // Would not error if using [untyped]!
+                              ^^^^^^^^^^^
+
+References:
+   node_modules/react-native/str2str.js:7:40
+    7| module.exports = function str2str(foo: string) {
+                                              ^^^^^^ [1]
+   A.js:11:15
+   11| const fooNum: number = str2str(39); // Would not error if using [untyped]!
+                     ^^^^^^ [2]
+
+
+Error ------------------------------------------------------------------------------------------------------- A.js:11:32
+
+Cannot call `str2str` with `39` bound to `foo` because number [1] is incompatible with string [2].
+
+   A.js:11:32
+   11| const fooNum: number = str2str(39); // Would not error if using [untyped]!
+                                      ^^ [1]
+
+References:
+   node_modules/react-native/str2str.js:7:40
+    7| module.exports = function str2str(foo: string) {
+                                              ^^^^^^ [2]
+
+
+Error -------------------------------------------------------------------------------------------------------- A.js:14:9
+
+Cannot call `str2str` with `39` bound to `foo` because number [1] is incompatible with string [2].
+
+   A.js:14:9
+   14| str2str(39);
+               ^^ [1]
+
+References:
+   node_modules/react-native/str2str.js:7:40
+    7| module.exports = function str2str(foo: string) {
+                                              ^^^^^^ [2]
+
+
+Error -------------------------------------------------------------------------------------------------------- B.js:4:28
+
+Cannot get `React.unstable_AsyncMode` because property `unstable_AsyncMode` is missing in exports [1].
+
+   4| const AsyncMode: boolean = React.unstable_AsyncMode;
+                                 ^^^^^^^^^^^^^^^^^^^^^^^^
+
+
+Error ---------------------------------------------------------------------------- node_modules/react-d3/str2str.js:4:19
+
+Cannot get `React.unstable_AsyncMode` because property `unstable_AsyncMode` is missing in exports [1].
+
+   4| const AsyncMode = React.unstable_AsyncMode;
+                        ^^^^^^^^^^^^^^^^^^^^^^^^
+
+
+
+Found 5 errors

--- a/tests/config_declarations_react/node_modules/react-d3/str2str.js
+++ b/tests/config_declarations_react/node_modules/react-d3/str2str.js
@@ -1,0 +1,9 @@
+// @flow
+
+const React = require('React');
+const AsyncMode = React.unstable_AsyncMode;
+
+// (string) => string
+module.exports = function str2str(foo: string) {
+  return foo;
+}

--- a/tests/config_declarations_react/node_modules/react-native/str2str.js
+++ b/tests/config_declarations_react/node_modules/react-native/str2str.js
@@ -1,0 +1,9 @@
+// @flow
+
+const React = require('React');
+const AsyncMode = React.unstable_AsyncMode;
+
+// (string) => string
+module.exports = function str2str(foo: string) {
+  return foo;
+}

--- a/tests/config_declarations_react/node_modules/react/package.json
+++ b/tests/config_declarations_react/node_modules/react/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "react",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC"
+}


### PR DESCRIPTION
# Overview

In #4916, @LegNeato wrote a feature to block reporting of errors in files matching regex patterns as `[silence]` in `.flowconfig`. This sat for about 9 months as an open PR despite strong public support. Just before merging, this was renamed to `[declarations]`. 

Why do we need it? As you can read in #4916's comments, and as I wrote in https://github.com/facebook/flow/pull/4916#issuecomment-382033025, nearly every Flow version introduces breaking changes. A library written for a given Flow version is unlikely to work with any other version. This is especially true of very complex libraries like `react-native` that seem to break on a monthly basis.

Unfortunately, by default, Flow reports errors *internal to a module*, even if these internal errors don't affect any user code. This means that, if a library uses a new feature that is not in the user's current version of Flow, or uses a feature that has been changes (like object types moving to exact-by-default), internal errors will abound. These errors make it difficult to distinguish actual user type errors, and make it impossible to rely on the `flow` binary's exit code for CI.

The current alternatives are `[ignore]`, which causes import errors, and `[untyped]`, which casts to `any`. `[declarations]`has the crucial distinction of *leaving exported typedefs intact while ignoring internal errors*, making it much easier to keep typedefs active while your project and its dependencies ebb and flow across many Flow versions.

Unfortunately, #4916 did not actually implement `[silence]` correctly, and doubly unfortunate was the naming pushed through in the final hour. This PR fixes the implementation. Additionally, it renames `[declarations]` back to `[silence]`. This was not taken lightly but has been done due to the overwhelming majority of feedback preferring `[silence]` and the confusion surrounding `[declarations]` as it relates to "declaration files" (i.e. `.js.flow` files) and "type declarations" generally. This becomes even more confusing when comparing to other `.flowconfig` directives such as `[include]`.

## What Was Wrong

There are two major flaws in the original approach:

1. Silencing errors at the merge site (`Context.remove_all_errors cx`) does not work for builtins,
as those errors are computed later, and
2. Putting that suppression in an if/else where the else block
parsed comment error suppressions can cause `[declarations]` to
actually create *more* errors, which was misleading a lot of people
and masked the source of bugs in this feature.

## Commits

Fixes #6631, #6717, #7803.

https://github.com/facebook/flow/pull/8105/commits/27fa53f61826ccc7dd7bc766022d6161d472ad36 is the first commit, which fixes `[declarations]` as written.

We now suppress entire files in error collation, at the very end
of the error reporting process.

----

The second commit is https://github.com/facebook/flow/pull/8105/commits/a0aa29ebaf6906eed495ed0fbb929760870b0554.

This backs out some of the code
in #4916 related to file error suppression in the merge phase.

This has the benefit of fixing erroneous ignoring of comment
suppressions within those files, which was causing unexpected
consequences as listed in 2) above.

----

The last commit is https://github.com/facebook/flow/pull/8105/commits/a2e11e1800c0f24ee6df6127bd7b78f62e3d8226.

We rename `[declarations]` to `[silence]`
This name has not gone over well: https://github.com/facebook/flow/issues/6631#issuecomment-411285015

and is confusing in multiple places, such as:
https://github.com/facebook/flow/blob/dd93de0a3796897fe07cca8a3bdc621c992a9880/website/en/docs/declarations/index.md
and
https://github.com/facebook/flow/blob/dd93de0a3796897fe07cca8a3bdc621c992a9880/tests/lib_interfaces/.flowconfig#L5-L6

It is difficult to grep for, difficult to distinguish versus type declarations,
and is widely used interchangeably with "interfaces".

For these reasons and many more, it is best to rename this option now that it
is usable.

Pinging @mroch and @mrkev who helped get the original version of this in.