### PR TITLE
Delete derivable from reasons, dead with classic mode

### DIFF
--- a/src/common/reason.ml
+++ b/src/common/reason.ml
@@ -326,7 +326,6 @@ let rec map_desc_locs f = function
   | RUnionBranching (desc, i) -> RUnionBranching (map_desc_locs f desc, i)
 
 type 'loc virtual_reason = {
-  derivable: bool;
   desc: 'loc virtual_reason_desc;
   loc: 'loc;
   def_loc_opt: 'loc option;
@@ -458,10 +457,10 @@ let json_of_loc ?strip_root ?catch_offset_errors ~offset_table loc =
 (* reason constructors, accessors, etc. *)
 
 let mk_reason_internal desc loc def_loc_opt annot_loc_opt =
-  { derivable = false; desc; loc; def_loc_opt; annot_loc_opt }
+  { desc; loc; def_loc_opt; annot_loc_opt }
 
 let map_reason_locs f reason =
-  let { def_loc_opt; annot_loc_opt; loc; desc; derivable } = reason in
+  let { def_loc_opt; annot_loc_opt; loc; desc } = reason in
   let loc' = f loc in
   let def_loc_opt' = Base.Option.map ~f def_loc_opt in
   let annot_loc_opt' = Base.Option.map ~f annot_loc_opt in
@@ -471,7 +470,6 @@ let map_reason_locs f reason =
     annot_loc_opt = annot_loc_opt';
     loc = loc';
     desc = desc';
-    derivable;
   }
 
 let mk_reason desc aloc = mk_reason_internal desc aloc None None
@@ -896,15 +894,10 @@ let is_literal_array_reason r =
     true
   | _ -> false
 
-let is_derivable_reason r = r.derivable
-
-let derivable_reason r = { r with derivable = true }
-
 let builtin_reason desc =
   { Loc.none with Loc.source = Some File_key.Builtins }
   |> ALoc.of_loc
   |> mk_reason desc
-  |> derivable_reason
 
 let is_builtin_reason f r = r.loc |> f |> ( = ) (Some File_key.Builtins)
 

--- a/src/common/reason.mli
+++ b/src/common/reason.mli
@@ -282,10 +282,6 @@ val is_literal_object_reason : 'loc virtual_reason -> bool
 
 val is_literal_array_reason : 'loc virtual_reason -> bool
 
-val derivable_reason : 'loc virtual_reason -> 'loc virtual_reason
-
-val is_derivable_reason : 'loc virtual_reason -> bool
-
 val builtin_reason : reason_desc -> reason
 
 (* reason location preds *)

--- a/src/services/inference/check_service.ml
+++ b/src/services/inference/check_service.ml
@@ -269,7 +269,7 @@ module ConsGen : Type_sig_merge.CONS_GEN = struct
     )
 
   let specialize cx t use_op reason_op reason_tapp ts =
