### PR TITLE
Add contentHint property for MediaStreamTrack

### DIFF
--- a/lib/bom.js
+++ b/lib/bom.js
@@ -1264,6 +1264,7 @@ declare class MediaStream extends EventTarget {
 }
 
 declare class MediaStreamTrack extends EventTarget {
+  contentHint?: string,
   enabled: bool;
   id: string;
   kind: string;


### PR DESCRIPTION
`contentHint` was introduced in Chrome 57 behind a flag but appears to be available without a flag from Chrome 60+. It also appears to be available in Safari but it is not available in Firefox, hence why the property should be flagged as optional. 

https://chromestatus.com/feature/5689466211532800
https://caniuse.com/mdn-api_mediastreamtrack_contenthint
https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamTrack#Browser_compatibility
https://www.w3.org/TR/mst-content-hint/

Though the IDL defines the type as:

```
partial interface MediaStreamTrack {
  attribute DOMString contentHint;
};
```
There is a fixed range of acceptable values so I could create a union type for this and make that the type instead.
https://www.w3.org/TR/mst-content-hint/#audio-content-hints
https://www.w3.org/TR/mst-content-hint/#video-content-hints
