### PR TITLE
fix dune build src/flow.exe on Darwin

### DIFF
--- a/src/heap/dune
+++ b/src/heap/dune
@@ -7,7 +7,6 @@
   (names hh_shared)
   (flags
    (:standard -I../../src/third-party/lz4)))
- (c_library_flags (-latomic))
  (preprocess
   (pps ppx_deriving.std visitors.ppx))
  (libraries utils_core))


### PR DESCRIPTION
<!--
  If this is a change to library defintions, please include links to relevant documentation.
  If this is a documentation change, please prefix the title with [DOCS].

  If this is neither, ensure you opened a discussion issue and link it in the PR description.
-->
I noticed in 0b6dece it was added, is this OS dependent thing? After removing it, it builds fine on MacOS