### PR TITLE
[DOCS] unescape characters in example vimrc

### DIFF
--- a/website/en/docs/editors/vim.md
+++ b/website/en/docs/editors/vim.md
@@ -51,7 +51,7 @@ set updatetime=300
 set shortmess+=c
 
 " Use leader T to show documentation in preview window
-nnoremap &lt;leader&gt;t :call &lt;SID&gt;show_documentation()&lt;CR&gt;
+nnoremap <leader>t :call <SID>show_documentation()<CR>
 
 
 function! s:show_documentation()


### PR DESCRIPTION
The example vimrc snippet for configuring `coc.nvim` contains a line with escaped html characters for `<` and `>`.
Copy and pasting this into a .vimrc does not work.
Replacing these escaped characters with the unescaped characters fixes the problem.
