### PR TITLE
[website] Add missing Medium blog post links

### DIFF
--- a/website/_posts/2020-03-16-Making-Flow-error-suppressions-more-specific.md
+++ b/website/_posts/2020-03-16-Making-Flow-error-suppressions-more-specific.md
@@ -1,0 +1,7 @@
+---
+title: "Making Flow error suppressions more specific"
+short-title: "Making Flow error suppressions"
+author: "Daniel Sainati"
+medium-link: "https://medium.com/flow-type/making-flow-error-suppressions-more-specific-280aa4e3c95c"
+---
+We’re improving Flow error suppressions so that they don’t accidentally hide errors.

--- a/website/_posts/2020-05-18-Types-First-A-Scalable-New-Architecture-for-Flow.md
+++ b/website/_posts/2020-05-18-Types-First-A-Scalable-New-Architecture-for-Flow.md
@@ -1,0 +1,7 @@
+---
+title: "Types-First: A Scalable New Architecture for Flow"
+short-title: "Types-First: A Scalable New"
+author: "Panagiotis Vekris"
+medium-link: "https://medium.com/flow-type/types-first-a-scalable-new-architecture-for-flow-3d8c7ba1d4eb"
+---
+Flow Types-First mode is out! It unlocks Flow’s potential at scale by leveraging fully typed module boundaries. Read more in our latest blog post.


### PR DESCRIPTION
The latest 2 Medium articles (from March and May) aren't linked to from the website.