### PR TITLE
[lib] Change Notification static/instance properties to read-only

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -4029,30 +4029,30 @@ type NotificationOptions = {
 
 declare class Notification extends EventTarget {
   constructor(title: string, options?: NotificationOptions): void;
-  static permission: NotificationPermission;
+  static +permission: NotificationPermission;
   static requestPermission(
     callback?: (perm: NotificationPermission) => mixed
   ): Promise<NotificationPermission>;
-  static maxActions: number;
+  static +maxActions: number;
   onclick: ?(evt: Event) => mixed;
   onclose: ?(evt: Event) => mixed;
   onerror: ?(evt: Event) => mixed;
   onshow: ?(evt: Event) => mixed;
-  title: string;
-  dir: NotificationDirection;
-  lang: string;
-  body: string;
-  tag: string;
-  image?: string;
-  icon?: string;
-  badge?: string;
-  vibrate?: Array<number>;
-  timestamp: number;
-  renotify: boolean;
-  silent: boolean;
-  requireInteraction: boolean;
-  data: any;
-  actions: Array<NotificationAction>;
+  +title: string;
+  +dir: NotificationDirection;
+  +lang: string;
+  +body: string;
+  +tag: string;
+  +image?: string;
+  +icon?: string;
+  +badge?: string;
+  +vibrate?: Array<number>;
+  +timestamp: number;
+  +renotify: boolean;
+  +silent: boolean;
+  +requireInteraction: boolean;
+  +data: any;
+  +actions: Array<NotificationAction>;
 
   close(): void;
 }


### PR DESCRIPTION
WHATWG Reference: https://notifications.spec.whatwg.org/#api
MDN Reference: https://wiki.developer.mozilla.org/en-US/docs/Web/API/Notification

Update the listed properties (static/instance) to a read-only version, to better match
the spec.