### PR TITLE
Represent shmem addrs as byte offsets into a char bigarray

### DIFF
--- a/src/heap/hh_shared.c
+++ b/src/heap/hh_shared.c
@@ -339,20 +339,6 @@ static _Bool should_scan(hh_tag_t tag) {
 // offset instead.
 #define Obj_field(addr, i) ((addr) + ((i) + 1) * WORD_SIZE)
 
-// In OCaml, we can read and write to shared memory by either (a) calling into C
-// functions, passing along an address or by (b) indexing into a Bigarray with
-// the "nativeint" element kind.
-//
-// The Bigarray API naturally requires word offsets for indexing operations into
-// word-sized elements. To accomplish this, we convert between byte offsets and
-// OCaml-encoded word offsets when passing address from C into OCaml, and vice
-// versa.
-//
-// Use these macros instead of Val_long/Long_val when dealing with addrs across
-// the OCaml/C boundary.
-#define Val_addr(addr) (Val_long((addr) / WORD_SIZE))
-#define Addr_val(v) (Long_val(v) * WORD_SIZE)
-
 // Each heap entry starts with a word-sized header. The header encodes the size
 // (in words) of the entry in the heap and the capacity (in words) of the buffer
 // needed to decompress the entry.
@@ -742,8 +728,8 @@ static void define_mappings(int page_bsize) {
 static value alloc_heap_bigarray(void) {
   CAMLparam0();
   CAMLlocal1(heap);
-  int heap_flags = CAML_BA_NATIVE_INT | CAML_BA_C_LAYOUT | CAML_BA_EXTERNAL;
-  intnat heap_dim[1] = {Wsize_bsize(info->hashtbl_bsize + info->heap_bsize)};
+  int heap_flags = CAML_BA_CHAR | CAML_BA_C_LAYOUT | CAML_BA_EXTERNAL;
+  intnat heap_dim[1] = {info->hashtbl_bsize + info->heap_bsize};
   heap = caml_ba_alloc(heap_flags, 1, hashtbl, heap_dim);
   CAMLreturn(heap);
 }
@@ -1397,7 +1383,7 @@ static addr_t hh_alloc(size_t wsize) {
 CAMLprim value hh_ml_alloc(value wsize) {
   CAMLparam1(wsize);
   addr_t addr = hh_alloc(Long_val(wsize));
-  CAMLreturn(Val_addr(addr));
+  CAMLreturn(Val_long(addr));
 }
 
 /*****************************************************************************/
@@ -1494,7 +1480,7 @@ CAMLprim value hh_store_ocaml(value v) {
   free(compressed);
 
   result = caml_alloc_tuple(3);
-  Store_field(result, 0, Val_addr(Addr_of_ptr(entry)));
+  Store_field(result, 0, Val_long(Addr_of_ptr(entry)));
   Store_field(result, 1, Val_long(compressed_size));
   Store_field(result, 2, Val_long(serialized_size));
 
@@ -1539,7 +1525,7 @@ CAMLprim value hh_add(value key, value addr) {
 
   helt_t elt;
   elt.hash = get_hash(key);
-  elt.addr = Addr_val(addr);
+  elt.addr = Long_val(addr);
 
   size_t hashtbl_slots = info->hashtbl_slots;
   unsigned int slot = elt.hash & (hashtbl_slots - 1);
@@ -1661,7 +1647,7 @@ CAMLprim value hh_deserialize(value addr_val) {
   CAMLlocal1(result);
   check_should_exit();
 
-  heap_entry_t *entry = Entry_of_addr(Addr_val(addr_val));
+  heap_entry_t *entry = Entry_of_addr(Long_val(addr_val));
   size_t compressed_bsize = entry_compressed_bsize(entry);
   size_t decompress_capacity = Entry_decompress_capacity(entry->header);
 
@@ -1689,7 +1675,7 @@ CAMLprim value hh_get(value key) {
 
   unsigned int slot = find_slot(key);
   assert(hashtbl[slot].hash == get_hash(key));
-  CAMLreturn(Val_addr(hashtbl[slot].addr));
+  CAMLreturn(Val_long(hashtbl[slot].addr));
 }
 
 /*****************************************************************************/
@@ -1697,7 +1683,7 @@ CAMLprim value hh_get(value key) {
 /*****************************************************************************/
 CAMLprim value hh_get_size(value addr_val) {
   CAMLparam1(addr_val);
-  heap_entry_t *entry = Entry_of_addr(Addr_val(addr_val));
+  heap_entry_t *entry = Entry_of_addr(Long_val(addr_val));
   size_t compressed_bsize = entry_compressed_bsize(entry);
   CAMLreturn(Val_long(compressed_bsize));
 }
@@ -1769,7 +1755,7 @@ CAMLprim value hh_remove(value key) {
 /*****************************************************************************/
 
 CAMLprim value hh_write_string(value addr, value s) {
-  memcpy(Ptr_of_addr(Addr_val(addr)), String_val(s), Bosize_val(s));
+  memcpy(Ptr_of_addr(Long_val(addr)), String_val(s), Bosize_val(s));
   return Val_unit;
 }
 
@@ -1784,6 +1770,6 @@ CAMLprim value hh_read_string(value addr, value wsize) {
   CAMLparam2(addr, wsize);
   CAMLlocal1(s);
   s = caml_alloc(Long_val(wsize), String_tag);
-  memcpy(String_val(s), Ptr_of_addr(Addr_val(addr)), Bsize_wsize(Long_val(wsize)));
+  memcpy(String_val(s), Ptr_of_addr(Long_val(addr)), Bsize_wsize(Long_val(wsize)));
   CAMLreturn(s);
 }

--- a/src/heap/sharedMem.ml
+++ b/src/heap/sharedMem.ml
@@ -23,7 +23,7 @@ type table_stats = {
   slots: int;
 }
 
-type heap = (nativeint, Bigarray.nativeint_elt, Bigarray.c_layout) Bigarray.Array1.t
+type heap = (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t
 
 (* Phantom type parameter provides type-safety to callers of this API.
  * Internally, these are all just ints, so be careful! *)
@@ -818,8 +818,6 @@ struct
 end
 
 module NewAPI = struct
-  open Bigarray
-
   type chunk = {
     heap: heap;
     mutable next_addr: int;
@@ -860,6 +858,10 @@ module NewAPI = struct
 
   type size = int
 
+  let bsize_wsize bsize = bsize * Sys.word_size / 8
+
+  let addr_offset addr size = addr + bsize_wsize size
+
   let get_heap () =
     match !heap_ref with
     | None -> failwith "get_heap: not connected"
@@ -873,7 +875,7 @@ module NewAPI = struct
     let x = f chunk in
     (* Ensure allocated space was initialized. *)
     assert (chunk.remaining_size = 0);
-    assert (chunk.next_addr = addr + size);
+    assert (chunk.next_addr = addr_offset addr size);
     x
 
   (* Addresses are relative to the hashtbl pointer, so the null address actually
@@ -1043,17 +1045,17 @@ module NewAPI = struct
 
   (* offsets *)
 
-  let module_addr file = file + 1
+  let module_addr file = addr_offset file 1
 
-  let module_refs_addr file = file + 2
+  let module_refs_addr file = addr_offset file 2
 
-  let local_defs_addr file = file + 3
+  let local_defs_addr file = addr_offset file 3
 
-  let remote_refs_addr file = file + 4
+  let remote_refs_addr file = addr_offset file 4
 
-  let pattern_defs_addr file = file + 5
+  let pattern_defs_addr file = addr_offset file 5
 
-  let patterns_addr file = file + 6
+  let patterns_addr file = addr_offset file 6
 
   (* read *)
 
@@ -1064,34 +1066,35 @@ module NewAPI = struct
    * must ensure that the given destination contains string data. *)
   external unsafe_read_string : _ addr -> int -> string = "hh_read_string"
 
+  (* Read int64 from given byte offset in the heap. This is bounds checked. *)
+  external read_int64 : heap -> int -> int64 = "%caml_bigstring_get64"
+
   (* Read a header from the heap. The low 2 bits of the header are reserved for
    * GC and not used in OCaml. *)
   let read_header heap addr =
-    let hd_nat = Array1.get heap addr in
+    let hd64 = read_int64 heap addr in
     (* Double-check that the data looks like a header. All reachable headers
      * will have the lsb set. *)
-    assert (Nativeint.(logand hd_nat 1n = 1n));
-    Nativeint.(to_int (shift_right_logical hd_nat 2))
+    assert (Int64.(logand hd64 1L = 1L));
+    Int64.(to_int (shift_right_logical hd64 2))
 
   let read_header_checked heap tag addr =
     let hd = read_header heap addr in
     assert_tag hd tag;
     hd
 
-  (* Read an address from the heap. In the heap, we store word-aligned byte
-   * offsets, but in OCaml we prefer word offsets. As with Val_addr when passing
-   * back addresses from C, we perform the byte->word offset conversion here. *)
+  (* Read an address from the heap. *)
   let read_addr heap addr =
-    let addr_nat = Array1.get heap addr in
+    let addr64 = read_int64 heap addr in
     (* double-check that the data looks like an address *)
-    assert (Nativeint.(logand addr_nat 1n = 0n));
-    Nativeint.(to_int (shift_right_logical addr_nat 3))
+    assert (Int64.logand addr64 1L = 0L);
+    Int64.to_int addr64
 
   let read_string_generic tag addr offset =
     let hd = read_header_checked (get_heap ()) tag addr in
-    let str_addr = addr + header_size + offset in
-    let str_length = obj_size hd - offset in
-    unsafe_read_string str_addr str_length
+    let str_addr = addr_offset addr (header_size + offset) in
+    let str_size = obj_size hd - offset in
+    unsafe_read_string str_addr str_size
 
   let read_string addr = read_string_generic String_tag addr 0
 
@@ -1101,7 +1104,7 @@ module NewAPI = struct
     else
       let heap = get_heap () in
       let hd = read_header_checked heap Addr_tbl_tag addr in
-      init (obj_size hd) (fun i -> f (read_addr heap (addr + header_size + i)))
+      init (obj_size hd) (fun i -> f (read_addr heap (addr_offset addr (header_size + i))))
 
   let read_addr_tbl f addr = read_addr_tbl_generic f addr Array.init
 
@@ -1156,36 +1159,38 @@ module NewAPI = struct
 
   let file_patterns file = read_addr (get_heap ()) (patterns_addr file)
 
-  let cjs_module_info m = read_addr (get_heap ()) (m + 1)
+  let cjs_module_info m = read_addr (get_heap ()) (addr_offset m 1)
 
-  let cjs_module_exports m = read_addr (get_heap ()) (m + 2)
+  let cjs_module_exports m = read_addr (get_heap ()) (addr_offset m 2)
 
-  let cjs_module_type_exports m = read_addr (get_heap ()) (m + 3)
+  let cjs_module_type_exports m = read_addr (get_heap ()) (addr_offset m 3)
 
-  let es_module_info m = read_addr (get_heap ()) (m + 1)
+  let es_module_info m = read_addr (get_heap ()) (addr_offset m 1)
 
-  let es_module_exports m = read_addr (get_heap ()) (m + 2)
+  let es_module_exports m = read_addr (get_heap ()) (addr_offset m 2)
 
-  let es_module_type_exports m = read_addr (get_heap ()) (m + 3)
+  let es_module_type_exports m = read_addr (get_heap ()) (addr_offset m 3)
 
   (* write *)
+
+  (* Read int64 from given byte offset in the heap. This is not bounds checked. *)
+  external unsafe_write_int64 : heap -> int -> int64 -> unit = "%caml_bigstring_set64u"
 
   (* Write a header at a specified address in the heap. This write is not
    * bounds checked; caller must ensure the given destination has already been
    * allocated. *)
   let unsafe_write_header_at heap dst hd =
-    Array1.unsafe_set heap dst Nativeint.(logor 1n (shift_left (of_int hd) 2))
+    unsafe_write_int64 heap dst Int64.(logor 1L (shift_left (of_int hd) 2))
 
   (* Write an address at a specified address in the heap. This write is not
    * bounds checked; caller must ensure the given destination has already been
    * allocated. *)
-  let unsafe_write_addr_at heap dst addr =
-    Array1.unsafe_set heap dst Nativeint.(shift_left (of_int addr) 3)
+  let unsafe_write_addr_at heap dst addr = unsafe_write_int64 heap dst (Int64.of_int addr)
 
   (* Write a 64-bit hash at a specified address in the heap. This write is not
    * bounds checked; caller must ensure the given destination has already been
    * allocated. *)
-  let unsafe_write_hash_at heap dst hash = Array1.unsafe_set heap dst (Int64.to_nativeint hash)
+  let unsafe_write_hash_at heap dst hash = unsafe_write_int64 heap dst hash
 
   (* Write a string at the specified address in the heap. This write is not
    * bounds checked; caller must ensure the given destination has already been
@@ -1197,28 +1202,28 @@ module NewAPI = struct
    * already been allocated. *)
   let unsafe_write_header chunk hd =
     unsafe_write_header_at chunk.heap chunk.next_addr hd;
-    chunk.next_addr <- chunk.next_addr + header_size
+    chunk.next_addr <- addr_offset chunk.next_addr header_size
 
   (* Write an address into the given chunk and advance the chunk address. This
    * write is not bounds checked; caller must ensure the given destination has
    * already been allocated. *)
   let unsafe_write_addr chunk addr =
     unsafe_write_addr_at chunk.heap chunk.next_addr addr;
-    chunk.next_addr <- chunk.next_addr + addr_size
+    chunk.next_addr <- addr_offset chunk.next_addr addr_size
 
   (* Write a 64-bit hash into the given chunk and advance the chunk address.
    * This write is not bounds checked; caller must ensure the given destination
    * has already been allocated. *)
   let unsafe_write_hash chunk hash =
     unsafe_write_hash_at chunk.heap chunk.next_addr hash;
-    chunk.next_addr <- chunk.next_addr + hash_size
+    chunk.next_addr <- addr_offset chunk.next_addr hash_size
 
   (* Write a string into the given chunk and advance the chunk address. This
    * write is not bounds checked; caller must ensure the given destination has
    * already been allocated. *)
   let unsafe_write_string chunk s =
     unsafe_write_string_at chunk.next_addr s;
-    chunk.next_addr <- chunk.next_addr + string_size s
+    chunk.next_addr <- addr_offset chunk.next_addr (string_size s)
 
   (* Consume space in the chunk for the object described by the given header,
    * write header, advance chunk address, and return address to the header. This
@@ -1321,11 +1326,11 @@ module NewAPI = struct
     else
       let hd = addr_tbl_header xs in
       let map = write_header chunk hd in
-      chunk.next_addr <- chunk.next_addr + obj_size hd;
+      chunk.next_addr <- addr_offset chunk.next_addr (obj_size hd);
       Array.iteri
         (fun i x ->
           let addr = f chunk x in
-          unsafe_write_addr_at chunk.heap (map + header_size + i) addr)
+          unsafe_write_addr_at chunk.heap (addr_offset map (header_size + i)) addr)
         xs;
       map
 
@@ -1337,11 +1342,11 @@ module NewAPI = struct
 
   let read_hash addr =
     let heap = get_heap () in
-    Int64.of_nativeint (Array1.get heap (addr + header_size))
+    read_int64 heap (addr_offset addr header_size)
 
   let write_hash addr hash =
     let heap = get_heap () in
-    unsafe_write_hash_at heap (addr + header_size) hash
+    unsafe_write_hash_at heap (addr_offset addr header_size) hash
 
   let read_type_export_hash = read_hash
 


### PR DESCRIPTION
Summary:
In the shared heap, addresses are stored as byte offsets from the heap base
pointer. Before this diff, when representing an address in OCaml, we would
convert this byte offset into a word offset. This diff removes the conversion,
so we also represent addresses as byte offsets in OCaml.

To make this work, I changed the word-based Bigarray to be char-based instead.
The parameterization of the Bigarray affects the get/set operations as well as
the size of the data returned, similar to changing a C array from int* to char*.

Because we still want to read/write words, just at char offsets, I changed from
using the get/set API to primitive functions, which do exactly what we want.

Note that we still represent sizes in word units, so we still need to take some
care when computing a new address from an existing address (byte offset) and a
size (in words).

The `(char, int8_unsigned_elt, c_layout) Array1.t` type is a more generally
useful type as well. It is sometimes called a "bigstring" and there are
libraries that provide useful functionality for it, notably Bin_prot.

Differential Revision: D28401827

