### PR TITLE
upgrade xcode

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,10 +70,11 @@ executors:
     working_directory: ~/flow
   mac:
     macos:
-      xcode: "9.4.1"
+      xcode: "12.1.0"
     environment:
       <<: *opam_env
       OPAM_VERSION: 2.0.5
+      MACOSX_DEPLOYMENT_TARGET: 10.13
     working_directory: ~/flow
   curl:
     docker:


### PR DESCRIPTION
upgrades to the latest stable xcode available on Circle, but specifies that we should still target macOS 10.13. this lets us use a version of xcode that will be available as long as currently possible.

note: when 10.16 Big Sur is released soon, 10.13 will be de facto EOL and we can bump this to 10.14.

```
% otool -l bin/flow | grep -B1 -A3 LC_VERSION_MIN_MACOSX
Load command 9
      cmd LC_VERSION_MIN_MACOSX
  cmdsize 16
  version 10.13
      sdk 10.15.6
```