### PR TITLE
extract flowlibs in server process instead of client

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -467,7 +467,7 @@ test-tool: bin/flow$(EXE)
 test: bin/flow$(EXE)
 	${MAKE} do-test
 
-js: _build/scripts/ppx_gen_flowlibs.exe $(BUILT_FUZZY_PATH_DEPS) $(BUILT_OBJECT_FILES) $(COPIED_FLOWLIB)
+js: _build/scripts/ppx_gen_flowlibs.exe $(BUILT_FUZZY_PATH_DEPS) $(BUILT_OBJECT_FILES) $(COPIED_FLOWLIB) $(COPIED_PRELUDE)
 	mkdir -p bin
 	# NOTE: temporarily disabling warning 31 because
 	# src/hack_forked/third-party/core/result.ml and the opam `result` module both define

--- a/src/commands/commandUtils.ml
+++ b/src/commands/commandUtils.ml
@@ -554,17 +554,6 @@ let remove_exclusion pattern =
     pattern
 
 let file_options =
-  let default_lib_dir ~no_flowlib tmp_dir =
-    try
-      let lib_dir = Flowlib.mkdir ~no_flowlib tmp_dir in
-      Flowlib.extract ~no_flowlib lib_dir;
-      lib_dir
-    with e ->
-      let e = Exception.wrap e in
-      let err = Exception.get_ctor_string e in
-      let msg = Printf.sprintf "Could not locate flowlib files: %s" err in
-      FlowExitStatus.(exit ~msg Could_not_extract_flowlibs)
-  in
   let ignores_of_arg root patterns extras =
     let expand_project_root_token = Files.expand_project_root_token ~root in
     let patterns = Base.List.rev_append extras patterns in
@@ -628,7 +617,7 @@ let file_options =
   fun ~root ~no_flowlib ~temp_dir ~includes ~ignores ~libs ~untyped ~declarations flowconfig ->
     let default_lib_dir =
       let no_flowlib = no_flowlib || FlowConfig.no_flowlib flowconfig in
-      Some (default_lib_dir ~no_flowlib temp_dir)
+      Some (Flowlib.libdir ~no_flowlib temp_dir)
     in
     let ignores = ignores_of_arg root (FlowConfig.ignores flowconfig) ignores in
     let untyped = ignores_of_arg root (FlowConfig.untyped flowconfig) untyped in

--- a/src/common/files.ml
+++ b/src/common/files.ml
@@ -8,7 +8,7 @@
 (************** file filter utils ***************)
 
 type options = {
-  default_lib_dir: Path.t option;
+  default_lib_dir: Flowlib.libdir option;
   ignores: (string * Str.regexp) list;
   untyped: (string * Str.regexp) list;
   declarations: (string * Str.regexp) list;
@@ -368,7 +368,9 @@ let init ?(flowlibs_only = false) (options : options) =
   let (libs, filter) =
     match options.default_lib_dir with
     | None -> (libs, is_valid_path ~options)
-    | Some root ->
+    | Some libdir ->
+      Flowlib.extract libdir;
+      let root = Flowlib.path_of_libdir libdir in
       let is_in_flowlib = is_prefix (Path.to_string root) in
       let is_valid_path = is_valid_path ~options in
       let filter path = is_in_flowlib path || is_valid_path path in

--- a/src/common/files.mli
+++ b/src/common/files.mli
@@ -8,7 +8,7 @@
 (* utilities for supported filenames *)
 
 type options = {
-  default_lib_dir: Path.t option;
+  default_lib_dir: Flowlib.libdir option;
   ignores: (string * Str.regexp) list;
   untyped: (string * Str.regexp) list;
   declarations: (string * Str.regexp) list;
@@ -19,7 +19,7 @@ type options = {
   node_resolver_dirnames: string list;
 }
 
-val default_lib_dir : options -> Path.t option
+val default_lib_dir : options -> Flowlib.libdir option
 
 val ignores : options -> (string * Str.regexp) list
 

--- a/src/flow_dot_js.ml
+++ b/src/flow_dot_js.ml
@@ -179,7 +179,6 @@ let stub_metadata ~root ~checked =
     strict_es6_import_export_excludes = [];
     strip_root = true;
     suppress_types = SSet.empty;
-    default_lib_dir = None;
     trust_mode = Options.NoTrust;
     type_asserts = false;
   }

--- a/src/flowlib/flowlib.ml
+++ b/src/flowlib/flowlib.ml
@@ -17,20 +17,43 @@ let contents no_flowlib : (string * string) array =
   else
     [%flowlib_contents]
 
-(** [mkdir ~no_flowlib parent_dir] creates a directory under [parent_dir]
+type libdir =
+  | Flowlib of Path.t
+  | Prelude of Path.t
+
+(** [libdir ~no_flowlib parent_dir] returns the directory under [parent_dir]
     within which the flowlib files will be extracted. This directory is
     named uniquely based on the flowlib contents, as well as the effective
     user ID (euid) of the current process. The euid is used to ensure that
     the directory is writable by the current user. *)
-let mkdir ~no_flowlib parent_dir =
+let libdir ~no_flowlib parent_dir =
   let euid = Unix.geteuid () in
-  let libdir = Path.concat parent_dir (Printf.sprintf "flowlib_%s_%d" (hash no_flowlib) euid) in
-  Sys_utils.mkdir_no_fail (Path.to_string parent_dir);
-  Sys_utils.mkdir_no_fail (Path.to_string libdir);
-  libdir
+  let basename = Printf.sprintf "flowlib_%s_%d" (hash no_flowlib) euid in
+  let path = Path.concat parent_dir basename in
+  if no_flowlib then
+    Prelude path
+  else
+    Flowlib path
+
+let path_of_libdir = function
+  | Prelude path -> path
+  | Flowlib path -> path
+
+let mkdir libdir =
+  let path = path_of_libdir libdir |> Path.to_string in
+  let parent_dir = Filename.dirname path in
+  Sys_utils.mkdir_no_fail parent_dir;
+  Sys_utils.mkdir_no_fail path
 
 let write_flowlib dir (filename, contents) =
   let file = Path.(concat dir filename |> to_string) in
   Sys_utils.write_file ~file contents
 
-let extract ~no_flowlib dir = Array.iter (write_flowlib dir) (contents no_flowlib)
+let extract libdir =
+  mkdir libdir;
+  let (path, no_flowlib) =
+    match libdir with
+    | Prelude path -> (path, true)
+    | Flowlib path -> (path, false)
+  in
+  Array.iter (write_flowlib path) (contents no_flowlib)

--- a/src/flowlib/flowlib.mli
+++ b/src/flowlib/flowlib.mli
@@ -5,6 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  *)
 
-val mkdir : no_flowlib:bool -> Path.t -> Path.t
+type libdir
 
-val extract : no_flowlib:bool -> Path.t -> unit
+val libdir : no_flowlib:bool -> Path.t -> libdir
+
+val path_of_libdir : libdir -> Path.t
+
+val extract : libdir -> unit

--- a/src/services/saved_state/saved_state.ml
+++ b/src/services/saved_state/saved_state.ml
@@ -264,8 +264,8 @@ end = struct
   let is_not_in_flowlib ~options =
     match (Options.file_options options).Files.default_lib_dir with
     | None -> (fun _ -> true) (* There are no flowlibs *)
-    | Some root ->
-      let root_str = Path.to_string root in
+    | Some libdir ->
+      let root_str = libdir |> Flowlib.path_of_libdir |> Path.to_string in
       (fun f -> not (Files.is_prefix root_str f))
 
   let normalize_error_set ~normalizer = Flow_error.ErrorSet.map (normalize_error ~normalizer)

--- a/src/typing/context.ml
+++ b/src/typing/context.ml
@@ -59,7 +59,6 @@ type metadata = {
   strip_root: bool;
   suppress_types: SSet.t;
   max_workers: int;
-  default_lib_dir: Path.t option;
   trust_mode: Options.trust_mode;
   type_asserts: bool;
 }
@@ -248,7 +247,6 @@ let metadata_of_options options =
     strict_es6_import_export_excludes = Options.strict_es6_import_export_excludes options;
     strip_root = Options.should_strip_root options;
     suppress_types = Options.suppress_types options;
-    default_lib_dir = (Options.file_options options).Files.default_lib_dir;
     trust_mode = Options.trust_mode options;
     type_asserts = Options.type_asserts options;
   }
