### PR TITLE
Support WebP File Types for Images

### DIFF
--- a/src/commands/config/flowConfig.ml
+++ b/src/commands/config/flowConfig.ml
@@ -140,6 +140,7 @@ module Opts = struct
     |> SSet.add ".woff2"
     |> SSet.add ".mp4"
     |> SSet.add ".webm"
+    |> SSet.add ".webp"
 
   let default_options =
     {


### PR DESCRIPTION
WebP is a now widely support image file extension, and it being utilised by many
companies.

This commit will add Flow support for the `.webp` file extensions, removing the
need to use `$FlowFixMe` in files using both Flow type checking and WebP images.

[WebP Support](https://caniuse.com/#feat=webp)
