### PR TITLE
Update lib/bom.js to have the getInstalledRelatedApps type

### DIFF
--- a/lib/bom.js
+++ b/lib/bom.js
@@ -256,10 +256,6 @@ declare class NavigatorConcurrentHardware {
     +hardwareConcurrency: number;
 }
 
-declare class NavigatorGetInstalledRelatedApps {
-  
-}
-
 declare class Navigator mixins
   NavigatorID,
   NavigatorLanguage,

--- a/lib/bom.js
+++ b/lib/bom.js
@@ -256,6 +256,10 @@ declare class NavigatorConcurrentHardware {
     +hardwareConcurrency: number;
 }
 
+declare class NavigatorGetInstalledRelatedApps {
+  
+}
+
 declare class Navigator mixins
   NavigatorID,
   NavigatorLanguage,
@@ -309,6 +313,13 @@ declare class Navigator mixins
     // Gecko
     taintEnabled?: () => false;
     oscpu: string;
+
+    // Chrome v0.70+
+    getInstalledRelatedApps?: $ReadOnlyArray<{
+      +platform: string,
+      +id: string
+      +url?: string
+    }>;
 }
 
 declare class Clipboard extends EventTarget {


### PR DESCRIPTION
[W3C GetInstalledRelatedApps definition](https://wicg.github.io/get-installed-related-apps/spec/) 

[CanIUse for getInstalledRelatedApps](https://caniuse.com/?search=getInstalledRelatedApps)

[WebDEV tutorial on the getInstalledRelatedApps](https://web.dev/get-installed-related-apps/)

I wasn't able to build the flow binary due to some know issues apparently but hopefully this PR is simple enough to be read
- flow_parser can not be installed correctly using opam 2.0 #7110 