### PR TITLE
don't normalize Windows drive letter in tool tests

### DIFF
--- a/packages/flow-dev-tools/package.json
+++ b/packages/flow-dev-tools/package.json
@@ -29,7 +29,7 @@
     "source-map-support": "~0.4.0",
     "twit": "^2.1.5",
     "vscode-jsonrpc": "^4.0.0",
-    "vscode-uri": "^2.0.3"
+    "vscode-uri": "^2.1.2"
   },
   "babel": {
     "presets": [

--- a/packages/flow-dev-tools/src/test/builder.js
+++ b/packages/flow-dev-tools/src/test/builder.js
@@ -12,7 +12,7 @@ import {format} from 'util';
 import EventEmitter from 'events';
 
 import * as rpc from 'vscode-jsonrpc';
-import {URI as VscodeURI} from 'vscode-uri';
+import {URI as VscodeURI, uriToFsPath} from 'vscode-uri';
 
 import type {LSPMessage, RpcConnection} from './lsp';
 
@@ -974,7 +974,8 @@ export default class Builder {
   static getDirForRun(runID: string): string {
     // tmpdir() is a symlink on macOS, canonicalize it
     const tmp = realpathSync(tmpdir());
-    return VscodeURI.file(join(tmp, 'flow', 'tests', runID)).fsPath;
+    const uri = VscodeURI.file(join(tmp, 'flow', 'tests', runID));
+    return uriToFsPath(uri, /* keepDriveLetterCasing */ true);
   }
 
   // doesMethodMatch(actual, 'M') judges whether the method name of the actual

--- a/yarn.lock
+++ b/yarn.lock
@@ -1700,7 +1700,7 @@ growly@^1.3.0:
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
   integrity sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=
 
-handlebars@>=4.0.14, handlebars@^4.0.3:
+handlebars@^4.0.3:
   version "4.7.6"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.6.tgz#d4c05c1baf90e9945f77aa68a7a219aa4a7df74e"
   integrity sha512-1f2BACcBfiwAfStCKZNrUCgqNZkGsAT7UM3kkYtXuLo0KnaVfjKOyf7PRzB6++aK9STyT1Pd2ZCPe3EGOXleXA==
@@ -2671,7 +2671,7 @@ lodash.sortby@^4.7.0:
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
   integrity sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
 
-lodash@>=4.17.14, lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.4:
+lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.4:
   version "4.17.19"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
   integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
@@ -3773,7 +3773,7 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
-sshpk@>=1.13.2, sshpk@^1.7.0:
+sshpk@^1.7.0:
   version "1.16.1"
   resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.16.1.tgz#fb661c0bef29b39db40769ee39fa70093d6f6877"
   integrity sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==
@@ -4127,10 +4127,10 @@ vscode-jsonrpc@^4.0.0:
   resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-4.0.0.tgz#a7bf74ef3254d0a0c272fab15c82128e378b3be9"
   integrity sha512-perEnXQdQOJMTDFNv+UF3h1Y0z4iSiaN9jIlb0OqIYgosPCZGYh/MCUlkFtV2668PL69lRDO32hmvL2yiidUYg==
 
-vscode-uri@^2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/vscode-uri/-/vscode-uri-2.0.3.tgz#25e5f37f552fbee3cec7e5f80cef8469cefc6543"
-  integrity sha512-4D3DI3F4uRy09WNtDGD93H9q034OHImxiIcSq664Hq1Y1AScehlP3qqZyTkX/RWxeu0MRMHGkrxYqm2qlDF/aw==
+vscode-uri@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/vscode-uri/-/vscode-uri-2.1.2.tgz#c8d40de93eb57af31f3c715dd650e2ca2c096f1c"
+  integrity sha512-8TEXQxlldWAuIODdukIb+TR5s+9Ds40eSJrw+1iDDA9IFORPjMELarNQE3myz5XIkWWpdprmJjm1/SxMlWOC8A==
 
 w3c-hr-time@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Summary: `tool test` uses `vscode-uri` to normalize paths, but that by default lowercases the drive letter, so we can't test what happens if you start Flow with an uppercase drive letter.

Differential Revision: D24893422

