### PR TITLE
[circle] set OPAMDOWNLOADJOBS=1 on Windows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -256,6 +256,7 @@ jobs:
     executor: win/default
     environment:
       - FLOW_TMP_DIR: 'C:\tmp\flow'
+      - OPAMDOWNLOADJOBS: 1
     steps:
       - run:
           name: Set up workspace
@@ -270,11 +271,11 @@ jobs:
           at: .
       - restore_cache:
           keys:
-          - opam-cache-{{ arch }}-opam_{{ checksum "C:/tmp/flow/opamversion" }}-ocaml_4_07_1-{{ checksum "opam" }}
+          - opam-cache-{{ arch }}-opam_{{ checksum "C:/tmp/flow/opamversion" }}-ocaml_4_07_1-{{ checksum "opam" }}-circle_{{ checksum ".circleci/config.yml" }}
       - opam_windows/init
       - opam_windows/create_switch
       - save_cache:
-          key: opam-cache-{{ arch }}-opam_{{ checksum "C:/tmp/flow/opamversion" }}-ocaml_4_07_1-{{ checksum "opam" }}
+          key: opam-cache-{{ arch }}-opam_{{ checksum "C:/tmp/flow/opamversion" }}-ocaml_4_07_1-{{ checksum "opam" }}-circle_{{ checksum ".circleci/config.yml" }}
           paths:
             - C:/tools/cygwin/home/circleci/.opam
             - _opam


### PR DESCRIPTION
when multiple opam packages have the same source, like `dune` and `dune-configurator`, and opam downloads them in parallel, there's a race in which they both try to write the same file to the cache. it seems that on Windows, the `cp` fails with `permission denied`, while on other platforms the `cp` just overwrites. by turning off parallel downloads, opam skips downloading the duplicate source because it's already cached.

See fdopen/opam-repository-mingw#71