### PR TITLE
[Feature] Improve $Compose Helper

### DIFF
--- a/src/typing/coverage.ml
+++ b/src/typing/coverage.ml
@@ -168,6 +168,7 @@ class visitor = object (self)
     | ShapeT t
     | ThisClassT (_, t)
     | ThisTypeAppT (_, t, _, _)
+    | ComposedFn (_, _, _, t)
       ->
       self#type_ cx t
 

--- a/src/typing/custom_fun_kit.ml
+++ b/src/typing/custom_fun_kit.ml
@@ -19,7 +19,7 @@ module Kit (Flow: Flow_common.S) = struct
   include Flow
   (* Creates the appropriate constraints for the compose() function and its
    * reversed variant. *)
-  let rec run_compose cx trace ~use_op reason_op reverse fns spread_fn tin tout =
+  let rec run_compose cx trace ~use_op reason_op reverse fns spread_fn tins tout =
     match reverse, fns, spread_fn with
       (* Call the tail functions in our array first and call our head function
        * last after that. *)
@@ -27,7 +27,7 @@ module Kit (Flow: Flow_common.S) = struct
         let reason = replace_desc_reason (RCustom "compose intermediate value")
           (reason_of_t fn) in
         let tvar = Tvar.mk_where cx reason (fun tvar ->
-          run_compose cx trace ~use_op reason_op reverse fns spread_fn tin tvar) in
+          run_compose cx trace ~use_op reason_op reverse fns spread_fn tins tvar) in
         rec_flow cx trace (fn,
           CallT (use_op, reason, mk_functioncalltype reason_op None [Arg tvar] tout))
 
@@ -36,14 +36,20 @@ module Kit (Flow: Flow_common.S) = struct
       | true, fn::fns, _ ->
         let reason = replace_desc_reason (RCustom "compose intermediate value")
           (reason_of_t fn) in
-        let tvar = Tvar.mk_where cx reason (fun tvar ->
-          rec_flow cx trace (fn,
-            CallT (use_op, reason, mk_functioncalltype reason_op None [Arg tin] tvar))) in
-        run_compose cx trace ~use_op reason_op reverse fns spread_fn tvar tout
+        let tvar = Tvar.mk_where cx reason (
+          fun tvar ->
+            let targs = List.map (fun tin -> Arg tin) tins in
+            rec_flow cx trace (
+              fn,
+              CallT (use_op, reason, mk_functioncalltype reason_op None targs tvar)
+            )
+        ) in
+        run_compose cx trace ~use_op reason_op reverse fns spread_fn [tvar] tout
 
       (* If there are no functions and no spread function then we are an identity
        * function. *)
       | _, [], None ->
