### PR TITLE
[DOCS] website: fix duplicate `declarations` path

### DIFF
--- a/website/_data/guides.yml
+++ b/website/_data/guides.yml
@@ -89,7 +89,6 @@
 - id: config
   pages:
     - path: "/docs/config/"
-    - path: "/docs/config/declarations/"
     - path: "/docs/config/include/"
     - path: "/docs/config/ignore/"
     - path: "/docs/config/untyped/"


### PR DESCRIPTION
Remove duplicate `declarations` nav-item on the [flowconfig page
![duplicate-entry](https://user-images.githubusercontent.com/14677379/67149672-bf5ca400-f2b6-11e9-8252-9cbef9c49ce1.png)
](https://flow.org/en/docs/config). 
