### PR TITLE
feat(node): add missing Brotli APIs to the zlib module

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -2381,15 +2381,38 @@ type zlib$options = {
   ...
 };
 
+type zlib$brotliOptions = {
+  flush?: number,
+  finishFlush?: number,
+  chunkSize?: number,
+  params?: {
+    [number]: boolean | number,
+    ...
+  },
+  maxOutputLength?: number,
+  ...
+}
+
 type zlib$syncFn = (
-  buffer: string | Buffer,
+  buffer: Buffer | $TypedArray | DataView | ArrayBuffer | string,
   options?: zlib$options
 ) => Buffer;
 
 type zlib$asyncFn = (
-  buffer: string | Buffer,
+  buffer: Buffer | $TypedArray | DataView | ArrayBuffer | string,
   options?: zlib$options,
-  callback?: ((error: ?Error, result: any) => void)
+  callback?: (error: ?Error, result: Buffer) => void
+) => void;
+
+type zlib$brotliSyncFn = (
+  buffer: Buffer | $TypedArray | DataView | ArrayBuffer | string,
+  options?: zlib$brotliOptions
+) => Buffer;
+
+type zlib$brotliAsyncFn = (
+  buffer: Buffer | $TypedArray | DataView | ArrayBuffer | string,
+  options?: zlib$brotliOptions,
+  callback?: (error: ?Error, result: Buffer) => void
 ) => void;
 
 // Accessing the constants directly from the module is currently still
