### PR TITLE
Delete test_id from reasons, dead since new-generics

### DIFF
--- a/src/common/reason.mli
+++ b/src/common/reason.mli
@@ -212,10 +212,6 @@ type concrete_reason = Loc.t virtual_reason
 
 type t = reason (* convenience *)
 
-module TestID : sig
-  val run : ('a -> 'b) -> 'a -> 'b
-end
-
 (* reason constructor *)
 val mk_reason : 'loc virtual_reason_desc -> 'loc -> 'loc virtual_reason
 


### PR DESCRIPTION
The one caller of Reason.TestID.run was the old generate_tests
machinery, which was deleted in 50b73c390 / D23687686
after the advent of new-generics.

With that never called, the ref inside TestID never gets mutated,
and `TestID.current ()` always returns None.

That then means the `test_id` field is always None on every reason,
because that was the only place we ever got a test_id that wasn't
either a literal None or the test_id of some existing reason.

So, we can delete that field as well as the Reason.TestID module.
The two things that had looked at it were dump_reason, and the
derived eq on reasons (the latter being the motivation for having
this field in the first place); so we leave each of those behaving the
same way as they already were with test_eq existing but always None.

I originally noticed this because I was studying the reason.ml code,
and spotted this block comment (on TestID) which sounded like it was
talking about the old generate_tests (as indeed it turned out it was.)
The rest of the comment is still quite relevant context to know when
reading this file, even though the TestID module is gone.  (Though I
can't tell if there are other details in it that could be updated.)
