### PR TITLE
Add PageTransitionEvent

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -448,6 +448,10 @@ declare class PromiseRejectionEvent extends Event {
   reason: any;
 }
 
+declare class PageTransitionEvent extends Event {
+  persisted: boolean;
+}
+
 // used for websockets and postMessage, for example. See:
 // https://www.w3.org/TR/2011/WD-websockets-20110419/
 // and


### PR DESCRIPTION
Adds typings for `PageTransitionEvent` as defined within the
[HTML spec](Add https://html.spec.whatwg.org/multipage/browsing-the-web.html#pagetransitionevent)

