### PR TITLE
Loc none fast comparison

### DIFF
--- a/src/parser/loc.ml
+++ b/src/parser/loc.ml
@@ -24,6 +24,13 @@ type t = {
 
 let none = { source = None; start = { line = 0; column = 0 }; _end = { line = 0; column = 0 } }
 
+let is_none (x : t) =
+  x == none
+  ||
+  match x with
+  | { source = None; start = { line = 0; column = 0 }; _end = { line = 0; column = 0 } } -> true
+  | _ -> false
+
 let btwn loc1 loc2 = { source = loc1.source; start = loc1.start; _end = loc2._end }
 
 (* Returns the position immediately before the start of the given loc. If the

--- a/src/parser/loc.mli
+++ b/src/parser/loc.mli
@@ -20,6 +20,8 @@ type t = {
 
 val none : t
 
+val is_none : t -> bool
+
 val btwn : t -> t -> t
 
 val char_before : t -> t

--- a/src/parser_utils/aloc/aLoc.ml
+++ b/src/parser_utils/aloc/aLoc.ml
@@ -92,7 +92,7 @@ end = struct
   let kind (loc : t) : kind =
     if is_keyed loc then
       Keyed
-    else if Obj.magic loc = Loc.none then
+    else if Loc.is_none (Obj.magic loc) then
       ALocNone
     else
       Concrete
@@ -218,7 +218,7 @@ let compare loc1 loc2 =
 let quick_compare loc1 loc2 =
   (* String comparisons are expensive, so we should only evaluate this lambda if
    * the other information we have ties *)
-  let source_compare () = File_key.compare_opt (Repr.source loc1) (Repr.source loc2) in
+  let[@local] source_compare () = File_key.compare_opt (Repr.source loc1) (Repr.source loc2) in
   match (Repr.kind loc1, Repr.kind loc2) with
   | (Repr.Keyed, Repr.Keyed) ->
     let k1 = Repr.get_key_exn loc1 in


### PR DESCRIPTION
<!--
  If this is a change to library defintions, please include links to relevant documentation.
  If this is a documentation change, please prefix the title with [DOCS].

  If this is neither, ensure you opened a discussion issue and link it in the PR description.
-->
This is part of the work of #8739
Aloc.kind is a hot path, this diff eliminate the polymorphic comparison amongst the hot path