### PR TITLE
Handle function type in useState

### DIFF
--- a/lib/react.js
+++ b/lib/react.js
@@ -337,15 +337,10 @@ declare module react {
 
   declare export function useContext<T>(context: React$Context<T>): T;
     
-  type NonFunctions = number | boolean | Object | string | null | void | Array<NonFunctions>;
-
-  declare export function useState<S: NonFunctions>(
-    initialState: (() => S) | S,
-  ): [S, ((S => S) | S) => void];
-  
-  declare export function useState<S: Function>(
-    initialState: (() => S),
-  ): [S, ((S => S)) => void];
+  declare type NonFunctions = number | boolean | Object | string | null | void | Array<NonFunctions>;
+  declare var useState:
+    & (<S: NonFunctions>(initialState: (() => S) | S) => [S, ((S => S) | S) => void])
+    & (<S: Function>(initialState: (() => S)) => [S, ((S => S)) => void]);
 
   declare type Dispatch<A> = (A) => void;
 

--- a/lib/react.js
+++ b/lib/react.js
@@ -336,10 +336,16 @@ declare module react {
   declare type MaybeCleanUpFn = void | (() => void);
 
   declare export function useContext<T>(context: React$Context<T>): T;
+    
+  type NonFunctions = number | boolean | Object | string | null | void | Array<NonFunctions>;
 
-  declare export function useState<S>(
+  declare export function useState<S: NonFunctions>(
     initialState: (() => S) | S,
   ): [S, ((S => S) | S) => void];
+  
+  declare export function useState<S: Function>(
+    initialState: (() => S),
+  ): [S, ((S => S)) => void];
 
   declare type Dispatch<A> = (A) => void;
 


### PR DESCRIPTION
This is not the most straightforward thing, but it does catch an edge case where the types allow incorrect behaviour the state value type is itself a function.

Context: https://flow.org/try/#0JYWwDg9gTgLgBAbwK4GcCmBlGBDGaC+cAZlBCHAORRrYDGMFA3AFDO0QB2K8A2t7mgA0cdDCwCAunAC8cVJhx4APAH4AFNyjAOAcwCU0gHwckAG1OG1J83pbNR4vGrUB9GAC4RMLboPGzprbMQA

This uses the overload type syntax. Hopefully that works correctly?