### PR TITLE
Fix unsound subtyping for PolyT ~> PolyT

### DIFF
--- a/src/typing/flow_js.ml
+++ b/src/typing/flow_js.ml
@@ -8233,52 +8233,6 @@ struct
           resolve_id cx trace ~use_op:(unify_flip use_op) id t
         | (DefT (_, _, PolyT { id = id1; _ }), DefT (_, _, PolyT { id = id2; _ })) when id1 = id2 ->
           ()
-        | ( DefT
-              (r1, _, PolyT { tparams_loc = tparams_loc1; tparams = params1; t_out = t1; id = id1 }),
-            DefT
-              (r2, _, PolyT { tparams_loc = tparams_loc2; tparams = params2; t_out = t2; id = id2 })
-          ) ->
-          let n1 = Nel.length params1 in
-          let n2 = Nel.length params2 in
-          if n2 > n1 then
-            add_output cx ~trace (Error_message.ETooManyTypeArgs (r2, r1, n1))
-          else if n2 < n1 then
-            add_output cx ~trace (Error_message.ETooFewTypeArgs (r2, r1, n1))
-          else
-            (* for equal-arity polymorphic types, unify param upper bounds
-               with each other, then instances parameterized by these *)
-            let args1 = instantiate_poly_param_upper_bounds cx params1 in
-            let args2 = instantiate_poly_param_upper_bounds cx params2 in
-            List.iter2 (rec_unify cx trace ~use_op) args1 args2;
-            let inst1 =
-              let r = reason_of_t t1 in
-              mk_typeapp_of_poly
-                cx
-                trace
-                ~use_op
-                ~reason_op:r
-                ~reason_tapp:r
-                id1
-                tparams_loc1
-                params1
-                t1
-                args1
-            in
-            let inst2 =
-              let r = reason_of_t t2 in
-              mk_typeapp_of_poly
-                cx
-                trace
-                ~use_op
-                ~reason_op:r
-                ~reason_tapp:r
-                id2
-                tparams_loc2
-                params2
-                t2
-                args2
-            in
-            rec_unify cx trace ~use_op inst1 inst2
         | (DefT (_, _, ArrT (ArrayAT (t1, ts1))), DefT (_, _, ArrT (ArrayAT (t2, ts2)))) ->
           let ts1 = Base.Option.value ~default:[] ts1 in
           let ts2 = Base.Option.value ~default:[] ts2 in

--- a/tests/poly/poly.exp
+++ b/tests/poly/poly.exp
@@ -282,6 +282,176 @@ References:
                  ^ [3]
 
 
