### PR TITLE
flow-remove-types: Remove variance sigil of class properties

### DIFF
--- a/packages/flow-remove-types/index.js
+++ b/packages/flow-remove-types/index.js
@@ -201,6 +201,9 @@ var removeFlowVisitor = {
     if (node.declare || (context.ignoreUninitializedFields && !node.value)) {
       return removeNode(context, node);
     }
+    if (node.variance != null) {
+      removeNode(context, node.variance);
+    }
   },
 
   ExportNamedDeclaration: function(context, node) {

--- a/packages/flow-remove-types/test/expected.js
+++ b/packages/flow-remove-types/test/expected.js
@@ -39,8 +39,14 @@ class Bar extends Other            /*.*/                 {
   // Class Property with default value
   answer         = 42;
 
+  // Class Property with default value and variance
+   covariant         = 42;
+
   // Class Property
   prop     ;
+
+  // Class Property with variance
+   propCo        ;
 
   method()        {
     return;

--- a/packages/flow-remove-types/test/source.js
+++ b/packages/flow-remove-types/test/source.js
@@ -39,8 +39,14 @@ class Bar extends Other implements /*.*/ Foo, ISomething {
   // Class Property with default value
   answer: number = 42;
 
+  // Class Property with default value and variance
+  +covariant: number = 42;
+
   // Class Property
   prop: any;
+
+  // Class Property with variance
+  +propCo: number;
 
   method(): mixed {
     return;


### PR DESCRIPTION
Closes https://github.com/facebook/flow/issues/8725
Closes https://github.com/facebook/flow/issues/8549

An alternative solution to the one I implemented would be to add `Variance: removeNode,` to the visitor:
https://github.com/facebook/flow/blob/f9afdbc9c5971c2517ce96c64d996325cd6e6405/packages/flow-remove-types/index.js#L153-L171