@@ -2483,6 +2506,70 @@ declare module "zlib" {
     Z_MIN_LEVEL: number,
     Z_MIN_MEMLEVEL: number,
     Z_MIN_WINDOWBITS: number,
+
+    BROTLI_DECODE: number,
+    BROTLI_ENCODE: number,
+    BROTLI_OPERATION_PROCESS: number,
+    BROTLI_OPERATION_FLUSH: number,
+    BROTLI_OPERATION_FINISH: number,
+    BROTLI_OPERATION_EMIT_METADATA: number,
+    BROTLI_PARAM_MODE: number,
+    BROTLI_MODE_GENERIC: number,
+    BROTLI_MODE_TEXT: number,
+    BROTLI_MODE_FONT: number,
+    BROTLI_DEFAULT_MODE: number,
+    BROTLI_PARAM_QUALITY: number,
+    BROTLI_MIN_QUALITY: number,
+    BROTLI_MAX_QUALITY: number,
+    BROTLI_DEFAULT_QUALITY: number,
+    BROTLI_PARAM_LGWIN: number,
+    BROTLI_MIN_WINDOW_BITS: number,
+    BROTLI_MAX_WINDOW_BITS: number,
+    BROTLI_LARGE_MAX_WINDOW_BITS: number,
+    BROTLI_DEFAULT_WINDOW: number,
+    BROTLI_PARAM_LGBLOCK: number,
+    BROTLI_MIN_INPUT_BLOCK_BITS: number,
+    BROTLI_MAX_INPUT_BLOCK_BITS: number,
+    BROTLI_PARAM_DISABLE_LITERAL_CONTEXT_MODELING: number,
+    BROTLI_PARAM_SIZE_HINT: number,
+    BROTLI_PARAM_LARGE_WINDOW: number,
+    BROTLI_PARAM_NPOSTFIX: number,
+    BROTLI_PARAM_NDIRECT: number,
+    BROTLI_DECODER_RESULT_ERROR: number,
+    BROTLI_DECODER_RESULT_SUCCESS: number,
+    BROTLI_DECODER_RESULT_NEEDS_MORE_INPUT: number,
+    BROTLI_DECODER_RESULT_NEEDS_MORE_OUTPUT: number,
+    BROTLI_DECODER_PARAM_DISABLE_RING_BUFFER_REALLOCATION: number,
+    BROTLI_DECODER_PARAM_LARGE_WINDOW: number,
+    BROTLI_DECODER_NO_ERROR: number,
+    BROTLI_DECODER_SUCCESS: number,
+    BROTLI_DECODER_NEEDS_MORE_INPUT: number,
+    BROTLI_DECODER_NEEDS_MORE_OUTPUT: number,
+    BROTLI_DECODER_ERROR_FORMAT_EXUBERANT_NIBBLE: number,
+    BROTLI_DECODER_ERROR_FORMAT_RESERVED: number,
+    BROTLI_DECODER_ERROR_FORMAT_EXUBERANT_META_NIBBLE: number,
+    BROTLI_DECODER_ERROR_FORMAT_SIMPLE_HUFFMAN_ALPHABET: number,
+    BROTLI_DECODER_ERROR_FORMAT_SIMPLE_HUFFMAN_SAME: number,
+    BROTLI_DECODER_ERROR_FORMAT_CL_SPACE: number,
+    BROTLI_DECODER_ERROR_FORMAT_HUFFMAN_SPACE: number,
+    BROTLI_DECODER_ERROR_FORMAT_CONTEXT_MAP_REPEAT: number,
+    BROTLI_DECODER_ERROR_FORMAT_BLOCK_LENGTH_1: number,
+    BROTLI_DECODER_ERROR_FORMAT_BLOCK_LENGTH_2: number,
+    BROTLI_DECODER_ERROR_FORMAT_TRANSFORM: number,
+    BROTLI_DECODER_ERROR_FORMAT_DICTIONARY: number,
+    BROTLI_DECODER_ERROR_FORMAT_WINDOW_BITS: number,
+    BROTLI_DECODER_ERROR_FORMAT_PADDING_1: number,
+    BROTLI_DECODER_ERROR_FORMAT_PADDING_2: number,
+    BROTLI_DECODER_ERROR_FORMAT_DISTANCE: number,
+    BROTLI_DECODER_ERROR_DICTIONARY_NOT_SET: number,
+    BROTLI_DECODER_ERROR_INVALID_ARGUMENTS: number,
+    BROTLI_DECODER_ERROR_ALLOC_CONTEXT_MODES: number,
+    BROTLI_DECODER_ERROR_ALLOC_TREE_GROUPS: number,
+    BROTLI_DECODER_ERROR_ALLOC_CONTEXT_MAP: number,
+    BROTLI_DECODER_ERROR_ALLOC_RING_BUFFER_1: number,
+    BROTLI_DECODER_ERROR_ALLOC_RING_BUFFER_2: number,
+    BROTLI_DECODER_ERROR_ALLOC_BLOCK_TYPE_TREES: number,
+    BROTLI_DECODER_ERROR_UNREACHABL: number,
     ...
   };
   declare var codes: {
@@ -2500,6 +2587,8 @@ declare module "zlib" {
   declare class Zlib extends stream$Duplex {
     // TODO
   }
+  declare class BrotliCompress extends Zlib {}
+  declare class BrotliDecompress extends Zlib {}
   declare class Deflate extends Zlib {}
   declare class Inflate extends Zlib {}
   declare class Gzip extends Zlib {}
@@ -2507,6 +2596,8 @@ declare module "zlib" {
   declare class DeflateRaw extends Zlib {}
   declare class InflateRaw extends Zlib {}
   declare class Unzip extends Zlib {}
+  declare function createBrotliCompress(options?: zlib$brotliOptions): BrotliCompress;
+  declare function createBrotliDecompress(options?: zlib$brotliOptions): BrotliDecompress;
   declare function createDeflate(options?: zlib$options): Deflate;
   declare function createInflate(options?: zlib$options): Inflate;
   declare function createDeflateRaw(options?: zlib$options): DeflateRaw;
@@ -2514,6 +2605,10 @@ declare module "zlib" {
   declare function createGzip(options?: zlib$options): Gzip;
   declare function createGunzip(options?: zlib$options): Gunzip;
   declare function createUnzip(options?: zlib$options): Unzip;
+  declare var brotliCompress: zlib$brotliAsyncFn;
+  declare var brotliCompressSync: zlib$brotliSyncFn;
+  declare var brotliDeompress: zlib$brotliAsyncFn;
+  declare var brotliDecompressSync: zlib$brotliSyncFn;
   declare var deflate: zlib$asyncFn;
   declare var deflateSync: zlib$syncFn;
   declare var gzip: zlib$asyncFn;

--- a/tests/node_tests/node_tests.exp
+++ b/tests/node_tests/node_tests.exp
@@ -1636,26 +1636,26 @@ References:
    process/emitWarning.js:10:1
      10| process.emitWarning(); // error
          ^^^^^^^^^^^^^^^^^^^^^ [1]
-   <BUILTINS>/node.js:2655:24
-   2655|   emitWarning(warning: string | Error): void;
+   <BUILTINS>/node.js:2750:24
+   2750|   emitWarning(warning: string | Error): void;
                                 ^^^^^^ [2]
-   <BUILTINS>/node.js:2655:33
-   2655|   emitWarning(warning: string | Error): void;
+   <BUILTINS>/node.js:2750:33
+   2750|   emitWarning(warning: string | Error): void;
                                          ^^^^^ [3]
-   <BUILTINS>/node.js:2656:3
-   2656|   emitWarning(warning: string, typeOrCtor: string | (...empty) => mixed): void;
+   <BUILTINS>/node.js:2751:3
+   2751|   emitWarning(warning: string, typeOrCtor: string | (...empty) => mixed): void;
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [4]
-   <BUILTINS>/node.js:2657:3
-   2657|   emitWarning(warning: string, type: string, codeOrCtor: string | (...empty) => mixed): void;
+   <BUILTINS>/node.js:2752:3
+   2752|   emitWarning(warning: string, type: string, codeOrCtor: string | (...empty) => mixed): void;
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [5]
-   <BUILTINS>/node.js:2658:3
+   <BUILTINS>/node.js:2753:3
            v-----------
-   2658|   emitWarning(
-   2659|     warning: string,
-   2660|     type: string,
-   2661|     code: string,
-   2662|     ctor?: (...empty) => mixed
-   2663|   ): void;
+   2753|   emitWarning(
+   2754|     warning: string,
+   2755|     type: string,
+   2756|     code: string,
+   2757|     ctor?: (...empty) => mixed
+   2758|   ): void;
            ------^ [6]
 
 
@@ -1674,14 +1674,14 @@ References:
    process/emitWarning.js:11:21
      11| process.emitWarning(42); // error
                              ^^ [1]
-   <BUILTINS>/node.js:2656:24
-   2656|   emitWarning(warning: string, typeOrCtor: string | (...empty) => mixed): void;
+   <BUILTINS>/node.js:2751:24
+   2751|   emitWarning(warning: string, typeOrCtor: string | (...empty) => mixed): void;
                                 ^^^^^^ [2]
-   <BUILTINS>/node.js:2657:24
-   2657|   emitWarning(warning: string, type: string, codeOrCtor: string | (...empty) => mixed): void;
+   <BUILTINS>/node.js:2752:24
+   2752|   emitWarning(warning: string, type: string, codeOrCtor: string | (...empty) => mixed): void;
                                 ^^^^^^ [3]
-   <BUILTINS>/node.js:2659:14
-   2659|     warning: string,
+   <BUILTINS>/node.js:2754:14
+   2754|     warning: string,
                       ^^^^^^ [4]
 
 
@@ -1699,11 +1699,11 @@ References:
    process/emitWarning.js:12:29
      12| process.emitWarning("blah", 42); // error
                                      ^^ [1]
-   <BUILTINS>/node.js:2657:38
-   2657|   emitWarning(warning: string, type: string, codeOrCtor: string | (...empty) => mixed): void;
+   <BUILTINS>/node.js:2752:38
+   2752|   emitWarning(warning: string, type: string, codeOrCtor: string | (...empty) => mixed): void;
                                               ^^^^^^ [2]
-   <BUILTINS>/node.js:2660:11
-   2660|     type: string,
+   <BUILTINS>/node.js:2755:11
+   2755|     type: string,
                    ^^^^^^ [3]
 
 
@@ -1719,8 +1719,8 @@ References:
    process/emitWarning.js:13:37
      13| process.emitWarning("blah", "blah", 42); // error
                                              ^^ [1]
-   <BUILTINS>/node.js:2661:11
-   2661|     code: string,
+   <BUILTINS>/node.js:2756:11
+   2756|     code: string,
                    ^^^^^^ [2]
 
 
@@ -1734,8 +1734,8 @@ Cannot cast `process.emitWarning(...)` to string because undefined [1] is incomp
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/node.js:2655:41
-   2655|   emitWarning(warning: string | Error): void;
+   <BUILTINS>/node.js:2750:41
+   2750|   emitWarning(warning: string | Error): void;
                                                  ^^^^ [1]
    process/emitWarning.js:14:31
      14| (process.emitWarning("blah"): string); // error
@@ -1800,8 +1800,8 @@ References:
    process/nextTick.js:27:3
      27|   (a: string, b: number, c: boolean) => {} // Error: too few arguments
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
-   <BUILTINS>/node.js:2684:21
-   2684|   nextTick: <T>(cb: (...T) => mixed, ...T) => void;
+   <BUILTINS>/node.js:2779:21
+   2779|   nextTick: <T>(cb: (...T) => mixed, ...T) => void;
                              ^^^^^^^^^^^^^^^ [2]
 
 
@@ -1815,8 +1815,8 @@ Cannot cast `process.allowedNodeEnvironmentFlags` to string because `Set` [1] is
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/node.js:2644:32
-   2644|   allowedNodeEnvironmentFlags: Set<string>;
+   <BUILTINS>/node.js:2739:32
+   2739|   allowedNodeEnvironmentFlags: Set<string>;
                                         ^^^^^^^^^^^ [1]
    process/process.js:5:39
       5| (process.allowedNodeEnvironmentFlags: string); // error


### PR DESCRIPTION
https://nodejs.org/api/zlib.html

Also, narrow the type of the second argument to the `asyncFn`'s
callbacks from `any` to `Buffer`, and expand the type of the first
argument to all functions to include more `Buffer`-like types, as
specified in the node documentation.

<!--
  If this is a change to library defintions, please include links to relevant documentation.
  If this is a documentation change, please prefix the title with [DOCS].

  If this is neither, ensure you opened a discussion issue and link it in the PR description.
-->
