### PR TITLE
Support .cjs extension

### DIFF
--- a/packages/flow-remove-types/flow-remove-types
+++ b/packages/flow-remove-types/flow-remove-types
@@ -79,7 +79,7 @@ function mkdirp(dirpath) {
 
 // Collect arguments
 var ignore = /node_modules/;
-var extensions = [ '.js', '.mjs', '.jsx', '.flow', '.es6' ];
+var extensions = [ '.js', '.mjs', '.cjs', '.jsx', '.flow', '.es6' ];
 var outDir;
 var outFile;
 var all;

--- a/packages/flow-remove-types/register.js
+++ b/packages/flow-remove-types/register.js
@@ -22,7 +22,7 @@ module.exports = function setOptions(newOptions) {
 };
 
 var jsLoader = require.extensions['.js'];
-var exts = ['.js', '.mjs', '.jsx', '.flow', '.es6'];
+var exts = ['.js', '.mjs', '.cjs', '.jsx', '.flow', '.es6'];
 
 var revert = pirates.addHook(
   function hook(code, filename) {

--- a/src/commands/config/flowConfig.ml
+++ b/src/commands/config/flowConfig.ml
@@ -120,7 +120,7 @@ module Opts = struct
     Ok (config, warnings)
 
   let module_file_exts =
-    SSet.empty |> SSet.add ".js" |> SSet.add ".jsx" |> SSet.add ".json" |> SSet.add ".mjs"
+    SSet.empty |> SSet.add ".js" |> SSet.add ".jsx" |> SSet.add ".json" |> SSet.add ".mjs" |> SSet.add ".cjs"
 
   let module_resource_exts =
     SSet.empty

--- a/website/en/docs/config/options.md
+++ b/website/en/docs/config/options.md
@@ -212,8 +212,8 @@ The default value of `max_header_tokens` is 10.
 
 #### `module.file_ext` _`(string)`_ <a class="toc" id="toc-module-file-ext-string" href="#toc-module-file-ext-string"></a>
 
-By default, Flow will look for files with the extensions `.js`, `.jsx`, `.mjs`
-and `.json`. You can override this behavior with this option.
+By default, Flow will look for files with the extensions `.js`, `.jsx`, `.mjs`,
+`.cjs` and `.json`. You can override this behavior with this option.
 
 For example, if you do:
 


### PR DESCRIPTION
Node.js recently introduced .cjs extension for better dual mode support.
https://nodejs.org/dist/latest-v14.x/docs/api/esm.html#esm_enabling

Some packages like nanoevents already adopted it. Though flow requires
to specify it in .flowconfig
https://unpkg.com/browse/nanoevents@5.1.5/

<!--
  If this is a change to library defintions, please include links to relevant documentation.
  If this is a documentation change, please prefix the title with [DOCS].

  If this is neither, ensure you opened a discussion issue and link it in the PR description.
-->
