### PR TITLE
Update ocaml to 4.10.2 for darwin-arm64 compatibility

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,7 @@ orbs:
                 PATH: /usr/local/bin:/usr/bin:/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/Wbem:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0
               command: |
                 cd /cygdrive/c/Users/circleci/project
-                [ -d _opam ] || opam switch create . ocaml-variants.4.09.1+mingw64c --deps-only --yes -vvv
+                [ -d _opam ] || opam switch create . ocaml-variants.4.10.2+mingw64c --deps-only --yes -vvv
 
 executors:
   linux-opam:
@@ -95,7 +95,7 @@ commands:
       - run:
           name: Create cache breaker
           command: |
-            echo "ocaml-4.09.1" > .circleci/opamcachebreaker
+            echo "ocaml-4.10.2" > .circleci/opamcachebreaker
             opam --version >> .circleci/opamcachebreaker
             cat flowtype.opam >> .circleci/opamcachebreaker
             cat flow_parser.opam >> .circleci/opamcachebreaker
@@ -119,7 +119,7 @@ commands:
           command: |
             eval $(opam env)
             if [ ! -d _opam ]; then
-              opam switch create . 4.09.1 --deps-only | cat
+              opam switch create . 4.10.2 --deps-only | cat
             fi
 
 jobs:
@@ -263,7 +263,7 @@ jobs:
           command: |
             cd /cygdrive/c/Users/circleci/project
             /usr/local/bin/opam --version > /cygdrive/c/tmp/flow/opamcachebreaker
-            echo "ocaml-4.09.1" >> /cygdrive/c/tmp/flow/opamcachebreaker
+            echo "ocaml-4.10.2" >> /cygdrive/c/tmp/flow/opamcachebreaker
             /usr/bin/cat flowtype.opam >> /cygdrive/c/tmp/flow/opamcachebreaker
             /usr/bin/cat flow_parser.opam >> /cygdrive/c/tmp/flow/opamcachebreaker
             /usr/bin/cat .circleci/config.yml >> /cygdrive/c/tmp/flow/opamcachebreaker

--- a/Makefile
+++ b/Makefile
@@ -326,7 +326,7 @@ all-homebrew:
 	export FLOW_RELEASE="1"; \
 	opam init --bare --no-setup --disable-sandboxing && \
 	rm -rf _opam && \
-	opam switch create . --deps-only ocaml-base-compiler.4.09.1 && \
+	opam switch create . --deps-only ocaml-base-compiler.4.10.2 && \
 	opam exec -- make
 
 clean:

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Flow-typed JavaScript can use this to generate Flow's syntax tree with annotated
 
 ## Building Flow from source
 
-Flow is written in OCaml (OCaml 4.09.1 is required).
+Flow is written in OCaml (OCaml 4.10.2 is required).
 
 1. Install [`opam`](https://opam.ocaml.org):
 

--- a/flow_parser.opam
+++ b/flow_parser.opam
@@ -10,7 +10,7 @@ license: "MIT"
 build: [ make "-C" "src/parser" "build-parser" ]
 install: [ make "-C" "src/parser" "ocamlfind-install"]
 depends: [
-  "ocaml" {>= "4.09.1"}
+  "ocaml" {>= "4.10.2"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "ppx_deriving" {build}

--- a/flowtype.opam
+++ b/flowtype.opam
@@ -8,8 +8,8 @@ homepage: "https://flow.org"
 doc: "https://flow.org/en/docs/getting-started/"
 bug-reports: "https://github.com/facebook/flow/issues"
 depends: [
-  "ocaml" {>= "4.09.1"}
-  "base" {= "v0.12.2"}
+  "ocaml" {>= "4.10.2"}
+  "base" {= "v0.14.0"}
   "base-unix"
   "base-bytes"
   "dtoa" {>= "0.3.1"}

--- a/src/codemods/utils/codemod_runner.mli
+++ b/src/codemods/utils/codemod_runner.mli
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *)
 
+[@@@ocaml.warning "-67"]
 type 'a unit_result = ('a, ALoc.t * Error_message.internal_error) result
 
 type ('a, 'ctx) abstract_visitor = (Loc.t, Loc.t) Flow_ast.Program.t -> 'ctx -> 'a

--- a/src/parser_utils/output/js_layout_generator.ml
+++ b/src/parser_utils/output/js_layout_generator.ml
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *)
 
+[@@@ocaml.warning "-60"]
 module Ast = Flow_ast
 open Layout
 

--- a/src/parser_utils/type_sig/type_sig_parse.ml
+++ b/src/parser_utils/type_sig/type_sig_parse.ml
@@ -3183,6 +3183,7 @@ let rec member_expr_of_generic_id scope locs chain =
       (val_ref scope ref_loc name)
       chain
 
+[@@@ocaml.warning "-60"]
 let declare_class_def =
   let module O = Ast.Type.Object in
   let module Acc = DeclareClassAcc in


### PR DESCRIPTION
These updates (inspired by a patch found posted by @maxsalven here: https://github.com/facebook/flow/issues/8538#issuecomment-756004548) are required to make flow compile on darwin-arm64. I tested this with Homebrew's formula - also works, allowing Homebrew users to easily build flow from source (and for Homebrew to host their own arm64 bottles) before Facebook is ready to ship arm64 binaries