### PR TITLE
Allow `mixed` args to `String.prototype.concat()`

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -1103,9 +1103,11 @@ declare class String {
     codePointAt(index: number): number;
     /**
      * Returns a string that contains the concatenation of two or more strings.
-     * @param strings The strings to append to the end of the string.
+     * If the arguments are not of the type string, they are converted to string values before
+     * concatenating.
+     * @param values The values to append to the end of the string.
      */
-    concat(...strings: Array<string>): string;
+    concat(...values: Array<mixed>): string;
     constructor(value?: mixed): void;
     /**
      * Returns true if the sequence of elements of searchString converted to a String is the

--- a/newtests/autocomplete/test.js
+++ b/newtests/autocomplete/test.js
@@ -158,7 +158,7 @@ export default (suite(({addFile, flowCmd}) => [
              },
              {
                "name": "concat",
-               "type": "(...strings: Array<string>) => string"
+               "type": "(...values: Array<mixed>) => string"
              },
              {
                "name": "endsWith",

--- a/tests/async/async.exp
+++ b/tests/async/async.exp
@@ -10,8 +10,8 @@ References:
    async.js:11:30
      11| async function f1(): Promise<bool> {
                                       ^^^^ [2]
-   <BUILTINS>/core.js:1809:24
-   1809| declare class Promise<+R> {
+   <BUILTINS>/core.js:1811:24
+   1811| declare class Promise<+R> {
                                 ^ [3]
 
 
@@ -31,8 +31,8 @@ References:
    async.js:30:48
      30| async function f4(p: Promise<number>): Promise<bool> {
                                                         ^^^^ [2]
-   <BUILTINS>/core.js:1809:24
-   1809| declare class Promise<+R> {
+   <BUILTINS>/core.js:1811:24
+   1811| declare class Promise<+R> {
                                 ^ [3]
 
 
@@ -99,8 +99,8 @@ undefined in type argument `R` [2]. [incompatible-return]
                      ^^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:1809:24
-   1809| declare class Promise<+R> {
+   <BUILTINS>/core.js:1811:24
+   1811| declare class Promise<+R> {
                                 ^ [2]
 
 
@@ -134,8 +134,8 @@ References:
    async_return_void.js:3:32
       3| async function foo1(): Promise<string> {
                                         ^^^^^^ [2]
-   <BUILTINS>/core.js:1809:24
-   1809| declare class Promise<+R> {
+   <BUILTINS>/core.js:1811:24
+   1811| declare class Promise<+R> {
                                 ^ [3]
 
 
@@ -152,8 +152,8 @@ References:
    async_return_void.js:7:32
       7| async function foo2(): Promise<string> {
                                         ^^^^^^ [2]
-   <BUILTINS>/core.js:1809:24
-   1809| declare class Promise<+R> {
+   <BUILTINS>/core.js:1811:24
+   1811| declare class Promise<+R> {
                                 ^ [3]
 
 
@@ -173,8 +173,8 @@ References:
    async_return_void.js:11:32
      11| async function foo3(): Promise<string> {
                                         ^^^^^^ [2]
-   <BUILTINS>/core.js:1809:24
-   1809| declare class Promise<+R> {
+   <BUILTINS>/core.js:1811:24
+   1811| declare class Promise<+R> {
                                 ^ [3]
 
 

--- a/tests/async_iteration/async_iteration.exp
+++ b/tests/async_iteration/async_iteration.exp
@@ -109,8 +109,8 @@ Cannot cast `result.value` to string because undefined [1] is incompatible with 
               ^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:1635:14
-   1635|     +value?: Return,
+   <BUILTINS>/core.js:1637:14
+   1637|     +value?: Return,
                       ^^^^^^ [1]
    return.js:20:20
      20|     (result.value: string); // error: number | void ~> string

--- a/tests/autocomplete/autocomplete.exp
+++ b/tests/autocomplete/autocomplete.exp
@@ -41,7 +41,7 @@ Flags: --pretty
     {"name":"charAt","type":"(pos: number) => string"},
     {"name":"charCodeAt","type":"(index: number) => number"},
     {"name":"codePointAt","type":"(index: number) => number"},
-    {"name":"concat","type":"(...strings: Array<string>) => string"},
+    {"name":"concat","type":"(...values: Array<mixed>) => string"},
     {
       "name":"endsWith",
       "type":"(searchString: string, position?: number) => boolean"
@@ -389,7 +389,7 @@ Flags: --pretty
     {"name":"charAt","type":"(pos: number) => string"},
     {"name":"charCodeAt","type":"(index: number) => number"},
     {"name":"codePointAt","type":"(index: number) => number"},
-    {"name":"concat","type":"(...strings: Array<string>) => string"},
+    {"name":"concat","type":"(...values: Array<mixed>) => string"},
     {
       "name":"endsWith",
       "type":"(searchString: string, position?: number) => boolean"

--- a/tests/core_tests/core_tests.exp
+++ b/tests/core_tests/core_tests.exp
@@ -7,8 +7,8 @@ Cannot cast `JSON.stringify(...)` to string because undefined [1] is incompatibl
           ^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:1627:17
-   1627|     ): string | void;
+   <BUILTINS>/core.js:1629:17
+   1629|     ): string | void;
                          ^^^^ [1]
    json_stringify.js:9:24
       9| (JSON.stringify(bad1): string);
@@ -28,11 +28,11 @@ References:
    map.js:23:22
      23|     let x = new Map(['foo', 123]); // error
                               ^^^^^ [1]
-   <BUILTINS>/core.js:1710:38
-   1710|     constructor(iterable?: ?Iterable<[K, V]>): void;
+   <BUILTINS>/core.js:1712:38
+   1712|     constructor(iterable?: ?Iterable<[K, V]>): void;
                                               ^^^^^^ [2]
-   <BUILTINS>/core.js:1644:22
-   1644| interface $Iterator<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:1646:22
+   1646| interface $Iterator<+Yield,+Return,-Next> {
                               ^^^^^ [3]
 
 
@@ -49,11 +49,11 @@ References:
    map.js:23:29
      23|     let x = new Map(['foo', 123]); // error
                                      ^^^ [1]
-   <BUILTINS>/core.js:1710:38
-   1710|     constructor(iterable?: ?Iterable<[K, V]>): void;
+   <BUILTINS>/core.js:1712:38
+   1712|     constructor(iterable?: ?Iterable<[K, V]>): void;
                                               ^^^^^^ [2]
-   <BUILTINS>/core.js:1644:22
-   1644| interface $Iterator<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:1646:22
+   1646| interface $Iterator<+Yield,+Return,-Next> {
                               ^^^^^ [3]
 
 
@@ -70,8 +70,8 @@ References:
    map.js:24:16
      24|     let y: Map<number, string> = new Map([['foo', 123]]); // error
                         ^^^^^^ [2]
-   <BUILTINS>/core.js:1708:19
-   1708| declare class Map<K, V> extends $ReadOnlyMap<K, V> {
+   <BUILTINS>/core.js:1710:19
+   1710| declare class Map<K, V> extends $ReadOnlyMap<K, V> {
                            ^ [3]
 
 
@@ -88,8 +88,8 @@ References:
    map.js:24:24
      24|     let y: Map<number, string> = new Map([['foo', 123]]); // error
                                 ^^^^^^ [2]
-   <BUILTINS>/core.js:1708:22
-   1708| declare class Map<K, V> extends $ReadOnlyMap<K, V> {
+   <BUILTINS>/core.js:1710:22
+   1710| declare class Map<K, V> extends $ReadOnlyMap<K, V> {
                               ^ [3]
 
 
@@ -102,8 +102,8 @@ Cannot cast `x.get(...)` to boolean because undefined [1] is incompatible with b
               ^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:1718:22
-   1718|     get(key: K): V | void;
+   <BUILTINS>/core.js:1720:22
+   1720|     get(key: K): V | void;
                               ^^^^ [1]
    map.js:29:20
      29|     (x.get('foo'): boolean); // error, string | void
@@ -183,17 +183,17 @@ property `@@iterator`: [incompatible-call]
                                ^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:1644:22
-   1644| interface $Iterator<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:1646:22
+   1646| interface $Iterator<+Yield,+Return,-Next> {
                               ^^^^^ [1]
    weakset.js:19:24
      19| let ws3 = new WeakSet([1, 2, 3]); // error, must be objects
                                 ^ [2]
-   <BUILTINS>/core.js:1796:26
-   1796| declare class WeakSet<T: {...} | $ReadOnlyArray<any>> extends $ReadOnlyWeakSet<T> {
+   <BUILTINS>/core.js:1798:26
+   1798| declare class WeakSet<T: {...} | $ReadOnlyArray<any>> extends $ReadOnlyWeakSet<T> {
                                   ^^^^^ [3]
-   <BUILTINS>/core.js:1796:34
-   1796| declare class WeakSet<T: {...} | $ReadOnlyArray<any>> extends $ReadOnlyWeakSet<T> {
+   <BUILTINS>/core.js:1798:34
+   1798| declare class WeakSet<T: {...} | $ReadOnlyArray<any>> extends $ReadOnlyWeakSet<T> {
                                           ^^^^^^^^^^^^^^^^^^^ [4]
 
 
@@ -209,17 +209,17 @@ property `@@iterator`: [incompatible-call]
                                ^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:1644:22
-   1644| interface $Iterator<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:1646:22
+   1646| interface $Iterator<+Yield,+Return,-Next> {
                               ^^^^^ [1]
    weakset.js:19:27
      19| let ws3 = new WeakSet([1, 2, 3]); // error, must be objects
                                    ^ [2]
-   <BUILTINS>/core.js:1796:26
-   1796| declare class WeakSet<T: {...} | $ReadOnlyArray<any>> extends $ReadOnlyWeakSet<T> {
+   <BUILTINS>/core.js:1798:26
+   1798| declare class WeakSet<T: {...} | $ReadOnlyArray<any>> extends $ReadOnlyWeakSet<T> {
                                   ^^^^^ [3]
-   <BUILTINS>/core.js:1796:34
-   1796| declare class WeakSet<T: {...} | $ReadOnlyArray<any>> extends $ReadOnlyWeakSet<T> {
+   <BUILTINS>/core.js:1798:34
+   1798| declare class WeakSet<T: {...} | $ReadOnlyArray<any>> extends $ReadOnlyWeakSet<T> {
                                           ^^^^^^^^^^^^^^^^^^^ [4]
 
 
@@ -235,17 +235,17 @@ property `@@iterator`: [incompatible-call]
                                ^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:1644:22
-   1644| interface $Iterator<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:1646:22
+   1646| interface $Iterator<+Yield,+Return,-Next> {
                               ^^^^^ [1]
    weakset.js:19:30
      19| let ws3 = new WeakSet([1, 2, 3]); // error, must be objects
                                       ^ [2]
-   <BUILTINS>/core.js:1796:26
-   1796| declare class WeakSet<T: {...} | $ReadOnlyArray<any>> extends $ReadOnlyWeakSet<T> {
+   <BUILTINS>/core.js:1798:26
+   1798| declare class WeakSet<T: {...} | $ReadOnlyArray<any>> extends $ReadOnlyWeakSet<T> {
                                   ^^^^^ [3]
-   <BUILTINS>/core.js:1796:34
-   1796| declare class WeakSet<T: {...} | $ReadOnlyArray<any>> extends $ReadOnlyWeakSet<T> {
+   <BUILTINS>/core.js:1798:34
+   1798| declare class WeakSet<T: {...} | $ReadOnlyArray<any>> extends $ReadOnlyWeakSet<T> {
                                           ^^^^^^^^^^^^^^^^^^^ [4]
 
 
@@ -260,17 +260,17 @@ Cannot call `WeakSet` with `numbers()` bound to `iterable` because in type argum
                                ^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:1650:22
-   1650| interface $Iterable<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:1652:22
+   1652| interface $Iterable<+Yield,+Return,-Next> {
                               ^^^^^ [1]
    weakset.js:29:31
      29| function* numbers(): Iterable<number> {
                                        ^^^^^^ [2]
-   <BUILTINS>/core.js:1796:26
-   1796| declare class WeakSet<T: {...} | $ReadOnlyArray<any>> extends $ReadOnlyWeakSet<T> {
+   <BUILTINS>/core.js:1798:26
+   1798| declare class WeakSet<T: {...} | $ReadOnlyArray<any>> extends $ReadOnlyWeakSet<T> {
                                   ^^^^^ [3]
-   <BUILTINS>/core.js:1796:34
-   1796| declare class WeakSet<T: {...} | $ReadOnlyArray<any>> extends $ReadOnlyWeakSet<T> {
+   <BUILTINS>/core.js:1798:34
+   1798| declare class WeakSet<T: {...} | $ReadOnlyArray<any>> extends $ReadOnlyWeakSet<T> {
                                           ^^^^^^^^^^^^^^^^^^^ [4]
 
 

--- a/tests/date/date.exp
+++ b/tests/date/date.exp
@@ -7,8 +7,8 @@ Cannot assign `d.getTime()` to `x` because number [1] is incompatible with strin
                         ^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:1364:16
-   1364|     getTime(): number;
+   <BUILTINS>/core.js:1366:16
+   1366|     getTime(): number;
                         ^^^^^^ [1]
    date.js:2:7
       2| var x:string = d.getTime(); // expect error
@@ -44,8 +44,8 @@ References:
    date.js:18:10
      18| new Date({});
                   ^^ [1]
-   <BUILTINS>/core.js:1344:23
-   1344|     constructor(date: Date): void;
+   <BUILTINS>/core.js:1346:23
+   1346|     constructor(date: Date): void;
                                ^^^^ [2]
 
 
@@ -61,8 +61,8 @@ References:
    date.js:19:16
      19| new Date(2015, '6');
                         ^^^ [1]
-   <BUILTINS>/core.js:1346:38
-   1346|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
+   <BUILTINS>/core.js:1348:38
+   1348|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
                                               ^^^^^^ [2]
 
 
@@ -78,8 +78,8 @@ References:
    date.js:20:19
      20| new Date(2015, 6, '18');
                            ^^^^ [1]
-   <BUILTINS>/core.js:1346:52
-   1346|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
+   <BUILTINS>/core.js:1348:52
+   1348|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
                                                             ^^^^^^ [2]
 
 
@@ -95,8 +95,8 @@ References:
    date.js:21:23
      21| new Date(2015, 6, 18, '11');
                                ^^^^ [1]
-   <BUILTINS>/core.js:1346:67
-   1346|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
+   <BUILTINS>/core.js:1348:67
+   1348|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
                                                                            ^^^^^^ [2]
 
 
@@ -112,8 +112,8 @@ References:
    date.js:22:27
      22| new Date(2015, 6, 18, 11, '55');
                                    ^^^^ [1]
-   <BUILTINS>/core.js:1346:84
-   1346|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
+   <BUILTINS>/core.js:1348:84
+   1348|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
                                                                                             ^^^^^^ [2]
 
 
@@ -129,8 +129,8 @@ References:
    date.js:23:31
      23| new Date(2015, 6, 18, 11, 55, '42');
                                        ^^^^ [1]
-   <BUILTINS>/core.js:1346:101
-   1346|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
+   <BUILTINS>/core.js:1348:101
+   1348|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
                                                                                                              ^^^^^^ [2]
 
 
@@ -146,8 +146,8 @@ References:
    date.js:24:35
      24| new Date(2015, 6, 18, 11, 55, 42, '999');
                                            ^^^^^ [1]
-   <BUILTINS>/core.js:1346:123
-   1346|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
+   <BUILTINS>/core.js:1348:123
+   1348|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
                                                                                                                                    ^^^^^^ [2]
 
 
@@ -165,20 +165,20 @@ Cannot call `Date` because: [incompatible-call]
              ^^^^
 
 References:
-   <BUILTINS>/core.js:1342:5
-   1342|     constructor(): void;
-             ^^^^^^^^^^^^^^^^^^^ [1]
-   <BUILTINS>/core.js:1343:5
-   1343|     constructor(timestamp: number): void;
-             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [2]
    <BUILTINS>/core.js:1344:5
-   1344|     constructor(date: Date): void;
-             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [3]
+   1344|     constructor(): void;
+             ^^^^^^^^^^^^^^^^^^^ [1]
    <BUILTINS>/core.js:1345:5
-   1345|     constructor(dateString: string): void;
-             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [4]
+   1345|     constructor(timestamp: number): void;
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [2]
    <BUILTINS>/core.js:1346:5
-   1346|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
+   1346|     constructor(date: Date): void;
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [3]
+   <BUILTINS>/core.js:1347:5
+   1347|     constructor(dateString: string): void;
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [4]
+   <BUILTINS>/core.js:1348:5
+   1348|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [5]
 
 
@@ -194,8 +194,8 @@ References:
    date.js:26:10
      26| new Date('2015', 6);
                   ^^^^^^ [1]
-   <BUILTINS>/core.js:1346:23
-   1346|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
+   <BUILTINS>/core.js:1348:23
+   1348|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
                                ^^^^^^ [2]
 
 

--- a/tests/enums/enums.exp
+++ b/tests/enums/enums.exp
@@ -1096,8 +1096,8 @@ implicitly-returned undefined in type argument `Return` [2]. [incompatible-retur
                                             ^^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:1655:29
-   1655| interface Generator<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:1657:29
+   1657| interface Generator<+Yield,+Return,-Next> {
                                      ^^^^^^ [2]
 
 
@@ -1126,8 +1126,8 @@ undefined in type argument `R` [2]. [incompatible-return]
                                          ^^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:1809:24
-   1809| declare class Promise<+R> {
+   <BUILTINS>/core.js:1811:24
+   1811| declare class Promise<+R> {
                                 ^ [2]
 
 
@@ -1261,8 +1261,8 @@ References:
    exhaustive-check.js:3:6
       3| enum E {
               ^ [2]
-   <BUILTINS>/core.js:2463:3
-   2463|   isValid(this: TEnumObject, input: ?TRepresentation): boolean,
+   <BUILTINS>/core.js:2465:3
+   2465|   isValid(this: TEnumObject, input: ?TRepresentation): boolean,
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [3]
 
 
@@ -1889,15 +1889,15 @@ Cannot get `E.nonExistent` because property `nonExistent` is missing in `$EnumPr
            ^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:2460:56
+   <BUILTINS>/core.js:2462:56
                                                                 v-
-   2460| type $EnumProto<TEnumObject, TEnum, TRepresentation> = {|
-   2461|   cast(this: TEnumObject, input: ?TRepresentation): void | TEnum,
-   2462|   getName(this: TEnumObject, input: TEnum): string,
-   2463|   isValid(this: TEnumObject, input: ?TRepresentation): boolean,
-   2464|   members(this: TEnumObject): Iterable<TEnum>,
-   2465|   __proto__: null,
-   2466| |}
+   2462| type $EnumProto<TEnumObject, TEnum, TRepresentation> = {|
+   2463|   cast(this: TEnumObject, input: ?TRepresentation): void | TEnum,
+   2464|   getName(this: TEnumObject, input: TEnum): string,
+   2465|   isValid(this: TEnumObject, input: ?TRepresentation): boolean,
+   2466|   members(this: TEnumObject): Iterable<TEnum>,
+   2467|   __proto__: null,
+   2468| |}
          -^ [1]
 
 
@@ -1910,15 +1910,15 @@ Cannot call `E.nonExistent` because property `nonExistent` is missing in `$EnumP
            ^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:2460:56
+   <BUILTINS>/core.js:2462:56
                                                                 v-
-   2460| type $EnumProto<TEnumObject, TEnum, TRepresentation> = {|
-   2461|   cast(this: TEnumObject, input: ?TRepresentation): void | TEnum,
-   2462|   getName(this: TEnumObject, input: TEnum): string,
-   2463|   isValid(this: TEnumObject, input: ?TRepresentation): boolean,
-   2464|   members(this: TEnumObject): Iterable<TEnum>,
-   2465|   __proto__: null,
-   2466| |}
+   2462| type $EnumProto<TEnumObject, TEnum, TRepresentation> = {|
+   2463|   cast(this: TEnumObject, input: ?TRepresentation): void | TEnum,
+   2464|   getName(this: TEnumObject, input: TEnum): string,
+   2465|   isValid(this: TEnumObject, input: ?TRepresentation): boolean,
+   2466|   members(this: TEnumObject): Iterable<TEnum>,
+   2467|   __proto__: null,
+   2468| |}
          -^ [1]
 
 
@@ -1945,15 +1945,15 @@ Cannot call `E.A` because property `A` is missing in `$EnumProto` [1]. [prop-mis
            ^
 
 References:
-   <BUILTINS>/core.js:2460:56
+   <BUILTINS>/core.js:2462:56
                                                                 v-
-   2460| type $EnumProto<TEnumObject, TEnum, TRepresentation> = {|
-   2461|   cast(this: TEnumObject, input: ?TRepresentation): void | TEnum,
-   2462|   getName(this: TEnumObject, input: TEnum): string,
-   2463|   isValid(this: TEnumObject, input: ?TRepresentation): boolean,
-   2464|   members(this: TEnumObject): Iterable<TEnum>,
-   2465|   __proto__: null,
-   2466| |}
+   2462| type $EnumProto<TEnumObject, TEnum, TRepresentation> = {|
+   2463|   cast(this: TEnumObject, input: ?TRepresentation): void | TEnum,
+   2464|   getName(this: TEnumObject, input: TEnum): string,
+   2465|   isValid(this: TEnumObject, input: ?TRepresentation): boolean,
+   2466|   members(this: TEnumObject): Iterable<TEnum>,
+   2467|   __proto__: null,
+   2468| |}
          -^ [1]
 
 
@@ -1966,15 +1966,15 @@ Cannot call `E.toString` because property `toString` is missing in `$EnumProto` 
            ^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:2460:56
+   <BUILTINS>/core.js:2462:56
                                                                 v-
-   2460| type $EnumProto<TEnumObject, TEnum, TRepresentation> = {|
-   2461|   cast(this: TEnumObject, input: ?TRepresentation): void | TEnum,
-   2462|   getName(this: TEnumObject, input: TEnum): string,
-   2463|   isValid(this: TEnumObject, input: ?TRepresentation): boolean,
-   2464|   members(this: TEnumObject): Iterable<TEnum>,
-   2465|   __proto__: null,
-   2466| |}
+   2462| type $EnumProto<TEnumObject, TEnum, TRepresentation> = {|
+   2463|   cast(this: TEnumObject, input: ?TRepresentation): void | TEnum,
+   2464|   getName(this: TEnumObject, input: TEnum): string,
+   2465|   isValid(this: TEnumObject, input: ?TRepresentation): boolean,
+   2466|   members(this: TEnumObject): Iterable<TEnum>,
+   2467|   __proto__: null,
+   2468| |}
          -^ [1]
 
 
@@ -1987,8 +1987,8 @@ Cannot cast `E.getName(...)` to boolean because string [1] is incompatible with 
           ^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:2462:45
-   2462|   getName(this: TEnumObject, input: TEnum): string,
+   <BUILTINS>/core.js:2464:45
+   2464|   getName(this: TEnumObject, input: TEnum): string,
                                                      ^^^^^^ [1]
    methods.js:42:18
      42| (E.getName(E.B): boolean); // Error - wrong type

--- a/tests/fetch/fetch.exp
+++ b/tests/fetch/fetch.exp
@@ -14,8 +14,8 @@ References:
    fetch.js:12:18
      12| const b: Promise<string> = fetch(myRequest); // incorrect
                           ^^^^^^ [2]
-   <BUILTINS>/core.js:1809:24
-   1809| declare class Promise<+R> {
+   <BUILTINS>/core.js:1811:24
+   1811| declare class Promise<+R> {
                                 ^ [3]
 
 
@@ -35,8 +35,8 @@ References:
    <BUILTINS>/bom.js:1601:76
    1601| declare function fetch(input: RequestInfo, init?: RequestOptions): Promise<Response>;
                                                                                     ^^^^^^^^ [2]
-   <BUILTINS>/core.js:1809:24
-   1809| declare class Promise<+R> {
+   <BUILTINS>/core.js:1811:24
+   1811| declare class Promise<+R> {
                                 ^ [3]
 
 
@@ -702,11 +702,11 @@ References:
    <BUILTINS>/bom.js:1509:62
    1509| type BodyInit = string | URLSearchParams | FormData | Blob | ArrayBuffer | $ArrayBufferView | ReadableStream;
                                                                       ^^^^^^^^^^^ [5]
-   <BUILTINS>/core.js:1925:25
-   1925| type $ArrayBufferView = $TypedArray | DataView;
+   <BUILTINS>/core.js:1927:25
+   1927| type $ArrayBufferView = $TypedArray | DataView;
                                  ^^^^^^^^^^^ [6]
-   <BUILTINS>/core.js:1925:39
-   1925| type $ArrayBufferView = $TypedArray | DataView;
+   <BUILTINS>/core.js:1927:39
+   1927| type $ArrayBufferView = $TypedArray | DataView;
                                                ^^^^^^^^ [7]
    <BUILTINS>/bom.js:1509:95
    1509| type BodyInit = string | URLSearchParams | FormData | Blob | ArrayBuffer | $ArrayBufferView | ReadableStream;

--- a/tests/forof/forof.exp
+++ b/tests/forof/forof.exp
@@ -58,8 +58,8 @@ Cannot cast `elem` to number because tuple type [1] is incompatible with number 
               ^^^^
 
 References:
-   <BUILTINS>/core.js:1709:28
-   1709|     @@iterator(): Iterator<[K, V]>;
+   <BUILTINS>/core.js:1711:28
+   1711|     @@iterator(): Iterator<[K, V]>;
                                     ^^^^^^ [1]
    forof.js:32:12
      32|     (elem: number); // Error - tuple ~> number
@@ -75,8 +75,8 @@ Cannot cast `elem` to number because tuple type [1] is incompatible with number 
               ^^^^
 
 References:
-   <BUILTINS>/core.js:1709:28
-   1709|     @@iterator(): Iterator<[K, V]>;
+   <BUILTINS>/core.js:1711:28
+   1711|     @@iterator(): Iterator<[K, V]>;
                                     ^^^^^^ [1]
    forof.js:39:12
      39|     (elem: number); // Error - tuple ~> number

--- a/tests/generators/generators.exp
+++ b/tests/generators/generators.exp
@@ -42,8 +42,8 @@ References:
    class.js:23:39
      23|   *stmt_return_err(): Generator<void, number, void> {
                                                ^^^^^^ [2]
-   <BUILTINS>/core.js:1655:29
-   1655| interface Generator<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:1657:29
+   1657| interface Generator<+Yield,+Return,-Next> {
                                      ^^^^^^ [3]
 
 
@@ -108,14 +108,14 @@ of property `@@iterator`. [incompatible-type-arg]
                     ^^
 
 References:
-   <BUILTINS>/core.js:1648:38
-   1648| type Iterator<+T> = $Iterator<T,void,void>;
+   <BUILTINS>/core.js:1650:38
+   1650| type Iterator<+T> = $Iterator<T,void,void>;
                                               ^^^^ [1]
    class.js:125:42
     125| examples.delegate_next_iterable([]).next(""); // error: Iterator has no next value
                                                   ^^ [2]
-   <BUILTINS>/core.js:1644:37
-   1644| interface $Iterator<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:1646:37
+   1646| interface $Iterator<+Yield,+Return,-Next> {
                                              ^^^^ [3]
 
 
@@ -282,8 +282,8 @@ References:
    generators.js:22:46
      22| function *stmt_return_err(): Generator<void, number, void> {
                                                       ^^^^^^ [2]
-   <BUILTINS>/core.js:1655:29
-   1655| interface Generator<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:1657:29
+   1657| interface Generator<+Yield,+Return,-Next> {
                                      ^^^^^^ [3]
 
 
@@ -399,14 +399,14 @@ of property `@@iterator`. [incompatible-type-arg]
                   ^^
 
 References:
-   <BUILTINS>/core.js:1648:38
-   1648| type Iterator<+T> = $Iterator<T,void,void>;
+   <BUILTINS>/core.js:1650:38
+   1650| type Iterator<+T> = $Iterator<T,void,void>;
                                               ^^^^ [1]
    generators.js:94:33
      94| delegate_next_iterable([]).next(""); // error: Iterator has no next value
                                          ^^ [2]
-   <BUILTINS>/core.js:1644:37
-   1644| interface $Iterator<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:1646:37
+   1646| interface $Iterator<+Yield,+Return,-Next> {
                                              ^^^^ [3]
 
 
@@ -541,8 +541,8 @@ Cannot cast `refuse_return_result.value` to string because undefined [1] is inco
             ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:1635:14
-   1635|     +value?: Return,
+   <BUILTINS>/core.js:1637:14
+   1637|     +value?: Return,
                       ^^^^^^ [1]
    return.js:20:32
      20|   (refuse_return_result.value: string); // error: number | void ~> string

--- a/tests/get_def_enums/get_def_enums.exp
+++ b/tests/get_def_enums/get_def_enums.exp
@@ -24,9 +24,9 @@ library.js:4:3,4:5
 
 main.js:23:13
 Flags:
-[LIB] core.js:2461:3,2461:6
+[LIB] core.js:2463:3,2463:6
 
 main.js:26:13
 Flags:
-[LIB] core.js:2463:3,2463:9
+[LIB] core.js:2465:3,2465:9
 

--- a/tests/iterable/iterable.exp
+++ b/tests/iterable/iterable.exp
@@ -14,8 +14,8 @@ References:
    array.js:7:19
       7| (["hi"]: Iterable<number>); // Error string ~> number
                            ^^^^^^ [2]
-   <BUILTINS>/core.js:1644:22
-   1644| interface $Iterator<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:1646:22
+   1646| interface $Iterator<+Yield,+Return,-Next> {
                               ^^^^^ [3]
 
 
@@ -35,8 +35,8 @@ References:
    array.js:8:22
       8| (["hi", 1]: Iterable<string>); // Error number ~> string
                               ^^^^^^ [2]
-   <BUILTINS>/core.js:1644:22
-   1644| interface $Iterator<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:1646:22
+   1646| interface $Iterator<+Yield,+Return,-Next> {
                               ^^^^^ [3]
 
 
@@ -56,8 +56,8 @@ References:
    caching_bug.js:21:62
      21| function miss_the_cache(x: Array<string | number>): Iterable<string> { return x; }
                                                                       ^^^^^^ [2]
-   <BUILTINS>/core.js:1644:22
-   1644| interface $Iterator<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:1646:22
+   1646| interface $Iterator<+Yield,+Return,-Next> {
                               ^^^^^ [3]
 
 
@@ -74,8 +74,8 @@ References:
    iterator_result.js:17:40
      17| function makeIterator(coin_flip: () => boolean ): Iterator<string> {
                                                 ^^^^^^^ [1]
-   <BUILTINS>/core.js:1639:11
-   1639|     done: false,
+   <BUILTINS>/core.js:1641:11
+   1641|     done: false,
                    ^^^^^ [2]
 
 
@@ -92,8 +92,8 @@ References:
    iterator_result.js:17:40
      17| function makeIterator(coin_flip: () => boolean ): Iterator<string> {
                                                 ^^^^^^^ [1]
-   <BUILTINS>/core.js:1634:11
-   1634|     done: true,
+   <BUILTINS>/core.js:1636:11
+   1636|     done: true,
                    ^^^^ [2]
 
 
@@ -107,14 +107,14 @@ value of property `@@iterator`. [incompatible-return]
                   ^^^
 
 References:
-   <BUILTINS>/core.js:1709:28
-   1709|     @@iterator(): Iterator<[K, V]>;
+   <BUILTINS>/core.js:1711:28
+   1711|     @@iterator(): Iterator<[K, V]>;
                                     ^^^^^^ [1]
    map.js:13:55
      13| function mapTest4(map: Map<number, string>): Iterable<string> {
                                                                ^^^^^^ [2]
-   <BUILTINS>/core.js:1644:22
-   1644| interface $Iterator<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:1646:22
+   1646| interface $Iterator<+Yield,+Return,-Next> {
                               ^^^^^ [3]
 
 
@@ -134,8 +134,8 @@ References:
    set.js:13:47
      13| function setTest4(set: Set<string>): Iterable<number> {
                                                        ^^^^^^ [2]
-   <BUILTINS>/core.js:1644:22
-   1644| interface $Iterator<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:1646:22
+   1646| interface $Iterator<+Yield,+Return,-Next> {
                               ^^^^^ [3]
 
 
@@ -155,8 +155,8 @@ References:
    string.js:5:17
       5| ("hi": Iterable<number>); // Error - string is a Iterable<string>
                          ^^^^^^ [2]
-   <BUILTINS>/core.js:1644:22
-   1644| interface $Iterator<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:1646:22
+   1646| interface $Iterator<+Yield,+Return,-Next> {
                               ^^^^^ [3]
 
 

--- a/tests/lib/lib.exp
+++ b/tests/lib/lib.exp
@@ -41,8 +41,8 @@ Cannot assign `(new TypeError()).name` to `z` because string [1] is incompatible
                         ^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:1550:11
-   1550|     name: string;
+   <BUILTINS>/core.js:1552:11
+   1552|     name: string;
                    ^^^^^^ [1]
    libtest.js:3:7
       3| var z:number = new TypeError().name;

--- a/tests/local_inference_annotations/local_inference_annotations.exp
+++ b/tests/local_inference_annotations/local_inference_annotations.exp
@@ -87,8 +87,8 @@ Property `@@iterator` is missing in function [1] but exists in `$Iterable` [2]. 
                 ^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:1650:11
-   1650| interface $Iterable<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:1652:11
+   1652| interface $Iterable<+Yield,+Return,-Next> {
                    ^^^^^^^^^ [2]
 
 
@@ -289,8 +289,8 @@ Property `@@iterator` is missing in function [1] but exists in `$Iterable` [2]. 
                           ^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:1650:11
-   1650| interface $Iterable<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:1652:11
+   1652| interface $Iterable<+Yield,+Return,-Next> {
                    ^^^^^^^^^ [2]
 
 

--- a/tests/object_api/object_api.exp
+++ b/tests/object_api/object_api.exp
@@ -465,8 +465,8 @@ Cannot assign `x.valueOf` to `xValueOf` because function type [1] is incompatibl
                                  ^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:1505:5
-   1505|     valueOf(): number;
+   <BUILTINS>/core.js:1507:5
+   1507|     valueOf(): number;
              ^^^^^^^^^^^^^^^^^ [1]
    object_prototype.js:122:16
     122| var xValueOf : number = x.valueOf; // error
@@ -483,8 +483,8 @@ Cannot get `x.valueOf` because property `valueOf` [1] cannot be unbound from the
                                    ^^^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:1505:5
-   1505|     valueOf(): number;
+   <BUILTINS>/core.js:1507:5
+   1507|     valueOf(): number;
              ^^^^^^^^^^^^^^^^^ [2]
 
 
@@ -536,8 +536,8 @@ Cannot assign `x.toLocaleString` to `xToLocaleString` because function type [1] 
                                         ^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:1493:5
-   1493|     toLocaleString(locales?: string | Array<string>, options?: Intl$DateTimeFormatOptions): string;
+   <BUILTINS>/core.js:1495:5
+   1495|     toLocaleString(locales?: string | Array<string>, options?: Intl$DateTimeFormatOptions): string;
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
    object_prototype.js:150:23
     150| var xToLocaleString : number = x.toLocaleString; // error
@@ -554,8 +554,8 @@ defined. [method-unbinding]
                                           ^^^^^^^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:1493:5
-   1493|     toLocaleString(locales?: string | Array<string>, options?: Intl$DateTimeFormatOptions): string;
+   <BUILTINS>/core.js:1495:5
+   1495|     toLocaleString(locales?: string | Array<string>, options?: Intl$DateTimeFormatOptions): string;
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [2]
 
 
@@ -569,8 +569,8 @@ where it was defined in the `this` parameter. [method-unbinding]
                                                ^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:1493:5
-   1493|     toLocaleString(locales?: string | Array<string>, options?: Intl$DateTimeFormatOptions): string;
+   <BUILTINS>/core.js:1495:5
+   1495|     toLocaleString(locales?: string | Array<string>, options?: Intl$DateTimeFormatOptions): string;
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 
@@ -584,8 +584,8 @@ value. [incompatible-type]
                                                ^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:1493:93
-   1493|     toLocaleString(locales?: string | Array<string>, options?: Intl$DateTimeFormatOptions): string;
+   <BUILTINS>/core.js:1495:93
+   1495|     toLocaleString(locales?: string | Array<string>, options?: Intl$DateTimeFormatOptions): string;
                                                                                                      ^^^^^^ [1]
    object_prototype.js:151:30
     151| var xToLocaleString2 : () => number = x.toLocaleString; // error
@@ -602,8 +602,8 @@ defined. [method-unbinding]
                                                  ^^^^^^^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:1493:5
-   1493|     toLocaleString(locales?: string | Array<string>, options?: Intl$DateTimeFormatOptions): string;
+   <BUILTINS>/core.js:1495:5
+   1495|     toLocaleString(locales?: string | Array<string>, options?: Intl$DateTimeFormatOptions): string;
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [2]
 
 

--- a/tests/overload/overload.exp
+++ b/tests/overload/overload.exp
@@ -46,8 +46,8 @@ Cannot get `"".match(...)[0]` because null [1] does not have properties. [incomp
                                       ^
 
 References:
-   <BUILTINS>/core.js:1149:58
-   1149|     match(regexp: string | RegExp): RegExp$matchResult | null;
+   <BUILTINS>/core.js:1151:58
+   1151|     match(regexp: string | RegExp): RegExp$matchResult | null;
                                                                   ^^^^ [1]
 
 
@@ -61,8 +61,8 @@ Cannot call `"".match` with `0` bound to `regexp` because number [1] is incompat
                                    ^ [1]
 
 References:
-   <BUILTINS>/core.js:1149:19
-   1149|     match(regexp: string | RegExp): RegExp$matchResult | null;
+   <BUILTINS>/core.js:1151:19
+   1151|     match(regexp: string | RegExp): RegExp$matchResult | null;
                            ^^^^^^ [2]
 
 
@@ -92,8 +92,8 @@ Cannot get `"".match(...)[0]` because null [1] does not have properties. [incomp
                                               ^
 
 References:
-   <BUILTINS>/core.js:1149:58
-   1149|     match(regexp: string | RegExp): RegExp$matchResult | null;
+   <BUILTINS>/core.js:1151:58
+   1151|     match(regexp: string | RegExp): RegExp$matchResult | null;
                                                                   ^^^^ [1]
 
 
@@ -106,8 +106,8 @@ Cannot assign `"".split(...)[0]` to `x4` because string [1] is incompatible with
                           ^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:1216:63
-   1216|     split(separator?: string | RegExp, limit?: number): Array<string>;
+   <BUILTINS>/core.js:1218:63
+   1218|     split(separator?: string | RegExp, limit?: number): Array<string>;
                                                                        ^^^^^^ [1]
    overload.js:10:9
      10| var x4: number = "".split(/pattern/)[0];

--- a/tests/promises/promises.exp
+++ b/tests/promises/promises.exp
@@ -109,8 +109,8 @@ Cannot call `Promise.all` because function [1] requires another argument. [incom
                  ^^^
 
 References:
-   <BUILTINS>/core.js:1884:5
-   1884|     static all<T: Iterable<mixed>>(promises: T): Promise<$TupleMap<T, typeof $await>>;
+   <BUILTINS>/core.js:1886:5
+   1886|     static all<T: Iterable<mixed>>(promises: T): Promise<$TupleMap<T, typeof $await>>;
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 
@@ -124,8 +124,8 @@ in `$Iterable` [2]. [prop-missing]
                      ^ [1]
 
 References:
-   <BUILTINS>/core.js:1884:19
-   1884|     static all<T: Iterable<mixed>>(promises: T): Promise<$TupleMap<T, typeof $await>>;
+   <BUILTINS>/core.js:1886:19
+   1886|     static all<T: Iterable<mixed>>(promises: T): Promise<$TupleMap<T, typeof $await>>;
                            ^^^^^^^^^^^^^^^ [2]
 
 
@@ -138,8 +138,8 @@ Cannot call `Promise.allSettled` because function [1] requires another argument.
                  ^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:1891:5
-   1891|     static allSettled<T: Iterable<mixed>>(promises: T): Promise<$TupleMap<T, <T>(p: Promise<T> | T) => $SettledPromiseResult<T>>>;
+   <BUILTINS>/core.js:1893:5
+   1893|     static allSettled<T: Iterable<mixed>>(promises: T): Promise<$TupleMap<T, <T>(p: Promise<T> | T) => $SettledPromiseResult<T>>>;
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 
@@ -153,8 +153,8 @@ exists in `$Iterable` [2]. [prop-missing]
                             ^ [1]
 
 References:
-   <BUILTINS>/core.js:1891:26
-   1891|     static allSettled<T: Iterable<mixed>>(promises: T): Promise<$TupleMap<T, <T>(p: Promise<T> | T) => $SettledPromiseResult<T>>>;
+   <BUILTINS>/core.js:1893:26
+   1893|     static allSettled<T: Iterable<mixed>>(promises: T): Promise<$TupleMap<T, <T>(p: Promise<T> | T) => $SettledPromiseResult<T>>>;
                                   ^^^^^^^^^^^^^^^ [2]
 
 
@@ -168,8 +168,8 @@ Cannot cast `first.status` to empty because string literal `rejected` [1] is inc
                 ^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:1905:12
-   1905|   +status: 'rejected',
+   <BUILTINS>/core.js:1907:12
+   1907|   +status: 'rejected',
                     ^^^^^^^^^^ [1]
    allSettled.js:36:22
      36|       (first.status: empty) // Error: 'rejected' case was not covered
@@ -517,8 +517,8 @@ References:
    resolve_void.js:3:29
       3| (Promise.resolve(): Promise<number>); // error
                                      ^^^^^^ [2]
-   <BUILTINS>/core.js:1809:24
-   1809| declare class Promise<+R> {
+   <BUILTINS>/core.js:1811:24
+   1811| declare class Promise<+R> {
                                 ^ [3]
 
 
@@ -535,8 +535,8 @@ References:
    resolve_void.js:5:38
       5| (Promise.resolve(undefined): Promise<number>); // error
                                               ^^^^^^ [2]
-   <BUILTINS>/core.js:1809:24
-   1809| declare class Promise<+R> {
+   <BUILTINS>/core.js:1811:24
+   1811| declare class Promise<+R> {
                                 ^ [3]
 
 

--- a/tests/proto/proto.exp
+++ b/tests/proto/proto.exp
@@ -478,8 +478,8 @@ property `constructor` [1] cannot be unbound from the context [2] where it was d
                                          ^^^^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:1549:5
-   1549|     constructor (message?: mixed): void;
+   <BUILTINS>/core.js:1551:5
+   1551|     constructor (message?: mixed): void;
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [2]
 
 

--- a/tests/react_16_6/react_16_6.exp
+++ b/tests/react_16_6/react_16_6.exp
@@ -76,8 +76,8 @@ References:
    <BUILTINS>/react.js:335:30
     335|     component: () => Promise<{ default: React$AbstractComponent<Config, Instance>, ... }>,
                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [2]
-   <BUILTINS>/core.js:1809:24
-   1809| declare class Promise<+R> {
+   <BUILTINS>/core.js:1811:24
+   1811| declare class Promise<+R> {
                                 ^ [3]
 
 
@@ -97,8 +97,8 @@ References:
    <BUILTINS>/react.js:335:30
     335|     component: () => Promise<{ default: React$AbstractComponent<Config, Instance>, ... }>,
                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [2]
-   <BUILTINS>/core.js:1809:24
-   1809| declare class Promise<+R> {
+   <BUILTINS>/core.js:1811:24
+   1811| declare class Promise<+R> {
                                 ^ [3]
 
 

--- a/tests/rec/rec.exp
+++ b/tests/rec/rec.exp
@@ -7,11 +7,11 @@ undefined [1] is incompatible with `$Iterable` [2]. [incompatible-type]
                          ^
 
 References:
-   <BUILTINS>/core.js:1718:22
-   1718|     get(key: K): V | void;
+   <BUILTINS>/core.js:1720:22
+   1720|     get(key: K): V | void;
                               ^^^^ [1]
-   <BUILTINS>/core.js:1650:11
-   1650| interface $Iterable<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:1652:11
+   1652| interface $Iterable<+Yield,+Return,-Next> {
                    ^^^^^^^^^ [2]
 
 
@@ -24,11 +24,11 @@ undefined [1] is incompatible with `$Iterable` [2]. [incompatible-type]
                          ^
 
 References:
-   <BUILTINS>/core.js:1718:22
-   1718|     get(key: K): V | void;
+   <BUILTINS>/core.js:1720:22
+   1720|     get(key: K): V | void;
                               ^^^^ [1]
-   <BUILTINS>/core.js:1650:11
-   1650| interface $Iterable<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:1652:11
+   1652| interface $Iterable<+Yield,+Return,-Next> {
                    ^^^^^^^^^ [2]
 
 
@@ -41,11 +41,11 @@ undefined [1] is incompatible with `$Iterable` [2]. [incompatible-type]
                          ^
 
 References:
-   <BUILTINS>/core.js:1718:22
-   1718|     get(key: K): V | void;
+   <BUILTINS>/core.js:1720:22
+   1720|     get(key: K): V | void;
                               ^^^^ [1]
-   <BUILTINS>/core.js:1650:11
-   1650| interface $Iterable<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:1652:11
+   1652| interface $Iterable<+Yield,+Return,-Next> {
                    ^^^^^^^^^ [2]
 
 
@@ -58,11 +58,11 @@ undefined [1] is incompatible with `$Iterable` [2]. [incompatible-type]
                          ^
 
 References:
-   <BUILTINS>/core.js:1718:22
-   1718|     get(key: K): V | void;
+   <BUILTINS>/core.js:1720:22
+   1720|     get(key: K): V | void;
                               ^^^^ [1]
-   <BUILTINS>/core.js:1650:11
-   1650| interface $Iterable<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:1652:11
+   1652| interface $Iterable<+Yield,+Return,-Next> {
                    ^^^^^^^^^ [2]
 
 

--- a/tests/regexp/regexp.exp
+++ b/tests/regexp/regexp.exp
@@ -7,8 +7,8 @@ Cannot assign `patt.test(...)` to `match` because boolean [1] is incompatible wi
                             ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:1335:27
-   1335|     test(string: string): boolean;
+   <BUILTINS>/core.js:1337:27
+   1337|     test(string: string): boolean;
                                    ^^^^^^^ [1]
    regexp.js:2:11
       2| var match:number = patt.test("Hello world!");

--- a/tests/return/return.exp
+++ b/tests/return/return.exp
@@ -40,8 +40,8 @@ undefined in type argument `R` [2]. [incompatible-return]
                                       ^^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:1809:24
-   1809| declare class Promise<+R> {
+   <BUILTINS>/core.js:1811:24
+   1811| declare class Promise<+R> {
                                 ^ [2]
 
 


### PR DESCRIPTION
Fixes #8728 and unblocks https://github.com/facebook/react/pull/22064.

According to the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/concat) for the `concat()` method of the `String` built-in type: 

> If the arguments are not of the type string, they are converted to string values before concatenating.

Passing numbers, objects, etc to `String.prototype.concat` is is valid JS behavior but causes an error in Flow. It's also blocking https://github.com/facebook/react/pull/22064.

This PR changes the arg type from `Array<string>` to `Array<mixed>`.

<!--
  If this is a change to library defintions, please include links to relevant documentation.
  If this is a documentation change, please prefix the title with [DOCS].

  If this is neither, ensure you opened a discussion issue and link it in the PR description.
-->
