### PR TITLE
libdefs: Add missing methods to Blob

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -17,6 +17,9 @@ declare class Blob {
   type: string;
   close(): void;
   slice(start?: number, end?: number, contentType?: string): Blob;
+  arrayBuffer(): Promise<ArrayBuffer>;
+  text(): Promise<string>,
+  stream(): ReadableStream,
 }
 
 declare class FileReader extends EventTarget {


### PR DESCRIPTION
[MDN](https://developer.mozilla.org/en-US/docs/Web/API/Blob#Methods)

Some of these are marked experimental, but it's unclear to me whether or not we care about that.