### PR TITLE
Improve the type for React.memo

### DIFF
--- a/lib/react.js
+++ b/lib/react.js
@@ -306,10 +306,10 @@ declare module react {
     ) => React$Node,
   ): React$AbstractComponent<Config, Instance>;
 
-  declare export function memo<Config, Instance = mixed>(
-    component: React$AbstractComponent<Config, Instance>,
+  declare export function memo<Config, Instance = mixed, Component = React$AbstractComponent<Config, Instance>>(
+    component: Component,
     equal?: (Config, Config) => boolean,
-  ): React$AbstractComponent<Config, Instance>;
+  ): Component;
 
   declare export function lazy<Config, Instance = mixed>(
     component: () => Promise<{ default: React$AbstractComponent<Config, Instance>, ... }>,


### PR DESCRIPTION
`React.memo` is almost only used for functional components. It is often useful to main the return type of those functions and this change will do so.

The change has been made in a backwards compatible way.

<!--
  If this is a change to library defintions, please include links to relevant documentation.
  If this is a documentation change, please prefix the title with [DOCS].

  If this is neither, ensure you opened a discussion issue and link it in the PR description.
-->
