### PR TITLE
Improve definitions for Node url.parse function

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -2150,18 +2150,18 @@ declare module "url" {
     parseQueryString?: boolean,
     slashesDenoteHost?: boolean
   ): {
-    protocol?: string,
-    slashes?: boolean,
-    auth?: string,
-    host?: string,
-    port?: string,
-    hostname?: string,
-    hash?: string,
-    search?: string,
+    protocol: string | null,
+    slashes: boolean | null,
+    auth: string | null,
+    host: string | null,
+    port: string | null,
+    hostname: string | null,
+    hash: string | null,
+    search: string | null,
     // null | string | Object
-    query?: any,
-    pathname?: string,
-    path?: string,
+    query: any | null,
+    pathname: string | null,
+    path: string | null,
     href: string,
     ...
   };

--- a/lib/node.js
+++ b/lib/node.js
@@ -2131,16 +2131,16 @@ declare module "tls" {
 
 type url$urlObject = {
   +href?: string,
-  +protocol?: string,
-  +slashes?: boolean,
-  +auth?: string,
-  +hostname?: string,
-  +port?: string | number,
-  +host?: string,
-  +pathname?: string,
-  +search?: string,
-  +query?: Object,
-  +hash?: string,
+  +protocol?: string | null,
+  +slashes?: boolean | null,
+  +auth?: string | null,
+  +hostname?: string | null,
+  +port?: string | number | null,
+  +host?: string | null,
+  +pathname?: string | null,
+  +search?: string | null,
+  +query?: Object | null,
+  +hash?: string | null,
   ...
 };
 


### PR DESCRIPTION
TypeScript does it right https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/url.d.ts#L20-L33

In Node every return value is monomorphic by design where it's possible.
Example of `parse` output in the worst case.
```bash
➜ node -p "require('url').parse('')"
Url {
  protocol: null,
  slashes: null,
  auth: null,
  host: null,
  port: null,
  hostname: null,
  hash: null,
  search: null,
  query: null,
  pathname: null,
  path: null,
  href: ''
}
```
`parse` throws an error when is called with invalid argument types, so there is no way for it to return `undefined` inside of it's return object.