### PR TITLE
Add dune target for flow_exit and fuzzy_path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@ npm-debug.log
 /tests/*/*.err
 *.swp
 *.swo
+*.o
+*.a
 flow.odocl
 flow.docdir
 *~
@@ -21,6 +23,8 @@ flow.docdir
 /flowlib.rc
 .merlin
 /test-results
-
+*.log
+*.cache
+.vscode/
 # This is an alias of flow-remove-types that we generate during publishing
 /packages/flow-node

--- a/dune
+++ b/dune
@@ -1,5 +1,5 @@
 (env
   (_
-    (flags (:standard -w @a-4-6-20-29-35-41-42-44-45-48-50 ))
+    (flags (:standard -w @a-4-6-20-29-35-41-42-44-45-48-50 -error-style short ))
   )
 )

--- a/dune-project
+++ b/dune-project
@@ -1,1 +1,1 @@
-(lang dune 1.9)
+(lang dune 2.8)

--- a/src/common/exit/dune
+++ b/src/common/exit/dune
@@ -1,0 +1,7 @@
+(library
+  (name flow_exit)
+  (wrapped false)
+  (libraries
+    flow_exit_status
+  )
+)

--- a/src/common/xx/dune
+++ b/src/common/xx/dune
@@ -1,7 +1,7 @@
 (library
   (name xx)
   (wrapped false)
-  (c_names xx_stubs)
+  (foreign_stubs (language c) (names xx_stubs))
   (libraries lz4)
 )
 

--- a/src/hack_forked/find/dune
+++ b/src/hack_forked/find/dune
@@ -2,8 +2,8 @@
   (name find_libc)
   (wrapped false)
   (modules)
-  (c_names
-    hh_readdir))
+  (foreign_stubs
+    (language c ) (names hh_readdir)))
 
 (library
   (name find)

--- a/src/hack_forked/fsevents/dune
+++ b/src/hack_forked/fsevents/dune
@@ -1,8 +1,8 @@
 (library
   (name fsevents)
   (wrapped false)
-  (c_names
-    fsevents_stubs)
+  (foreign_stubs (language c) (names
+    fsevents_stubs))
   (c_library_flags
     -framework CoreServices
     -framework CoreFoundation)

--- a/src/hack_forked/fsnotify_win/dune
+++ b/src/hack_forked/fsnotify_win/dune
@@ -1,7 +1,7 @@
 (library
-  (name fsnotify_Windows)
-  (wrapped false)
-  (c_names
-    fsnotify_stubs)
-  (libraries
-    utils_core))
+ (name fsnotify_Windows)
+ (wrapped false)
+ (foreign_stubs
+  (language c)
+  (names fsnotify_stubs))
+ (libraries utils_core))

--- a/src/hack_forked/third-party/inotify/dune
+++ b/src/hack_forked/third-party/inotify/dune
@@ -1,5 +1,6 @@
 (library
-  (name inotify)
-  (wrapped false)
-  (c_names
-    inotify_stubs))
+ (name inotify)
+ (wrapped false)
+ (foreign_stubs
+  (language c)
+  (names inotify_stubs)))

--- a/src/hack_forked/utils/core/dune
+++ b/src/hack_forked/utils/core/dune
@@ -1,19 +1,14 @@
 (copy_files ../../../../scripts/get_build_id_gen.c)
 
 (library
-  (name utils_core)
-  (wrapped false)
-  (c_names
-    get_build_id
-    get_build_id_gen)
-  (c_flags (:standard
-    (:include config/build-timestamp-opt)))
-  (libraries
-    base
-    string
-    imported_core
-    hh_json
-    str
-    unix)
-  (preprocess
-    (pps lwt_ppx ppx_deriving.std ppx_deriving.enum)))
+ (name utils_core)
+ (wrapped false)
+ (foreign_stubs
+  (language c)
+  (names get_build_id get_build_id_gen)
+  (flags
+   (:standard
+    (:include config/build-timestamp-opt))))
+ (libraries base string imported_core hh_json str unix)
+ (preprocess
+  (pps lwt_ppx ppx_deriving.std ppx_deriving.enum)))

--- a/src/hack_forked/utils/sys/dune
+++ b/src/hack_forked/utils/sys/dune
@@ -1,19 +1,16 @@
 (library
-  (name sys_utils)
-  (wrapped false)
-  (libraries
-    collections
-    disk
-    str
-    unix
-    utils_core)
-  (c_names
-    files
-    gc_profiling
-    getrusage
-    handle_stubs
-    nproc
-    priorities
-    processor_info
-    realpath
-    sysinfo))
+ (name sys_utils)
+ (wrapped false)
+ (libraries collections disk str unix utils_core)
+ (foreign_stubs
+  (language c)
+  (names
+   files
+   gc_profiling
+   getrusage
+   handle_stubs
+   nproc
+   priorities
+   processor_info
+   realpath
+   sysinfo)))

--- a/src/heap/dune
+++ b/src/heap/dune
@@ -1,44 +1,36 @@
 (library
-  (name heap_libc)
-  (wrapped false)
-  (modules)
-  (c_names
-    hh_shared)
-  (c_flags (:standard -I../../src/third-party/lz4))
-  (preprocess (pps ppx_deriving.std visitors.ppx))
-  (libraries
-    utils_core))
+ (name heap_libc)
+ (wrapped false)
+ (modules)
+ (foreign_stubs
+  (language c)
+  (names hh_shared)
+  (flags
+   (:standard -I../../src/third-party/lz4)))
+ (preprocess
+  (pps ppx_deriving.std visitors.ppx))
+ (libraries utils_core))
 
 (library
-  (name heap_ident)
-  (wrapped false)
-  (modules
-    ident)
-  (libraries
-    collections
-    heap_libc)
-  (preprocess (pps ppx_deriving.std visitors.ppx)))
+ (name heap_ident)
+ (wrapped false)
+ (modules ident)
+ (libraries collections heap_libc)
+ (preprocess
+  (pps ppx_deriving.std visitors.ppx)))
 
 (library
-  (name heap_shared_mem)
-  (wrapped false)
-  (modules
-    prefix
-    sharedMem)
-  (preprocess (pps ppx_deriving.std visitors.ppx))
-  (libraries
-    heap_libc
-    logging_common
-    utils_core
-    worker_cancel))
+ (name heap_shared_mem)
+ (wrapped false)
+ (modules prefix sharedMem)
+ (preprocess
+  (pps ppx_deriving.std visitors.ppx))
+ (libraries heap_libc logging_common utils_core worker_cancel))
 
 (library
-  (name worker_cancel)
-  (wrapped false)
-  (modules
-    workerCancel)
-  (preprocess (pps ppx_deriving.std visitors.ppx))
-  (libraries
-    heap_libc
-    utils_core))
-
+ (name worker_cancel)
+ (wrapped false)
+ (modules workerCancel)
+ (preprocess
+  (pps ppx_deriving.std visitors.ppx))
+ (libraries heap_libc utils_core))

--- a/src/services/saved_state/compression/dune
+++ b/src/services/saved_state/compression/dune
@@ -1,6 +1,7 @@
 (library
-  (name flow_service_saved_state_compression)
-  (wrapped false)
-  (c_names saved_state_compression_stubs)
-  (libraries lz4)
-)
+ (name flow_service_saved_state_compression)
+ (wrapped false)
+ (foreign_stubs
+  (language c)
+  (names saved_state_compression_stubs))
+ (libraries lz4))

--- a/src/third-party/fuzzy-path/Makefile
+++ b/src/third-party/fuzzy-path/Makefile
@@ -1,0 +1,22 @@
+
+ifeq ($(OS), Windows_NT)
+  CXX:=x86_64-w64-mingw32-g++
+  AR:=x86_64-w64-mingw32-gcc-ar
+endif
+
+OCAML_INCLUDES := $(shell ocamlc 2>/dev/null -where || echo /usr/local/lib/ocaml)
+
+CFLAGS= -I $(OCAML_INCLUDES)
+
+CXXFLAGS=-std=c++11 -Wall -O3 
+
+libfuzzy-path.a: src/fuzzy_path_stubs.o src/fuzzy_path_wrapper.o vendor/MatcherBase.o vendor/score_match.o
+	$(AR) $(ARFLAGS) $@ $^
+clean:
+	rm  -rf *.o *.a src/*.o vendor/*.o
+
+# Those deps are listed manually since they rarely changed
+vendor/MatcherBase.o : vendor/MatcherBase.cpp vendor/MatcherBase.h vendor/score_match.h	
+vendor/score_match.o : vendor/score_match.cpp vendor/score_match.h
+src/fuzzy_path_wrapper.o : src/fuzzy_path_wrapper.cpp src/fuzzy_path_wrapper.h vendor/MatcherBase.h
+src/fuzzy_path_stubs.o : src/fuzzy_path_stubs.c src/fuzzy_path_wrapper.h

--- a/src/third-party/fuzzy-path/dune
+++ b/src/third-party/fuzzy-path/dune
@@ -1,0 +1,8 @@
+(rule
+ (targets libfuzzy-path.a)
+ (deps
+  (source_tree .))
+ (action
+  (no-infer
+   (progn
+    (run make libfuzzy-path.a)))))

--- a/src/third-party/fuzzy-path/src/dune
+++ b/src/third-party/fuzzy-path/src/dune
@@ -1,0 +1,6 @@
+(library 
+ (name fuzzy_path)
+ (wrapped false)
+ (foreign_archives ../fuzzy-path)
+ (c_library_flags -lstdc++)
+)

--- a/src/third-party/fuzzy-path/test/dune
+++ b/src/third-party/fuzzy-path/test/dune
@@ -1,0 +1,4 @@
+(executable
+ (name test)
+ (libraries fuzzy_path ounit)
+ )

--- a/src/third-party/lz4/dune
+++ b/src/third-party/lz4/dune
@@ -1,5 +1,6 @@
 (library
-  (name lz4)
-  (preprocess no_preprocessing)
-  (c_names lz4 lz4frame lz4hc xxhash)
-)
+ (name lz4)
+ (preprocess no_preprocessing)
+ (foreign_stubs
+  (language c)
+  (names lz4 lz4frame lz4hc xxhash)))


### PR DESCRIPTION
<!--
  If this is a change to library defintions, please include links to relevant documentation.
  If this is a documentation change, please prefix the title with [DOCS].

  If this is neither, ensure you opened a discussion issue and link it in the PR description.
-->
This commits added missing target for flow_exit and fuzzy_path, this is a safe PR that should not 
break any existing workflow, the first five commits are self-explained, the real meat is the last one.

The first target `flow_exit` is trivial since it is pure ocaml libs. 
The second one is a bit tricky since it depends on stubs written in both C and C++, it is in the last commit.

To avoid breaking other build systems, e.g, ocamlbuild. I tried to avoid moving source code, this could certainly be improved if we are okay to move files around later. 

So we treat the src/third-party/fuzzy-path C++ stubs as a sandbox in dune, it is specified in `src/third-party/fuzz-path/Makefile`, in `src/third-party/fuzz-path/dune` we tell dune how to build the foreign stubs.

After that it is easy to refer it as `foreign_archives`, see `src/third-party/fuzzy-path/src/dune`, since we have C++ stubs, so make sure `-lstdc++` is added in c_library_flags.

After all the work, fuzzy_path is just a plain library that can be used everywhere, see `src/third-party/fuzzy-path/test/dune`

# How to test it?

```
flow$dune --version
2.8.5
flow$dune build src/third-party/fuzzy-path/
        make src/third-party/fuzzy-path/libfuzzy-path.a
cc -I /**/***/ocaml   -c -o src/fuzzy_path_stubs.o src/fuzzy_path_stubs.c
c++ -std=c++11 -Wall -O3    -c -o src/fuzzy_path_wrapper.o src/fuzzy_path_wrapper.cpp
c++ -std=c++11 -Wall -O3    -c -o vendor/MatcherBase.o vendor/MatcherBase.cpp
c++ -std=c++11 -Wall -O3    -c -o vendor/score_match.o vendor/score_match.cpp
ar rv libfuzzy-path.a src/fuzzy_path_stubs.o src/fuzzy_path_wrapper.o vendor/MatcherBase.o vendor/score_match.o
ar: creating archive libfuzzy-path.a
a - src/fuzzy_path_stubs.o
a - src/fuzzy_path_wrapper.o
a - vendor/MatcherBase.o
a - vendor/score_match.o
flow$dune build src/third-party/fuzzy-path/test
flow$dune exec src/third-party/fuzzy-path/test/test.exe
......                  
Ran: 6 tests in: 0.11 seconds.
OK
```

# fuzzy-path in REPL

As a bonus, you can build the toplevel and play with fuzzy_path interactively:

```
dune utop src/third-paty/fuzzy-path
```

<img width="910" alt="Screenshot 2021-06-09 at 11 43 19 AM" src="https://user-images.githubusercontent.com/747051/121289656-e64a6c80-c917-11eb-9102-452af01a45e2.png">
