### PR TITLE
Store shmem layout in info page, break up memory mappings

### DIFF
--- a/src/hack_forked/procs/workerController.ml
+++ b/src/hack_forked/procs/workerController.ml
@@ -256,7 +256,7 @@ let make ?call_wrapper ~saved_state ~entry ~nbr_procs ~gc_control ~heap_handle =
       (None, None)
   in
   let spawn worker_id name child_fd () =
-    Unix.clear_close_on_exec heap_handle.SharedMem.h_fd;
+    Unix.clear_close_on_exec heap_handle;
 
     (* Daemon.spawn runs exec after forking. We explicitly *do* want to "leak"
      * child_fd to this one spawned process because it will be using that FD to
@@ -267,7 +267,7 @@ let make ?call_wrapper ~saved_state ~entry ~nbr_procs ~gc_control ~heap_handle =
     let handle =
       Daemon.spawn ~name (Daemon.null_fd (), Unix.stdout, Unix.stderr) entry (state, child_fd)
     in
-    Unix.set_close_on_exec heap_handle.SharedMem.h_fd;
+    Unix.set_close_on_exec heap_handle;
 
     (* This process no longer needs child_fd after its spawned the child.
      * Messages are read using controller_fd. *)

--- a/src/heap/sharedMem.ml
+++ b/src/heap/sharedMem.ml
@@ -15,11 +15,7 @@ type config = {
   log_level: int;
 }
 
-(* Allocated in C only. *)
-type handle = private {
-  h_fd: Unix.file_descr;
-  h_heap_size: int;
-}
+type handle = Unix.file_descr
 
 exception Out_of_shared_memory
 

--- a/src/heap/sharedMem.mli
+++ b/src/heap/sharedMem.mli
@@ -11,10 +11,7 @@ type config = {
   log_level: int;
 }
 
-type handle = private {
-  h_fd: Unix.file_descr;
-  h_heap_size: int;
-}
+type handle = Unix.file_descr
 
 exception Out_of_shared_memory
 


### PR DESCRIPTION
Summary:
This diff changes the info page to include information about the layout of
shared memory, specifically the size of the locals, hash table, and heap
sections.

Since this information is available in the info page, we no longer need to pass
it out-of-band to workers in the heap handle record. Instead, the heap handle
can be just a file descriptor.

After this change, instead of creating a single memory mapping, processes will
have separate mappings for each of the info page, locals, and the hashtbl+heap.
Workers create the info page mapping first and use the layout information there
to create the other mappings.

Note that the hashtbl and heap are combined. This is necessary because they both
use relative offsets from the same base pointer.

Reviewed By: jbrown215

Differential Revision: D19320669

