### PR TITLE
Change the type of SVG elements to HTMLElement

### DIFF
--- a/lib/react-dom.js
+++ b/lib/react-dom.js
@@ -788,7 +788,7 @@ type ReactDOM$HTMLElementJSXIntrinsic = {
 };
 
 type ReactDOM$SVGElementJSXIntrinsic = {
-  instance: Element,
+  instance: HTMLElement,
   props: {
     [key: string]: any,
     children?: React$Node,


### PR DESCRIPTION
SVG elements appear to be `HTMLElements`:

```
document.createElement('svg') instanceof HTMLElement &&
document.createElement('animate') instanceof HTMLElement &&
document.createElement('circle') instanceof HTMLElement &&
document.createElement('defs') instanceof HTMLElement &&
document.createElement('ellipse') instanceof HTMLElement &&
document.createElement('g') instanceof HTMLElement &&
document.createElement('image') instanceof HTMLElement &&
document.createElement('line') instanceof HTMLElement &&
document.createElement('linearGradient') instanceof HTMLElement &&
document.createElement('mask') instanceof HTMLElement &&
document.createElement('path') instanceof HTMLElement &&
document.createElement('pattern') instanceof HTMLElement &&
document.createElement('polygon') instanceof HTMLElement &&
document.createElement('polyline') instanceof HTMLElement &&
document.createElement('radialGradient') instanceof HTMLElement &&
document.createElement('rect') instanceof HTMLElement &&
document.createElement('stop') instanceof HTMLElement &&
document.createElement('symbol') instanceof HTMLElement &&
document.createElement('text') instanceof HTMLElement &&
document.createElement('tspan') instanceof HTMLElement &&
document.createElement('use') instanceof HTMLElement
> true
```

Now, React refs of type `HTMLElement` are usable on SVG elements:

```
const ref = useRef<HTMLElement | null>(null);
return <svg ref={ref} />;  // No more Flow error
```

Addresses #8202.

