### PR TITLE
Add optional cb for node dgram socket.close function

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -674,7 +674,7 @@ declare class dgram$Socket extends events$EventEmitter {
   addMembership(multicastAddress: string, multicastInterface?: string): void;
   address(): net$Socket$address;
   bind(port?: number, address?: string, callback?: () => void): void;
-  close(): void;
+  close(callback?: () => void): void;
   dropMembership(multicastAddress: string, multicastInterface?: string): void;
   ref(): void;
   send(


### PR DESCRIPTION
This optional callback seems to always have been part of the node dgram api and was probably just overlooked

https://nodejs.org/api/dgram.html#dgram_socket_close_callback
