### PR TITLE
Add dns.promises typedef to node.js

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -772,6 +772,54 @@ declare module "dns" {
     ...
   };
 
+  // Rest of this object mirrors the result types below.
+  declare type AnyResult = {
+    type: 'A' | 'AAAA' | 'CNAME' | 'MX' | 'NAPTR' | 'NS' | 'PTR' | 'SOA' | 'SRV' | 'TXT',
+    ...
+  };
+
+  declare type CaaResult = {
+    critical: number,
+    issue?: string,
+    issuewild?: string,
+    iodef?: string
+  };
+
+  declare type MxResult = {
+    priority: number,
+    exchange: string
+  };
+
+  declare type NaptrResult = {
+    flags: string,
+    service: string,
+    regexp: string,
+    replacement: string,
+    order: number,
+    preference: number
+  };
+
+  declare type SoaResult = {
+    nsName: string,
+    hostmaster: string,
+    serial: number,
+    refresh: number,
+    retry: number,
+    expire: number,
+    minttl: number
+  };
+
+  declare type SrvResult = {
+    priority: number,
+    weight: number,
+    port: number,
+    name: string
+  };
+
+  declare function cancel(): void;
+
+  declare function getServers(): Array<string>;
+
   declare function lookup(
     domain: string,
     options: number | LookupOptions,
@@ -780,6 +828,12 @@ declare module "dns" {
   declare function lookup(
     domain: string,
     callback: (err: ?Error, address: string, family: number) => void
+  ): void;
+
+  declare function lookupService(
+      address: string,
+      port: number,
+      callback: (err: ?Error, hostname: string, service: string) => void
   ): void;
 
   declare function resolve(
@@ -798,39 +852,149 @@ declare module "dns" {
     callback: (err: ?Error, addresses: Array<any>) => void
   ): void;
 
+  declare function resolveAny(
+    domain: string,
+    callback: (err: ?Error, results: Array<AnyResult>) => void
+  ): void;
+
   declare function resolveCname(
     domain: string,
-    callback: (err: ?Error, addresses: Array<any>) => void
+    callback: (err: ?Error, addresses: Array<string>) => void
+  ): void;
+
+  declare function resolveCaa(
+    domain: string,
+    callback: (err: ?Error, results: Array<CaaResult>) => void
   ): void;
 
   declare function resolveMx(
     domain: string,
-    callback: (err: ?Error, addresses: Array<any>) => void
+    callback: (err: ?Error, results: Array<MxResult>) => void
+  ): void;
+
+  declare function resolveNaptr(
+    domain: string,
+    callback: (err: ?Error, results: Array<NaptrResult>) => void
   ): void;
 
   declare function resolveNs(
     domain: string,
-    callback: (err: ?Error, addresses: Array<any>) => void
+    callback: (err: ?Error, addresses: Array<string>) => void
+  ): void;
+
+  declare function resolvePtr(
+    domain: string,
+    callback: (err: ?Error, addresses: Array<string>) => void
+  ): void;
+
+  declare function resolveSoa(
+    domain: string,
+    // Note: not an array
+    callback: (err: ?Error, result: SoaResult) => void
   ): void;
 
   declare function resolveSrv(
     domain: string,
-    callback: (err: ?Error, addresses: Array<any>) => void
+    callback: (err: ?Error, addresses: Array<SrvResult>) => void
   ): void;
 
   declare function resolveTxt(
     domain: string,
-    callback: (err: ?Error, addresses: Array<any>) => void
+    callback: (err: ?Error, addresses: Array<[string, string]>) => void
   ): void;
 
   declare function reverse(
     ip: string,
-    callback: (err: ?Error, domains: Array<any>) => void
+    callback: (err: ?Error, domains: Array<string>) => void
   ): void;
-  declare function timingSafeEqual(
-    a: Buffer | $TypedArray | DataView,
-    b: Buffer | $TypedArray | DataView
-  ): boolean;
+
+  // >= 15.1.0
+  declare function setLocalAddress(
+    ipv4?: string,
+    ipv6?: string
+  ): void;
+
+  declare function setServers(
+    servers: string[]
+  ): void
+
+  declare class DNSPromise {
+
+    getServers(): Array<string>;
+
+    lookup(
+      domain: string,
+      options?: number | LookupOptions
+    ): Promise<{address: string, family: number}>;
+
+    lookupService(
+      address: string,
+      port: number,
+    ): Promise<{hostname: string, service: string}>;
+
+    resolve(
+      domain: string,
+      rrtype?: string
+    ): Promise<Array<any>>;
+
+    resolve4(
+      domain: string,
+    ): Promise<Array<any>>;
+
+    resolve6(
+      domain: string,
+    ): Promise<Array<any>>;
+
+    resolveAny(
+      domain: string
+    ): Promise<Array<AnyResult>>;
+
+    resolveCaa(
+      domain: string,
+    ): Promise<Array<CaaResult>>;
+
+    resolveCname(
+      domain: string,
+    ): Promise<Array<string>>;
+
+    resolveMx(
+      domain: string,
+    ): Promise<Array<MxResult>>;
+
+    resolveNaptr(
+      domain: string,
+    ): Promise<Array<NaptrResult>>;
+
+    resolveNs(
+      domain: string,
+    ): Promise<Array<string>>;
+
+    resolvePtr(
+      domain: string,
+    ): Promise<Array<string>>;
+
+    resolveSoa(
+      domain: string,
+    ): Promise<SoaResult>; // Note: not an array
+
+    resolveSrv(
+      domain: string,
+    ): Promise<Array<SrvResult>>;
+
+    resolveTxt(
+      domain: string,
+    ): Promise<Array<[string, string]>>;
+
+    reverse(
+      domain: string,
+    ): Promise<Array<string>>;
+
+    setServers(
+      servers: string[]
+    ): void
+  }
+
+  declare var promises: DNSPromise;
 }
 
 declare class events$EventEmitter {

--- a/tests/node_tests/dns/dnsPromises.js
+++ b/tests/node_tests/dns/dnsPromises.js
@@ -1,0 +1,17 @@
+var dns = require("dns");
+
+/* lookup */
+async function lookup() {
+  type LookupResult = {address: string, family: number};
+
+  const result1: LookupResult = await dns.lookup("test.com");
+  const result2: LookupResult = await dns.lookup("test.com", 6);
+  const result2: LookupResult = await dns.lookup("test.com", {family: 6});
+
+  // errors
+  await dns.lookup(); // error, hostname expected
+  await dns.lookup("test.com", (err, address, family) => {}); // error, no callback expected
+  await dns.lookup("test.com", null); // second param can't be null
+}
+
+


### PR DESCRIPTION
As of Node 10, [DNS has a `dns.promises` API](https://nodejs.org/api/dns.html#dns_dns_promises_api). 

Only tricky thing about this is that `dns.promises.lookup()` resolves an object `{address: string, family: number}`.

Also added missing methods (a few were added in v10) and removed `any` types where possible.