### PR TITLE
Missing types in crypto randomFill & randomFillSync node definitions

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -628,24 +628,24 @@ declare module "crypto" {
     size: number,
     callback: (err: ?Error, buffer: Buffer) => void
   ): void;
-  declare function randomFillSync(buffer: Buffer): void
-  declare function randomFillSync(buffer: Buffer, offset: number): void
+  declare function randomFillSync(buffer: Buffer | $TypedArray | DataView): void
+  declare function randomFillSync(buffer: Buffer | $TypedArray | DataView, offset: number): void
   declare function randomFillSync(
-    buffer: Buffer,
+    buffer: Buffer | $TypedArray | DataView,
     offset: number,
     size: number
   ): void
   declare function randomFill(
-    buffer: Buffer,
+    buffer: Buffer | $TypedArray | DataView,
     callback: (err: ?Error, buffer: Buffer) => void
   ): void
   declare function randomFill(
-    buffer: Buffer,
+    buffer: Buffer | $TypedArray | DataView,
     offset: number,
     callback: (err: ?Error, buffer: Buffer) => void
   ): void
   declare function randomFill(
-    buffer: Buffer,
+    buffer: Buffer | $TypedArray | DataView,
     offset: number,
     size: number,
     callback: (err: ?Error, buffer: Buffer) => void


### PR DESCRIPTION
In current definitions `buffer` arg only accepts `Buffer` type, but
according to docs [1] it should accept `Buffer | $TypedArray | DataView`.

[1] https://nodejs.org/api/crypto.html#crypto_crypto_randomfillsync_buffer_offset_size