### PR TITLE
log additional info for Out_of_shared_memory exceptions

### DIFF
--- a/src/flow.ml
+++ b/src/flow.ml
@@ -108,12 +108,14 @@ let _ =
     (* this call might not return *)
     FlowShell.main ()
   with
-  | SharedMem.Out_of_shared_memory as e ->
+  | SharedMem.Out_of_shared_memory (msg, err) as e ->
     let e = Exception.wrap e in
     let bt = Exception.get_backtrace_string e in
     let msg =
       Utils.spf
-        "Out of shared memory%s"
+        "Out of shared memory: %s (%s)%s"
+        msg
+        (Unix.error_message err)
         ( if bt = "" then
           bt
         else

--- a/src/hack_forked/procs/worker.ml
+++ b/src/hack_forked/procs/worker.ml
@@ -143,7 +143,9 @@ let worker_main ic oc =
       exit 0
     with
     | Connection_closed -> exit 1
-    | SharedMem.Out_of_shared_memory -> FlowExitStatus.(exit Out_of_shared_memory)
+    | SharedMem.Out_of_shared_memory (msg, err) ->
+      let msg = Printf.sprintf "Out of shared memory: %s (%s)" msg (Unix.error_message err) in
+      FlowExitStatus.(exit ~msg Out_of_shared_memory)
     | SharedMem.Hash_table_full -> FlowExitStatus.(exit Hash_table_full)
     | SharedMem.Heap_full -> FlowExitStatus.(exit Heap_full)
   with e ->

--- a/src/hack_forked/procs/workerController.ml
+++ b/src/hack_forked/procs/workerController.ml
@@ -309,7 +309,8 @@ let read (type result) worker_pid infd : (result * Measure.record_data) Lwt.t =
         Exception.reraise exn
       | (_, Unix.WEXITED i) ->
         (match FlowExitStatus.error_type_opt i with
-        | Some FlowExitStatus.Out_of_shared_memory -> raise SharedMem.Out_of_shared_memory
+        | Some FlowExitStatus.Out_of_shared_memory ->
+          raise (SharedMem.Out_of_shared_memory ("reraised from worker", Unix.EUNKNOWNERR ~-1))
         | Some FlowExitStatus.Hash_table_full -> raise SharedMem.Hash_table_full
         | Some FlowExitStatus.Heap_full -> raise SharedMem.Heap_full
         | _ ->

--- a/src/heap/sharedMem.mli
+++ b/src/heap/sharedMem.mli
@@ -23,7 +23,7 @@ type effort =
   | `always_TEST
   ]
 
-exception Out_of_shared_memory
+exception Out_of_shared_memory of (string * Unix.error)
 
 exception Hash_table_full
 

--- a/src/server/server.ml
+++ b/src/server/server.ml
@@ -238,9 +238,13 @@ let exit_msg_of_exception exn msg =
 
 let run_from_daemonize ~init_id ~monitor_channels ~shared_mem_config options =
   try run ~monitor_channels ~shared_mem_config ~init_id options with
-  | SharedMem.Out_of_shared_memory as exn ->
+  | SharedMem.Out_of_shared_memory (msg, err) as exn ->
     let exn = Exception.wrap exn in
-    let msg = exit_msg_of_exception exn "Out of shared memory" in
+    let msg =
+      exit_msg_of_exception
+        exn
+        (Utils.spf "Out of shared memory: %s (%s)" msg (Unix.error_message err))
+    in
     FlowExitStatus.(exit ~msg Out_of_shared_memory)
   | SharedMem.Hash_table_full as exn ->
     let exn = Exception.wrap exn in

--- a/src/services/inference/merge_service.ml
+++ b/src/services/inference/merge_service.ml
@@ -586,8 +586,8 @@ let merge_job ~worker_mutator ~reader ~job ~options merged elements =
                );
                (Nel.hd component, ret) :: merged)
          with
-        | (SharedMem.Out_of_shared_memory | SharedMem.Heap_full | SharedMem.Hash_table_full) as exc
-          ->
+        | (SharedMem.Out_of_shared_memory _ | SharedMem.Heap_full | SharedMem.Hash_table_full) as
+          exc ->
           raise exc
         (* A catch all suppression is probably a bad idea... *)
         | unwrapped_exc ->
@@ -714,7 +714,7 @@ let check options ~reader file =
                 raise (Error_message.ECheckTimeout (run_time, file_str))))
         ~f:(fun () -> Ok (check_file options ~reader file))
     with
-    | (SharedMem.Out_of_shared_memory | SharedMem.Heap_full | SharedMem.Hash_table_full) as exc ->
+    | (SharedMem.Out_of_shared_memory _ | SharedMem.Heap_full | SharedMem.Hash_table_full) as exc ->
       raise exc
     (* A catch all suppression is probably a bad idea... *)
     | unwrapped_exc ->


### PR DESCRIPTION
Summary:
there are many places where an `Out_of_shared_memory` exception can be raised. since none of us have an M1 Mac to test on, I'm adding some additional info to the exception so that users can help us track down which C call is failing, which should help generate a minimal repro.

`Out_of_shared_memory` is never actually raised directly on Mac in `hh_shared.c`, so it must be coming from a `Failed_memfd_init` raised by `memfd_init`, which gets rethrown into an `Out_of_shared_memory`. So, also changed that one as well.

Ref https://github.com/facebook/flow/issues/8538

Differential Revision: D25964626

