### PR TITLE
Add Utility types for `Pick` and `Omit`

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -2553,3 +2553,6 @@ declare var Atomics: {
   +[key: $SymbolToStringTag]: 'Atomics',
   ...
 };
+                             
+type $Pick<T: {...}, P: {...}> = $Exact<$ObjMapi<$Exact<P>, <K>(K) => $ElementType<T, K>>>;
+type $Omit<T: {...}, P: {...}> = $Exact<$Rest<T, $ReadOnly<$Exact<P>>>>;


### PR DESCRIPTION
These are common utility function people reach for, but Flow doesn't have them. The $Omit function is a bit redundant as you achieve the same thing by using $Rest directly, but the implementation here takes care of some things people tend to forget (making the second object $ReadOnly so you don't need the exact value types)