+        let tin = List.hd tins in
         rec_flow_t cx trace (tin, tout)
 
       (* Correctly implementing spreads of unknown arity for the compose function
@@ -96,9 +102,38 @@ module Kit (Flow: Flow_common.S) = struct
        * The implementation of Flow should be able to terminate these recursive
        * constraints. If it doesn't then we have a bug. *)
       | _, [], Some spread_fn ->
-        run_compose cx trace ~use_op reason_op reverse [] None tin tout;
-        run_compose cx trace ~use_op reason_op reverse [spread_fn] None tin tout;
-        run_compose cx trace ~use_op reason_op reverse [spread_fn] None tout tin
+        run_compose cx trace ~use_op reason_op reverse [] None tins tout;
+        run_compose cx trace ~use_op reason_op reverse [spread_fn] None tins tout;
+        let tin = List.hd tins in
+        run_compose cx trace ~use_op reason_op reverse [spread_fn] None [tout] tin
+
+  let mk_compose_tins cx reason_op reverse fns spread_fn = match reverse, fns, spread_fn with
+    | true, fn::_, _ -> (
+      match fn with
+        | DefT(_, _, FunT (_, _, ft)) ->
+          List.map (fun _ -> Tvar.mk cx reason_op) ft.params
+        | _ ->
+          let tin = Tvar.mk cx reason_op in
+          [tin]
+    )
+    | false, fns, None -> (
+      let lastFn = ListUtils.last_opt fns in
+      match lastFn with
+        | Some fn -> (
+          match fn with
+            | DefT(_, _, FunT (_, _, ft)) ->
+              List.map (fun _ -> Tvar.mk cx reason_op) ft.params
+            | _ ->
+              let tin = Tvar.mk cx reason_op in
+              [tin]
+        )
+        | _ ->
+          let tin = Tvar.mk cx reason_op in
+          [tin]
+    )
+    | _, _, _ ->
+      let tin = Tvar.mk cx reason_op in
+      [tin]
 
   let run cx trace ~use_op reason_op kind args spread_arg tout = match kind with
   | Compose reverse ->
@@ -110,13 +145,13 @@ module Kit (Flow: Flow_common.S) = struct
         Op (FunCallMethod {op; fn; prop; args = []; local})
     | _ -> use_op
     in
-    let tin = Tvar.mk cx reason_op in
+    let tins = mk_compose_tins cx reason_op reverse args spread_arg in
     let tvar = Tvar.mk cx reason_op in
-    run_compose cx trace ~use_op reason_op reverse args spread_arg tin tvar;
+    run_compose cx trace ~use_op reason_op reverse args spread_arg tins tvar;
     let funt = FunT (
       dummy_static reason_op,
       dummy_prototype,
-      mk_functiontype reason_op [tin] ~rest_param:None ~def_reason:reason_op tvar
+      mk_functiontype reason_op tins ~rest_param:None ~def_reason:reason_op tvar
     ) in
     rec_flow_t cx trace (DefT (reason_op, bogus_trust (), funt), tout)
 

--- a/src/typing/debug_js.ml
+++ b/src/typing/debug_js.ml
@@ -178,6 +178,7 @@ and _json_of_t_impl json_cx t = Hh_json.(
   | FunProtoApplyT _
   | FunProtoBindT _
   | FunProtoCallT _
+  | ComposedFn (_, _, _, _)
     -> []
 
   | DefT (_, _, FunT (static, proto, funtype)) -> [
@@ -439,8 +440,10 @@ and _json_of_custom_fun_kind kind = Hh_json.JSON_String (match kind with
   | ObjectAssign -> "Object.assign"
   | ObjectGetPrototypeOf -> "Object.getPrototypeOf"
   | ObjectSetPrototypeOf -> "Object.setPrototypeOf"
-  | Compose false -> "Compose"
-  | Compose true -> "ComposeReverse"
+  | Compose (false, false) -> "Compose"
+  | Compose (false, true) -> "ComposeVariadic"
+  | Compose (true, false) -> "ComposeReverse"
+  | Compose (true, true) -> "ComposeReverseVariadic"
   | ReactPropType _ -> "ReactPropsCheckType"
   | ReactCreateClass -> "React.createClass"
   | ReactCreateElement -> "React.createElement"
@@ -1788,8 +1791,10 @@ let rec dump_t_ (depth, tvars) cx t =
     | ObjectAssign -> "ObjectAssign"
     | ObjectGetPrototypeOf -> "ObjectGetPrototypeOf"
     | ObjectSetPrototypeOf -> "ObjectSetPrototypeOf"
-    | Compose false -> "Compose"
-    | Compose true -> "ComposeReverse"
+    | Compose (false, false) -> "Compose"
+    | Compose (false, true) -> "ComposeVariadic"
+    | Compose (true, false) -> "ComposeReverse"
+    | Compose (true, true) -> "ComposeReverseVariadic"
     | ReactPropType p -> spf "ReactPropType (%s)" (react_prop_type p)
     | ReactCreateElement -> "ReactCreateElement"
     | ReactCloneElement -> "ReactCloneElement"
@@ -1835,6 +1840,7 @@ let rec dump_t_ (depth, tvars) cx t =
   | FunProtoT _
   | FunProtoApplyT _
   | FunProtoBindT _
+  | ComposedFn (_, _, _, _)
   | FunProtoCallT _ -> p t
   | DefT (_, trust, PolyT (_, tps, c, id)) -> p ~trust:(Some trust) ~extra:(spf "%s [%s] #%d"
       (kid c)

--- a/src/typing/members.ml
+++ b/src/typing/members.ml
@@ -411,6 +411,9 @@ let rec extract_type cx this_t = match this_t with
   | DefT (_, _, ReactAbstractComponentT _) as t ->
       Success t
 
+  | ComposedFn (_, _, _, _) as t ->
+    Success t
+
   | ReposT (_, t)
   | InternalT (ReposUpperT (_, t)) ->
       extract_type cx t

--- a/src/typing/resolvableTypeJob.ml
+++ b/src/typing/resolvableTypeJob.ml
@@ -170,6 +170,7 @@ and collect_of_type ?log_unresolved cx acc = function
   | TypeDestructorTriggerT _
   | ModuleT (_, _, _)
   | InternalT (ExtendsT _)
+  | ComposedFn (_, _, _, _)
     ->
     acc
 

--- a/src/typing/sigHash.ml
+++ b/src/typing/sigHash.ml
@@ -92,7 +92,10 @@ type hash =
   | CustomFunObjectGetPrototypeOfH
   | CustomFunObjectSetPrototypeOfH
   | CustomFunComposeH
+  | CustomFunComposeVariadicH
   | CustomFunReverseComposeH
+  | CustomFunReverseComposeVariadicH
+  | ComposedFnH
   | CustomFunReactPropTypePrimitiveRequiredH
   | CustomFunReactPropTypePrimitiveNotRequiredH
   | CustomFunReactPropTypeComplexArrayOfH
@@ -262,8 +265,11 @@ let hash_of_ctor = Type.(function
   | CustomFunT (_, ObjectAssign) -> CustomFunObjectAssignH
   | CustomFunT (_, ObjectGetPrototypeOf) -> CustomFunObjectGetPrototypeOfH
   | CustomFunT (_, ObjectSetPrototypeOf) -> CustomFunObjectSetPrototypeOfH
-  | CustomFunT (_, Compose true) -> CustomFunComposeH
-  | CustomFunT (_, Compose false) -> CustomFunReverseComposeH
+  | CustomFunT (_, Compose (true, false)) -> CustomFunComposeH
+  | CustomFunT (_, Compose (true, true)) -> CustomFunComposeVariadicH
+  | CustomFunT (_, Compose (false, false)) -> CustomFunReverseComposeH
+  | CustomFunT (_, Compose (false, true)) -> CustomFunReverseComposeVariadicH
+  | ComposedFn (_, _, _, _) -> ComposedFnH
   | CustomFunT (_, ReactPropType rpt) ->
     let open React.PropType in
     begin match rpt with

--- a/src/typing/ty_normalizer.ml
+++ b/src/typing/ty_normalizer.ml
@@ -712,6 +712,9 @@ end = struct
       else
          return Ty.(TypeOf FunProtoCall)
 
+    | ComposedFn (_, _, _, _) ->
+      return Ty.Void
+
     | ModuleT (reason, exports, _) -> module_t env reason exports t
 
     | NullProtoT _ -> return Ty.Null
@@ -1428,8 +1431,10 @@ end = struct
     | ObjectAssign -> return (builtin_t "Object$Assign")
     | ObjectGetPrototypeOf -> return (builtin_t "Object$GetPrototypeOf")
     | ObjectSetPrototypeOf -> return (builtin_t "Object$SetPrototypeOf")
-    | Compose false -> return (builtin_t "$Compose")
-    | Compose true -> return (builtin_t "$ComposeReverse")
+    | Compose (false, false) -> return (builtin_t "$Compose")
+    | Compose (false, true) -> return (builtin_t "$ComposeVariadic")
+    | Compose (true, false) -> return (builtin_t "$ComposeReverse")
+    | Compose (true, true) -> return (builtin_t "$ComposeReverseVariadic")
     | ReactPropType t -> react_prop_type ~env t
     | ReactCreateClass -> return (builtin_t "React$CreateClass")
     | ReactCreateElement -> return (builtin_t "React$CreateElement")

--- a/src/typing/type.ml
+++ b/src/typing/type.ml
@@ -57,6 +57,7 @@ module rec TypeTerm : sig
     (*************)
 
     | DefT of reason * Trust.trust_rep * def_t
+    | ComposedFn of reason * t * t * t
 
     (* type expression whose evaluation is deferred *)
     (* Usually a type expression is evaluated by splitting it into a def type
@@ -1110,7 +1111,7 @@ module rec TypeTerm : sig
   | ObjectSetPrototypeOf
 
   (* common community functions *)
-  | Compose of bool
+  | Compose of bool * bool
 
   (* 3rd party libs *)
   | ReactPropType of React.PropType.t
@@ -2196,6 +2197,7 @@ end = struct
     | InternalT (ChoiceKitT (reason, _)) -> reason
     | TypeDestructorTriggerT (_, reason, _, _, _) -> reason
     | CustomFunT (reason, _) -> reason
+    | ComposedFn (reason, _, _, _) -> reason
     | DefT (reason, _, _) -> reason
     | EvalT (_, defer_use_t, _) -> reason_of_defer_use_t defer_use_t
     | ExactT (reason, _) -> reason
@@ -2383,6 +2385,7 @@ end = struct
     | ThisClassT (reason, t) -> ThisClassT (f reason, t)
     | ThisTypeAppT (reason, t1, t2, t3) -> ThisTypeAppT (f reason, t1, t2, t3)
     | TypeAppT (reason, t1, t2, t3) -> TypeAppT (f reason, t1, t2, t3)
+    | ComposedFn (reason, fn0, fn0_tout, tout) -> ComposedFn (reason, fn0, fn0_tout, tout)
 
   and mod_reason_of_defer_use_t f = function
     | LatentPredT (reason, p) -> LatentPredT (f reason, p)
@@ -3201,6 +3204,7 @@ let string_of_ctor = function
   | IntersectionT _ -> "IntersectionT"
   | OptionalT _ -> "OptionalT"
   | MaybeT _ -> "MaybeT"
+  | ComposedFn (_, _, _, _) -> "ComposedFn"
 
 let string_of_internal_use_op = function
   | CopyEnv -> "CopyEnv"

--- a/src/typing/type_annotation.ml
+++ b/src/typing/type_annotation.ml
@@ -874,10 +874,13 @@ let rec convert cx tparams_map = Ast.Type.(function
       mk_custom_fun cx loc t_ast targs ident ObjectSetPrototypeOf
 
   | "$Compose" ->
-      mk_custom_fun cx loc t_ast targs ident (Compose false)
+      mk_custom_fun cx loc t_ast targs ident (Compose (false, false))
+  | "$ComposeVariadic" ->
+      mk_custom_fun cx loc t_ast targs ident (Compose (false, true))
   | "$ComposeReverse" ->
-      mk_custom_fun cx loc t_ast targs ident (Compose true)
-
+      mk_custom_fun cx loc t_ast targs ident (Compose (true, false))
+  | "$ComposeReverseVariadic" ->
+      mk_custom_fun cx loc t_ast targs ident (Compose (true, true))
   | "React$AbstractComponent" ->
       check_type_arg_arity cx loc t_ast targs 2 (fun () ->
         let ts, targs = convert_type_params () in

--- a/src/typing/type_mapper.ml
+++ b/src/typing/type_mapper.ml
@@ -107,6 +107,7 @@ class virtual ['a] t = object(self)
       | NullProtoT _
       | FunProtoApplyT _
       | FunProtoBindT _
+      | ComposedFn (_, _, _, _)
       | FunProtoCallT _ -> t
       | AnyWithLowerBoundT t' ->
           let t'' = self#type_ cx map_cx t' in
@@ -451,7 +452,7 @@ class virtual ['a] t = object(self)
     | ObjectAssign
     | ObjectGetPrototypeOf
     | ObjectSetPrototypeOf
-    | Compose _
+    | Compose (_, _)
     | ReactPropType _
     | ReactCreateClass
     | ReactCreateElement

--- a/src/typing/type_visitor.ml
+++ b/src/typing/type_visitor.ml
@@ -39,6 +39,9 @@ class ['a] t = object(self)
   | NullProtoT _
     -> acc
 
+  | ComposedFn (_, _, _, _) ->
+    acc
+
   | CustomFunT (_, kind) -> self#custom_fun_kind cx acc kind
 
   | EvalT (t, defer_use_t, id) ->
@@ -253,7 +256,7 @@ class ['a] t = object(self)
   | ObjectAssign
   | ObjectGetPrototypeOf
   | ObjectSetPrototypeOf
-  | Compose _
+  | Compose (_, _)
   | ReactPropType _
   | ReactCreateClass
   | ReactCreateElement

--- a/tests/compose/compose.exp
+++ b/tests/compose/compose.exp
@@ -88,6 +88,679 @@ References:
                ^^^^^ [2]
 
 
+Error ----------------------------------------------------------------------------------- composeReverseVariadic.js:13:2
+
+Cannot cast `pipeVariadic(...)(...)` to empty because number [1] is incompatible with empty [2].
+
+   composeReverseVariadic.js:13:2
+   13| (pipeVariadic(inc)(0): empty); // Error: number ~> empty
+        ^^^^^^^^^^^^^^^^^^^^
+
+References:
+   composeReverseVariadic.js:9:28
+    9| declare var inc: number => number;
+                                  ^^^^^^ [1]
+   composeReverseVariadic.js:13:24
+   13| (pipeVariadic(inc)(0): empty); // Error: number ~> empty
+                              ^^^^^ [2]
+
+
+Error ----------------------------------------------------------------------------------- composeReverseVariadic.js:16:3
+
+Cannot call `pipeVariadic(...)` with empty string bound to the first parameter because string [1] is incompatible with
+number [2].
+
+   composeReverseVariadic.js:16:3
+   16|   "" // Error: string ~> number
+         ^^ [1]
+
+References:
+   composeReverseVariadic.js:9:18
+    9| declare var inc: number => number;
+                        ^^^^^^ [2]
+
+
+Error ----------------------------------------------------------------------------------- composeReverseVariadic.js:19:2
+
+Cannot cast `pipeVariadic(...)(...)` to empty because string [1] is incompatible with empty [2].
+
+   composeReverseVariadic.js:19:2
+   19| (pipeVariadic(inc, toString)(10): empty); // Error: string ~> empty
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+References:
+   composeReverseVariadic.js:11:33
+   11| declare var toString: number => string;
+                                       ^^^^^^ [1]
+   composeReverseVariadic.js:19:35
+   19| (pipeVariadic(inc, toString)(10): empty); // Error: string ~> empty
+                                         ^^^^^ [2]
+
+
+Error ----------------------------------------------------------------------------------- composeReverseVariadic.js:22:3
+
+Cannot call `pipeVariadic(...)` with empty string bound to the first parameter because string [1] is incompatible with
+number [2].
+
+   composeReverseVariadic.js:22:3
+   22|   "" // Error: string ~> number
+         ^^ [1]
+
+References:
+   composeReverseVariadic.js:9:18
+    9| declare var inc: number => number;
+                        ^^^^^^ [2]
+
+
+Error ----------------------------------------------------------------------------------- composeReverseVariadic.js:25:1
+
+Cannot call `pipeVariadic` with call of `pipeVariadic` bound to the first parameter because string [1] is incompatible
+with number [2].
+
+   composeReverseVariadic.js:25:1
+       v------------
+   25| pipeVariadic(
+   26|   toString,
+   27|   inc // Error: string ~> number
+   28| )(9);
+       ^
+
+References:
+   composeReverseVariadic.js:11:33
+   11| declare var toString: number => string;
+                                       ^^^^^^ [1]
+   composeReverseVariadic.js:9:18
+    9| declare var inc: number => number;
+                        ^^^^^^ [2]
+
+
+Error ---------------------------------------------------------------------------------- composeReverseVariadic.js:30:15
+
+number [1] is incompatible with string [2].
+
+   composeReverseVariadic.js:30:15
+   30| (pipeVariadic(inc): string => number); // Error: string ~> number
+                     ^^^
+
+References:
+   composeReverseVariadic.js:9:18
+    9| declare var inc: number => number;
+                        ^^^^^^ [1]
+   composeReverseVariadic.js:30:21
+   30| (pipeVariadic(inc): string => number); // Error: string ~> number
+                           ^^^^^^ [2]
+
+
+Error ----------------------------------------------------------------------------------- composeReverseVariadic.js:31:2
+
+Cannot cast `pipeVariadic(...)` to function type because number [1] is incompatible with string [2].
+
+   composeReverseVariadic.js:31:2
+   31| (pipeVariadic(inc): number => string); // Error: number ~> string
+        ^^^^^^^^^^^^^^^^^
+
+References:
+   composeReverseVariadic.js:9:28
+    9| declare var inc: number => number;
+                                  ^^^^^^ [1]
+   composeReverseVariadic.js:31:31
+   31| (pipeVariadic(inc): number => string); // Error: number ~> string
+                                     ^^^^^^ [2]
+
+
+Error ----------------------------------------------------------------------------------- composeReverseVariadic.js:32:3
+
+Cannot cast `pipeVariadic(...)` to empty because function type [1] is incompatible with empty [2].
+
+   composeReverseVariadic.js:32:3
+   32| ((pipeVariadic(inc): number => number): empty); // Error: (number => number) ~> empty
+         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+References:
+   composeReverseVariadic.js:32:22
+   32| ((pipeVariadic(inc): number => number): empty); // Error: (number => number) ~> empty
+                            ^^^^^^^^^^^^^^^^ [1]
+   composeReverseVariadic.js:32:41
+   32| ((pipeVariadic(inc): number => number): empty); // Error: (number => number) ~> empty
+                                               ^^^^^ [2]
+
+
+Error ----------------------------------------------------------------------------------- composeReverseVariadic.js:34:1
+
+Cannot call call of `pipeVariadic` [1] without exactly 1 type argument.
+
+   34| pipeVariadic(); // Error: pipeVariadic min_arity = 1
+       ^^^^^^^^^^^^^^ [1]
+
+
+Error ----------------------------------------------------------------------------------- composeReverseVariadic.js:38:3
+
+Cannot call `pipeVariadic` with compose intermediate value bound to the first parameter because string [1] is
+incompatible with number [2].
+
+   composeReverseVariadic.js:38:3
+   38|   toString,
+         ^^^^^^^^
+
+References:
+   composeReverseVariadic.js:11:33
+   11| declare var toString: number => string;
+                                       ^^^^^^ [1]
+   composeReverseVariadic.js:9:18
+    9| declare var inc: number => number;
+                        ^^^^^^ [2]
+
+
+Error ----------------------------------------------------------------------------------- composeReverseVariadic.js:42:1
+
+Cannot call `pipeVariadic(...)` because no more than 1 argument is expected by function type [1].
+
+   composeReverseVariadic.js:42:1
+   42| pipeVariadic(inc)(1, 2); // Error: No more than 1 argument is expected
+       ^^^^^^^^^^^^^^^^^^^^^^^
+
+References:
+   composeReverseVariadic.js:9:18
+    9| declare var inc: number => number;
+                        ^^^^^^^^^^^^^^^^ [1]
+
+
+Error ----------------------------------------------------------------------------------- composeReverseVariadic.js:44:2
+
+Cannot cast `pipeVariadic(...)(...)` to empty because number [1] is incompatible with empty [2].
+
+   composeReverseVariadic.js:44:2
+   44| (pipeVariadic(add)(1, 2): empty); // Error: number ~> empty
+        ^^^^^^^^^^^^^^^^^^^^^^^
+
+References:
+   composeReverseVariadic.js:10:38
+   10| declare var add: (number, number) => number;
+                                            ^^^^^^ [1]
+   composeReverseVariadic.js:44:27
+   44| (pipeVariadic(add)(1, 2): empty); // Error: number ~> empty
+                                 ^^^^^ [2]
+
+
+Error ---------------------------------------------------------------------------------- composeReverseVariadic.js:46:22
+
+Cannot call `pipeVariadic(...)` with empty string bound to the second parameter because string [1] is incompatible with
+number [2].
+
+   composeReverseVariadic.js:46:22
+   46| pipeVariadic(add)(1, ""); // Error: string ~> number
+                            ^^ [1]
+
+References:
+   composeReverseVariadic.js:10:27
+   10| declare var add: (number, number) => number;
+                                 ^^^^^^ [2]
+
+
+Error ---------------------------------------------------------------------------------- composeReverseVariadic.js:48:22
+
+Cannot call `pipeVariadic(...)` with empty string bound to the second parameter because string [1] is incompatible with
+number [2].
+
+   composeReverseVariadic.js:48:22
+   48| pipeVariadic(add)(1, ""); // Error: string ~> number
+                            ^^ [1]
+
+References:
+   composeReverseVariadic.js:10:27
+   10| declare var add: (number, number) => number;
+                                 ^^^^^^ [2]
+
+
+Error ----------------------------------------------------------------------------------- composeReverseVariadic.js:50:2
+
+Cannot cast `pipeVariadic(...)` to empty because call of `pipeVariadic` [1] is incompatible with empty [2].
+
+   composeReverseVariadic.js:50:2
+   50| (pipeVariadic(add, ...fns1): empty); // Error: ((number, number) => number) ~> empty
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
+
+References:
+   composeReverseVariadic.js:50:30
+   50| (pipeVariadic(add, ...fns1): empty); // Error: ((number, number) => number) ~> empty
+                                    ^^^^^ [2]
+
+
+Error ----------------------------------------------------------------------------------- composeReverseVariadic.js:52:2
+
+Cannot cast `pipeVariadic(...)(...)` to empty because:
+ - number [1] is incompatible with empty [2].
+ - number [3] is incompatible with empty [2].
+
+   composeReverseVariadic.js:52:2
+   52| (pipeVariadic(inc, ...fns1)(1): empty); // Error: number ~> empty
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+References:
+   composeReverseVariadic.js:5:37
+    5| declare var fns1: Array<(number) => number>;
+                                           ^^^^^^ [1]
+   composeReverseVariadic.js:52:33
+   52| (pipeVariadic(inc, ...fns1)(1): empty); // Error: number ~> empty
+                                       ^^^^^ [2]
+   composeReverseVariadic.js:9:28
+    9| declare var inc: number => number;
+                                  ^^^^^^ [3]
+
+
+Error ----------------------------------------------------------------------------------- composeReverseVariadic.js:54:1
+
+Cannot call `pipeVariadic` with call of `pipeVariadic` bound to the first parameter because string [1] is incompatible
+with number [2].
+
+   composeReverseVariadic.js:54:1
+       v------------
+   54| pipeVariadic(
+   55|   ...fns2 // Error: string ~> number
+   56| );
+       ^
+
+References:
+   composeReverseVariadic.js:6:37
+    6| declare var fns2: Array<(number) => string>;
+                                           ^^^^^^ [1]
+   composeReverseVariadic.js:6:26
+    6| declare var fns2: Array<(number) => string>;
+                                ^^^^^^ [2]
+
+
+Error ----------------------------------------------------------------------------------- composeReverseVariadic.js:58:1
+
+Cannot call `pipeVariadic` because function [1] requires another argument.
+
+   composeReverseVariadic.js:58:1
+       v------------
+   58| pipeVariadic(
+   59|   ...fns3 // Error: Requires another argument
+   60| );
+       ^
+
+References:
+   composeReverseVariadic.js:7:25
+    7| declare var fns3: Array<(number, number) => string>;
+                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
+
+
+Error ----------------------------------------------------------------------------------- composeReverseVariadic.js:58:1
+
+Cannot call `pipeVariadic` with call of `pipeVariadic` bound to the first parameter because string [1] is incompatible
+with number [2].
+
+   composeReverseVariadic.js:58:1
+       v------------
+   58| pipeVariadic(
+   59|   ...fns3 // Error: Requires another argument
+   60| );
+       ^
+
+References:
+   composeReverseVariadic.js:7:45
+    7| declare var fns3: Array<(number, number) => string>;
+                                                   ^^^^^^ [1]
+   composeReverseVariadic.js:7:26
+    7| declare var fns3: Array<(number, number) => string>;
+                                ^^^^^^ [2]
+
+
+Error ----------------------------------------------------------------------------------- composeReverseVariadic.js:62:1
+
+Cannot call `pipeVariadic(...)` because no more than 1 argument is expected by function type [1].
+
+   composeReverseVariadic.js:62:1
+       v--------------------------
+   62| pipeVariadic(inc, ...fns1)(
+   63|   1,
+   64|   2 // Error: No more than 1 argument is expected
+   65| );
+       ^
+
+References:
+   composeReverseVariadic.js:9:18
+    9| declare var inc: number => number;
+                        ^^^^^^^^^^^^^^^^ [1]
+
+
+Error ------------------------------------------------------------------------------------------ composeVariadic.js:13:2
+
+Cannot cast `composeVariadic(...)(...)` to empty because number [1] is incompatible with empty [2].
+
+   composeVariadic.js:13:2
+   13| (composeVariadic(inc)(0): empty); // Error: number ~> empty
+        ^^^^^^^^^^^^^^^^^^^^^^^
+
+References:
+   composeVariadic.js:9:28
+    9| declare var inc: number => number;
+                                  ^^^^^^ [1]
+   composeVariadic.js:13:27
+   13| (composeVariadic(inc)(0): empty); // Error: number ~> empty
+                                 ^^^^^ [2]
+
+
+Error ------------------------------------------------------------------------------------------ composeVariadic.js:16:3
+
+Cannot call `composeVariadic(...)` with empty string bound to the first parameter because string [1] is incompatible
+with number [2].
+
+   composeVariadic.js:16:3
+   16|   "" // Error: string ~> number
+         ^^ [1]
+
+References:
+   composeVariadic.js:9:18
+    9| declare var inc: number => number;
+                        ^^^^^^ [2]
+
+
+Error ------------------------------------------------------------------------------------------ composeVariadic.js:19:2
+
+Cannot cast `composeVariadic(...)(...)` to empty because string [1] is incompatible with empty [2].
+
+   composeVariadic.js:19:2
+   19| (composeVariadic(toString, inc)(10): empty); // Error: string ~> empty
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+References:
+   composeVariadic.js:11:33
+   11| declare var toString: number => string;
+                                       ^^^^^^ [1]
+   composeVariadic.js:19:38
+   19| (composeVariadic(toString, inc)(10): empty); // Error: string ~> empty
+                                            ^^^^^ [2]
+
+
+Error ------------------------------------------------------------------------------------------ composeVariadic.js:22:3
+
+Cannot call `composeVariadic(...)` with empty string bound to the first parameter because string [1] is incompatible
+with number [2].
+
+   composeVariadic.js:22:3
+   22|   "" // Error: string ~> number
+         ^^ [1]
+
+References:
+   composeVariadic.js:9:18
+    9| declare var inc: number => number;
+                        ^^^^^^ [2]
+
+
+Error ------------------------------------------------------------------------------------------ composeVariadic.js:25:1
+
+Cannot call `composeVariadic` with call of `composeVariadic` bound to the first parameter because string [1] is
+incompatible with number [2].
+
+   composeVariadic.js:25:1
+       v---------------
+   25| composeVariadic(
+   26|   inc, // Error: string ~> number
+   27|   toString
+   28| )(9);
+       ^
+
+References:
+   composeVariadic.js:11:33
+   11| declare var toString: number => string;
+                                       ^^^^^^ [1]
+   composeVariadic.js:9:18
+    9| declare var inc: number => number;
+                        ^^^^^^ [2]
+
+
+Error ----------------------------------------------------------------------------------------- composeVariadic.js:30:18
+
+number [1] is incompatible with string [2].
+
+   composeVariadic.js:30:18
+   30| (composeVariadic(inc): string => number); // Error: string ~> number
+                        ^^^
+
+References:
+   composeVariadic.js:9:18
+    9| declare var inc: number => number;
+                        ^^^^^^ [1]
+   composeVariadic.js:30:24
+   30| (composeVariadic(inc): string => number); // Error: string ~> number
+                              ^^^^^^ [2]
+
+
+Error ------------------------------------------------------------------------------------------ composeVariadic.js:31:2
+
+Cannot cast `composeVariadic(...)` to function type because number [1] is incompatible with string [2].
+
+   composeVariadic.js:31:2
+   31| (composeVariadic(inc): number => string); // Error: number ~> string
+        ^^^^^^^^^^^^^^^^^^^^
+
+References:
+   composeVariadic.js:9:28
+    9| declare var inc: number => number;
+                                  ^^^^^^ [1]
+   composeVariadic.js:31:34
+   31| (composeVariadic(inc): number => string); // Error: number ~> string
+                                        ^^^^^^ [2]
+
+
+Error ------------------------------------------------------------------------------------------ composeVariadic.js:32:3
+
+Cannot cast `composeVariadic(...)` to empty because function type [1] is incompatible with empty [2].
+
+   composeVariadic.js:32:3
+   32| ((composeVariadic(inc): number => number): empty); // Error: (number => number) ~> empty
+         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+References:
+   composeVariadic.js:32:25
+   32| ((composeVariadic(inc): number => number): empty); // Error: (number => number) ~> empty
+                               ^^^^^^^^^^^^^^^^ [1]
+   composeVariadic.js:32:44
+   32| ((composeVariadic(inc): number => number): empty); // Error: (number => number) ~> empty
+                                                  ^^^^^ [2]
+
+
+Error ------------------------------------------------------------------------------------------ composeVariadic.js:34:1
+
+Cannot call call of `composeVariadic` [1] without exactly 1 type argument.
+
+   34| composeVariadic(); // Error: composeVariadic min_arity = 1
+       ^^^^^^^^^^^^^^^^^ [1]
+
+
+Error ------------------------------------------------------------------------------------------ composeVariadic.js:38:3
+
+Cannot call `composeVariadic` with compose intermediate value bound to the first parameter because string [1] is
+incompatible with number [2].
+
+   composeVariadic.js:38:3
+   38|   toString,
+         ^^^^^^^^
+
+References:
+   composeVariadic.js:11:33
+   11| declare var toString: number => string;
+                                       ^^^^^^ [1]
+   composeVariadic.js:9:18
+    9| declare var inc: number => number;
+                        ^^^^^^ [2]
+
+
+Error ------------------------------------------------------------------------------------------ composeVariadic.js:42:1
+
+Cannot call `composeVariadic(...)` because no more than 1 argument is expected by function type [1].
+
+   composeVariadic.js:42:1
+   42| composeVariadic(inc)(1, 2); // Error: No more than 1 argument is expected
+       ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+References:
+   composeVariadic.js:9:18
+    9| declare var inc: number => number;
+                        ^^^^^^^^^^^^^^^^ [1]
+
+
+Error ------------------------------------------------------------------------------------------ composeVariadic.js:44:2
+
+Cannot cast `composeVariadic(...)(...)` to empty because number [1] is incompatible with empty [2].
+
+   composeVariadic.js:44:2
+   44| (composeVariadic(add)(1, 2): empty); // Error: number ~> empty
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+References:
+   composeVariadic.js:10:38
+   10| declare var add: (number, number) => number;
+                                            ^^^^^^ [1]
+   composeVariadic.js:44:30
+   44| (composeVariadic(add)(1, 2): empty); // Error: number ~> empty
+                                    ^^^^^ [2]
+
+
+Error ----------------------------------------------------------------------------------------- composeVariadic.js:46:25
+
+Cannot call `composeVariadic(...)` with empty string bound to the second parameter because string [1] is incompatible
+with number [2].
+
+   composeVariadic.js:46:25
+   46| composeVariadic(add)(1, ""); // Error: string ~> number
+                               ^^ [1]
+
+References:
+   composeVariadic.js:10:27
+   10| declare var add: (number, number) => number;
+                                 ^^^^^^ [2]
+
+
+Error ----------------------------------------------------------------------------------------- composeVariadic.js:48:25
+
+Cannot call `composeVariadic(...)` with empty string bound to the second parameter because string [1] is incompatible
+with number [2].
+
+   composeVariadic.js:48:25
+   48| composeVariadic(add)(1, ""); // Error: string ~> number
+                               ^^ [1]
+
+References:
+   composeVariadic.js:10:27
+   10| declare var add: (number, number) => number;
+                                 ^^^^^^ [2]
+
+
+Error ------------------------------------------------------------------------------------------ composeVariadic.js:50:1
+
+Cannot call `composeVariadic` because function [1] requires another argument.
+
+   composeVariadic.js:50:1
+       v---------------
+   50| composeVariadic(
+   51|   add, // Error: require another argument
+   52|   ...fns1
+   53| );
+       ^
+
+References:
+   composeVariadic.js:10:18
+   10| declare var add: (number, number) => number;
+                        ^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
+
+
+Error ------------------------------------------------------------------------------------------ composeVariadic.js:55:2
+
+Cannot cast `composeVariadic(...)(...)` to empty because number [1] is incompatible with empty [2].
+
+   composeVariadic.js:55:2
+   55| (composeVariadic(inc, ...fns1)(1): empty); // Error: number ~> empty
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+References:
+   composeVariadic.js:9:28
+    9| declare var inc: number => number;
+                                  ^^^^^^ [1]
+   composeVariadic.js:55:36
+   55| (composeVariadic(inc, ...fns1)(1): empty); // Error: number ~> empty
+                                          ^^^^^ [2]
+
+
+Error ------------------------------------------------------------------------------------------ composeVariadic.js:57:1
+
+Cannot call `composeVariadic` with compose intermediate value bound to the first parameter because string [1] is
+incompatible with number [2].
+
+   composeVariadic.js:57:1
+       v---------------
+   57| composeVariadic(
+   58|   ...fns2 // Error: string ~> number
+   59| );
+       ^
+
+References:
+   composeVariadic.js:6:37
+    6| declare var fns2: Array<(number) => string>;
+                                           ^^^^^^ [1]
+   composeVariadic.js:6:26
+    6| declare var fns2: Array<(number) => string>;
+                                ^^^^^^ [2]
+
+
+Error ------------------------------------------------------------------------------------------ composeVariadic.js:61:1
+
+Cannot call `composeVariadic` because function [1] requires another argument.
+
+   composeVariadic.js:61:1
+       v---------------
+   61| composeVariadic(
+   62|   ...fns3 // Error: Requires another argument
+   63| );
+       ^
+
+References:
+   composeVariadic.js:7:25
+    7| declare var fns3: Array<(number, number) => string>;
+                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
+
+
+Error ------------------------------------------------------------------------------------------ composeVariadic.js:61:1
+
+Cannot call `composeVariadic` with compose intermediate value bound to the first parameter because string [1] is
+incompatible with number [2].
+
+   composeVariadic.js:61:1
+       v---------------
+   61| composeVariadic(
+   62|   ...fns3 // Error: Requires another argument
+   63| );
+       ^
+
+References:
+   composeVariadic.js:7:45
+    7| declare var fns3: Array<(number, number) => string>;
+                                                   ^^^^^^ [1]
+   composeVariadic.js:7:26
+    7| declare var fns3: Array<(number, number) => string>;
+                                ^^^^^^ [2]
+
+
+Error ------------------------------------------------------------------------------------------ composeVariadic.js:65:1
+
+Cannot call `composeVariadic(...)` because no more than 1 argument is expected by call of `composeVariadic` [1].
+
+   composeVariadic.js:65:1
+       v-----------------------------
+   65| composeVariadic(inc, ...fns1)(
+   66|   1,
+   67|   2 // Error: No more than 1 argument is expected
+   68| );
+       ^
+
+References:
+   composeVariadic.js:65:1
+   65| composeVariadic(inc, ...fns1)(
+       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
+
+
 Error ----------------------------------------------------------------------------------------------- recompose.js:23:19
 
 Cannot call `Math.round` with `props.p` bound to `x` because string [1] is incompatible with number [2].
@@ -109,6 +782,8 @@ Error --------------------------------------------------------------------------
 
 Cannot cast `compose(...)(...)` to empty because:
  - number [1] is incompatible with empty [2].
+ - number [1] is incompatible with empty [2].
+ - number [3] is incompatible with empty [2].
  - number [3] is incompatible with empty [2].
 
    spread.js:8:2
@@ -155,6 +830,8 @@ Error --------------------------------------------------------------------------
 
 Cannot cast `compose(...)(...)` to empty because:
  - number [1] is incompatible with empty [2].
+ - number [1] is incompatible with empty [2].
+ - string [3] is incompatible with empty [2].
  - string [3] is incompatible with empty [2].
 
    spread.js:12:2
@@ -201,6 +878,8 @@ Error --------------------------------------------------------------------------
 
 Cannot cast `compose(...)(...)` to empty because:
  - string [1] is incompatible with empty [2].
+ - string [1] is incompatible with empty [2].
+ - number [3] is incompatible with empty [2].
  - number [3] is incompatible with empty [2].
 
    spread.js:16:2
@@ -245,8 +924,13 @@ Cannot cast `compose(...)(...)` to empty because:
  - object literal [1] is incompatible with empty [2].
  - object literal [3] is incompatible with empty [2].
  - object literal [4] is incompatible with empty [2].
- - object literal [5] is incompatible with empty [2].
- - number [6] is incompatible with empty [2].
+ - number [5] is incompatible with empty [2].
+ - object literal [6] is incompatible with empty [2].
+ - object literal [1] is incompatible with empty [2].
+ - object literal [3] is incompatible with empty [2].
+ - object literal [4] is incompatible with empty [2].
+ - number [5] is incompatible with empty [2].
+ - object literal [6] is incompatible with empty [2].
 
    spread.js:21:2
         v-------
@@ -256,29 +940,31 @@ Cannot cast `compose(...)(...)` to empty because:
        ----^
 
 References:
-   spread.js:20:12
+   spread.js:20:17
    20| const x1 = { p: { p: { p: { p: 42 } } } };
-                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
+                       ^^^^^^^^^^^^^^^^^^^^^^^ [1]
    spread.js:23:8
    23| )(x1): empty); // Error: number ~> empty and object ~> empty
               ^^^^^ [2]
-   spread.js:20:17
-   20| const x1 = { p: { p: { p: { p: 42 } } } };
-                       ^^^^^^^^^^^^^^^^^^^^^^^ [3]
    spread.js:20:22
    20| const x1 = { p: { p: { p: { p: 42 } } } };
-                            ^^^^^^^^^^^^^^^^ [4]
+                            ^^^^^^^^^^^^^^^^ [3]
    spread.js:20:27
    20| const x1 = { p: { p: { p: { p: 42 } } } };
-                                 ^^^^^^^^^ [5]
+                                 ^^^^^^^^^ [4]
    spread.js:20:32
    20| const x1 = { p: { p: { p: { p: 42 } } } };
-                                      ^^ [6]
+                                      ^^ [5]
+   spread.js:20:12
+   20| const x1 = { p: { p: { p: { p: 42 } } } };
+                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [6]
 
 
 Error --------------------------------------------------------------------------------------------------- spread.js:27:2
 
 Cannot cast `compose(...)(...)` to empty because:
+ - `X2` [1] is incompatible with empty [2].
+ - `X2` [3] is incompatible with empty [2].
  - `X2` [1] is incompatible with empty [2].
  - `X2` [3] is incompatible with empty [2].
 
@@ -302,4 +988,4 @@ References:
 
 
 
-Found 22 errors
+Found 76 errors

--- a/tests/compose/composeReverseVariadic.js
+++ b/tests/compose/composeReverseVariadic.js
@@ -1,0 +1,65 @@
+// @flow
+
+declare var pipeVariadic: $ComposeReverseVariadic;
+
+declare var fns1: Array<(number) => number>;
+declare var fns2: Array<(number) => string>;
+declare var fns3: Array<(number, number) => string>;
+
+declare var inc: number => number;
+declare var add: (number, number) => number;
+declare var toString: number => string;
+
+(pipeVariadic(inc)(0): empty); // Error: number ~> empty
+
+pipeVariadic(inc)(
+  "" // Error: string ~> number
+);
+
+(pipeVariadic(inc, toString)(10): empty); // Error: string ~> empty
+
+pipeVariadic(inc, toString)(
+  "" // Error: string ~> number
+);
+
+pipeVariadic(
+  toString,
+  inc // Error: string ~> number
+)(9);
+
+(pipeVariadic(inc): string => number); // Error: string ~> number
+(pipeVariadic(inc): number => string); // Error: number ~> string
+((pipeVariadic(inc): number => number): empty); // Error: (number => number) ~> empty
+
+pipeVariadic(); // Error: pipeVariadic min_arity = 1
+
+pipeVariadic(
+  inc,
+  toString,
+  inc // Error: string ~> number
+);
+
+pipeVariadic(inc)(1, 2); // Error: No more than 1 argument is expected
+
+(pipeVariadic(add)(1, 2): empty); // Error: number ~> empty
+
+pipeVariadic(add)(1, ""); // Error: string ~> number
+
+pipeVariadic(add)(1, ""); // Error: string ~> number
+
+(pipeVariadic(add, ...fns1): empty); // Error: ((number, number) => number) ~> empty
+
+(pipeVariadic(inc, ...fns1)(1): empty); // Error: number ~> empty
+
+pipeVariadic(
+  ...fns2 // Error: string ~> number
+);
+
+pipeVariadic(
+  ...fns3 // Error: Requires another argument
+);
+
+pipeVariadic(inc, ...fns1)(
+  1,
+  2 // Error: No more than 1 argument is expected
+);

--- a/tests/compose/composeVariadic.js
+++ b/tests/compose/composeVariadic.js
@@ -1,0 +1,68 @@
+// @flow
+
+declare var composeVariadic: $ComposeVariadic;
+
+declare var fns1: Array<(number) => number>;
+declare var fns2: Array<(number) => string>;
+declare var fns3: Array<(number, number) => string>;
+
+declare var inc: number => number;
+declare var add: (number, number) => number;
+declare var toString: number => string;
+
+(composeVariadic(inc)(0): empty); // Error: number ~> empty
+
+composeVariadic(inc)(
+  "" // Error: string ~> number
+);
+
+(composeVariadic(toString, inc)(10): empty); // Error: string ~> empty
+
+composeVariadic(toString, inc)(
+  "" // Error: string ~> number
+);
+
+composeVariadic(
+  inc, // Error: string ~> number
+  toString
+)(9);
+
+(composeVariadic(inc): string => number); // Error: string ~> number
+(composeVariadic(inc): number => string); // Error: number ~> string
+((composeVariadic(inc): number => number): empty); // Error: (number => number) ~> empty
+
+composeVariadic(); // Error: composeVariadic min_arity = 1
+
+composeVariadic(
+  inc, // Error: string ~> number
+  toString,
+  inc
+);
+
+composeVariadic(inc)(1, 2); // Error: No more than 1 argument is expected
+
+(composeVariadic(add)(1, 2): empty); // Error: number ~> empty
+
+composeVariadic(add)(1, ""); // Error: string ~> number
+
+composeVariadic(add)(1, ""); // Error: string ~> number
+
+composeVariadic(
+  add, // Error: require another argument
+  ...fns1
+);
+
+(composeVariadic(inc, ...fns1)(1): empty); // Error: number ~> empty
+
+composeVariadic(
+  ...fns2 // Error: string ~> number
+);
+
+composeVariadic(
+  ...fns3 // Error: Requires another argument
+);
+
+composeVariadic(inc, ...fns1)(
+  1,
+  2 // Error: No more than 1 argument is expected
+);


### PR DESCRIPTION
**Related issue:** https://github.com/facebook/flow/issues/8137

It's my first PR to flow, and I'm not sure this is the best way to improve $Compose helper.

The idea of the PR is to be able to define proper `compose` & `pipe` definitions from function libraries such as `ramda`. 

Considering the following example

```javascript
const r = compose(
 fn2,
 fn1,
 fn0,
)(a, b, c) 
```

First we handle `compose(fn2, fn1, fn0)` by:
- Identity `fn0` as init function
- Create `fn0_tout` representing the future call of `fn0` output
- Create `compose_tout` representing the final result
- Flow `fn1(fn0_tout) ~> fn2 ~> compose_tout`

Then when calling with `(a, b, c)`:
- Flow `fn0(a, b, c) ~> fn0_tout`
- Flow `compose_tout ~> r`

I open this PR as Draft, as I had to add some pattern matching at some places where I don't know the purpose. Also, I'm not sure how to handle `reason`, I would need some help reviewing this PR in order to improve my understanding.

Finally not a fan about creating `$ComposeVariadic`, but was the easiest way I found. I think we might use a type parameter