### PR TITLE
updated PointerCapture method definitions

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -1494,7 +1494,7 @@ declare class Element extends Node implements Animatable {
   matches(selector: string): bool;
   querySelector(selector: string): HTMLElement | null;
   querySelectorAll(selector: string): NodeList<HTMLElement>;
-  releasePointerCapture(pointerId: string): void;
+  releasePointerCapture(pointerId: number): void;
   removeAttribute(name?: string): void;
   removeAttributeNode(attributeNode: Attr): Attr;
   removeAttributeNS(namespaceURI: string | null, localName: string): void;
@@ -1517,7 +1517,7 @@ declare class Element extends Node implements Animatable {
   setAttributeNS(namespaceURI: string | null, qualifiedName: string, value: string): void;
   setAttributeNode(newAttr: Attr): Attr | null;
   setAttributeNodeNS(newAttr: Attr): Attr | null;
-  setPointerCapture(pointerId: string): void;
+  setPointerCapture(pointerId: number): void;
   shadowRoot?: ShadowRoot;
   slot?: string;
 


### PR DESCRIPTION
changed `pointerId` type from `string` to `number` to match `PointerEvent` types
fixes https://github.com/facebook/flow/issues/8055
spec https://w3c.github.io/pointerevents/#pointerevent-interface