### PR TITLE
Allow URL objects when starting workers

### DIFF
--- a/lib/bom.js
+++ b/lib/bom.js
@@ -735,7 +735,7 @@ type WorkerOptions = {
 }
 
 declare class Worker extends EventTarget {
-    constructor(stringUrl: string, workerOptions?: WorkerOptions): void;
+    constructor(url: string | URL, workerOptions?: WorkerOptions): void;
     onerror: null | (ev: any) => mixed;
     onmessage: null | (ev: MessageEvent) => mixed;
     onmessageerror: null | (ev: MessageEvent) => mixed;
@@ -744,8 +744,8 @@ declare class Worker extends EventTarget {
 }
 
 declare class SharedWorker extends EventTarget {
-    constructor(stringUrl: string, name?: string): void;
-    constructor(stringUrl: string, workerOptions?: WorkerOptions): void;
+    constructor(url: string | URL, name?: string): void;
+    constructor(url: string | URL, workerOptions?: WorkerOptions): void;
     port: MessagePort;
     onerror: (ev: any) => mixed;
 }

--- a/lib/serviceworkers.js
+++ b/lib/serviceworkers.js
@@ -148,7 +148,7 @@ declare class ServiceWorkerContainer extends EventTarget {
   getRegistration(clientURL?: string): Promise<ServiceWorkerRegistration | void>,
   getRegistrations(): Promise<Iterator<ServiceWorkerRegistration>>,
   register(
-    scriptURL: string,
+    scriptURL: string | URL,
     options?: RegistrationOptions
   ): Promise<ServiceWorkerRegistration>,
   startMessages(): void,


### PR DESCRIPTION
Passing URL object into worker construtors/`navigator.serviceWorker.register` should be allowed

For example described here: https://webpack.js.org/guides/web-workers/