+Error ------------------------------------------------------------------------------------------------ subtyping.js:9:40
+
+Cannot return `o` because mixed [1] is incompatible with `S` [2] in the return value. [incompatible-return]
+
+   subtyping.js:9:40
+   9|   (o: <T>() => mixed): (<S>() => S) => o; // error
+                                             ^
+
+References:
+   subtyping.js:9:16
+   9|   (o: <T>() => mixed): (<S>() => S) => o; // error
+                     ^^^^^ [1]
+   subtyping.js:9:34
+   9|   (o: <T>() => mixed): (<S>() => S) => o; // error
+                                       ^ [2]
+
+
+Error ----------------------------------------------------------------------------------------------- subtyping.js:12:48
+
+Cannot return `o` because `A` [1] is incompatible with `S` [2] in the return value. [incompatible-return]
+
+   subtyping.js:12:48
+   12|     const g = (o: <T>() => A): (<S>() => S) => o; // error
+                                                      ^
+
+References:
+   subtyping.js:12:28
+   12|     const g = (o: <T>() => A): (<S>() => S) => o; // error
+                                  ^ [1]
+   subtyping.js:12:42
+   12|     const g = (o: <T>() => A): (<S>() => S) => o; // error
+                                                ^ [2]
+
+
+Error ----------------------------------------------------------------------------------------------- subtyping.js:22:46
+
+Cannot return `f` because mixed [1] is incompatible with `S` [2] in the return value. [incompatible-return]
+
+   subtyping.js:22:46
+   22|   (f: <T>(T) => mixed): (<S>(mixed) => S) => f; // error
+                                                    ^
+
+References:
+   subtyping.js:22:17
+   22|   (f: <T>(T) => mixed): (<S>(mixed) => S) => f; // error
+                       ^^^^^ [1]
+   subtyping.js:22:40
+   22|   (f: <T>(T) => mixed): (<S>(mixed) => S) => f; // error
+                                              ^ [2]
+
+
+Error ----------------------------------------------------------------------------------------------- subtyping.js:25:58
+
+Cannot return `f` because mixed [1] is incompatible with `S` [2] in the return value. [incompatible-return]
+
+   subtyping.js:25:58
+   25|     const g = (f: <T>(T) => mixed): (<S>(mixed) => S) => f; // error
+                                                                ^
+
+References:
+   subtyping.js:25:29
+   25|     const g = (f: <T>(T) => mixed): (<S>(mixed) => S) => f; // error
+                                   ^^^^^ [1]
+   subtyping.js:25:52
+   25|     const g = (f: <T>(T) => mixed): (<S>(mixed) => S) => f; // error
+                                                          ^ [2]
+
+
+Error ----------------------------------------------------------------------------------------------- subtyping.js:48:51
+
+Cannot return `f` because boolean [1] is incompatible with `T` [2] in the second parameter. [incompatible-return]
+
+   subtyping.js:48:51
+   48| (f: <R, S>(R, S) => S): (<T>(T, T) => boolean) => f; // error
+                                                         ^
+
+References:
+   subtyping.js:48:39
+   48| (f: <R, S>(R, S) => S): (<T>(T, T) => boolean) => f; // error
+                                             ^^^^^^^ [1]
+   subtyping.js:48:33
+   48| (f: <R, S>(R, S) => S): (<T>(T, T) => boolean) => f; // error
+                                       ^ [2]
+
+
+Error ----------------------------------------------------------------------------------------------- subtyping.js:52:49
+
+Cannot return `f` because `T` [1] is incompatible with `S` [2] in the first parameter. [incompatible-return]
+
+   subtyping.js:52:49
+   52| (f: <R>(R, mixed) => R): (<S, T>(S, T) => T) => f; // error
+                                                       ^
+
+References:
+   subtyping.js:52:43
+   52| (f: <R>(R, mixed) => R): (<S, T>(S, T) => T) => f; // error
+                                                 ^ [1]
+   subtyping.js:52:34
+   52| (f: <R>(R, mixed) => R): (<S, T>(S, T) => T) => f; // error
+                                        ^ [2]
+
+
+Error ----------------------------------------------------------------------------------------------- subtyping.js:57:54
+
+Cannot return `f` because number [1] is incompatible with `T` [2] in the first parameter. [incompatible-return]
+
+   subtyping.js:57:54
+   57| (f: (number, number) => number): (<T>(T, T) => T) => f; // error
+                                                            ^
+
+References:
+   subtyping.js:57:6
+   57| (f: (number, number) => number): (<T>(T, T) => T) => f; // error
+            ^^^^^^ [1]
+   subtyping.js:57:39
+   57| (f: (number, number) => number): (<T>(T, T) => T) => f; // error
+                                             ^ [2]
+
+
+Error ----------------------------------------------------------------------------------------------- subtyping.js:57:54
+
+Cannot return `f` because number [1] is incompatible with `T` [2] in the second parameter. [incompatible-return]
+
+   subtyping.js:57:54
+   57| (f: (number, number) => number): (<T>(T, T) => T) => f; // error
+                                                            ^
+
+References:
+   subtyping.js:57:14
+   57| (f: (number, number) => number): (<T>(T, T) => T) => f; // error
+                    ^^^^^^ [1]
+   subtyping.js:57:42
+   57| (f: (number, number) => number): (<T>(T, T) => T) => f; // error
+                                                ^ [2]
+
+
+Error ----------------------------------------------------------------------------------------------- subtyping.js:57:54
+
+Cannot return `f` because number [1] is incompatible with `T` [2] in the return value. [incompatible-return]
+
+   subtyping.js:57:54
+   57| (f: (number, number) => number): (<T>(T, T) => T) => f; // error
+                                                            ^
+
+References:
+   subtyping.js:57:25
+   57| (f: (number, number) => number): (<T>(T, T) => T) => f; // error
+                               ^^^^^^ [1]
+   subtyping.js:57:48
+   57| (f: (number, number) => number): (<T>(T, T) => T) => f; // error
+                                                      ^ [2]
+
+
+Error ----------------------------------------------------------------------------------------------- subtyping.js:61:54
+
+Cannot return `f` because number [1] is incompatible with string [2] in the second parameter. [incompatible-return]
+
+   subtyping.js:61:54
+   61| (f: <T>(T, T) => T): ((number, string) => number) => f; // error
+                                                            ^
+
+References:
+   subtyping.js:61:43
+   61| (f: <T>(T, T) => T): ((number, string) => number) => f; // error
+                                                 ^^^^^^ [1]
+   subtyping.js:61:32
+   61| (f: <T>(T, T) => T): ((number, string) => number) => f; // error
+                                      ^^^^^^ [2]
+
+
 Error ----------------------------------------------------------------------------------------------------- test.js:8:10
 
 Cannot extend `C` [1] with `D` because number [2] is incompatible with `X` [3] in the first parameter of property `foo`.
