### PR TITLE
[DOCS]: Fix broken urls caused by typo

### DIFF
--- a/website/en/docs/config/declarations.md
+++ b/website/en/docs/config/declarations.md
@@ -16,7 +16,7 @@ etc are extracted and used by the typechecker when checking other code.
 
 Conceptually one can think of declaration mode as if Flow still typechecks the
 files but acts as if there is a comment that matches
-[`suppress_comment`](https://flow.org/en/docs/config/options/#toc-suppress-comment-regex) on every line.
+[`suppress_comment`](../options/#toc-suppress-comment-regex) on every line.
 
 See also `[untyped]`(untyped) for not typechecking files, and instead using `any` for all contents.
 

--- a/website/en/docs/config/declarations.md
+++ b/website/en/docs/config/declarations.md
@@ -16,7 +16,7 @@ etc are extracted and used by the typechecker when checking other code.
 
 Conceptually one can think of declaration mode as if Flow still typechecks the
 files but acts as if there is a comment that matches
-[`suppress_comment`](options#toc-suppress-comment-regex") on every line.
+[`suppress_comment`](https://flow.org/en/docs/config/options/#toc-suppress-comment-regex) on every line.
 
 See also `[untyped]`(untyped) for not typechecking files, and instead using `any` for all contents.
 

--- a/website/en/docs/types/utilities.md
+++ b/website/en/docs/types/utilities.md
@@ -211,7 +211,7 @@ type B = $Diff<{}, {nope: number | void}>; // OK
 
 ## `$Rest<A, B>` <a class="toc" id="toc-rest" href="#toc-rest"></a>
 
-`$Rest<A, B>` is the type that represents the runtime object rest operation, e.g.: `const {foo, ...rest} = obj`, where `A` and `B` are both [object types](../objects/). The resulting type from this operation will be an object type containing `A`'s *own* properties that are not *own* properties in `B`. In flow, we treat all properties on [exact object types]((../objects/#toc-exact-object-types)) as [own](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwnProperty). In in-exact objects, a property may or may not be own.
+`$Rest<A, B>` is the type that represents the runtime object rest operation, e.g.: `const {foo, ...rest} = obj`, where `A` and `B` are both [object types](../objects/). The resulting type from this operation will be an object type containing `A`'s *own* properties that are not *own* properties in `B`. In flow, we treat all properties on [exact object types](../objects/#toc-exact-object-types) as [own](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwnProperty). In in-exact objects, a property may or may not be own.
 
 For example:
 


### PR DESCRIPTION
### Description 
(The link in the docs is leading to 404 pages, so I replaced it with the correct one.)