### PR TITLE
doc(react/components): use $Shape<Props> for defaults

### DIFF
--- a/website/en/docs/react/components.md
+++ b/website/en/docs/react/components.md
@@ -167,18 +167,11 @@ don't have to add any type annotations to use default props.
 If you would like to add a type annotation to `defaultProps` you can define the
 type as
 ```js
-type DefaultProps = {|
+type DefaultProps: $Shape<Props> = {
   foo: number,
-|}
-```
-and spread that into the `Props` type:
-```js
-type Props = {
-  ...DefaultProps,
-  bar: string,
 }
 ```
-This way you avoid duplicating the properties that happen to have a default value.
+This declares the defaults as a [subset shape](../types/utilities/#toc-shape) of the props, avoiding duplication of the properties that happen to have a default value.
 
 ## Stateless Functional Components <a class="toc" id="toc-stateless-functional-components" href="#toc-stateless-functional-components"></a>
 


### PR DESCRIPTION
Instead of declaring a type for the default props and composing that inside the component props, suggest using `$Shape<Props>` instead.  This increases readability of the declaration of the composed props.

<!--
  If this is a change to library defintions, please include links to relevant documentation.
  If this is a documentation change, please prefix the title with [DOCS].

  If this is neither, ensure you opened a discussion issue and link it in the PR description.
-->
