### PR TITLE
Declare AggregateError class

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -1595,6 +1595,12 @@ declare class URIError extends Error {
     static (message?:string):Error;
 }
 
+declare class AggregateError extends Error {
+  static (errors: Iterable<mixed>, message?: string): Error;
+  constructor (errors: Iterable<mixed>, message?: mixed): void;
+  errors: Iterable<mixed>;
+}
+
 /**
  * An intrinsic object that provides functions to convert JavaScript values to and from the JavaScript Object Notation (JSON) format.
  */


### PR DESCRIPTION
Fixes #8764 

Declaration for AggregateError class.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AggregateError