### PR TITLE
Fix Windows binary: statically link libstdc++

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -237,8 +237,19 @@ NATIVE_FINDLIB_PACKAGES=\
   unix
 
 NATIVE_LIBRARIES=\
+  stdc++\
   pthread\
   $(EXTRA_LIBS)
+
+# On Windows, the linker (flexlink) handles -lfoo by searching for "libfoo",
+# then "libfoo.dll.a" (dynamic linking), then "libfoo.a". Since we don't want
+# users to have to install mingw64, we can either package the DLLs or
+# statically link them. We choose to statically link them to maintain a single
+# binary, by passing `-lfoo.a` which finds `libfoo.a` before looking (in vain)
+# for `libfoo.a.dll.a`.
+ifeq ($(UNAME_S), Windows)
+NATIVE_LIBRARIES:=$(addsuffix .a,$(NATIVE_LIBRARIES))
+endif
 
 COPIED_FLOWLIB=\
 	$(foreach lib,$(wildcard lib/*.js),_build/$(lib))
@@ -282,7 +293,7 @@ BUILT_LZ4_OBJECT_FILES=$(addprefix _build/,$(LZ4_OBJECT_FILES))
 
 FUZZY_PATH_DEPS=src/third-party/fuzzy-path/libfuzzy-path.a
 BUILT_FUZZY_PATH_DEPS=$(addprefix _build/,$(FUZZY_PATH_DEPS))
-FUZZY_PATH_LINKER_FLAGS=-cclib -lstdc++ $(FUZZY_PATH_DEPS)
+FUZZY_PATH_LINKER_FLAGS=$(FUZZY_PATH_DEPS)
 
 # Any additional C flags can be added here
 CC_FLAGS=-mcx16


### PR DESCRIPTION
The Windows binary we distribute is compiled with mingw64. The addition of C++ code in v0.143.0 caused us to start dynamically linking `libstdc++-6.dll`. this requires users to have mingw64 installed (not acceptable), or for us to package that DLL next to `flow.exe`. That's possible in theory but I couldn't get it to work correctly, and it's nice for the binary to be self-contained.

So we statically link `libstdc++` and `pthread` instead. The linker on Windows, `flexlink` from [flexdll](https://github.com/alainfrisch/flexdll), doesn't support `-static` or `-static-libstdc++` and [prefers](https://github.com/alainfrisch/flexdll/blob/1ba65c105ecf9976a663d67170b746cf3e679aa5/reloc.ml#L258-L268) the `.dll.a` dynamic interface over the `.a` static one, so I'm taking advantage of/abusing its search algorithm to resolve to `libstdc++-6.a` before `libstdc++-6.dll.a` by passing `-lstdc++.a` instead of `-lstdc++`.

Fixes #8574