### PR TITLE
[lsp] fix test URIs on windows

### DIFF
--- a/hack/utils/file_url/file_url.ml
+++ b/hack/utils/file_url/file_url.ml
@@ -40,7 +40,7 @@ let escape ~(safe_chars : string) (s : string) : string =
       let code = Char.code c in
       if code < 32 || code > 127 then
         failwith ("only 7bit ascii allowed in " ^ s);
-      Buffer.add_string buf (Printf.sprintf "%%%02x" code)
+      Buffer.add_string buf (Printf.sprintf "%%%02X" code)
   in
   String.iter f s;
   Buffer.contents buf
@@ -99,7 +99,7 @@ let dos_re = Str.regexp {|^\([a-zA-Z]\):\([/\].*\)$|} (* e.g. c:\ or z:/ *)
 let backslash_re = Str.regexp {|\\|} (* matches a single backslash *)
 
 let path_safe_chars =
-  "/-._~!$&'()*+,;=:@0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+  "/-._~!$&'()*+,;=@0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
 
 let create (path : string) : string =
   let absolute_path =

--- a/newtests/lsp/code-action-disabled/test.js
+++ b/newtests/lsp/code-action-disabled/test.js
@@ -30,7 +30,7 @@ export default suite(
       lspStartAndConnect(),
       lspRequestAndWaitUntilResponse('textDocument/codeAction', {
         textDocument: {
-          uri: '<PLACEHOLDER_PROJECT_URL_SLASH>error1.js',
+          uri: '<PLACEHOLDER_PROJECT_URL>/error1.js',
         },
         range: {
           start: {
@@ -55,7 +55,7 @@ export default suite(
       lspStartAndConnect(),
       lspRequestAndWaitUntilResponse('textDocument/codeAction', {
         textDocument: {
-          uri: '<PLACEHOLDER_PROJECT_URL_SLASH>error1.js',
+          uri: '<PLACEHOLDER_PROJECT_URL>/error1.js',
         },
         range: {
           start: {
@@ -97,7 +97,7 @@ export default suite(
       lspStartAndConnect(),
       lspRequestAndWaitUntilResponse('textDocument/codeAction', {
         textDocument: {
-          uri: '<PLACEHOLDER_PROJECT_URL_SLASH>error1.js',
+          uri: '<PLACEHOLDER_PROJECT_URL>/error1.js',
         },
         range: {
           start: {

--- a/newtests/lsp/code-action/test.js
+++ b/newtests/lsp/code-action/test.js
@@ -30,7 +30,7 @@ export default suite(
       lspStartAndConnect(),
       lspRequestAndWaitUntilResponse('textDocument/codeAction', {
         textDocument: {
-          uri: '<PLACEHOLDER_PROJECT_URL_SLASH>error1.js',
+          uri: '<PLACEHOLDER_PROJECT_URL>/error1.js',
         },
         range: {
           start: {
@@ -55,7 +55,7 @@ export default suite(
       lspStartAndConnect(),
       lspRequestAndWaitUntilResponse('textDocument/codeAction', {
         textDocument: {
-          uri: '<PLACEHOLDER_PROJECT_URL_SLASH>error1.js',
+          uri: '<PLACEHOLDER_PROJECT_URL>/error1.js',
         },
         range: {
           start: {
@@ -109,7 +109,7 @@ export default suite(
               ],
               edit: {
                 changes: {
-                  '<PLACEHOLDER_PROJECT_URL_SLASH>error1.js': [
+                  '<PLACEHOLDER_PROJECT_URL>/error1.js': [
                     {
                       range: {
                         start: {line: 1, character: 22},
@@ -131,7 +131,7 @@ export default suite(
       lspStartAndConnect(),
       lspRequestAndWaitUntilResponse('textDocument/codeAction', {
         textDocument: {
-          uri: '<PLACEHOLDER_PROJECT_URL_SLASH>error1.js',
+          uri: '<PLACEHOLDER_PROJECT_URL>/error1.js',
         },
         range: {
           start: {
@@ -155,7 +155,7 @@ export default suite(
               diagnostics: [],
               edit: {
                 changes: {
-                  '<PLACEHOLDER_PROJECT_URL_SLASH>error1.js': [
+                  '<PLACEHOLDER_PROJECT_URL>/error1.js': [
                     {
                       range: {
                         start: {

--- a/newtests/lsp/completion/test.js
+++ b/newtests/lsp/completion/test.js
@@ -19,7 +19,7 @@ export default suite(
       addFile('completion.js'),
       lspStartAndConnect(),
       lspRequestAndWaitUntilResponse('textDocument/completion', {
-        textDocument: {uri: '<PLACEHOLDER_PROJECT_URL_SLASH>completion.js'},
+        textDocument: {uri: '<PLACEHOLDER_PROJECT_URL>/completion.js'},
         position: {line: 10, character: 15}, // statement position
       }).verifyAllLSPMessagesInStep(
         [
@@ -89,7 +89,7 @@ export default suite(
       addFile('kind.js'),
       lspStartAndConnect(),
       lspRequestAndWaitUntilResponse('textDocument/completion', {
-        textDocument: {uri: '<PLACEHOLDER_PROJECT_URL_SLASH>kind.js'},
+        textDocument: {uri: '<PLACEHOLDER_PROJECT_URL>/kind.js'},
         position: {line: 13, character: 15},
         context: {triggerKind: 1},
       }).verifyAllLSPMessagesInStep(
@@ -196,7 +196,7 @@ export default suite(
         },
       }),
       lspRequestAndWaitUntilResponse('textDocument/completion', {
-        textDocument: {uri: '<PLACEHOLDER_PROJECT_URL_SLASH>params.js'},
+        textDocument: {uri: '<PLACEHOLDER_PROJECT_URL>/params.js'},
         position: {line: 9, character: 15},
         context: {triggerKind: 1},
       }).verifyAllLSPMessagesInStep(
@@ -275,7 +275,7 @@ export default suite(
       addFile('jsx.js'),
       lspStartAndConnect(),
       lspRequestAndWaitUntilResponse('textDocument/completion', {
-        textDocument: {uri: '<PLACEHOLDER_PROJECT_URL_SLASH>jsx.js'},
+        textDocument: {uri: '<PLACEHOLDER_PROJECT_URL>/jsx.js'},
         position: {line: 12, character: 4},
         context: {triggerKind: 2, triggerCharacter: ' '},
       }).verifyAllLSPMessagesInStep(
@@ -303,7 +303,7 @@ export default suite(
       addFile('jsx.js'),
       lspStartAndConnect(),
       lspRequestAndWaitUntilResponse('textDocument/completion', {
-        textDocument: {uri: '<PLACEHOLDER_PROJECT_URL_SLASH>jsx.js'},
+        textDocument: {uri: '<PLACEHOLDER_PROJECT_URL>/jsx.js'},
         position: {line: 11, character: 1},
         context: {triggerKind: 2, triggerCharacter: ' '},
       }).verifyAllLSPMessagesInStep(
@@ -323,7 +323,7 @@ export default suite(
       addFile('jsx.js'),
       lspStartAndConnect(),
       lspRequestAndWaitUntilResponse('textDocument/completion', {
-        textDocument: {uri: '<PLACEHOLDER_PROJECT_URL_SLASH>jsx.js'},
+        textDocument: {uri: '<PLACEHOLDER_PROJECT_URL>/jsx.js'},
         position: {line: 11, character: 1},
         context: {triggerKind: 1},
       }).verifyAllLSPMessagesInStep(
@@ -374,7 +374,7 @@ export default suite(
       addFile('jsx.js'),
       lspStartAndConnect(),
       lspRequestAndWaitUntilResponse('textDocument/completion', {
-        textDocument: {uri: '<PLACEHOLDER_PROJECT_URL_SLASH>jsx.js'},
+        textDocument: {uri: '<PLACEHOLDER_PROJECT_URL>/jsx.js'},
         position: {line: 12, character: 4},
         context: {triggerKind: 1},
       }).verifyAllLSPMessagesInStep(
@@ -404,7 +404,7 @@ export default suite(
         addFile('jsx.js'),
         lspStartAndConnect(),
         lspRequestAndWaitUntilResponse('textDocument/completion', {
-          textDocument: {uri: '<PLACEHOLDER_PROJECT_URL_SLASH>jsx.js'},
+          textDocument: {uri: '<PLACEHOLDER_PROJECT_URL>/jsx.js'},
           position: {line: 13, character: 4},
           context: {triggerKind: 2, triggerCharacter: ' '},
         }).verifyAllLSPMessagesInStep(
@@ -438,7 +438,7 @@ export default suite(
       addFile('jsx.js'),
       lspStartAndConnect(),
       lspRequestAndWaitUntilResponse('textDocument/completion', {
-        textDocument: {uri: '<PLACEHOLDER_PROJECT_URL_SLASH>jsx.js'},
+        textDocument: {uri: '<PLACEHOLDER_PROJECT_URL>/jsx.js'},
         position: {line: 13, character: 4},
         context: {triggerKind: 1},
       }).verifyAllLSPMessagesInStep(
@@ -466,7 +466,7 @@ export default suite(
       addFile('jsx.js'),
       lspStartAndConnect(),
       lspRequestAndWaitUntilResponse('textDocument/completion', {
-        textDocument: {uri: '<PLACEHOLDER_PROJECT_URL_SLASH>jsx.js'},
+        textDocument: {uri: '<PLACEHOLDER_PROJECT_URL>/jsx.js'},
         position: {line: 14, character: 3},
         context: {triggerKind: 2, triggerCharacter: '.'},
       }).verifyAllLSPMessagesInStep(
@@ -542,7 +542,7 @@ export default suite(
       addFile('jsx.js'),
       lspStartAndConnect(),
       lspRequestAndWaitUntilResponse('textDocument/completion', {
-        textDocument: {uri: '<PLACEHOLDER_PROJECT_URL_SLASH>jsx.js'},
+        textDocument: {uri: '<PLACEHOLDER_PROJECT_URL>/jsx.js'},
         position: {line: 15, character: 2},
         context: {triggerKind: 2, triggerCharacter: '.'},
       }).verifyAllLSPMessagesInStep(

--- a/newtests/lsp/connection/test.js
+++ b/newtests/lsp/connection/test.js
@@ -173,7 +173,7 @@ export default suite(
       lspStartAndConnect(),
       lspNotification('textDocument/didOpen', {
         textDocument: {
-          uri: '<PLACEHOLDER_PROJECT_URL_SLASH>open.js',
+          uri: '<PLACEHOLDER_PROJECT_URL>/open.js',
           languageId: 'javascript',
           version: 1,
           text: `// @flow
@@ -183,7 +183,7 @@ jones();
         },
       })
         .lspRequestAndWaitUntilResponse('textDocument/definition', {
-          textDocument: {uri: '<PLACEHOLDER_PROJECT_URL_SLASH>open.js'},
+          textDocument: {uri: '<PLACEHOLDER_PROJECT_URL>/open.js'},
           position: {line: 2, character: 1},
         })
         .verifyAllLSPMessagesInStep(
@@ -191,14 +191,14 @@ jones();
           [...lspIgnoreStatusAndCancellation],
         ),
       lspRequestAndWaitUntilResponse('textDocument/definition', {
-        textDocument: {uri: '<PLACEHOLDER_PROJECT_URL_SLASH>open.js'},
+        textDocument: {uri: '<PLACEHOLDER_PROJECT_URL>/open.js'},
         position: {line: 2, character: 1},
       }).verifyAllLSPMessagesInStep(
         ['textDocument/definition{open.js,"line":1}'],
         [...lspIgnoreStatusAndCancellation],
       ),
       lspRequestAndWaitUntilResponse('textDocument/definition', {
-        textDocument: {uri: '<PLACEHOLDER_PROJECT_URL_SLASH>open.js'},
+        textDocument: {uri: '<PLACEHOLDER_PROJECT_URL>/open.js'},
         position: {line: 2, character: 1},
       }).verifyAllLSPMessagesInStep(
         ['textDocument/definition{open.js,"line":1}'],
@@ -218,7 +218,7 @@ jones();
           [...lspIgnoreStatusAndCancellation],
         ),
       lspRequestAndWaitUntilResponse('textDocument/definition', {
-        textDocument: {uri: '<PLACEHOLDER_PROJECT_URL_SLASH>open.js'},
+        textDocument: {uri: '<PLACEHOLDER_PROJECT_URL>/open.js'},
         position: {line: 2, character: 1},
       }).verifyAllLSPMessagesInStep(
         ['textDocument/definition{open.js,line":1}'],

--- a/newtests/lsp/diagnostics/test.js
+++ b/newtests/lsp/diagnostics/test.js
@@ -96,7 +96,7 @@ export default suite(
       // Open a document with errors. We should get a live syntax error immediately.
       lspNotification('textDocument/didOpen', {
         textDocument: {
-          uri: '<PLACEHOLDER_PROJECT_URL_SLASH>syntaxError1.js',
+          uri: '<PLACEHOLDER_PROJECT_URL>/syntaxError1.js',
           languageId: 'javascript',
           version: 1,
           text: `// @flow
@@ -112,7 +112,7 @@ function fred(): number {return 1+;}
       // Edit it fix the problem. The live syntax error should be dismissed immediately.
       lspNotification('textDocument/didChange', {
         textDocument: {
-          uri: '<PLACEHOLDER_PROJECT_URL_SLASH>syntaxError1.js',
+          uri: '<PLACEHOLDER_PROJECT_URL>/syntaxError1.js',
           version: 2,
         },
         contentChanges: [
@@ -131,7 +131,7 @@ function fred(): number {return 1+2;}
       // Make another change that doesn't introduce errors. We should get no reports.
       lspNotification('textDocument/didChange', {
         textDocument: {
-          uri: '<PLACEHOLDER_PROJECT_URL_SLASH>syntaxError1.js',
+          uri: '<PLACEHOLDER_PROJECT_URL>/syntaxError1.js',
           version: 2,
         },
         contentChanges: [
@@ -147,7 +147,7 @@ function fred(): number {return 1+2;}
       // Make a change that introduces the error. We should get a report immediately.
       lspNotification('textDocument/didChange', {
         textDocument: {
-          uri: '<PLACEHOLDER_PROJECT_URL_SLASH>syntaxError1.js',
+          uri: '<PLACEHOLDER_PROJECT_URL>/syntaxError1.js',
           version: 3,
         },
         contentChanges: [
@@ -166,7 +166,7 @@ function fred(): number {return 1+2;}
       // Close the file. The live error should go away.
       lspNotification('textDocument/didClose', {
         textDocument: {
-          uri: '<PLACEHOLDER_PROJECT_URL_SLASH>syntaxError1.js',
+          uri: '<PLACEHOLDER_PROJECT_URL>/syntaxError1.js',
           version: 3,
         },
       })
@@ -181,7 +181,7 @@ function fred(): number {return 1+2;}
       // Open a document with no errors. We should not see errors
       lspNotification('textDocument/didOpen', {
         textDocument: {
-          uri: '<PLACEHOLDER_PROJECT_URL_SLASH>typeError1.js',
+          uri: '<PLACEHOLDER_PROJECT_URL>/typeError1.js',
           languageId: 'javascript',
           version: 1,
           text: `// @flow`,
@@ -192,7 +192,7 @@ function fred(): number {return 1+2;}
       // Edit it and add a type error. We should see the error.
       lspNotification('textDocument/didChange', {
         textDocument: {
-          uri: '<PLACEHOLDER_PROJECT_URL_SLASH>typeError1.js',
+          uri: '<PLACEHOLDER_PROJECT_URL>/typeError1.js',
           version: 2,
         },
         contentChanges: [
@@ -213,7 +213,7 @@ function fred(): number {return 1+2;}
       // Edit it fix the problem. The live type error should be dismissed.
       lspNotification('textDocument/didChange', {
         textDocument: {
-          uri: '<PLACEHOLDER_PROJECT_URL_SLASH>typeError1.js',
+          uri: '<PLACEHOLDER_PROJECT_URL>/typeError1.js',
           version: 3,
         },
         contentChanges: [
@@ -232,7 +232,7 @@ function fred(): number {return 1+2;}
       // Make another change that doesn't introduce errors. We should get no reports.
       lspNotification('textDocument/didChange', {
         textDocument: {
-          uri: '<PLACEHOLDER_PROJECT_URL_SLASH>typeError1.js',
+          uri: '<PLACEHOLDER_PROJECT_URL>/typeError1.js',
           version: 4,
         },
         contentChanges: [
@@ -248,7 +248,7 @@ function fred(): number {return 1+2;}
       // Make a change that introduces the error. We should get a report immediately.
       lspNotification('textDocument/didChange', {
         textDocument: {
-          uri: '<PLACEHOLDER_PROJECT_URL_SLASH>typeError1.js',
+          uri: '<PLACEHOLDER_PROJECT_URL>/typeError1.js',
           version: 5,
         },
         contentChanges: [
@@ -270,7 +270,7 @@ function fred(): number {return 1+2;}
       // Close the file. The live error should go away.
       lspNotification('textDocument/didClose', {
         textDocument: {
-          uri: '<PLACEHOLDER_PROJECT_URL_SLASH>typeError1.js',
+          uri: '<PLACEHOLDER_PROJECT_URL>/typeError1.js',
           version: 6,
         },
       })
@@ -286,7 +286,7 @@ function fred(): number {return 1+2;}
       // Open a document with errors. We should immediately see the live non-parse errors
       lspNotification('textDocument/didOpen', {
         textDocument: {
-          uri: '<PLACEHOLDER_PROJECT_URL_SLASH>typeError1.js',
+          uri: '<PLACEHOLDER_PROJECT_URL>/typeError1.js',
           languageId: 'javascript',
           version: 1,
           text: `// @flow
@@ -311,7 +311,7 @@ function fred(): number {return 1+2;}
       // Open a document with no errors. We should not see errors
       lspNotification('textDocument/didOpen', {
         textDocument: {
-          uri: '<PLACEHOLDER_PROJECT_URL_SLASH>typeError1.js',
+          uri: '<PLACEHOLDER_PROJECT_URL>/typeError1.js',
           languageId: 'javascript',
           version: 1,
           text: `// @flow`,
@@ -324,7 +324,7 @@ function fred(): number {return 1+2;}
       // is set in the .flowconfig
       lspNotification('textDocument/didChange', {
         textDocument: {
-          uri: '<PLACEHOLDER_PROJECT_URL_SLASH>typeError1.js',
+          uri: '<PLACEHOLDER_PROJECT_URL>/typeError1.js',
           version: 2,
         },
         contentChanges: [
@@ -363,7 +363,7 @@ function fred(): number {return 1+2;}
         ),
       lspNotification('textDocument/didOpen', {
         textDocument: {
-          uri: '<PLACEHOLDER_PROJECT_URL_SLASH>pseudo_parse_error.js',
+          uri: '<PLACEHOLDER_PROJECT_URL>/pseudo_parse_error.js',
           languageId: 'javascript',
           version: 1,
           text: `// @flow
@@ -395,7 +395,7 @@ obj?.foo(); // Error
         9000,
         (() => {
           const expectedMessage = {
-            uri: '<PLACEHOLDER_PROJECT_URL_SLASH>importsFakeSymbol.js',
+            uri: '<PLACEHOLDER_PROJECT_URL>/importsFakeSymbol.js',
             diagnostics: [
               {
                 range: {
@@ -415,7 +415,7 @@ obj?.foo(); // Error
                 relatedInformation: [
                   {
                     location: {
-                      uri: '<PLACEHOLDER_PROJECT_URL_SLASH>empty.js',
+                      uri: '<PLACEHOLDER_PROJECT_URL>/empty.js',
                       range: {
                         start: {
                           line: 0,
@@ -433,7 +433,7 @@ obj?.foo(); // Error
                 relatedLocations: [
                   {
                     location: {
-                      uri: '<PLACEHOLDER_PROJECT_URL_SLASH>empty.js',
+                      uri: '<PLACEHOLDER_PROJECT_URL>/empty.js',
                       range: {
                         start: {line: 0, character: 0},
                         end: {line: 0, character: 0},

--- a/newtests/lsp/edits/test.js
+++ b/newtests/lsp/edits/test.js
@@ -17,7 +17,7 @@ export default suite(
       lspStartAndConnect(),
       lspNotification('textDocument/didOpen', {
         textDocument: {
-          uri: '<PLACEHOLDER_PROJECT_URL_SLASH>open.js',
+          uri: '<PLACEHOLDER_PROJECT_URL>/open.js',
           languageId: 'javascript',
           version: 1,
           text: `// @flow
@@ -28,7 +28,7 @@ jones();
         },
       }).verifyAllLSPMessagesInStep([''], [...lspIgnoreStatusAndCancellation]),
       lspRequestAndWaitUntilResponse('textDocument/definition', {
-        textDocument: {uri: '<PLACEHOLDER_PROJECT_URL_SLASH>open.js'},
+        textDocument: {uri: '<PLACEHOLDER_PROJECT_URL>/open.js'},
         position: {line: 3, character: 1},
       }).verifyAllLSPMessagesInStep(
         ['textDocument/definition{open.js,line":2}'],
@@ -36,7 +36,7 @@ jones();
       ),
       lspNotification('textDocument/didChange', {
         textDocument: {
-          uri: '<PLACEHOLDER_PROJECT_URL_SLASH>open.js',
+          uri: '<PLACEHOLDER_PROJECT_URL>/open.js',
           version: 2,
         },
         contentChanges: [
@@ -50,17 +50,17 @@ wilbur();
         ],
       }).verifyAllLSPMessagesInStep([''], [...lspIgnoreStatusAndCancellation]),
       lspRequestAndWaitUntilResponse('textDocument/definition', {
-        textDocument: {uri: '<PLACEHOLDER_PROJECT_URL_SLASH>open.js'},
+        textDocument: {uri: '<PLACEHOLDER_PROJECT_URL>/open.js'},
         position: {line: 3, character: 1},
       }).verifyAllLSPMessagesInStep(
         ['textDocument/definition{open.js,"line":1}'],
         [...lspIgnoreStatusAndCancellation],
       ),
       lspNotification('textDocument/didClose', {
-        textDocument: {uri: '<PLACEHOLDER_PROJECT_URL_SLASH>open.js'},
+        textDocument: {uri: '<PLACEHOLDER_PROJECT_URL>/open.js'},
       }).verifyAllLSPMessagesInStep([''], [...lspIgnoreStatusAndCancellation]),
       lspRequestAndWaitUntilResponse('textDocument/definition', {
-        textDocument: {uri: '<PLACEHOLDER_PROJECT_URL_SLASH>open.js'},
+        textDocument: {uri: '<PLACEHOLDER_PROJECT_URL>/open.js'},
         position: {line: 3, character: 1},
       }).verifyAllLSPMessagesInStep(
         ['textDocument/definition{unexpected error}'],

--- a/newtests/lsp/queries/test.js
+++ b/newtests/lsp/queries/test.js
@@ -32,7 +32,7 @@ export default suite(
       addFile('definition.js'),
       lspStartAndConnect(),
       lspRequestAndWaitUntilResponse('textDocument/definition', {
-        textDocument: {uri: '<PLACEHOLDER_PROJECT_URL_SLASH>definition.js'},
+        textDocument: {uri: '<PLACEHOLDER_PROJECT_URL>/definition.js'},
         position: {line: 6, character: 1},
       }).verifyAllLSPMessagesInStep(
         [
@@ -46,7 +46,7 @@ export default suite(
       addFile('definition.js'),
       lspStartAndConnect(),
       lspRequestAndWaitUntilResponse('textDocument/definition', {
-        textDocument: {uri: '<PLACEHOLDER_PROJECT_URL_SLASH>definition.js'},
+        textDocument: {uri: '<PLACEHOLDER_PROJECT_URL>/definition.js'},
         position: {line: 7, character: 11}, // over a comment
       }).verifyAllLSPMessagesInStep(
         ['textDocument/definition{[]}'],
@@ -58,7 +58,7 @@ export default suite(
       addFile('definition.js'),
       lspStartAndConnect(),
       lspRequestAndWaitUntilResponse('textDocument/definition', {
-        textDocument: {uri: '<PLACEHOLDER_PROJECT_URL_SLASH>definition.js'},
+        textDocument: {uri: '<PLACEHOLDER_PROJECT_URL>/definition.js'},
         position: {line: 7, character: 1}, // over whitespace
       }).verifyAllLSPMessagesInStep(
         ['textDocument/definition{[]}'],
@@ -70,42 +70,42 @@ export default suite(
       addFile('hover.js'),
       lspStartAndConnect(),
       lspRequestAndWaitUntilResponse('textDocument/hover', {
-        textDocument: {uri: '<PLACEHOLDER_PROJECT_URL_SLASH>hover.js'},
+        textDocument: {uri: '<PLACEHOLDER_PROJECT_URL>/hover.js'},
         position: {line: 6, character: 1}, // over a function use
       }).verifyAllLSPMessagesInStep(
         ['textDocument/hover{() => number}'],
         [...lspIgnoreStatusAndCancellation],
       ),
       lspRequestAndWaitUntilResponse('textDocument/hover', {
-        textDocument: {uri: '<PLACEHOLDER_PROJECT_URL_SLASH>hover.js'},
+        textDocument: {uri: '<PLACEHOLDER_PROJECT_URL>/hover.js'},
         position: {line: 3, character: 1}, // over whitespace
       }).verifyAllLSPMessagesInStep(
         ['textDocument/hover{null}'],
         [...lspIgnoreStatusAndCancellation],
       ),
       lspRequestAndWaitUntilResponse('textDocument/hover', {
-        textDocument: {uri: '<PLACEHOLDER_PROJECT_URL_SLASH>hover.js'},
+        textDocument: {uri: '<PLACEHOLDER_PROJECT_URL>/hover.js'},
         position: {line: 2, character: 1}, // over a keyword
       }).verifyAllLSPMessagesInStep(
         ['textDocument/hover{null}'],
         [...lspIgnoreStatusAndCancellation],
       ),
       lspRequestAndWaitUntilResponse('textDocument/hover', {
-        textDocument: {uri: '<PLACEHOLDER_PROJECT_URL_SLASH>hover.js'},
+        textDocument: {uri: '<PLACEHOLDER_PROJECT_URL>/hover.js'},
         position: {line: 0, character: 1}, // over a comment
       }).verifyAllLSPMessagesInStep(
         ['textDocument/hover{null}'],
         [...lspIgnoreStatusAndCancellation],
       ),
       lspRequestAndWaitUntilResponse('textDocument/hover', {
-        textDocument: {uri: '<PLACEHOLDER_PROJECT_URL_SLASH>hover.js'},
+        textDocument: {uri: '<PLACEHOLDER_PROJECT_URL>/hover.js'},
         position: {line: 6, character: 100}, // past the end of a line
       }).verifyAllLSPMessagesInStep(
         ['textDocument/hover{null}'],
         [...lspIgnoreStatusAndCancellation],
       ),
       lspRequestAndWaitUntilResponse('textDocument/hover', {
-        textDocument: {uri: '<PLACEHOLDER_PROJECT_URL_SLASH>hover.js'},
+        textDocument: {uri: '<PLACEHOLDER_PROJECT_URL>/hover.js'},
         position: {line: 100, character: 0}, // past the end of the file
       }).verifyAllLSPMessagesInStep(
         ['textDocument/hover{null}'],
@@ -117,28 +117,28 @@ export default suite(
       addFiles('references.js', 'references2.js'),
       lspStartAndConnect(),
       lspRequestAndWaitUntilResponse('textDocument/documentHighlight', {
-        textDocument: {uri: '<PLACEHOLDER_PROJECT_URL_SLASH>references.js'},
+        textDocument: {uri: '<PLACEHOLDER_PROJECT_URL>/references.js'},
         position: {line: 9, character: 17}, // on an identifier
       }).verifyAllLSPMessagesInStep(
         ['textDocument/documentHighlight{"line":3,"line":9}'],
         [...lspIgnoreStatusAndCancellation],
       ),
       lspRequestAndWaitUntilResponse('textDocument/documentHighlight', {
-        textDocument: {uri: '<PLACEHOLDER_PROJECT_URL_SLASH>references.js'},
+        textDocument: {uri: '<PLACEHOLDER_PROJECT_URL>/references.js'},
         position: {line: 9, character: 1}, // on a keyword
       }).verifyAllLSPMessagesInStep(
         ['textDocument/documentHighlight{[]}'],
         [...lspIgnoreStatusAndCancellation],
       ),
       lspRequestAndWaitUntilResponse('textDocument/documentHighlight', {
-        textDocument: {uri: '<PLACEHOLDER_PROJECT_URL_SLASH>references.js'},
+        textDocument: {uri: '<PLACEHOLDER_PROJECT_URL>/references.js'},
         position: {line: 6, character: 0}, // on whitespace
       }).verifyAllLSPMessagesInStep(
         ['textDocument/documentHighlight{[]}'],
         [...lspIgnoreStatusAndCancellation],
       ),
       lspRequestAndWaitUntilResponse('textDocument/documentHighlight', {
-        textDocument: {uri: '<PLACEHOLDER_PROJECT_URL_SLASH>references.js'},
+        textDocument: {uri: '<PLACEHOLDER_PROJECT_URL>/references.js'},
         position: {line: 6, character: 100}, // off the right edge of the text
       }).verifyAllLSPMessagesInStep(
         ['textDocument/documentHighlight{[]}'],
@@ -150,14 +150,14 @@ export default suite(
       addFiles('references.js', 'references2.js'),
       lspStartAndConnect(),
       lspRequestAndWaitUntilResponse('textDocument/references', {
-        textDocument: {uri: '<PLACEHOLDER_PROJECT_URL_SLASH>references.js'},
+        textDocument: {uri: '<PLACEHOLDER_PROJECT_URL>/references.js'},
         position: {line: 9, character: 17}, // on an identifier
       }).verifyAllLSPMessagesInStep(
         ['textDocument/references{line":3,"line":5,"line":9}'],
         [...lspIgnoreStatusAndCancellation],
       ),
       lspRequestAndWaitUntilResponse('textDocument/references', {
-        textDocument: {uri: '<PLACEHOLDER_PROJECT_URL_SLASH>references.js'},
+        textDocument: {uri: '<PLACEHOLDER_PROJECT_URL>/references.js'},
         position: {
           line: 9,
           character: 17,
@@ -173,7 +173,7 @@ export default suite(
       addFiles('references.js', 'references2.js'),
       lspStartAndConnect(),
       lspRequestAndWaitUntilResponse('textDocument/rename', {
-        textDocument: {uri: '<PLACEHOLDER_PROJECT_URL_SLASH>references.js'},
+        textDocument: {uri: '<PLACEHOLDER_PROJECT_URL>/references.js'},
         position: {line: 9, character: 17}, // on an identifier
         newName: 'foobar',
       }).verifyAllLSPMessagesInStep(
@@ -186,7 +186,7 @@ export default suite(
       addFiles('outline.js', 'references.js'),
       lspStartAndConnect(),
       lspRequestAndWaitUntilResponse('textDocument/documentSymbol', {
-        textDocument: {uri: '<PLACEHOLDER_PROJECT_URL_SLASH>outline.js'},
+        textDocument: {uri: '<PLACEHOLDER_PROJECT_URL>/outline.js'},
       }).verifyAllLSPMessagesInStep(
         [
           'textDocument/documentSymbol{WORD_REGEX,State,Preferences,pref1,EPrefs,pref2,MyClass1,_projectRoot,command,constructor,dispose,MyInterface2,getFoo,myFunction3}',
@@ -199,7 +199,7 @@ export default suite(
       addFiles('coverage.js'),
       lspStartAndConnect(),
       lspRequestAndWaitUntilResponse('textDocument/typeCoverage', {
-        textDocument: {uri: '<PLACEHOLDER_PROJECT_URL_SLASH>coverage.js'},
+        textDocument: {uri: '<PLACEHOLDER_PROJECT_URL>/coverage.js'},
       }).verifyAllLSPMessagesInStep(
         ['textDocument/typeCoverage'],
         ['window/showStatus', '$/cancelRequest'],

--- a/newtests/lsp/wait_for_recheck/test.js
+++ b/newtests/lsp/wait_for_recheck/test.js
@@ -65,7 +65,7 @@ export default suite(
         [...lspIgnoreStatusAndCancellation],
       ),
       lspRequestAndWaitUntilResponse('textDocument/definition', {
-        textDocument: {uri: '<PLACEHOLDER_PROJECT_URL_SLASH>definition.js'},
+        textDocument: {uri: '<PLACEHOLDER_PROJECT_URL>/definition.js'},
         position: {line: 6, character: 1},
       })
         .verifyAllLSPMessagesInStep([], [...lspIgnoreStatusAndCancellation])
@@ -80,7 +80,7 @@ export default suite(
         [...lspIgnoreStatusAndCancellation],
       ),
       lspRequestAndWaitUntilResponse('textDocument/definition', {
-        textDocument: {uri: '<PLACEHOLDER_PROJECT_URL_SLASH>definition.js'},
+        textDocument: {uri: '<PLACEHOLDER_PROJECT_URL>/definition.js'},
         position: {line: 6, character: 1},
       })
         .verifyAllLSPMessagesInStep(
@@ -100,7 +100,7 @@ export default suite(
         [...lspIgnoreStatusAndCancellation],
       ),
       lspRequestAndWaitUntilResponse('textDocument/hover', {
-        textDocument: {uri: '<PLACEHOLDER_PROJECT_URL_SLASH>hover.js'},
+        textDocument: {uri: '<PLACEHOLDER_PROJECT_URL>/hover.js'},
         position: {line: 6, character: 1}, // over a function use
       })
         .verifyAllLSPMessagesInStep([], [...lspIgnoreStatusAndCancellation])
@@ -115,7 +115,7 @@ export default suite(
         [...lspIgnoreStatusAndCancellation],
       ),
       lspRequestAndWaitUntilResponse('textDocument/hover', {
-        textDocument: {uri: '<PLACEHOLDER_PROJECT_URL_SLASH>hover.js'},
+        textDocument: {uri: '<PLACEHOLDER_PROJECT_URL>/hover.js'},
         position: {line: 6, character: 1}, // over a function use
       })
         .verifyAllLSPMessagesInStep(
@@ -133,7 +133,7 @@ export default suite(
         [...lspIgnoreStatusAndCancellation],
       ),
       lspRequestAndWaitUntilResponse('textDocument/completion', {
-        textDocument: {uri: '<PLACEHOLDER_PROJECT_URL_SLASH>completion.js'},
+        textDocument: {uri: '<PLACEHOLDER_PROJECT_URL>/completion.js'},
         position: {line: 10, character: 15}, // statement position
       })
         .verifyAllLSPMessagesInStep([], [...lspIgnoreStatusAndCancellation])
@@ -148,7 +148,7 @@ export default suite(
         [...lspIgnoreStatusAndCancellation],
       ),
       lspRequestAndWaitUntilResponse('textDocument/completion', {
-        textDocument: {uri: '<PLACEHOLDER_PROJECT_URL_SLASH>completion.js'},
+        textDocument: {uri: '<PLACEHOLDER_PROJECT_URL>/completion.js'},
         position: {line: 10, character: 15}, // statement position
       })
         .verifyAllLSPMessagesInStep(
@@ -170,7 +170,7 @@ export default suite(
           [...lspIgnoreStatusAndCancellation],
         ),
         lspRequestAndWaitUntilResponse('textDocument/documentHighlight', {
-          textDocument: {uri: '<PLACEHOLDER_PROJECT_URL_SLASH>references.js'},
+          textDocument: {uri: '<PLACEHOLDER_PROJECT_URL>/references.js'},
           position: {line: 9, character: 17}, // on an identifier
         })
           .verifyAllLSPMessagesInStep(
@@ -191,7 +191,7 @@ export default suite(
           [...lspIgnoreStatusAndCancellation],
         ),
         lspRequestAndWaitUntilResponse('textDocument/documentHighlight', {
-          textDocument: {uri: '<PLACEHOLDER_PROJECT_URL_SLASH>references.js'},
+          textDocument: {uri: '<PLACEHOLDER_PROJECT_URL>/references.js'},
           position: {line: 9, character: 17}, // on an identifier
         })
           .verifyAllLSPMessagesInStep([], [...lspIgnoreStatusAndCancellation])
@@ -207,7 +207,7 @@ export default suite(
         [...lspIgnoreStatusAndCancellation],
       ),
       lspRequestAndWaitUntilResponse('textDocument/references', {
-        textDocument: {uri: '<PLACEHOLDER_PROJECT_URL_SLASH>references.js'},
+        textDocument: {uri: '<PLACEHOLDER_PROJECT_URL>/references.js'},
         position: {line: 9, character: 17}, // on an identifier
       })
         .verifyAllLSPMessagesInStep([], [...lspIgnoreStatusAndCancellation])
@@ -222,7 +222,7 @@ export default suite(
         [...lspIgnoreStatusAndCancellation],
       ),
       lspRequestAndWaitUntilResponse('textDocument/references', {
-        textDocument: {uri: '<PLACEHOLDER_PROJECT_URL_SLASH>references.js'},
+        textDocument: {uri: '<PLACEHOLDER_PROJECT_URL>/references.js'},
         position: {line: 9, character: 17}, // on an identifier
       })
         .verifyAllLSPMessagesInStep([], [...lspIgnoreStatusAndCancellation])
@@ -237,7 +237,7 @@ export default suite(
         [...lspIgnoreStatusAndCancellation],
       ),
       lspRequestAndWaitUntilResponse('textDocument/rename', {
-        textDocument: {uri: '<PLACEHOLDER_PROJECT_URL_SLASH>references.js'},
+        textDocument: {uri: '<PLACEHOLDER_PROJECT_URL>/references.js'},
         position: {line: 9, character: 17}, // on an identifier
         newName: 'foobar',
       })
@@ -253,7 +253,7 @@ export default suite(
         [...lspIgnoreStatusAndCancellation],
       ),
       lspRequestAndWaitUntilResponse('textDocument/rename', {
-        textDocument: {uri: '<PLACEHOLDER_PROJECT_URL_SLASH>references.js'},
+        textDocument: {uri: '<PLACEHOLDER_PROJECT_URL>/references.js'},
         position: {line: 9, character: 17}, // on an identifier
         newName: 'foobar',
       })
@@ -269,7 +269,7 @@ export default suite(
         [...lspIgnoreStatusAndCancellation],
       ),
       lspRequestAndWaitUntilResponse('textDocument/documentSymbol', {
-        textDocument: {uri: '<PLACEHOLDER_PROJECT_URL_SLASH>outline.js'},
+        textDocument: {uri: '<PLACEHOLDER_PROJECT_URL>/outline.js'},
       })
         .verifyAllLSPMessagesInStep(
           [
@@ -290,7 +290,7 @@ export default suite(
           [...lspIgnoreStatusAndCancellation],
         ),
         lspRequestAndWaitUntilResponse('textDocument/documentSymbol', {
-          textDocument: {uri: '<PLACEHOLDER_PROJECT_URL_SLASH>outline.js'},
+          textDocument: {uri: '<PLACEHOLDER_PROJECT_URL>/outline.js'},
         })
           .verifyAllLSPMessagesInStep(
             [
@@ -310,7 +310,7 @@ export default suite(
         [...lspIgnoreStatusAndCancellation],
       ),
       lspRequestAndWaitUntilResponse('textDocument/typeCoverage', {
-        textDocument: {uri: '<PLACEHOLDER_PROJECT_URL_SLASH>coverage.js'},
+        textDocument: {uri: '<PLACEHOLDER_PROJECT_URL>/coverage.js'},
       })
         .verifyAllLSPMessagesInStep([], [...lspIgnoreStatusAndCancellation])
         .timeout(2000),
@@ -324,7 +324,7 @@ export default suite(
         [...lspIgnoreStatusAndCancellation],
       ),
       lspRequestAndWaitUntilResponse('textDocument/typeCoverage', {
-        textDocument: {uri: '<PLACEHOLDER_PROJECT_URL_SLASH>coverage.js'},
+        textDocument: {uri: '<PLACEHOLDER_PROJECT_URL>/coverage.js'},
       })
         .verifyAllLSPMessagesInStep(
           ['textDocument/typeCoverage{"line":12,"line":8,"line":6}'],

--- a/packages/flow-dev-tools/package.json
+++ b/packages/flow-dev-tools/package.json
@@ -29,7 +29,8 @@
     "semver": "^5.6.0",
     "source-map-support": "~0.4.0",
     "twit": "^2.1.5",
-    "vscode-jsonrpc": "^4.0.0"
+    "vscode-jsonrpc": "^4.0.0",
+    "vscode-uri": "^2.0.3"
   },
   "babel": {
     "presets": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -1699,9 +1699,9 @@ growly@^1.3.0:
   integrity sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=
 
 handlebars@>=4.0.14, handlebars@^4.0.3:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.2.0.tgz#57ce8d2175b9bbb3d8b3cf3e4217b1aec8ddcb2e"
-  integrity sha512-Kb4xn5Qh1cxAKvQnzNWZ512DhABzyFNmsaJf3OAkWNa4NkaqWcNI8Tao8Tasi0/F4JD9oyG0YxuFyvyR57d+Gw==
+  version "4.4.3"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.4.3.tgz#180bae52c1d0e9ec0c15d7e82a4362d662762f6e"
+  integrity sha512-B0W4A2U1ww3q7VVthTKfh+epHx+q4mCt6iK+zEAzbMBpWQAwxCeKxEGpj/1oQTpzPXDNSOG7hmG14TsISH50yw==
   dependencies:
     neo-async "^2.6.0"
     optimist "^0.6.1"
@@ -4126,6 +4126,11 @@ vscode-jsonrpc@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-4.0.0.tgz#a7bf74ef3254d0a0c272fab15c82128e378b3be9"
   integrity sha512-perEnXQdQOJMTDFNv+UF3h1Y0z4iSiaN9jIlb0OqIYgosPCZGYh/MCUlkFtV2668PL69lRDO32hmvL2yiidUYg==
+
+vscode-uri@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/vscode-uri/-/vscode-uri-2.0.3.tgz#25e5f37f552fbee3cec7e5f80cef8469cefc6543"
+  integrity sha512-4D3DI3F4uRy09WNtDGD93H9q034OHImxiIcSq664Hq1Y1AScehlP3qqZyTkX/RWxeu0MRMHGkrxYqm2qlDF/aw==
 
 w3c-hr-time@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Summary:
the tests were sending invalid URIs on Windows:

`C:\foo\bar` should become `file:///C:/foo/bar`, but was `file:///C:\foo\bar`. when decoded, the backslashes are escaped so this becomes a file named "C:\foo\bar" in the root directory.

since URIs always use forward slashes, `<PLACEHOLDER_PROJECT_URL_SLASH>` is redundant with `<PLACEHOLDER_PROJECT_URL>/`, so I replaced it.

node 10.12 added `url.pathToFileURL` which should do what we want here, but to avoid bumping the required node version, I went with `vscode-uri` instead.

Differential Revision: D18001370

