### PR TITLE
DOCS: Update the repository URL for flow-remove-types in the docs

### DIFF
--- a/website/en/docs/_install/compiler-flow-remove-types.md
+++ b/website/en/docs/_install/compiler-flow-remove-types.md
@@ -1,4 +1,4 @@
-[flow-remove-types](https://github.com/flowtype/flow-remove-types) is a small
+[flow-remove-types](https://github.com/facebook/flow/tree/master/packages/flow-remove-types) is a small
 CLI tool for stripping Flow type annotations from files. It's a lighter-weight
 alternative to Babel for projects that don't need everything Babel provides.
 

--- a/website/en/docs/_install/compiler-intro.md
+++ b/website/en/docs/_install/compiler-intro.md
@@ -2,4 +2,4 @@
 
 First you'll need to setup a compiler to strip away Flow types. You can
 choose between [Babel](http://babeljs.io/) and
-[flow-remove-types](https://github.com/flowtype/flow-remove-types).
+[flow-remove-types](https://github.com/facebook/flow/tree/master/packages/flow-remove-types).

--- a/website/en/docs/tools/flow-remove-types.md
+++ b/website/en/docs/tools/flow-remove-types.md
@@ -2,7 +2,7 @@
 layout: guide
 ---
 
-[`flow-remove-types`](https://github.com/flowtype/flow-remove-types) is a small
+[`flow-remove-types`](https://github.com/facebook/flow/tree/master/packages/flow-remove-types) is a small
 CLI tool for stripping Flow type annotations from files. It's a lighter-weight
 alternative to Babel for projects that don't need everything Babel provides.
 


### PR DESCRIPTION
<!--
  If this is a change to library defintions, please include links to relevant documentation.
  If this is a documentation change, please prefix the title with [DOCS].

  If this is neither, ensure you opened a discussion issue and link it in the PR description.
-->

The existing URL 301s to https://github.com/facebookarchive/flow-remove-types, which is archived.

It was actually not obvious that the package was moved into this tree.  I only found it via npm's repository link.  Maybe the description of https://github.com/facebookarchive/flow-remove-types could be updated to point here as well?