### PR TITLE
[DOCS] Correct number of flowconfig sections

### DIFF
--- a/website/en/docs/config/index.md
+++ b/website/en/docs/config/index.md
@@ -13,7 +13,7 @@ not proud of our custom format and plan to support a better format in the
 future. [GitHub issue #153](https://github.com/facebook/flow/issues/153) tracks
 this.
 
-The `.flowconfig` consists of 7 sections:
+The `.flowconfig` consists of 8 sections:
 
 * [`[declarations]`](declarations)
 * [`[include]`](include)

--- a/website/en/docs/config/index.md
+++ b/website/en/docs/config/index.md
@@ -15,7 +15,6 @@ this.
 
 The `.flowconfig` consists of 8 sections:
 
-* [`[declarations]`](declarations)
 * [`[include]`](include)
 * [`[ignore]`](ignore)
 * [`[untyped]`](untyped)
@@ -23,6 +22,7 @@ The `.flowconfig` consists of 8 sections:
 * [`[lints]`](lints)
 * [`[options]`](options)
 * [`[version]`](version)
+* [`[declarations]`](declarations)
 
 ### Comments <a class="toc" id="toc-comments" href="#toc-comments"></a>
 


### PR DESCRIPTION
<!--
  If this is a change to library defintions, please include links to relevant documentation.
  If this is a documentation change, please prefix the title with [DOCS].

  If this is neither, ensure you opened a discussion issue and link it in the PR description.
-->
Closes #8600
Also moved declarations to last of the list to match list in contents
<img width="226" alt="Screen Shot 2021-03-06 at 9 42 39 pm" src="https://user-images.githubusercontent.com/12436524/110203983-e5431280-7ec4-11eb-8608-8ba925300e45.png">

