### PR TITLE
make: fix all-homebrew target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -302,7 +302,7 @@ all-homebrew:
 	export FLOW_RELEASE="1"; \
 	opam init --bare --no-setup --disable-sandboxing && \
 	rm -rf _opam && \
-	opam switch create . --deps-only && \
+	opam switch create . --deps-only ocaml-base-compiler.4.07.1 && \
 	opam exec -- make
 
 clean:


### PR DESCRIPTION
This PR fixes `No available version of ocaml-base-compiler satisfies the constraints` from `make all-homebrew`.

I've tested it in https://github.com/Homebrew/homebrew-core/pull/67203 and it seems it helped.

Since I'm not familiar with OCaml/opam, I can't verify if this fix is legitimate or is there's a better way to fix this error. 
We already use it in several other homebrew formulae like `semgrep` and `corectl`, so I hope it's not terribly wrong.

Full error, for a record:
```
==> make all-homebrew
export OPAMROOT="/var/folders/v5/ly_6fqkn1_l7g5w7lmwm_qlh0000gn/T/tmp.kLZp8QZI"; \
	export OPAMYES="1"; \
	export FLOW_RELEASE="1"; \
	opam init --bare --no-setup --disable-sandboxing && \
	rm -rf _opam && \
	opam switch create . --deps-only && \
	opam exec -- make
[NOTE] Will configure from built-in defaults.
Checking for available remotes: rsync and local, git.
  - you won't be able to use mercurial repositories unless you install the hg command on your system.
  - you won't be able to use darcs repositories unless you install the darcs command on your system.


<><> Fetching repository information ><><><><><><><><><><><><><><><><><><><>  🐫 
[default] Initialised
[ERROR] Could not resolve set of base packages:
        Your request can't be satisfied:
          - No available version of ocaml-base-compiler satisfies the constraints


Switch initialisation failed: clean up? ('n' will leave the switch partially installed) [Y/n] y
make: *** [all-homebrew] Error 20
```
