### PR TITLE
fix exception with long socket paths

### DIFF
--- a/src/hack_forked/socket/socket.ml
+++ b/src/hack_forked/socket/socket.ml
@@ -5,6 +5,40 @@
  * LICENSE file in the root directory of this source tree.
  *)
 
+type addr =
+  | Inet of Unix.inet_addr * int
+  | Unix of string
+
+(* On Linux/Mac/BSD, sockaddr_un.sun_path is a fixed length. To handle longer paths,
+   we chdir to that directory and use a relative path instead. The callback provides
+   a Unix.sockaddr with a relative path that you can use to bind or read from. Perform
+   as little as possible within the callback, since it has an unexpected working dir.
+   This function tries to make it awkward for the Unix.sockaddr with the relative path
+   to escape from the callback. *)
+let with_addr addr f =
+  let cwd = Sys.getcwd () in
+  try
+    let sockaddr =
+      match addr with
+      | Inet (inet, port) -> Unix.ADDR_INET (inet, port)
+      | Unix file ->
+        let dir = Filename.dirname file in
+        let base = Filename.basename file in
+        let () = Sys.chdir dir in
+        Unix.ADDR_UNIX (Filename.concat "." base)
+    in
+    let result = f sockaddr in
+    let () = Sys.chdir cwd in
+    result
+  with exn ->
+    let exn = Exception.wrap exn in
+    let () =
+      match addr with
+      | Unix _ -> Sys.chdir cwd
+      | Inet _ -> ()
+    in
+    Exception.reraise exn
+
 (* Initializes the unix domain socket *)
 let unix_socket sock_name =
   try
@@ -13,14 +47,14 @@ let unix_socket sock_name =
         if Sys.file_exists sock_name then Sys.remove sock_name;
         let (domain, addr) =
           if Sys.win32 then
-            Unix.(PF_INET, Unix.ADDR_INET (inet_addr_loopback, 0))
+            Unix.(PF_INET, Inet (inet_addr_loopback, 0))
           else
-            Unix.(PF_UNIX, Unix.ADDR_UNIX sock_name)
+            Unix.(PF_UNIX, Unix sock_name)
         in
         let sock = Unix.socket domain Unix.SOCK_STREAM 0 in
         let () = Unix.set_close_on_exec sock in
         let () = Unix.setsockopt sock Unix.SO_REUSEADDR true in
-        let () = Unix.bind sock addr in
+        let () = with_addr addr @@ Unix.bind sock in
         let () = Unix.listen sock 10 in
         let () =
           match Unix.getsockname sock with
@@ -35,32 +69,24 @@ let unix_socket sock_name =
     Printf.eprintf "%s\n" (Unix.error_message err);
     Exit_status.(exit Socket_error)
 
-(* So the sockaddr_un structure puts a strict limit on the length of a socket
-  * address. This appears to be 104 chars on mac os x and 108 chars on my
-  * centos box. *)
+(* The sockaddr_un structure puts a strict limit on the length of a socket
+   address. This appears to be 104 chars on mac os x and 108 chars on my
+   centos box. Since `with_addr` uses a relative path, `get_path` shortens
+   the basename to fit if necessary. *)
 let max_addr_length = 103
-
-let min_name_length = 17
 
 let get_path path =
   (* Path will resolve the realpath, in case two processes are referring to the
    * same socket using different paths (like with symlinks *)
   let path = path |> Path.make |> Path.to_string in
-  let dir = Filename.dirname path ^ "/" in
+  let dir = Filename.dirname path in
   let filename = Filename.basename path in
   let root_part = Filename.chop_extension filename in
   let root_length = String.length root_part in
   let extension_length = String.length filename - root_length in
   let extension = String.sub filename root_length extension_length in
-  (* It's possible that the directory path is too long. If so, let's give up and
-   * use /tmp/ *)
-  let dir =
-    if String.length dir > max_addr_length - min_name_length then
-      Filename.get_temp_dir_name ()
-    else
-      dir
-  in
-  let max_root_part_length = max_addr_length - String.length dir - extension_length in
+  let dir_sep_length = String.length Filename.dir_sep in
+  let max_root_part_length = max_addr_length - dir_sep_length - extension_length - 1 in
   let root_part =
     if root_length > max_root_part_length then
       let len = String.length root_part in
@@ -70,7 +96,10 @@ let get_path path =
       (* 5 char prefix + 5 char suffix + 2 periods *)
       let max_digest_length = max_root_part_length - 12 in
       let digest_part =
-        if String.length digest > max_digest_length then
+        if max_digest_length <= 0 then
+          let () = Printf.eprintf "Socket name is too long: %S\n" filename in
+          raise Exit_status.(Exit_with Socket_error)
+        else if String.length digest > max_digest_length then
           String.sub digest 0 max_digest_length
         else
           digest
@@ -80,5 +109,15 @@ let get_path path =
       root_part
   in
   Filename.concat dir (Printf.sprintf "%s%s" root_part extension)
+
+let addr_for_open sockfile =
+  let sock_name = get_path sockfile in
+  if Sys.win32 then (
+    let ic = open_in_bin sock_name in
+    let port = input_binary_int ic in
+    close_in ic;
+    Inet (Unix.inet_addr_loopback, port)
+  ) else
+    Unix sock_name
 
 let init_unix_socket socket_file = unix_socket (get_path socket_file)

--- a/src/hack_forked/socket/socket.mli
+++ b/src/hack_forked/socket/socket.mli
@@ -1,0 +1,14 @@
+(*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *)
+
+type addr
+
+val with_addr : addr -> (Unix.sockaddr -> 'a) -> 'a
+
+val addr_for_open : string -> addr
+
+val init_unix_socket : string -> Unix.file_descr

--- a/tests/socket/.testconfig
+++ b/tests/socket/.testconfig
@@ -1,0 +1,2 @@
+shell: test.sh
+auto_start: false

--- a/tests/socket/test.sh
+++ b/tests/socket/test.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+LONG="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+mkdir "$LONG"
+touch "$LONG/.flowconfig"
+assert_ok "$FLOW" start "$LONG"
+assert_ok "$FLOW" stop "$LONG"
+
+mkdir -p "tmp/$LONG"
+TMPDIR="$(realpath tmp/$LONG)"
+export TMPDIR
+FLOW_TEMP_DIR="$TMPDIR"
+export FLOW_TEMP_DIR
+assert_ok "$FLOW" start "$LONG"
+assert_ok "$FLOW" stop "$LONG"


### PR DESCRIPTION
Summary:
the C struct used for unix sockets only allocates around 104 characters for the socket path.

for example, consider `$TMPDIR/flow/zSpathzStozSroot.sockv3`. we try removing the `flow/` dir, and then replacing part of the basename with a hash, like  `$TMPDIR/zSpat.MD5HASHHERE.Sroot.sockv3`.

If `$TMPDIR` is long enough, we still don't have enough space. Worse, when we try to `String.sub 0 max_digest_length`, `max_digest_length` could be negative and cause an exception! This is actually responsible for several failing tests in Circle on Windows right now.

Instead, we now `chdir` into `$TMPDIR/flow/` and then use `./zSpathzStozSroot.sockv3` (or the hashed version), which is guaranteed to fit.

Differential Revision: D20313040

