### PR TITLE
Added aarch64 job in CircleCI

### DIFF
--- a/.circleci/Dockerfile_aarch64
+++ b/.circleci/Dockerfile_aarch64
@@ -1,0 +1,5 @@
+FROM arm64v8/ubuntu:latest
+
+ADD build_flow_aarch64.sh .
+
+ENTRYPOINT ["/bin/bash", "build_flow_aarch64.sh"]

--- a/.circleci/build_flow_aarch64.sh
+++ b/.circleci/build_flow_aarch64.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+apt-get -qq update
+apt-get install -qq opam git wget curl build-essential m4 zip > /dev/null
+echo | sh <(curl -sL https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh)
+opam init --disable-sandboxing --reinit -ni -y
+eval $(opam env)
+cd /flow
+if [ ! -d _opam ]; then
+  opam switch create . 4.07.1 --deps-only -y
+fi
+eval $(opam env)
+make bin/flow dist/flow.zip
+mkdir -p bin/linux-aarch64 && cp bin/flow bin/linux-aarch64/flow

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -209,6 +209,38 @@ jobs:
           path: dist/flow_parser.js
           destination: flow_parser.js
 
+  build_aarch64_linux:
+    machine:
+      image: ubuntu-1604:201903-01
+    working_directory: ~/flow
+    steps:
+      - attach_workspace:
+          at: ~/flow
+      - run:
+          name: Activate QEMU
+          command:
+            sudo docker run -it --rm --privileged multiarch/qemu-user-static --reset --credential yes --persistent yes
+      - run:
+          name: Build flow
+          no_output_timeout: 30m
+          command: |
+            cp .circleci/Dockerfile_aarch64 .
+            cp .circleci/build_flow_aarch64.sh .
+            docker build -t flow-image -f Dockerfile_aarch64 .
+            sudo docker run --rm -it -v$(pwd):/flow flow-image
+      - run:
+          name: Create artifacts
+          command: |
+            sudo cp dist/flow.zip dist/flow-linux-aarch64.zip
+      - persist_to_workspace:
+          root: .
+          paths:
+            - bin/linux-aarch64/flow
+            - dist/flow-linux-aarch64.zip
+      - store_artifacts:
+          path: dist/flow-linux-aarch64.zip
+          destination: flow-linux-aarch64.zip
+
   build_macos:
     executor: mac
     steps:
@@ -551,6 +583,9 @@ workflows:
       - build_linux:
           requires:
             - checkout
+      - build_aarch64_linux:
+          requires:
+            - checkout
       - build_macos:
           requires:
             - checkout
@@ -595,6 +630,10 @@ workflows:
       - checkout:
           <<: *run_on_release_tags
       - build_linux:
+          <<: *run_on_release_tags
+          requires:
+            - checkout
+      - build_aarch64_linux:
           <<: *run_on_release_tags
           requires:
             - checkout

--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,10 @@ INTERNAL_FLAGS=
 
 ifeq ($(OS), Windows_NT)
   UNAME_S=Windows
+  UNAME_M=
 else
   UNAME_S=$(shell uname -s)
+  UNAME_M=$(shell uname -m)
 endif
 
 # Default to `ocamlbuild -j 0` (unlimited parallelism), but you can limit it
@@ -263,7 +265,11 @@ BUILT_OBJECT_FILES=$(addprefix _build/,$(NATIVE_OBJECT_FILES))
 BUILT_OUNIT_TESTS=$(addprefix _build/,$(OUNIT_TESTS))
 
 # Any additional C flags can be added here
-CC_FLAGS=-mcx16
+ifeq ($(UNAME_M), aarch64)
+  CC_FLAGS=
+else
+  CC_FLAGS=-mcx16
+endif
 CC_FLAGS += $(EXTRA_CC_FLAGS)
 CC_OPTS=$(foreach flag, $(CC_FLAGS), -ccopt $(flag))
 INCLUDE_OPTS=$(foreach dir,$(MODULES),-I $(dir))


### PR DESCRIPTION
@mroch ,

Added aarch64 job using executor type machine in CircleCI config file and related Dockerfile and build script. AArch64 flow binary is created and stored as an artifact. 

Tested in my local CircleCI environment. AArch64 flow binary can be downloaded and verified from [here](https://89-274139798-gh.circle-artifacts.com/0/flow-linux-aarch64.zip).

Closes #7556.

Please review and let me know if any changes required.