### PR TITLE
Add missing label to List.sort compare function

### DIFF
--- a/src/heap/sharedMem.ml
+++ b/src/heap/sharedMem.ml
@@ -1004,7 +1004,7 @@ end)
         end
         cache;
       Hashtbl.clear cache;
-      l := List.sort (fun (_, x, _) (_, y, _) -> y - x) !l;
+      l := List.sort ~compare:(fun (_, x, _) (_, y, _) -> y - x) !l;
       let i = ref 0 in
       while !i < Config.capacity do
         match !l with


### PR DESCRIPTION
<!--
  If this is a change to library defintions, please include links to relevant documentation.
  If this is a documentation change, please prefix the title with [DOCS].

  If this is neither, ensure you opened a discussion issue and link it in the PR description.
-->
Otherwise the build fails with:
```
…
ocamlfind: [WARNING] Package `threads': Linking problems may arise because of the missing -thread or -vmthread switch
File "hack/heap/sharedMem.ml", line 1198, characters 21-55:
Error: This expression should not be a function, the expected type is
'a Hh_core.List.t
Command exited with code 2.
Compilation unsuccessful after building 181 targets (0 cached) in 00:00:44.
make: *** [Makefile:291: build-flow] Error 10
```
