### PR TITLE
CLI: print autofix subcommands

### DIFF
--- a/src/commands/autofixCommand.ml
+++ b/src/commands/autofixCommand.ml
@@ -256,7 +256,7 @@ let command =
     {
       CommandSpec.name = "autofix";
       doc = "";
-      usage = Printf.sprintf "Usage: %s autofix SUBCOMMAND [OPTIONS]...\n" CommandUtils.exe_name;
+      usage = Printf.sprintf "Usage: %s autofix SUBCOMMAND [OPTIONS]...\n\nSUBCOMMANDS:\nsuggest: Provides type annotation suggestions for a given program\ninsert-type: Insert type information at file and position\nexports: Automatically fix signature verification errors\n" CommandUtils.exe_name;
       args =
         CommandSpec.ArgSpec.(
           empty


### PR DESCRIPTION
Before:

```
Usage: flow autofix SUBCOMMAND [OPTIONS]...

  --help  This list of options
```

After:

```
Usage: flow autofix SUBCOMMAND [OPTIONS]...

SUBCOMMANDS:
suggest: Provides type annotation suggestions for a given program
insert-type: Insert type information at file and position
exports: Automatically fix signature verification errors

  --help  This list of options
```

<!--
  If this is a change to library defintions, please include links to relevant documentation.
  If this is a documentation change, please prefix the title with [DOCS].

  If this is neither, ensure you opened a discussion issue and link it in the PR description.
-->
