### PR TITLE
[DOCS] Remove Nuclide from docs for Atom

### DIFF
--- a/website/en/docs/editors/atom.md
+++ b/website/en/docs/editors/atom.md
@@ -11,27 +11,11 @@ integrate Flow into your code base.
 apm install atom-ide-ui && apm install ide-flowtype
 ```
 
-[Flow for Atom IDE](https://atom.io/packages/ide-flowtype) is extracted from 
-Nuclide, and works with the [Atom IDE](https://ide.atom.io/) UI. It brings 
-the core features you expect in a full-featured IDE into Atom, such as 
-language-aware autocomplete, diagnostics, go-to-definition, type hints, and 
+[Flow for Atom IDE](https://atom.io/packages/ide-flowtype) is extracted from
+[Nuclide](https://nuclide.io), and works with the [Atom IDE](https://ide.atom.io/) UI. It brings
+the core features you expect in a full-featured IDE into Atom, such as
+language-aware autocomplete, diagnostics, go-to-definition, type hints, and
 symbol outlines.
-
-### Nuclide <a class="toc" id="toc-nuclide" href="#toc-nuclide"></a>
-
-```sh
-apm install nuclide
-```
-
-[Nuclide](https://nuclide.io) is a full IDE created by people at Facebook that
-has support for Flow built-in. It provides a linter, autocomplete and type
-coverage support, click-to-definition and type description on hover.
-
-However, it currently lacks support for on-the-fly type-checking (showing your
-type errors before you save your file).
-
-Nuclide also comes with many other features including support for remote
-projects, hack, mercurial etc.
 
 ### Flow-IDE <a class="toc" id="toc-flow-ide" href="#toc-flow-ide"></a>
 

--- a/website/en/docs/linting/ide-integration.md
+++ b/website/en/docs/linting/ide-integration.md
@@ -2,19 +2,6 @@
 layout: guide
 ---
 
-Flow has worked with Nuclide directly on adding support for the new warning
-severity level. Certain features are likely to be in other editors, but others
-might not yet be implemented.
-
-### Nuclide <a class="toc" id="toc-nuclide" href="#toc-nuclide"></a>
-
-In Nuclide, Flow warnings are distinct from Flow errors and rendered in a different color.
-
-Nuclide v0.243.0 onward has support for working with Flow to limit the reported warnings to the working fileset.
-This allows Nuclide and Flow to work efficiently on large codebases with tens of thousands of unsuppressed warnings.
-
-### Other Editors <a class="toc" id="toc-other-editors" href="#toc-other-editors"></a>
-
 In most editors, Flow warnings are likely to be rendered the same way as other
 warnings are rendered by that editor.
 


### PR DESCRIPTION
According to official web site https://nuclide.io/ Nuclide is not supported anymore. After upgrading from old version of Atom it leads to an error. It is also not possible to install it anymore:

  Request for package information failed: Not Found

This will preven confusion and will save time for developers who still try to follow docs and use Atom with Nuclide for flow types.
