### PR TITLE
Change buf.write(string, ...): void  return type

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -87,7 +87,7 @@ declare class Buffer extends Uint8Array {
   toJSON(): buffer$ToJSONRet;
   toString(encoding?: buffer$Encoding, start?: number, end?: number): string;
   values(): Iterator<number>;
-  write(string: string, offset?: number, length?: number, encoding?: buffer$Encoding): void;
+  write(string: string, offset?: number, length?: number, encoding?: buffer$Encoding): number;
   writeDoubleBE(value: number, offset?: number, noAssert?: boolean): number;
   writeDoubleLE(value: number, offset?: number, noAssert?: boolean): number;
   writeFloatBE(value: number, offset?: number, noAssert?: boolean): number;


### PR DESCRIPTION
Change Buffer
`write(string: string, offset?: number, length?: number, encoding?: buffer$Encoding): void;`
return type to `number` according to [Node.js doc](https://nodejs.org/api/buffer.html#buffer_buf_write_string_offset_length_encoding)

