### PR TITLE
Change return type of window.getComputedStyle(...)

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -3963,7 +3963,7 @@ declare function alert(message?: any): void;
 declare function prompt(message?: any, value?: any): string;
 declare function close(): void;
 declare function confirm(message?: string): boolean;
-declare function getComputedStyle(elt: Element, pseudoElt?: string): any;
+declare function getComputedStyle(elt: Element, pseudoElt?: string): CSSStyleDeclaration;
 declare opaque type AnimationFrameID;
 declare function requestAnimationFrame(callback: (timestamp: number) => void): AnimationFrameID;
 declare function cancelAnimationFrame(requestId: AnimationFrameID): void;


### PR DESCRIPTION
I have changed return type of `window.getComputedStyle(...)` from `any` to `CSSStyleDeclaration` according to information from [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Window/getComputedStyle) page.
Related [issue](https://github.com/facebook/flow/issues/8167).

