### PR TITLE
Fix navigator.clipboard.write type and add ClipboardItem

### DIFF
--- a/lib/bom.js
+++ b/lib/bom.js
@@ -316,7 +316,7 @@ declare class Navigator mixins
 declare class Clipboard extends EventTarget {
     read(): Promise<DataTransfer>;
     readText(): Promise<string>;
-    write(data: DataTransfer): Promise<void>;
+    write(data: $ReadOnlyArray<ClipboardItem>): Promise<void>;
     writeText(data: string): Promise<void>;
 }
 

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -710,6 +710,25 @@ declare class StorageEvent extends Event {
   storageArea: ?Storage,
 }
 
+
+type ClipboardItemData = string | Blob;
+
+type PresentationStyle = "attachment" | "inline" | "unspecified";
+
+type ClipboardItemOptions = {
+  presentationStyle?: PresentationStyle;
+}
+
+declare interface ClipboardItemInterface {
+  +types: $ReadOnlyArray<string>;
+  getType(type: string): Promise<Blob>;
+}
+
+declare class ClipboardItem {
+  +prototype: ClipboardItemInterface;
+  constructor(items: {[type: string]: ClipboardItemData}, options?: ClipboardItemOptions): ClipboardItem
+}
+
 // https://w3c.github.io/clipboard-apis/ as of 15 May 2018
 type ClipboardEvent$Init = {
   ...Event$Init,


### PR DESCRIPTION
Summary:
I noticed that the type for clipboard.write was expecting a DataTransfer, when this doesn't seem to be the case on any browser. I updated it according to the spec by adding the new ClipboardItem type.

I essentially just took the types from the [W3C spec](https://w3c.github.io/clipboard-apis/#clipboarditem) and the [Typescript definitions](https://github.com/microsoft/TypeScript/blob/80e1a2924853f87926fc13d684920813499193e4/lib/lib.dom.d.ts#L3548) and copied them here in Flow.

I'm by no means a Flow expert so please let me know if any changes are needed!

Differential Revision: D31668972

