### PR TITLE
Fix dune

### DIFF
--- a/src/server/protocol/dune
+++ b/src/server/protocol/dune
@@ -5,6 +5,7 @@
     flow_autofix_options
     flow_common
     flow_common_profiling
+    flow_coverage
     flow_exit_status
     flow_parser_utils_replacement_printer
     flow_server_status

--- a/src/services/coverage/dune
+++ b/src/services/coverage/dune
@@ -1,0 +1,8 @@
+(library
+  (name flow_coverage)
+  (wrapped false)
+  (libraries
+    flow_typing
+    flow_typing_type
+  )
+)

--- a/src/typing/dune
+++ b/src/typing/dune
@@ -5,6 +5,7 @@
   (libraries
     flow_typing_key
   )
+  (preprocess (pps ppx_let))
 )
 
 (library
@@ -15,6 +16,7 @@
     flow_common
     flow_common_utils
   )
+  (preprocess (pps ppx_let))
 )
 
 (library
@@ -26,6 +28,7 @@
     flow_typing_trust
     flow_typing_type
   )
+  (preprocess (pps ppx_let))
 )
 
 (library
@@ -35,6 +38,7 @@
   (libraries
     flow_common_utils
   )
+  (preprocess (pps ppx_let))
 )
 
 (library
@@ -48,6 +52,7 @@
     flow_typing_polarity
     flow_typing_trust
   )
+  (preprocess (pps ppx_let))
 )
 
 (library
@@ -70,4 +75,5 @@
     xx
   )
   (modules_without_implementation graph partition resolvable_type_job)
+  (preprocess (pps ppx_let))
 )


### PR DESCRIPTION
This was pretty easy to do. The one subtle thing was that the `flow_typing` rule needed `ppx_let` but none of the other rules in the same directory did. This meant the `.merlin` file wasn't completely accurate, leading to the warning

```
$ dune build src/flow.exe
File "src/typing/dune", line 73, characters 14-27:
73 |   (preprocess (pps ppx_let))
                   ^^^^^^^^^^^^^
Warning: .merlin generated is inaccurate. Cannot mix preprocessed and non
preprocessed specificiations.
Split the stanzas into different directories or silence this warning by
adding (allow_approximate_merlin) to your dune-project.
```

I ended up adding the ppx to everything in that directory to work around this warning. Felt better than suppressing it, and easier than moving each target into a different directory.