### PR TITLE
[DOCS] Replace Haskell with Go in examples for structurally typed languages

### DIFF
--- a/website/en/docs/lang/nominal-structural.md
+++ b/website/en/docs/lang/nominal-structural.md
@@ -34,7 +34,7 @@ different names.
 
 #### Structural typing <a class="toc" id="toc-structural-typing" href="#toc-structural-typing"></a>
 
-Languages like OCaml, Haskell, and Elm have primarily structural type systems.
+Languages like OCaml, Go, and Elm have primarily structural type systems.
 
 ```js
 class Foo { method(input: string) { /* ... */ } }
@@ -44,7 +44,7 @@ let foo: Foo = new Bar(); // Works!
 ```
 
 Here you can see a pseudo-example of a structural type system passing when
-you're trying to put a Bar where a `Foo` is required because their structure is
+you're trying to put a `Bar` where a `Foo` is required because their structure is
 exactly the same.
 
 But as soon as you change the shape it will start to cause errors.


### PR DESCRIPTION
The docs list Haskell as an example of a language with a structural type system. However, Haskell has a predominantly nominal type system:
```haskell
data Foo = Foo Int
data Bar = Bar Int

a:: Foo
a = Bar 3          -- type error
```
While one could argue that there are constructs in Haskell based on structural typing rules (e.g., type classes), IMO it makes more sense to use an obvious structural type system as an example, so I replaced Haskell with Go.

References:
- https://stackoverflow.com/a/21073407 (also see the comments)