### PR TITLE
Fix add-comments empty space after each line

### DIFF
--- a/packages/flow-dev-tools/src/comment/add-commentsRunner.js
+++ b/packages/flow-dev-tools/src/comment/add-commentsRunner.js
@@ -735,7 +735,7 @@ export async function addCommentsToCode(
         wrap = false;
       }
       const comments = [...new Set(error_codes)].map(
-        error_code => '$FlowFixMe[' + error_code + '] ' + c,
+        error_code => `$FlowFixMe[${error_code}]${c ? ` ${c}` : ''}`,
       );
       for (c of comments) {
         code = addCommentToCode(c, code, loc, path, wrap);


### PR DESCRIPTION
Issue was introduced in 1eaa9dba104a8b39bb6dccda6c0b72237e15b50e /cc @dsainati1 

When we ran `add-comments` on our codebase, we noticed an empty space after each `$FlowFixMe`:

![image](https://user-images.githubusercontent.com/127199/84708085-afb06080-af14-11ea-9d92-2c5974315092.png)

Command we used:
```bash
~/code/flow/tool add-comments . --bin ~/code/repo/node_modules/.bin/flow --all
```