@@ -319,4 +489,4 @@ References:
 
 
 
-Found 19 errors
+Found 29 errors

--- a/tests/poly/subtyping.js
+++ b/tests/poly/subtyping.js
@@ -1,0 +1,61 @@
+// @flow
+//
+// Tests for subtyping PolyT ~> PolyT.
+
+// Test issue #8766: we'd accept when the subtyping looked OK with the
+// upper tparams set to their bounds, even if it wasn't OK for other
+// possible arguments.
+{
+  (o: <T>() => mixed): (<S>() => S) => o; // error
+
+  function coerce<A, B>(x: A): B {
+    const g = (o: <T>() => A): (<S>() => S) => o; // error
+    return g(<T>() => x)();
+  }
+
+  const a: number = coerce('a');
+  a.toFixed();
+}
+
+// Test issue #8766, round 2.
+{
+  (f: <T>(T) => mixed): (<S>(mixed) => S) => f; // error
+
+  function coerce<A, B>(x: A): B {
+    const g = (f: <T>(T) => mixed): (<S>(mixed) => S) => f; // error
+    return g(<T>(y: T) => x)();
+  }
+
+  (coerce('a'): empty);
+  coerce('a').toFixed();
+}
+
+// Test another symptom of #8766: we'd reject a subtyping when setting
+// the lower tparams to their bounds didn't make it work, even if some
+// other setting would work fine.
+{
+  (f: <T>(T) => T): (<S>(number) => number) => f; // ok
+
+  const f: <T>(T) => T = <T>(x: T): T => x;
+  f(3);
+  (f: <S>(number) => number); // ok
+  (f: <S>(number) => number)(3); // ok
+}
+
+
+// Test subtyping where lower has more parameters than upper…
+(f: <R, S>(R, S) => S): (<T>(T, T) => T) => f; // ok
+(f: <R, S>(R, S) => S): (<T>(T, T) => boolean) => f; // error
+
+// … or fewer.
+(f: <R>(R, mixed) => R): (<S, T>(S, T) => S) => f; // ok
+(f: <R>(R, mixed) => R): (<S, T>(S, T) => T) => f; // error
+
+
+// Test subtyping where only upper is polymorphic…
+(f: mixed => boolean): (<T>(T) => boolean) => f; // ok
+(f: (number, number) => number): (<T>(T, T) => T) => f; // error
+
+// … or only lower.
+(f: <T>(T, T) => T): ((number, number) => number) => f; // ok
+(f: <T>(T, T) => T): ((number, string) => number) => f; // error


### PR DESCRIPTION
Fixes #8766.

When checking a flow between polymorphic types PolyT ~> PolyT, we had
an attempted shortcut that wasn't sound, and also rejected some valid
flows.

The shortcut was added in 1aa5c63ba / D7454529 as an optimization to
avoid reaching the general case for flows _ ~> PolyT, which at the
time was the exponential `generate_tests`.  Happily new-generics means
that the general case is now efficient as well as correct.  So, simply
delete the code for the shortcut.

The test suite takes about 161s to run on my machine before this
change, and about 161s after it too.

The logic in question exists in two versions, one in subtyping_kit.ml
and one in flow_js.ml, in the unify function.  Both have the same
unsoundness; in fact both would accept each pair of types given as
examples in #8766.  But the unify version seems to also be dead code:
I tried replacing that case's body with an assert and ran the test
suite, and the assert never fired.  In any event, delete both.
Also fix and update some comments on this code.

In addition to the unsoundness in #8766, the tests demonstrate some
valid cases we previously rejected, including where the PolyT's have
different numbers of parameters.  Plus for completeness a couple of
cases we already got right, where one end of the flow is polymorphic
but the other isn't.

<!--
  If this is a change to library defintions, please include links to relevant documentation.
  If this is a documentation change, please prefix the title with [DOCS].

  If this is neither, ensure you opened a discussion issue and link it in the PR description.
-->
