### PR TITLE
Add headers timeout to http & https server

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -1420,6 +1420,7 @@ declare class http$Server extends net$Server {
   close(callback?: (error: ?Error) => mixed): this;
   maxHeadersCount: number;
   keepAliveTimeout: number;
+  headersTimeout: number;
   setTimeout(msecs: number, callback: Function): this;
   timeout: number;
 }
@@ -1444,6 +1445,7 @@ declare class https$Server extends tls$Server {
   }, callback?: Function): this;
   close(callback?: (error: ?Error) => mixed): this;
   keepAliveTimeout: number;
+  headersTimeout: number;
   setTimeout(msecs: number, callback: Function): this;
   timeout: number;
 }


### PR DESCRIPTION
Noticed when extending our server the type for `headersTimeout` was missing. This was added in NodeJS v11.3 ([docs](https://nodejs.org/api/http.html#http_server_headerstimeout)).

Only changes are where I have added the type to the `http$Server` class and also the `https$Server` class.