### PR TITLE
[COMMENTS] Clarify ConcretizeTypeAppsT logic after Subtyping_kit refactor

### DIFF
--- a/src/typing/flow_js.ml
+++ b/src/typing/flow_js.ml
@@ -1440,10 +1440,13 @@ struct
           let reason_op = reason_of_use_t u in
           let t = mk_typeapp_instance cx ~trace ~use_op ~reason_op ~reason_tapp ~cache:[] c ts in
           rec_flow cx trace (t, u)
-        (* When we have concretized the c for our upper bound TypeAppT then we want
-         * to concretize the lower bound. We flip all our arguments to
-         * ConcretizeTypeAppsT and set the final element to false to signal that we
-         * have concretized the upper bound's c.
+        (* This is the second step in checking a TypeAppT (c, ts) ~> TypeAppT (c, ts).
+         * The first step is in subtyping_kit.ml, and concretizes the c for our
+         * upper bound TypeAppT.
+         *
+         * When we have done that, then we want to concretize the lower bound. We
+         * flip all our arguments to ConcretizeTypeAppsT and set the final element
+         * to false to signal that we have concretized the upper bound's c.
          *
          * If the upper bound's c is not a PolyT then we will fall down to an
          * incompatible use error. *)

--- a/src/typing/subtyping_kit.ml
+++ b/src/typing/subtyping_kit.ml
@@ -621,7 +621,11 @@ module Make (Flow : INPUT) : OUTPUT = struct
      * We use the ConcretizeTypeAppsT use type to concretize both the c of our
      * upper and lower TypeAppT bound. We start by concretizing the upper bound
      * which we signal by setting the final element in ConcretizeTypeAppsT to
-     * true. *)
+     * true.
+     *
+     * The next step happens back in flow_js.ml, at the cases for a
+     * ConcretizeTypeAppsT use type.
+     *)
     | (TypeAppT (r1, op1, c1, ts1), TypeAppT (r2, op2, c2, ts2)) ->
       if TypeAppExpansion.push_unless_loop cx (c1, ts1) then (
         if TypeAppExpansion.push_unless_loop cx (c2, ts2) then (


### PR DESCRIPTION
These comments were originally written (in e4b2c0590 / D5648147)
to appear in sequence next to each other, and each one implicitly
refers to the one before it in order to be understood.

Now that one of these steps is in Subtyping_kit while the others are
in Flow_js, add a few more words to point at each other and stitch
them together.  This reduces the amount of code spelunking needed in
order to understand how this logic is meant to work.
