### PR TITLE
Add parameter to MediaStreamTrack.applyConstraints()

### DIFF
--- a/lib/bom.js
+++ b/lib/bom.js
@@ -1243,7 +1243,7 @@ declare class MediaStreamTrack extends EventTarget {
   onoverconstrained: (ev: any) => mixed;
   onended: (ev: any) => mixed;
   getConstraints(): MediaTrackConstraints;
-  applyConstraints(): Promise<void>;
+  applyConstraints(constraints?: MediaTrackConstraints): Promise<void>;
   getSettings(): MediaTrackSettings;
   getCapabilities(): MediaTrackCapabilities;
   clone(): MediaStreamTrack;


### PR DESCRIPTION
`applyConstraints` takes an optional `MediaTrackConstraints` parameter 
> # Parameters
> `constraints` Optional
> A MediaTrackConstraints object listing the constraints to apply to the track's constrainable properties; any existing constraints are replaced with the new values specified, and any constrainable properties not included are restored to their default constraints. If this parameter is omitted, all currently set custom constraints are cleared. This object represents the basic set of constraints that must apply for the Promise to resolve. The object may contain an advanced property containing an array of additional MediaTrackConstrants objects, which are treated as exact requires. 

https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamTrack/applyConstraints
