### PR TITLE
Flow_set printer

### DIFF
--- a/src/common/utils/utils_js.ml
+++ b/src/common/utils/utils_js.ml
@@ -15,7 +15,13 @@ let prerr_endlinef fmt = Printf.ksprintf prerr_endline fmt
 
 let exe_name = Filename.basename Sys.executable_name
 
-module FilenameSet = Flow_set.Make (File_key)
+module FilenameSet = struct
+  include Flow_set.Make (File_key)
+
+  let pp = make_pp File_key.pp
+
+  let show x = Format.asprintf "%a" pp x
+end
 
 module FilenameMap = struct
   include WrappedMap.Make (File_key)

--- a/src/hack_forked/utils/collections/flow_set.ml
+++ b/src/hack_forked/utils/collections/flow_set.ml
@@ -71,6 +71,29 @@ module type S = sig
   val to_seq : t -> elt Seq.t
 
   val of_list : elt list -> t
+
+  val make_pp : (Format.formatter -> elt -> unit) -> Format.formatter -> t -> unit
 end
 
-module Make : functor (Ord : Set.OrderedType) -> S with type elt = Ord.t = Set.Make
+module Make (Ord : Set.OrderedType) : S with type elt = Ord.t = struct
+  include Set.Make (Ord)
+
+  let make_pp pp_key fmt iset =
+    Format.fprintf fmt "@[<2>{";
+    let elements = elements iset in
+    (match elements with
+    | [] -> ()
+    | _ -> Format.fprintf fmt " ");
+    ignore
+      (List.fold_left
+         (fun sep s ->
+           if sep then Format.fprintf fmt ";@ ";
+           pp_key fmt s;
+           true)
+         false
+         elements);
+    (match elements with
+    | [] -> ()
+    | _ -> Format.fprintf fmt " ");
+    Format.fprintf fmt "@,}@]"
+end

--- a/src/hack_forked/utils/collections/iMap.ml
+++ b/src/hack_forked/utils/collections/iMap.ml
@@ -8,6 +8,6 @@
 include WrappedMap.Make (IntKey)
 
 let pp : (Format.formatter -> 'a -> unit) -> Format.formatter -> 'a t -> unit =
- (fun pp_data -> make_pp Format.pp_print_int pp_data)
+ (fun pp_data -> make_pp IntKey.pp pp_data)
 
 let show pp_data x = Format.asprintf "%a" (pp pp_data) x

--- a/src/hack_forked/utils/collections/iSet.ml
+++ b/src/hack_forked/utils/collections/iSet.ml
@@ -7,24 +7,7 @@
 
 include Flow_set.Make (IntKey)
 
-let pp fmt iset =
-  Format.fprintf fmt "@[<2>{";
-  let elements = elements iset in
-  (match elements with
-  | [] -> ()
-  | _ -> Format.fprintf fmt " ");
-  ignore
-    (List.fold_left
-       (fun sep s ->
-         if sep then Format.fprintf fmt ";@ ";
-         Format.pp_print_int fmt s;
-         true)
-       false
-       elements);
-  (match elements with
-  | [] -> ()
-  | _ -> Format.fprintf fmt " ");
-  Format.fprintf fmt "@,}@]"
+let pp = make_pp IntKey.pp
 
 let show iset = Format.asprintf "%a" pp iset
 

--- a/src/hack_forked/utils/collections/intKey.ml
+++ b/src/hack_forked/utils/collections/intKey.ml
@@ -8,3 +8,5 @@
 type t = int
 
 let compare = ( - )
+
+let pp = Format.pp_print_int

--- a/src/hack_forked/utils/collections/sMap.ml
+++ b/src/hack_forked/utils/collections/sMap.ml
@@ -8,6 +8,6 @@
 include WrappedMap.Make (StringKey)
 
 let pp : (Format.formatter -> 'a -> unit) -> Format.formatter -> 'a t -> unit =
- (fun pp_data -> make_pp (fun fmt s -> Format.fprintf fmt "%S" s) pp_data)
+ (fun pp_data -> make_pp StringKey.pp pp_data)
 
 let show pp_data x = Format.asprintf "%a" (pp pp_data) x

--- a/src/hack_forked/utils/collections/sSet.ml
+++ b/src/hack_forked/utils/collections/sSet.ml
@@ -7,24 +7,7 @@
 
 include Flow_set.Make (StringKey)
 
-let pp fmt sset =
-  Format.fprintf fmt "@[<2>{";
-  let elements = elements sset in
-  (match elements with
-  | [] -> ()
-  | _ -> Format.fprintf fmt " ");
-  ignore
-    (List.fold_left
-       (fun sep s ->
-         if sep then Format.fprintf fmt ";@ ";
-         Format.fprintf fmt "%S" s;
-         true)
-       false
-       elements);
-  (match elements with
-  | [] -> ()
-  | _ -> Format.fprintf fmt " ");
-  Format.fprintf fmt "@,}@]"
+let pp = make_pp StringKey.pp
 
 let show sset = Format.asprintf "%a" pp sset
 

--- a/src/hack_forked/utils/collections/stringKey.ml
+++ b/src/hack_forked/utils/collections/stringKey.ml
@@ -10,3 +10,5 @@ type t = string
 let compare (x : t) (y : t) = String.compare x y
 
 let to_string x = x
+
+let pp fmt x = Format.fprintf fmt "%S" x


### PR DESCRIPTION
Summary:
very useful for debugging. `deriving` doesn't handle sets or maps, so we have to implement `pp` ourselves. we do the same pattern in `WrappedMap`.

Changelog: [internal]

Differential Revision: D31054814