-    Tvar.mk_derivable_where cx reason_op (fun tout ->
+    Tvar.mk_where cx reason_op (fun tout ->
         Flow_js.flow cx (t, Type.SpecializeT (use_op, reason_op, reason_tapp, None, ts, tout))
     )
 
@@ -290,7 +290,7 @@ module ConsGen : Type_sig_merge.CONS_GEN = struct
     Tvar.mk_no_wrap_where cx reason (fun tout -> Flow_js.flow cx (t, Type.NotT (reason, tout)))
 
   let mixin cx reason t =
-    Tvar.mk_derivable_where cx reason (fun tout -> Flow_js.flow cx (t, Type.MixinT (reason, tout)))
+    Tvar.mk_where cx reason (fun tout -> Flow_js.flow cx (t, Type.MixinT (reason, tout)))
 
   let object_spread cx use_op reason target state t =
     let tool = Type.Object.(Resolve Next) in

--- a/src/typing/class_sig.ml
+++ b/src/typing/class_sig.ml
@@ -563,7 +563,7 @@ module Make
     let open Type in
     let open TypeUtil in
     let reason = reason_of_t c in
-    Tvar.mk_derivable_where cx reason (fun tvar ->
+    Tvar.mk_where cx reason (fun tvar ->
         Flow.flow cx (c, SpecializeT (unknown_use, reason, reason, None, targs, tvar))
     )
 

--- a/src/typing/statement.ml
+++ b/src/typing/statement.ml
@@ -1548,7 +1548,7 @@ module Make (Env : Env_sig.S) = struct
               reason
               (OrdinaryName "Promise")
               [
-                Tvar.mk_derivable_where cx reason (fun tvar ->
+                Tvar.mk_where cx reason (fun tvar ->
                     let funt = Flow.get_builtin cx (OrdinaryName "$await") reason in
                     let callt = mk_functioncalltype reason None [Arg t] (open_tvar tvar) in
                     let reason = repos_reason (aloc_of_reason (reason_of_t t)) reason in
@@ -1568,7 +1568,7 @@ module Make (Env : Env_sig.S) = struct
               (OrdinaryName "Generator")
               [
                 Env.get_internal_var cx "yield" loc;
-                Tvar.mk_derivable_where cx reason (fun tvar -> Flow.flow_t cx (t, tvar));
+                Tvar.mk_where cx reason (fun tvar -> Flow.flow_t cx (t, tvar));
                 Env.get_internal_var cx "next" loc;
               ]
           in
@@ -1582,7 +1582,7 @@ module Make (Env : Env_sig.S) = struct
               (OrdinaryName "AsyncGenerator")
               [
                 Env.get_internal_var cx "yield" loc;
-                Tvar.mk_derivable_where cx reason (fun tvar -> Flow.flow_t cx (t, tvar));
+                Tvar.mk_where cx reason (fun tvar -> Flow.flow_t cx (t, tvar));
                 Env.get_internal_var cx "next" loc;
               ]
           in
@@ -5651,7 +5651,7 @@ module Make (Env : Env_sig.S) = struct
             DefT (reason, trust, NumT (Literal (sense, (value, raw))))
           | arg ->
             let reason = mk_reason (desc_of_t arg) loc in
-            Tvar.mk_derivable_where cx reason (fun t -> Flow.flow cx (arg, UnaryMinusT (reason, t)))
+            Tvar.mk_where cx reason (fun t -> Flow.flow cx (arg, UnaryMinusT (reason, t)))
         end,
         { operator = Minus; argument; comments }
       )

--- a/src/typing/tvar.ml
+++ b/src/typing/tvar.ml
@@ -32,10 +32,3 @@ let mk_no_wrap_where cx reason f =
   let tvar = mk_no_wrap cx reason in
   let () = f (reason, tvar) in
   Type.OpenT (reason, tvar)
-
-(* This function is used in lieu of mk_where or mk when the reason must be
-   marked internal. This has the effect of not forcing annotations where this
-   type variable appears. See `assume_ground` and `assert_ground` in Flow_js. *)
-let mk_derivable_where cx reason f =
-  let reason = Reason.derivable_reason reason in
-  mk_where cx reason f

--- a/src/typing/type_annotation.ml
+++ b/src/typing/type_annotation.ml
@@ -2254,7 +2254,7 @@ module Make (Env : Env_sig.S) (Abnormal : module type of Abnormal.Make (Env)) = 
           convert_qualification ~lookup_mode cx "mixins" id
         in
         let props_bag =
-          Tvar.mk_derivable_where cx r (fun tvar -> Flow.flow cx (i, Type.MixinT (r, tvar)))
+          Tvar.mk_where cx r (fun tvar -> Flow.flow cx (i, Type.MixinT (r, tvar)))
         in
         let (t, targs) = mk_super cx tparams_map loc props_bag targs in
         (t, (loc, { Ast.Type.Generic.id; targs; comments }))


### PR DESCRIPTION
This flag was used by classic mode for reporting missing-annotation
errors.  Since classic mode was deleted in cc78534ed / D25721686,
no remaining code has consulted this flag.

Specifically: the getter is_derivable_reason had one remaining caller,
which used it only to propagate the derivable bit to a new reason.
Other than that getter, nothing else in reason.ml looked at this flag
except to propagate it to a new reason, and no other code can see it.

Because the flag was unused, we can delete it.  This makes
derivable_reason the identity function, so delete that too; and that
makes Tvar.mk_decidable_where equivalent to Tvar.mk_where, so delete
it in favor of the latter.

(Looking at one of the other derivable_reason callers, builtin_reason,
I notice it's also dead.  But that one, I'm not quite sure if it's
permanently dead or might gain a caller later, so leave it for now.)

With this change following #8772 / D31971520,
a reason now consists of its desc, its loc, and two loc options,
with no other flags or additional fields.
