### PR TITLE
libdefs: specify process.env values as non-null (but allow void)

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -2580,7 +2580,7 @@ declare class Process extends events$EventEmitter {
   cwd() : string;
   disconnect? : () => void;
   domain? : domain$Domain;
-  env : { [key: string] : ?string, ... };
+  env : { [key: string] : string | void, ... };
   emitWarning(warning: string | Error): void;
   emitWarning(warning: string, typeOrCtor: string | (...empty) => mixed): void;
   emitWarning(warning: string, type: string, codeOrCtor: string | (...empty) => mixed): void;


### PR DESCRIPTION
<!--
  If this is a change to library defintions, please include links to relevant documentation.
  If this is a documentation change, please prefix the title with [DOCS].

  If this is neither, ensure you opened a discussion issue and link it in the PR description.
-->

Node's `process.env` is specified as an object mapping environment variable names to string values.  Since a requested environment variable might not be defined, the libdef has previously been specified as `{ [string]: ?string }`.

However, in practice I believe the value is never `null` (it'd be either a string, or `undefined` if you try to access a nonexistent environment variable). This causes trouble when trying to destructure `process.env`:
```js
const {
  FOO = 'some-default-value',
} = process.env;
// `FOO` has type `?string` rather than `string`
```

This PR updates the libdef to remove the possibility of `null`, so that a default value when destructuring is enough to exhaust all non-`string` possibilities.