### PR TITLE
[lib] Add brotli functions and class to NodeJS zlib

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -2321,15 +2321,26 @@ type zlib$brotliOptions = {
   ...
 };
 
+type zlib$brotliSyncFn = (
+  buffer: Buffer | $TypedArray | DataView | ArrayBuffer | string,
+  options?: zlib$brotliOptions
+) => Buffer;
+
+type zlib$brotliAsyncFn = (
+  buffer: Buffer | $TypedArray | DataView | ArrayBuffer | string,
+  options?: zlib$brotliOptions,
+  callback?: ((error: ?Error, result: Buffer) => void)
+) => void;
+
 type zlib$syncFn = (
-  buffer: string | Buffer,
+  buffer: Buffer | $TypedArray | DataView | ArrayBuffer | string,
   options?: zlib$options
 ) => Buffer;
 
 type zlib$asyncFn = (
-  buffer: string | Buffer,
+  buffer: Buffer | $TypedArray | DataView | ArrayBuffer | string,
   options?: zlib$options,
-  callback?: ((error: ?Error, result: any) => void)
+  callback?: ((error: ?Error, result: Buffer) => void)
 ) => void;
 
 // Accessing the constants directly from the module is currently still
@@ -2515,6 +2526,11 @@ declare module "zlib" {
   declare function createGzip(options?: zlib$options): Gzip;
   declare function createGunzip(options?: zlib$options): Gunzip;
   declare function createUnzip(options?: zlib$options): Unzip;
+  declare var brotliCompress: zlib$brotliAsyncFn;
+  declare var brotliCompressSync: zlib$brotliSyncFn;
+  declare var brotliDecompress: zlib$brotliAsyncFn;
+  declare var brotliDecompressSync: zlib$brotliSyncFn;
+  declare var deflateSync: zlib$syncFn;
   declare var deflate: zlib$asyncFn;
   declare var deflateSync: zlib$syncFn;
   declare var gzip: zlib$asyncFn;

--- a/lib/node.js
+++ b/lib/node.js
@@ -2311,6 +2311,16 @@ type zlib$options = {
   ...
 };
 
+type zlib$brotliOptions = {
+  flush?: number,
+  finishFlush?: number,
+  chunkSize?: number,
+  params?: {
+    ...
+  },
+  ...
+};
+
 type zlib$syncFn = (
   buffer: string | Buffer,
   options?: zlib$options
@@ -2332,7 +2342,6 @@ declare module "zlib" {
   declare var Z_FULL_FLUSH: number;
   declare var Z_FINISH: number;
   declare var Z_BLOCK: number;
-  declare var Z_TREES: number;
   declare var Z_OK: number;
   declare var Z_STREAM_END: number;
   declare var Z_NEED_DICT: number;
@@ -2351,12 +2360,6 @@ declare module "zlib" {
   declare var Z_RLE: number;
   declare var Z_FIXED: number;
   declare var Z_DEFAULT_STRATEGY: number;
-  declare var Z_BINARY: number;
-  declare var Z_TEXT: number;
-  declare var Z_ASCII: number;
-  declare var Z_UNKNOWN: number;
-  declare var Z_DEFLATED: number;
-  declare var Z_NULL: number;
   declare var Z_DEFAULT_CHUNK: number;
   declare var Z_DEFAULT_LEVEL: number;
   declare var Z_DEFAULT_MEMLEVEL: number;
@@ -2376,7 +2379,6 @@ declare module "zlib" {
     Z_FULL_FLUSH: number,
     Z_FINISH: number,
     Z_BLOCK: number,
-    Z_TREES: number,
     Z_OK: number,
     Z_STREAM_END: number,
     Z_NEED_DICT: number,
@@ -2395,12 +2397,16 @@ declare module "zlib" {
     Z_RLE: number,
     Z_FIXED: number,
     Z_DEFAULT_STRATEGY: number,
-    Z_BINARY: number,
-    Z_TEXT: number,
-    Z_ASCII: number,
-    Z_UNKNOWN: number,
-    Z_DEFLATED: number,
-    Z_NULL: number,
+    ZLIB_VERNUM: number,
+    DEFLATE: number,
+    INFLATE: number,
+    GZIP: number,
+    GUNZIP: number,
+    DEFLATERAW: number,
+    INFLATERAW: number,
+    UNZIP: number,
+    BROTLI_DECODE: number,
+    BROTLI_ENCODE: number,
     Z_DEFAULT_CHUNK: number,
     Z_DEFAULT_LEVEL: number,
     Z_DEFAULT_MEMLEVEL: number,
@@ -2413,6 +2419,67 @@ declare module "zlib" {
     Z_MIN_LEVEL: number,
     Z_MIN_MEMLEVEL: number,
     Z_MIN_WINDOWBITS: number,
+    BROTLI_OPERATION_PROCESS: number,
+    BROTLI_OPERATION_FLUSH: number,
+    BROTLI_OPERATION_FINISH: number,
+    BROTLI_OPERATION_EMIT_METADATA: number,
+    BROTLI_PARAM_MODE: number,
+    BROTLI_MODE_GENERIC: number,
+    BROTLI_MODE_TEXT: number,
+    BROTLI_MODE_FONT: number,
+    BROTLI_DEFAULT_MODE: number,
+    BROTLI_PARAM_QUALITY: number,
+    BROTLI_MIN_QUALITY: number,
+    BROTLI_MAX_QUALITY: number,
+    BROTLI_DEFAULT_QUALITY: number,
+    BROTLI_PARAM_LGWIN: number,
+    BROTLI_MIN_WINDOW_BITS: number,
+    BROTLI_MAX_WINDOW_BITS: number,
+    BROTLI_LARGE_MAX_WINDOW_BITS: number,
+    BROTLI_DEFAULT_WINDOW: number,
+    BROTLI_PARAM_LGBLOCK: number,
+    BROTLI_MIN_INPUT_BLOCK_BITS: number,
+    BROTLI_MAX_INPUT_BLOCK_BITS: number,
+    BROTLI_PARAM_DISABLE_LITERAL_CONTEXT_MODELING: number,
+    BROTLI_PARAM_SIZE_HINT: number,
+    BROTLI_PARAM_LARGE_WINDOW: number,
+    BROTLI_PARAM_NPOSTFIX: number,
+    BROTLI_PARAM_NDIRECT: number,
+    BROTLI_DECODER_RESULT_ERROR: number,
+    BROTLI_DECODER_RESULT_SUCCESS: number,
+    BROTLI_DECODER_RESULT_NEEDS_MORE_INPUT: number,
+    BROTLI_DECODER_RESULT_NEEDS_MORE_OUTPUT: number,
+    BROTLI_DECODER_PARAM_DISABLE_RING_BUFFER_REALLOCATION: number,
+    BROTLI_DECODER_PARAM_LARGE_WINDOW: number,
+    BROTLI_DECODER_NO_ERROR: number,
+    BROTLI_DECODER_SUCCESS: number,
+    BROTLI_DECODER_NEEDS_MORE_INPUT: number,
+    BROTLI_DECODER_NEEDS_MORE_OUTPUT: number,
+    BROTLI_DECODER_ERROR_FORMAT_EXUBERANT_NIBBLE: number,
+    BROTLI_DECODER_ERROR_FORMAT_RESERVED: number,
+    BROTLI_DECODER_ERROR_FORMAT_EXUBERANT_META_NIBBLE: number,
+    BROTLI_DECODER_ERROR_FORMAT_SIMPLE_HUFFMAN_ALPHABET: number,
+    BROTLI_DECODER_ERROR_FORMAT_SIMPLE_HUFFMAN_SAME: number,
+    BROTLI_DECODER_ERROR_FORMAT_CL_SPACE: number,
+    BROTLI_DECODER_ERROR_FORMAT_HUFFMAN_SPACE: number,
+    BROTLI_DECODER_ERROR_FORMAT_CONTEXT_MAP_REPEAT: number,
+    BROTLI_DECODER_ERROR_FORMAT_BLOCK_LENGTH_1: number,
+    BROTLI_DECODER_ERROR_FORMAT_BLOCK_LENGTH_2: number,
+    BROTLI_DECODER_ERROR_FORMAT_TRANSFORM: number,
+    BROTLI_DECODER_ERROR_FORMAT_DICTIONARY: number,
+    BROTLI_DECODER_ERROR_FORMAT_WINDOW_BITS: number,
+    BROTLI_DECODER_ERROR_FORMAT_PADDING_1: number,
+    BROTLI_DECODER_ERROR_FORMAT_PADDING_2: number,
+    BROTLI_DECODER_ERROR_FORMAT_DISTANCE: number,
+    BROTLI_DECODER_ERROR_DICTIONARY_NOT_SET: number,
+    BROTLI_DECODER_ERROR_INVALID_ARGUMENTS: number,
+    BROTLI_DECODER_ERROR_ALLOC_CONTEXT_MODES: number,
+    BROTLI_DECODER_ERROR_ALLOC_TREE_GROUPS: number,
+    BROTLI_DECODER_ERROR_ALLOC_CONTEXT_MAP: number,
+    BROTLI_DECODER_ERROR_ALLOC_RING_BUFFER_1: number,
+    BROTLI_DECODER_ERROR_ALLOC_RING_BUFFER_2: number,
+    BROTLI_DECODER_ERROR_ALLOC_BLOCK_TYPE_TREES: number,
+    BROTLI_DECODER_ERROR_UNREACHABLE: number,
     ...
   };
   declare var codes: {
@@ -2430,6 +2497,8 @@ declare module "zlib" {
   declare class Zlib extends stream$Duplex {
     // TODO
   }
+  declare class BrotliCompress extends Zlib {}
+  declare class BrotliDecompress extends Zlib {}
   declare class Deflate extends Zlib {}
   declare class Inflate extends Zlib {}
   declare class Gzip extends Zlib {}
@@ -2437,6 +2506,8 @@ declare module "zlib" {
   declare class DeflateRaw extends Zlib {}
   declare class InflateRaw extends Zlib {}
   declare class Unzip extends Zlib {}
+  declare function createBrotliCompress(options?: zlib$brotliOptions): BrotliCompress;
+  declare function createBrotliDecompress(options?: zlib$brotliOptions): BrotliDecompress;
   declare function createDeflate(options?: zlib$options): Deflate;
   declare function createInflate(options?: zlib$options): Inflate;
   declare function createDeflateRaw(options?: zlib$options): DeflateRaw;


### PR DESCRIPTION
New constants are only added in the zlib.constants object, since the NodeJS documentation states that they are deprecated in the zlib object

Also updated constants to match those available in node v12.14.0. Note that some constants were removed. It turns out that they are mentioned in the NodeJS docs, but not in the code as per current master (v 12.14.0 and https://github.com/nodejs/node/blob/5289f80/lib/zlib.js).

Official documentation: https://nodejs.org/dist/latest-v12.x/docs/api/zlib.html
