### PR TITLE
More robust ppx genlibs

### DIFF
--- a/scripts/ppx_gen_flowlibs/ppx_gen_flowlibs.ml
+++ b/scripts/ppx_gen_flowlibs/ppx_gen_flowlibs.ml
@@ -20,8 +20,11 @@ let get_libs dir =
   Sys.readdir dir
   |> Array.fold_left
        (fun acc file ->
-         let contents = Script_utils.string_of_file (Filename.concat dir file) in
-         (file, contents) :: acc)
+         if Filename.check_suffix file ".js" then
+           let contents = Script_utils.string_of_file (Filename.concat dir file) in
+           (file, contents) :: acc
+         else
+           acc)
        []
 
 (* Turn the (name, contents) list into a PPX ast (string * string) array

--- a/src/common/packed_locs/dune
+++ b/src/common/packed_locs/dune
@@ -1,5 +1,5 @@
 (library
  (name packed_locs)
  (libraries
-  leb128)
+  leb128 flow_parser)
  )

--- a/src/parser_utils/aloc/dune
+++ b/src/parser_utils/aloc/dune
@@ -2,6 +2,7 @@
   (name flow_parser_utils_aloc)
   (wrapped false)
   (libraries
+    packed_locs
     flow_common_utils
     flow_parser)
   (preprocess (pps ppx_deriving.std)))


### PR DESCRIPTION
<!--
  If this is a change to library defintions, please include links to relevant documentation.
  If this is a documentation change, please prefix the title with [DOCS].

  If this is neither, ensure you opened a discussion issue and link it in the PR description.
-->
- The first commit add a filter for the ppx, so that it does not try to copy non .js files 
(I got bitten by this since APACHE LICENSE is also copied, the ocamlbuild works because it only copies the .js file to 
a separate directory)
Note we could fix it in the build system too, but I think fix it directly in the ppx itself is more robust.

I feel that the ppx_gen_flowlib is a bit complicated for such task, maybe in the future, we can replace it with a script

- The second commit fix the build