### PR TITLE
Add Js target and fix leb128

### DIFF
--- a/src/common/leb128/dune
+++ b/src/common/leb128/dune
@@ -1,0 +1,3 @@
+(library
+ (name leb128)
+)

--- a/src/parser/dune
+++ b/src/parser/dune
@@ -1,8 +1,14 @@
 (library
-  (name flow_parser)
-  (wrapped false)
-  (modules (:standard \ flow_parser_js flow_parser_dot_js))
-  (libraries
-    sedlex
-    wtf8)
-  (preprocess (pps ppx_gen_rec ppx_deriving.std sedlex.ppx)))
+ (name flow_parser)
+ (wrapped false)
+ (modules
+  (:standard \ flow_parser_js flow_parser_dot_js))
+ (libraries sedlex wtf8)
+ (preprocess
+  (pps ppx_gen_rec ppx_deriving.std sedlex.ppx)))
+
+(executable
+ (name flow_parser_dot_js)
+ (modes js)
+ (modules flow_parser_js flow_parser_dot_js)
+ (libraries flow_parser js_of_ocaml))

--- a/src/parser_utils/type_sig/dune
+++ b/src/parser_utils/type_sig/dune
@@ -2,6 +2,7 @@
  (name flow_type_sig)
  (wrapped false)
  (libraries
+  leb128
   flow_parser_utils
   cycle_hash
   dtoa


### PR DESCRIPTION
<!--
  If this is a change to library defintions, please include links to relevant documentation.
  If this is a documentation change, please prefix the title with [DOCS].

  If this is neither, ensure you opened a discussion issue and link it in the PR description.
-->

- First commit fixes the latest leb128 extraction
- Second commit finish the parser's js backend target

# How to test 

```
flow$dune build @all
flow$node               
Welcome to Node.js v14.16.1.
Type ".help" for more information.

> var parser = require('./_build/default/src/parser/flow_parser_dot_js.bc.js')
undefined
> parser.parse('1+2')
{
  type: 'Program',
  loc: {
    source: null,
    start: { line: 1, column: 0 },
    end: { line: 1, column: 3 }
  },
  range: [ 0, 3 ],
  body: [
    {
      type: 'ExpressionStatement',
      loc: [Object],
      range: [Array],
      expression: [Object],
      directive: null
    }
  ],
  comments: [],
  errors: []
}
```
