### PR TITLE
Mark ref as write-only for forwardRef

### DIFF
--- a/lib/react.js
+++ b/lib/react.js
@@ -302,7 +302,7 @@ declare module react {
   declare export function forwardRef<Config, Instance>(
     render: (
       props: Config,
-      ref: { current: null | Instance, ... } | ((null | Instance) => mixed),
+      ref: { -current: null | Instance, ... } | ((null | Instance) => mixed),
     ) => React$Node,
   ): React$AbstractComponent<Config, Instance>;
 


### PR DESCRIPTION
Ideally, we need to redefine the forwardRef type entirely to account for certain patterns as:

```ts
 declare export function functionalForwardRef<Config, TRef: {current: mixed, ...} | (mixed) => void, TReturn>(
    render: (props: Config, ref: Ref) => TReturn,
  ): (props: {...Config, ref: Ref}) => TReturn
```

Here's why:
1. Ref type - Although a ref can be an object or a function, there are cases where a component requires the ref that's passed in to always be an object. Sometime the passed in ref is even read from.
2. Return type - It's useful to know the outermost element that is rendered from a component for various compositional components. Right now, `forwardRef` erases the type, we should update the type to keep the types included.

<!--
  If this is a change to library defintions, please include links to relevant documentation.
  If this is a documentation change, please prefix the title with [DOCS].

  If this is neither, ensure you opened a discussion issue and link it in the PR description.
-->
