### PR TITLE
use node 12 in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ executors:
     working_directory: ~/flow
   linux-node:
     docker:
-      - image: circleci/node:8
+      - image: circleci/node:12
     working_directory: ~/flow
   mac:
     macos:


### PR DESCRIPTION
Summary:
node 12 is the oldest version that's still maintained, so that's the oldest we are going to target.

Changelog: [internal]

Differential Revision: D30609813

