### PR TITLE
[autoimports] handle node_modules

### DIFF
--- a/src/common/files.ml
+++ b/src/common/files.ml
@@ -525,30 +525,30 @@ and normalize_path_ dir names =
 
 and construct_path = List.fold_left Filename.concat
 
+let split_path =
+  let rec f acc rest =
+    let dir = Filename.dirname rest in
+    if rest = dir then
+      if Filename.is_relative dir (* True for things like ".", false for "/", "C:/" *) then
+        acc
+      (* "path/to/foo.js" becomes ["path"; "to"; "foo.js"] *)
+      else
+        match acc with
+        | [] -> [dir] (* "/" becomes ["/"] *)
+        | last_dir :: rest ->
+          (* "/path/to/foo.js" becomes ["/path"; "to"; "foo.js"] *)
+          Filename.concat dir last_dir :: rest
+    else
+      f (Filename.basename rest :: acc) dir
+  in
+  (fun path -> f [] path)
+
 (* relative_path: (/path/to/foo, /path/to/bar/baz) -> ../bar/baz
  * absolute_path (/path/to/foo, ../bar/baz) -> /path/to/bar/baz
  *
  * Both of these are designed to avoid using Path and realpath so that we don't actually read the
  * file system *)
 let (relative_path, absolute_path) =
-  let split_path =
-    let rec f acc rest =
-      let dir = Filename.dirname rest in
-      if rest = dir then
-        if Filename.is_relative dir (* True for things like ".", false for "/", "C:/" *) then
-          acc
-        (* "path/to/foo.js" becomes ["path"; "to"; "foo.js"] *)
-        else
-          match acc with
-          | [] -> [dir] (* "/" becomes ["/"] *)
-          | last_dir :: rest ->
-            (* "/path/to/foo.js" becomes ["/path"; "to"; "foo.js"] *)
-            Filename.concat dir last_dir :: rest
-      else
-        f (Filename.basename rest :: acc) dir
-    in
-    (fun path -> f [] path)
-  in
   let rec make_relative = function
     | (dir1 :: root, dir2 :: file) when dir1 = dir2 -> make_relative (root, file)
     | (root, file) -> List.fold_left (fun path _ -> Filename.parent_dir_name :: path) file root

--- a/src/common/files.mli
+++ b/src/common/files.mli
@@ -105,6 +105,8 @@ val normalize_path : string -> string -> string
 (* given a base directory and a relative path, return an absolute path *)
 val construct_path : string -> string list -> string
 
+val split_path : string -> string list
+
 val relative_path : string -> string -> string
 
 val absolute_path : string -> string -> string

--- a/src/parser_utils/package_json.ml
+++ b/src/parser_utils/package_json.ml
@@ -18,6 +18,8 @@ let ( >>= ) = Base.Result.( >>= )
 
 let empty = { name = None; main = None }
 
+let create ~name ~main = { name; main }
+
 let name package = package.name
 
 let main package = package.main

--- a/src/parser_utils/package_json.mli
+++ b/src/parser_utils/package_json.mli
@@ -11,6 +11,8 @@ type 'a t_or_error = (t, 'a * string) result
 
 val empty : t
 
+val create : name:string option -> main:string option -> t
+
 val name : t -> string option
 
 val main : t -> string option

--- a/src/services/autocomplete/autocompleteService_js.ml
+++ b/src/services/autocomplete/autocompleteService_js.ml
@@ -396,9 +396,17 @@ let flow_text_edit_of_lsp_text_edit { Lsp.TextEdit.range; newText } =
 
 let completion_item_of_autoimport
     ~options ~reader ~src_dir ~ast ~ac_loc { Export_search.name; source; kind } =
-  let options = text_edit_options options in
+  let layout_options = text_edit_options options in
   match
-    Code_action_service.text_edits_of_import ~options ~reader ~src_dir ~ast kind name source
+    Code_action_service.text_edits_of_import
+      ~options
+      ~layout_options
+      ~reader
+      ~src_dir
+      ~ast
+      kind
+      name
+      source
   with
   | None ->
     {
@@ -589,14 +597,22 @@ let autocomplete_jsx_element
   | AcResult { result; errors_to_log } ->
     if should_autoimport_react ~options ~imports ~file_sig then
       let open ServerProt.Response.Completion in
-      let options = text_edit_options options in
+      let layout_options = text_edit_options options in
       let import_edit =
         let src_dir = src_dir_of_loc (loc_of_aloc ~reader ac_loc) in
         let kind = Export_index.Namespace in
         let name = "React" in
         (* TODO: make this configurable between React and react *)
         let source = Export_index.Builtin "react" in
-        Code_action_service.text_edits_of_import ~options ~reader ~src_dir ~ast kind name source
+        Code_action_service.text_edits_of_import
+          ~options
+          ~layout_options
+          ~reader
+          ~src_dir
+          ~ast
+          kind
+          name
+          source
       in
       match import_edit with
       | None -> results

--- a/src/services/code_action/__tests__/code_action_tests.ml
+++ b/src/services/code_action/__tests__/code_action_tests.ml
@@ -7,6 +7,12 @@
 
 open OUnit2
 
+let _handle =
+  let one_gig = 1024 * 1024 * 1024 in
+  SharedMem.init
+    ~num_workers:0
+    { SharedMem.heap_size = 5 * one_gig; hash_table_pow = 19; log_level = 0 }
+
 let tests =
   "code_action"
   >::: [

--- a/src/services/code_action/code_action_service.mli
+++ b/src/services/code_action/code_action_service.mli
@@ -13,7 +13,8 @@ type text_edits = {
 }
 
 val text_edits_of_import :
-  options:Js_layout_generator.opts ->
+  options:Options.t ->
+  layout_options:Js_layout_generator.opts ->
   reader:State_reader.t ->
   src_dir:string option ->
   ast:(Loc.t, Loc.t) Flow_ast.Program.t ->
@@ -59,5 +60,10 @@ val insert_type :
   (Replacement_printer.patch, string) result Lwt.t
 
 module For_tests : sig
-  val path_of_modulename : string option -> Modulename.t -> string option
+  val path_of_modulename :
+    node_resolver_dirnames:string list ->
+    reader:State_reader.t ->
+    string option ->
+    Modulename.t ->
+    string option
 end


### PR DESCRIPTION
Summary:
when autoimporting `/a/b/node_modules/foo/bar.js` in `/a/b/c/d.js`, we should require `foo/bar`, not `../../node_modules/foo/bar`.

if `foo/package.json` has a `main` field containing `bar.js`, then just require `foo`.

if we try to import it from `/a/e.js`, then we'd require `./b/node_modules/foo/bar` because it's a child rather than an ancestor, so not part of Node's search path. likewise, from `/a/other/f.js` we'd require `../b/node_modules/foo/bar` because it's a "cousin" directory.

NOTE: for these latter cases, we should probably just not suggest that item at all. I didn't want to implement that here because it seems better to filter unreachable items before/during the search, rather than filtering the results. similarly, we shouldn't even suggest things in parent node_modules unless they're actually in your `package.json`, so that you can't implicitly depend on things that happen to be in a parent `node_modules` (this should also be true for typechecking!)

Differential Revision: D26304845

