### PR TITLE
[DOCS] Revert "[PR] Fix typo in docs"

### DIFF
--- a/website/en/docs/lang/depth-subtyping.md
+++ b/website/en/docs/lang/depth-subtyping.md
@@ -20,8 +20,8 @@ var employee: Employee = new Employee;
 var person: Person = employee; // OK
 ```
 
-However, it is not valid to use an object containing an `Person` instance
-where an object containing a `Employee` instance is expected.
+However, it is not valid to use an object containing an `Employee` instance
+where an object containing a `Person` instance is expected.
 
 ```js
 // @flow


### PR DESCRIPTION
The original text was correctly describing the error example:

This reverts commit 39cb6bd32f0ce1d1258f0a582dc3b9844135713f.

<img width="695" alt="Screenshot 2020-05-10 at 16 29 01" src="https://user-images.githubusercontent.com/5914530/81503572-38b3f680-92dc-11ea-84c9-646d38a8733c.png">


<!--
  If this is a change to library defintions, please include links to relevant documentation.
  If this is a documentation change, please prefix the title with [DOCS].

  If this is neither, ensure you opened a discussion issue and link it in the PR description.
-->
