### PR TITLE
Add $FlowIgnore to the suppression comments

### DIFF
--- a/src/typing/errors/suppression_comments.ml
+++ b/src/typing/errors/suppression_comments.ml
@@ -8,7 +8,7 @@
 (*
     Suppression comments have the following syntax:
 
-    <SUPPRESSOR> := $FlowIssue | $FlowFixMe | $FlowExpectedError
+    <SUPPRESSOR> := $FlowIssue | $FlowFixMe | $FlowExpectedError | $FlowIgnore
 
     //<SUPPRESSOR>[CODE]...
 *)
@@ -72,7 +72,7 @@ let should_suppress comment loc =
   let (comment, is_suppressor) =
     consume_tokens [" "; "\n"; "\t"; "\r"; "*"] comment
     |> fst
-    |> consume_tokens ["$FlowFixMe"; "$FlowIssue"; "$FlowExpectedError"]
+    |> consume_tokens ["$FlowFixMe"; "$FlowIssue"; "$FlowExpectedError"; "$FlowIgnore"]
   in
   if not is_suppressor then
     Ok None

--- a/tests/suppress_default/suppress_default.exp
+++ b/tests/suppress_default/suppress_default.exp
@@ -1,14 +1,14 @@
-Error ----------------------------------------------------------------------------------------------------- test.js:28:2
+Error ----------------------------------------------------------------------------------------------------- test.js:31:2
 
 Cannot cast `3` to string because number [1] is incompatible with string [2]. [incompatible-cast]
 
-   test.js:28:2
-   28| (3 : string);  // error
+   test.js:31:2
+   31| (3 : string);  // error
         ^ [1]
 
 References:
-   test.js:28:6
-   28| (3 : string);  // error
+   test.js:31:6
+   31| (3 : string);  // error
             ^^^^^^ [2]
 
 

--- a/tests/suppress_default/test.js
+++ b/tests/suppress_default/test.js
@@ -12,6 +12,9 @@
 /* $FlowFixMe */
 (3 : string);  // no error
 
+/* $FlowIgnore */
+(3 : string);  // no error
+
 /** $FlowFixMe */
 (3 : string);  // no error
 


### PR DESCRIPTION
Fixes #8392. Allow suppressing Flow errors with a $FlowIgnore comment.

<!--
  If this is a change to library defintions, please include links to relevant documentation.
  If this is a documentation change, please prefix the title with [DOCS].

  If this is neither, ensure you opened a discussion issue and link it in the PR description.
-->
