### PR TITLE
Fix the dune build (remove extraneous module)

### DIFF
--- a/src/heap/dune
+++ b/src/heap/dune
@@ -24,8 +24,7 @@
   (wrapped false)
   (modules
     prefix
-    sharedMem
-    value)
+    sharedMem)
   (preprocess (pps ppx_deriving.std visitors.ppx))
   (libraries
     heap_libc


### PR DESCRIPTION
The module `value` in `src/heap` doesn't exist. This makes the dune build work again for the parser.