@@ -528,8 +526,6 @@ let should_munge_underscores cx = cx.metadata.munge_underscores
 let should_strip_root cx = cx.metadata.strip_root
 
 let suppress_types cx = cx.metadata.suppress_types
-
-let default_lib_dir cx = cx.metadata.default_lib_dir
 
 let type_asserts_map cx = cx.ccx.type_asserts_map
 

--- a/src/typing/context.mli
+++ b/src/typing/context.mli
@@ -85,7 +85,6 @@ type metadata = {
   strip_root: bool;
   suppress_types: SSet.t;
   max_workers: int;
-  default_lib_dir: Path.t option;
   trust_mode: Options.trust_mode;
   type_asserts: bool;
 }
@@ -273,8 +272,6 @@ val should_munge_underscores : 'phase t_ -> bool
 val should_strip_root : 'phase t_ -> bool
 
 val suppress_types : 'phase t_ -> SSet.t
-
-val default_lib_dir : 'phase t_ -> Path.t option
 
 val trust_mode : 'phase t_ -> Options.trust_mode
 


### PR DESCRIPTION
Summary:
the `flow start` command extracts libs and concurrent `flow start` calls can cause the libs to be missing or partially written when the server is starting up, leading to errors in lib files.

instead, the libs should be extracted in `flow server`.

### Background

the `flow` binary has all of its libs built into itself, and writes them to `/tmp/flow/flowlib_<hash>_<uid>` via the `Flowlib.extract` function.

currently this function is called by `CommandUtils.file_options` which is called by the `server`, `check`, `start`, and `ls` commands.

`server` and `check` make sense -- these commands actually need to read the libs and do typechecking. `start` and `ls` are client commands. they can run multiple times throughout the life of the server.

it's even expected that two `flow start` calls might race. they both call `flow server` and then the server uses `Lock` to make sure only one actually starts; the other exits with `Lock_stolen` exit code and whoever called `flow start` can go ahead and connect to the now-already-running server.

however! these two racing `flow start` calls means that if we're unlucky, the 2nd one can be in the process of re-extracting the flowlibs when the newly-started `flow server` process is trying to read them. this causes the server to have missing-lib errors that can't be resolved without `flow stop`.

### Fix

We only need the path to the libs in `flow start`. they don't need to be extracted yet. Instead, the server can extract them just before it needs to list them, in `files.ml`.

### Future work

The only reason we need the path to the libs in `flow start` is because it's part of `Options.t`, and the only reason for that is that it depends on the `--no-flowlib` flag. I think we could just store `no_flowlib` in `Options` and only care about the path in the server. I wanted to keep this minimally invasive to merge it, so let's follow up on that.

Differential Revision: D27136789

