### PR TITLE
Update Readable definition so that _read always takes a size

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -1858,7 +1858,7 @@ type readableStreamOptions = {
   highWaterMark?: number,
   encoding?: string,
   objectMode?: boolean,
-  read?: (size?: number) => void,
+  read?: (size: number) => void,
   destroy?: (error: ?Error, callback: (error?: Error) => void) => void,
   autoDestroy?: boolean,
   ...
@@ -1878,7 +1878,7 @@ declare class stream$Readable extends stream$Stream {
   unpipe(dest?: stream$Writable): this;
   unshift(chunk: Buffer | Uint8Array | string): void;
   wrap(oldReadable: stream$Stream): this;
-  _read(size?: number): void;
+  _read(size: number): void;
   _destroy(error: ?Error, callback: (error?: Error) => void): void;
   push(chunk: ?(Buffer | Uint8Array | string), encoding? : string): boolean;
   @@asyncIterator(): AsyncIterator<string | Buffer>;


### PR DESCRIPTION
According to the documentation, `_read` takes a non-optional size as argument. Marking it non-optional still allows to extend the class and ignore it, so this should be backward compatible. However this change makes it possible to handle this argument without checking the presence first.

Documentation links:
* https://nodejs.org/docs/latest-v12.x/api/stream.html#stream_readable_read_size_1
* https://nodejs.org/docs/latest-v12.x/api/stream.html#stream_new_stream_readable_options

I looked as far as node v4 which has the same documentation.
