### PR TITLE
Support method unbound for fs/promises in flow 0.154

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -1321,7 +1321,7 @@ declare module "fs" {
   }
 
   declare type FSPromisePath = string | Buffer | URL;
-  declare class FSPromise {
+  declare type FSPromise = {
     access(path: FSPromisePath, mode?: number): Promise<void>,
     appendFile(path: FSPromisePath | FileHandle, data: string | Buffer, options: WriteOptions | string): Promise<void>,
     chmod(path: FSPromisePath, mode: number): Promise<void>,
@@ -1356,12 +1356,15 @@ declare module "fs" {
       ...
     }>,
     readdir(path: FSPromisePath, options?: string | EncodingOptions): Promise<string[]>,
-    readFile(path: FSPromisePath | FileHandle, options: string): Promise<string>,
-    readFile(path: FSPromisePath | FileHandle, options?: EncodingFlag): Promise<Buffer>,
-    readlink(path: FSPromisePath, options: BufferEncoding): Promise<Buffer>,
-    readlink(path: FSPromisePath, options?: string | EncodingOptions): Promise<string>,
-    realpath(path: FSPromisePath, options: BufferEncoding): Promise<Buffer>,
-    realpath(path: FSPromisePath, options?: string | EncodingOptions): Promise<string>,
+    readFile:
+      & (path: FSPromisePath | FileHandle, options: string) => Promise<string>
+      & (path: FSPromisePath | FileHandle, options?: EncodingFlag) => Promise<Buffer>,
+    readlink:
+      & (path: FSPromisePath, options: BufferEncoding) => Promise<Buffer>
+      & (path: FSPromisePath, options?: string | EncodingOptions) => Promise<string>,
+    realpath:
+      & (path: FSPromisePath, options: BufferEncoding) => Promise<Buffer>
+      & (path: FSPromisePath, options?: string | EncodingOptions) => Promise<string>,
     rename(oldPath: FSPromisePath, newPath: FSPromisePath): Promise<void>,
     rmdir(path: FSPromisePath): Promise<void>,
     stat(path: FSPromisePath): Promise<Stats>,

--- a/lib/node.js
+++ b/lib/node.js
@@ -1357,14 +1357,14 @@ declare module "fs" {
     }>,
     readdir(path: FSPromisePath, options?: string | EncodingOptions): Promise<string[]>,
     readFile:
-      & (path: FSPromisePath | FileHandle, options: string) => Promise<string>
-      & (path: FSPromisePath | FileHandle, options?: EncodingFlag) => Promise<Buffer>,
+      & ((path: FSPromisePath | FileHandle, options: string) => Promise<string>)
+      & ((path: FSPromisePath | FileHandle, options?: EncodingFlag) => Promise<Buffer>),
     readlink:
-      & (path: FSPromisePath, options: BufferEncoding) => Promise<Buffer>
-      & (path: FSPromisePath, options?: string | EncodingOptions) => Promise<string>,
+      & ((path: FSPromisePath, options: BufferEncoding) => Promise<Buffer>)
+      & ((path: FSPromisePath, options?: string | EncodingOptions) => Promise<string>),
     realpath:
-      & (path: FSPromisePath, options: BufferEncoding) => Promise<Buffer>
-      & (path: FSPromisePath, options?: string | EncodingOptions) => Promise<string>,
+      & ((path: FSPromisePath, options: BufferEncoding) => Promise<Buffer>)
+      & ((path: FSPromisePath, options?: string | EncodingOptions) => Promise<string>),
     rename(oldPath: FSPromisePath, newPath: FSPromisePath): Promise<void>,
     rmdir(path: FSPromisePath): Promise<void>,
     stat(path: FSPromisePath): Promise<Stats>,


### PR DESCRIPTION
<!--
  If this is a change to library defintions, please include links to relevant documentation.
  If this is a documentation change, please prefix the title with [DOCS].

  If this is neither, ensure you opened a discussion issue and link it in the PR description.
-->
This PR allows using fs/promises like this in flow 0.154:
```js
const {writeFile} = require('fs').promises;
```

Node fs/promises doc: https://nodejs.org/api/fs.html#fs_promises_api
