### PR TITLE
update ppx_gen_flowlibs to ppxlib

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -409,7 +409,7 @@ _build/scripts/ppx_gen_flowlibs/ppx_gen_flowlibs_standalone.cmxa: scripts/ppx_ge
 
 _build/scripts/ppx_gen_flowlibs.exe: $(BUILT_LZ4_OBJECT_FILES) _build/src/common/xx/xx_stubs.o _build/scripts/ppx_gen_flowlibs/ppx_gen_flowlibs.cmxa _build/scripts/ppx_gen_flowlibs/ppx_gen_flowlibs_standalone.cmxa
 	ocamlfind ocamlopt -linkpkg -linkall \
-		-package ocaml-migrate-parsetree,unix \
+		-package ppxlib,unix \
 		-I _build/scripts/ppx_gen_flowlibs \
 		-ccopt "$(BUILT_LZ4_OBJECT_FILES) _build/src/common/xx/xx_stubs.o" \
 		_build/scripts/ppx_gen_flowlibs/ppx_gen_flowlibs.cmxa \

--- a/_tags
+++ b/_tags
@@ -1,6 +1,6 @@
 <**/*.ml*>: ocaml, warn_A, warn(-4-6-29-35-42-44-48-50), warn_error_A, safe_string
 (not <src/parser/**>) or <src/parser/test/**>: package(base), package(ppx_deriving), package(ppx_deriving.eq), package(ppx_deriving.iter), package(ppx_deriving.map), package(ppx_deriving.ord), package(ppx_deriving.show), package(dtoa), package(wtf8), package(visitors.runtime), package(sedlex.ppx)
-<scripts/ppx_gen_flowlibs/**>: package(ocaml-migrate-parsetree)
+<scripts/ppx_gen_flowlibs/**>: package(ppxlib)
 <**/__tests__/**>: package(ounit2)
 <hack/heap/*.ml*>: warn(-27-34)
 <hack/third-party/core/result.ml>: warn(-41)

--- a/flow_parser.opam
+++ b/flow_parser.opam
@@ -15,7 +15,7 @@ depends: [
   "ocamlbuild" {build}
   "ppx_deriving" {build}
   "ppx_gen_rec" {build}
-  "sedlex" {= "2.1"}
+  "sedlex" {>= "2.1"}
   "wtf8"
 ]
 dev-repo: "git+https://github.com/facebook/flow.git"

--- a/flowtype.opam
+++ b/flowtype.opam
@@ -9,22 +9,21 @@ doc: "https://flow.org/en/docs/getting-started/"
 bug-reports: "https://github.com/facebook/flow/issues"
 depends: [
   "ocaml" {>= "4.09.1"}
-  "base" {= "v0.12.2"}
+  "base" {>= "v0.12.2"}
   "base-unix"
   "base-bytes"
   "dtoa" {>= "0.3.1"}
   "ocamlbuild" {build}
   "ocamlfind" {build}
-  "ocaml-migrate-parsetree" {build}
   "ounit2" {with-test}
-  "sedlex" {= "2.1"}
+  "sedlex" {>= "2.1"}
   "lwt" {>= "4.5.0" & < "5.0.0"}
   "lwt_log" {>= "1.1.0"}
-  "lwt_ppx" {>= "1.2.4" < "2.0.0"}
+  "lwt_ppx"
+  "ppxlib"
   "ppx_let" {>= "0.11.0"}
   "ppx_deriving" {build}
   "ppx_gen_rec" {build}
-  "ppx_tools_versioned" {build}
   "visitors" {build}
   "wtf8"
 ]

--- a/scripts/_tags
+++ b/scripts/_tags
@@ -1,2 +1,0 @@
-true: safe_string
-<ppx_gen_rec.*>: package(compiler-libs.common)

--- a/scripts/ppx_gen_flowlibs/dune
+++ b/scripts/ppx_gen_flowlibs/dune
@@ -1,6 +1,6 @@
 (library
   (name ppx_gen_flowlibs)
   (modules ppx_gen_flowlibs)
-  (libraries flow_script_utils ocaml-migrate-parsetree xx)
+  (libraries flow_script_utils ppxlib xx)
   (kind ppx_rewriter)
 )

--- a/scripts/ppx_gen_flowlibs/ppx_gen_flowlibs_standalone.ml
+++ b/scripts/ppx_gen_flowlibs/ppx_gen_flowlibs_standalone.ml
@@ -5,6 +5,4 @@
  * LICENSE file in the root directory of this source tree.
  *)
 
-open Migrate_parsetree
-
-let () = Driver.run_main ()
+let () = Ppxlib.Driver.standalone ()

--- a/src/hack_forked/_tags
+++ b/src/hack_forked/_tags
@@ -9,7 +9,6 @@ true: package(unix),package(str),package(bigarray),package(ppx_deriving.std)
 <heap/*.ml*>: warn(-27-34)
 <naming/*.ml*>: warn(-27-45)
 <parsing/*.ml*>: warn(-27)
-<ppx/*.ml*>: package(ocaml-migrate-parsetree)
 <ppx>: -traverse
 <procs/*.ml*>: warn(-27)
 <server/serverInit.ml>: warn(-41-45)


### PR DESCRIPTION
Summary:
upgrades to `ppxlib`, the new hotness instead of `ppx_tools_versioned` and the `ocaml-migrate-parsetree` driver.

this unblocks upgrading `ppx_gen_rec` because that will require `ppxlib >= 0.18` which is incompatible with `ocaml-migrate-parsetree < 2.0` which we were depending on via `ppx_tools_versioned`.

Differential Revision: D27840712

