### PR TITLE
fix: module specifier for react in lowercase

### DIFF
--- a/src/services/code_action/insert_type_imports.ml
+++ b/src/services/code_action/insert_type_imports.ml
@@ -545,7 +545,7 @@ end = struct
              * use `import type { ... } from 'react'` and hard-code the module string
              * here. *)
             if is_react_file_key remote_source then
-              Modulename.String "React"
+              Modulename.String "react"
             else if is_react_redux_file_key remote_source then
               Modulename.String "react-redux"
             else


### PR DESCRIPTION
The module specifier that the annotate-exports codemod adds for react is with a capital `R`. This does not seem to work.