### PR TITLE
Remove unnecessary "--" from build script in docs.

### DIFF
--- a/website/en/docs/_install/include.html
+++ b/website/en/docs/_install/include.html
@@ -1,7 +1,7 @@
 {% if include.package_manager == "yarn" %}
   {% assign install_command = "yarn add --dev" %}
   {% if include.compiler == "babel" %}
-    {% assign run_command = "yarn run babel src/ -- -d lib/" %}
+    {% assign run_command = "yarn run babel src/ -d lib/" %}
   {% elsif include.compiler == "flow-remove-types" %}
     {% assign run_command = "yarn run flow-remove-types src/ -- -d lib/" %}
   {% endif %}


### PR DESCRIPTION
I noticed there was an unnecessary "--" in the build script recommended in the docs (https://flow.org/en/docs/install/). This PR removes it, such that it now matches what appears later on in that page in package.json, namely `babel src/ -d lib/`.