### PR TITLE
Add support for the node 'console' module

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -2439,7 +2439,6 @@ declare var console: {
     dir(...data: Array<any>): void,
     dirxml(...data: Array<any>): void,
     error(...data: Array<any>): void,
-    _exception(...data: Array<any>): void,
     group(...data: Array<any>): void,
     groupCollapsed(...data: Array<any>): void,
     groupEnd(): void,

--- a/lib/node.js
+++ b/lib/node.js
@@ -2802,6 +2802,23 @@ declare module 'repl' {
   }
 }
 
+declare module 'console' {
+  // These constructors are declared as functions instead of constructors on a
+  // Console class both because node doesn't require `new` for everything to
+  // work, and because it allows instances of Console to be cast to the type of
+  // the global `console`.
+  declare function Console(stdout: stream$Writable, stderr?: stream$Writable, ignoreErrors?: boolean): typeof console;
+  declare function Console(options: {
+    stdout: stream$Writable,
+    stderr?: stream$Writable,
+    ignoreErrors?: boolean,
+    colorMode?: boolean | 'auto',
+    inspectOptions?: util$InspectOptions,
+    groupIndentation?: number,
+    ...
+  }): typeof console;
+}
+
 /* globals: https://nodejs.org/api/globals.html */
 
 type process$CPUUsage = {

--- a/tests/enums/enums.exp
+++ b/tests/enums/enums.exp
@@ -1261,8 +1261,8 @@ References:
    exhaustive-check.js:3:6
       3| enum E {
               ^ [2]
-   <BUILTINS>/core.js:2463:3
-   2463|   isValid(this: TEnumObject, input: ?TRepresentation): boolean,
+   <BUILTINS>/core.js:2462:3
+   2462|   isValid(this: TEnumObject, input: ?TRepresentation): boolean,
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [3]
 
 
@@ -1889,15 +1889,15 @@ Cannot get `E.nonExistent` because property `nonExistent` is missing in `$EnumPr
            ^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:2460:56
+   <BUILTINS>/core.js:2459:56
                                                                 v-
-   2460| type $EnumProto<TEnumObject, TEnum, TRepresentation> = {|
-   2461|   cast(this: TEnumObject, input: ?TRepresentation): void | TEnum,
-   2462|   getName(this: TEnumObject, input: TEnum): string,
-   2463|   isValid(this: TEnumObject, input: ?TRepresentation): boolean,
-   2464|   members(this: TEnumObject): Iterable<TEnum>,
-   2465|   __proto__: null,
-   2466| |}
+   2459| type $EnumProto<TEnumObject, TEnum, TRepresentation> = {|
+   2460|   cast(this: TEnumObject, input: ?TRepresentation): void | TEnum,
+   2461|   getName(this: TEnumObject, input: TEnum): string,
+   2462|   isValid(this: TEnumObject, input: ?TRepresentation): boolean,
+   2463|   members(this: TEnumObject): Iterable<TEnum>,
+   2464|   __proto__: null,
+   2465| |}
          -^ [1]
 
 
@@ -1910,15 +1910,15 @@ Cannot call `E.nonExistent` because property `nonExistent` is missing in `$EnumP
            ^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:2460:56
+   <BUILTINS>/core.js:2459:56
                                                                 v-
-   2460| type $EnumProto<TEnumObject, TEnum, TRepresentation> = {|
-   2461|   cast(this: TEnumObject, input: ?TRepresentation): void | TEnum,
-   2462|   getName(this: TEnumObject, input: TEnum): string,
-   2463|   isValid(this: TEnumObject, input: ?TRepresentation): boolean,
-   2464|   members(this: TEnumObject): Iterable<TEnum>,
-   2465|   __proto__: null,
-   2466| |}
+   2459| type $EnumProto<TEnumObject, TEnum, TRepresentation> = {|
+   2460|   cast(this: TEnumObject, input: ?TRepresentation): void | TEnum,
+   2461|   getName(this: TEnumObject, input: TEnum): string,
+   2462|   isValid(this: TEnumObject, input: ?TRepresentation): boolean,
+   2463|   members(this: TEnumObject): Iterable<TEnum>,
+   2464|   __proto__: null,
+   2465| |}
          -^ [1]
 
 
@@ -1945,15 +1945,15 @@ Cannot call `E.A` because property `A` is missing in `$EnumProto` [1]. [prop-mis
            ^
 
 References:
-   <BUILTINS>/core.js:2460:56
+   <BUILTINS>/core.js:2459:56
                                                                 v-
-   2460| type $EnumProto<TEnumObject, TEnum, TRepresentation> = {|
-   2461|   cast(this: TEnumObject, input: ?TRepresentation): void | TEnum,
-   2462|   getName(this: TEnumObject, input: TEnum): string,
-   2463|   isValid(this: TEnumObject, input: ?TRepresentation): boolean,
-   2464|   members(this: TEnumObject): Iterable<TEnum>,
-   2465|   __proto__: null,
-   2466| |}
+   2459| type $EnumProto<TEnumObject, TEnum, TRepresentation> = {|
+   2460|   cast(this: TEnumObject, input: ?TRepresentation): void | TEnum,
+   2461|   getName(this: TEnumObject, input: TEnum): string,
+   2462|   isValid(this: TEnumObject, input: ?TRepresentation): boolean,
+   2463|   members(this: TEnumObject): Iterable<TEnum>,
+   2464|   __proto__: null,
+   2465| |}
          -^ [1]
 
 
@@ -1966,15 +1966,15 @@ Cannot call `E.toString` because property `toString` is missing in `$EnumProto` 
            ^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:2460:56
+   <BUILTINS>/core.js:2459:56
                                                                 v-
-   2460| type $EnumProto<TEnumObject, TEnum, TRepresentation> = {|
-   2461|   cast(this: TEnumObject, input: ?TRepresentation): void | TEnum,
-   2462|   getName(this: TEnumObject, input: TEnum): string,
-   2463|   isValid(this: TEnumObject, input: ?TRepresentation): boolean,
-   2464|   members(this: TEnumObject): Iterable<TEnum>,
-   2465|   __proto__: null,
-   2466| |}
+   2459| type $EnumProto<TEnumObject, TEnum, TRepresentation> = {|
+   2460|   cast(this: TEnumObject, input: ?TRepresentation): void | TEnum,
+   2461|   getName(this: TEnumObject, input: TEnum): string,
+   2462|   isValid(this: TEnumObject, input: ?TRepresentation): boolean,
+   2463|   members(this: TEnumObject): Iterable<TEnum>,
+   2464|   __proto__: null,
+   2465| |}
          -^ [1]
 
 
@@ -1987,8 +1987,8 @@ Cannot cast `E.getName(...)` to boolean because string [1] is incompatible with 
           ^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:2462:45
-   2462|   getName(this: TEnumObject, input: TEnum): string,
+   <BUILTINS>/core.js:2461:45
+   2461|   getName(this: TEnumObject, input: TEnum): string,
                                                      ^^^^^^ [1]
    methods.js:42:18
      42| (E.getName(E.B): boolean); // Error - wrong type

--- a/tests/get_def_enums/get_def_enums.exp
+++ b/tests/get_def_enums/get_def_enums.exp
@@ -24,9 +24,9 @@ library.js:4:3,4:5
 
 main.js:23:13
 Flags:
-[LIB] core.js:2461:3,2461:6
+[LIB] core.js:2460:3,2460:6
 
 main.js:26:13
 Flags:
-[LIB] core.js:2463:3,2463:9
+[LIB] core.js:2462:3,2462:9
 

--- a/tests/node_tests/console/console.js
+++ b/tests/node_tests/console/console.js
@@ -1,0 +1,25 @@
+// @flow
+
+const { Console } = require("console");
+const stream = require("stream");
+
+const myConsole = new Console(new stream.Writable());
+
+// Instances of Console should be compatible with the global console.
+(myConsole: typeof console);
+
+const consoleOptions = new Console({
+  stdout: new stream.Writable(),
+  stderr: new stream.Writable(),
+  ignoreErrors: false,
+  colorMode: "auto",
+  inspectOptions: {
+    showHidden: true,
+    depth: 42,
+    colors: false,
+    customInspect: false
+  },
+  groupIndentation: 42
+});
+
+const noNew = Console(new stream.Writable(), new stream.Writable(), true);

--- a/tests/node_tests/node_tests.exp
+++ b/tests/node_tests/node_tests.exp
@@ -1636,26 +1636,26 @@ References:
    process/emitWarning.js:10:1
      10| process.emitWarning(); // error
          ^^^^^^^^^^^^^^^^^^^^^ [1]
-   <BUILTINS>/node.js:2826:24
-   2826|   emitWarning(warning: string | Error): void;
+   <BUILTINS>/node.js:2843:24
+   2843|   emitWarning(warning: string | Error): void;
                                 ^^^^^^ [2]
-   <BUILTINS>/node.js:2826:33
-   2826|   emitWarning(warning: string | Error): void;
+   <BUILTINS>/node.js:2843:33
+   2843|   emitWarning(warning: string | Error): void;
                                          ^^^^^ [3]
-   <BUILTINS>/node.js:2827:3
-   2827|   emitWarning(warning: string, typeOrCtor: string | (...empty) => mixed): void;
+   <BUILTINS>/node.js:2844:3
+   2844|   emitWarning(warning: string, typeOrCtor: string | (...empty) => mixed): void;
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [4]
-   <BUILTINS>/node.js:2828:3
-   2828|   emitWarning(warning: string, type: string, codeOrCtor: string | (...empty) => mixed): void;
+   <BUILTINS>/node.js:2845:3
+   2845|   emitWarning(warning: string, type: string, codeOrCtor: string | (...empty) => mixed): void;
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [5]
-   <BUILTINS>/node.js:2829:3
+   <BUILTINS>/node.js:2846:3
            v-----------
-   2829|   emitWarning(
-   2830|     warning: string,
-   2831|     type: string,
-   2832|     code: string,
-   2833|     ctor?: (...empty) => mixed
-   2834|   ): void;
+   2846|   emitWarning(
+   2847|     warning: string,
+   2848|     type: string,
+   2849|     code: string,
+   2850|     ctor?: (...empty) => mixed
+   2851|   ): void;
            ------^ [6]
 
 
@@ -1674,14 +1674,14 @@ References:
    process/emitWarning.js:11:21
      11| process.emitWarning(42); // error
                              ^^ [1]
-   <BUILTINS>/node.js:2827:24
-   2827|   emitWarning(warning: string, typeOrCtor: string | (...empty) => mixed): void;
+   <BUILTINS>/node.js:2844:24
+   2844|   emitWarning(warning: string, typeOrCtor: string | (...empty) => mixed): void;
                                 ^^^^^^ [2]
-   <BUILTINS>/node.js:2828:24
-   2828|   emitWarning(warning: string, type: string, codeOrCtor: string | (...empty) => mixed): void;
+   <BUILTINS>/node.js:2845:24
+   2845|   emitWarning(warning: string, type: string, codeOrCtor: string | (...empty) => mixed): void;
                                 ^^^^^^ [3]
-   <BUILTINS>/node.js:2830:14
-   2830|     warning: string,
+   <BUILTINS>/node.js:2847:14
+   2847|     warning: string,
                       ^^^^^^ [4]
 
 
@@ -1699,11 +1699,11 @@ References:
    process/emitWarning.js:12:29
      12| process.emitWarning("blah", 42); // error
                                      ^^ [1]
-   <BUILTINS>/node.js:2828:38
-   2828|   emitWarning(warning: string, type: string, codeOrCtor: string | (...empty) => mixed): void;
+   <BUILTINS>/node.js:2845:38
+   2845|   emitWarning(warning: string, type: string, codeOrCtor: string | (...empty) => mixed): void;
                                               ^^^^^^ [2]
-   <BUILTINS>/node.js:2831:11
-   2831|     type: string,
+   <BUILTINS>/node.js:2848:11
+   2848|     type: string,
                    ^^^^^^ [3]
 
 
@@ -1719,8 +1719,8 @@ References:
    process/emitWarning.js:13:37
      13| process.emitWarning("blah", "blah", 42); // error
                                              ^^ [1]
-   <BUILTINS>/node.js:2832:11
-   2832|     code: string,
+   <BUILTINS>/node.js:2849:11
+   2849|     code: string,
                    ^^^^^^ [2]
 
 
@@ -1734,8 +1734,8 @@ Cannot cast `process.emitWarning(...)` to string because undefined [1] is incomp
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/node.js:2826:41
-   2826|   emitWarning(warning: string | Error): void;
+   <BUILTINS>/node.js:2843:41
+   2843|   emitWarning(warning: string | Error): void;
                                                  ^^^^ [1]
    process/emitWarning.js:14:31
      14| (process.emitWarning("blah"): string); // error
@@ -1800,8 +1800,8 @@ References:
    process/nextTick.js:27:3
      27|   (a: string, b: number, c: boolean) => {} // Error: too few arguments
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
-   <BUILTINS>/node.js:2855:21
-   2855|   nextTick: <T>(cb: (...T) => mixed, ...T) => void;
+   <BUILTINS>/node.js:2872:21
+   2872|   nextTick: <T>(cb: (...T) => mixed, ...T) => void;
                              ^^^^^^^^^^^^^^^ [2]
 
 
@@ -1815,8 +1815,8 @@ Cannot cast `process.allowedNodeEnvironmentFlags` to string because `Set` [1] is
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/node.js:2815:32
-   2815|   allowedNodeEnvironmentFlags: Set<string>;
+   <BUILTINS>/node.js:2832:32
+   2832|   allowedNodeEnvironmentFlags: Set<string>;
                                         ^^^^^^^^^^^ [1]
    process/process.js:5:39
       5| (process.allowedNodeEnvironmentFlags: string); // error


### PR DESCRIPTION
- Define the 'console' module.  This module exports the Console
  constructor, which creates objects of the same type as the global
  `console`. https://nodejs.org/api/console.html
- Note that while the pre-existing type of the global `console` variable
  does not exactly conform to the type indicated in the node docs, it is
  functionally equivalent. For example, some methods on the global
  variable are typed `(...any): void` whereas the node docs indicate a
  named first parameter which is still any, as in `(any, ...any): void`.
- In order to ensure that the cross-environment `console` definition is
  correct for node, remove the `_exception` method.  I can find no
  evidence that a method named '_exception' ever existed on a console in
  any environment.  There is the deprecated `exception` method, which is
  an alias for `error` and MDN indicates is only supported in Firefox
  today:
  https://developer.mozilla.org/en-US/docs/Web/API/console#browser_compatibility.
  Because of that, it seems fine to eliminate this method without replacement.

<!--
  If this is a change to library defintions, please include links to relevant documentation.
  If this is a documentation change, please prefix the title with [DOCS].

  If this is neither, ensure you opened a discussion issue and link it in the PR description.
-->
