### PR TITLE
Change the return type of fileURLToPath

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -2213,7 +2213,7 @@ declare module "url" {
   declare function domainToASCII(domain: string): string;
   declare function domainToUnicode(domain: string): string;
   declare function pathToFileURL(path: string): url$urlObject;
-  declare function fileURLToPath(path: url$urlObject | string): url$urlObject;
+  declare function fileURLToPath(path: url$urlObject | string): string;
   declare class URLSearchParams {
     constructor(init?: string | Array<[string, string]> | { [string]: string, ... } ): void;
     append(name: string, value: string): void;

--- a/tests/node_tests/url/url.js
+++ b/tests/node_tests/url/url.js
@@ -7,3 +7,5 @@ url.format(url.parse('https://example.com/foo'));
 function f(parseQueryString: boolean) {
   (url.parse('http://example.com/?foo=bar', parseQueryString).query: empty); // error, string | null | object
 }
+
+(url.fileURLToPath('file:///'): string);


### PR DESCRIPTION
Change the return type of fileURLToPath to string as indicated in the documentation.

https://nodejs.org/api/url.html#url_url_fileurltopath_url

<!--
  If this is a change to library defintions, please include links to relevant documentation.
  If this is a documentation change, please prefix the title with [DOCS].

  If this is neither, ensure you opened a discussion issue and link it in the PR description.
-->
