### PR TITLE
[easy 1 line change] Make exact the return type for Object.fromEntries

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -58,7 +58,7 @@ declare class Object {
         '0': K,
         '1': V,
         ...
-    }>): { [K]: V, ... };
+    }>): {| [K]: V |};
 
     static getOwnPropertyDescriptor<T>(o: $NotNullOrVoid, p: any): PropertyDescriptor<T> | void;
     static getOwnPropertyDescriptors(o: {...}): PropertyDescriptorMap;


### PR DESCRIPTION
According to the ECMAScript spec, `Object.fromEntries` asserts:

> obj is an extensible ordinary object with no own properties.

As such, it seems appropriate that the object returned only contains key value pairs of this type, and no additional (unexpected) keys.

https://tc39.es/ecma262/#sec-object.fromentries


