### PR TITLE
fix for missing bytesWritten in WriteStream.

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -882,15 +882,16 @@ declare module "fs" {
   }
 
   declare class FSWatcher extends events$EventEmitter {
-    close(): void
+    close(): void;
   }
 
   declare class ReadStream extends stream$Readable {
-    close(): void
+    close(): void;
   }
 
   declare class WriteStream extends stream$Writable {
-    close(): void
+    close(): void;
+    bytesWritten: number;
   }
 
   declare function rename(oldPath: string, newPath: string, callback?: (err: ?ErrnoError) => void): void;


### PR DESCRIPTION
This is a fix for https://github.com/facebook/flow/issues/7293.
This change brings  flow in parity with [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/f9dcdecd8b24587009fb01962b2eb867e7779abc/types/node/v4/index.d.ts#L1736)

