### PR TITLE
Add tests for refinements staying invalidated once invalidated

### DIFF
--- a/tests/refinements/invalidation.js
+++ b/tests/refinements/invalidation.js
@@ -1,0 +1,257 @@
+// @flow
+// Test that an invalidated refinement stays invalidated.
+// In particular issues #8251, #8777, #8778, and #8779.
+
+// First, write `coerce`, to demonstrate each issue in turn.
+
+const v: { f?: mixed } = {};
+const vv = v;
+const store = (x: mixed) => { v.f = () => x; };
+
+function coerce8251<A, B>(x: A): B {
+  v.f = () => { throw null };  // Refine v.f.
+  if (true) store(x);  // Invalidate the refinement.
+  return v.f(); // TODO error: trying to still use the refinement.
+}
+
+function coerce8777<A, B>(x: A): B {
+  v.f = () => { throw null };  // Refine v.f.
+  if (true) vv.f = () => x;  // Invalidate the refinement.
+  return v.f(); // TODO error: trying to still use the refinement.
+}
+
+function coerce8778<A, B>(x: A): B {
+  v.f = () => { throw null };  // Refine v.f.
+  for (const i of [0]) store(x);  // Invalidate the refinement.
+  return v.f(); // TODO error: trying to still use the refinement.
+}
+
+function coerce8779<A, B>(x: A): B {
+  v.f = () => { throw null };  // Refine v.f.
+  for (let i = 0; i < 1; i++) store(x);  // Invalidate the refinement.
+  return v.f(); // TODO error: trying to still use the refinement.
+}
+
+
+// Then, systematically explore different cases.
+
+type A = {b?: {c: boolean}};
+
+// Heap refinements, on `a.b` where `a` is local,
+// invalidated by a function call.
+(a: A) => {
+  // Here's an error, a refinement that fixes it,
+  // and a function call correctly invalidating the refinement.
+  if (1)                                      a.b.c;   // error
+  if (a.b)                                    a.b.c;   // ok
+  if (a.b) { f();                             a.b.c; } // error
+
+  // The refinement should stay invalidated anywhere that the control
+  // flow could reach after the function call (without passing through
+  // somewhere it gets refined again.)
+
+  // Conditional constructs: the short-circuiting operators…
+  if (a.b) { true && f();                     a.b.c; } // TODO error
+  if (a.b) { f() && true;                     a.b.c; } // error
+  if (a.b) { false || f();                    a.b.c; } // TODO error
+  if (a.b) { f() || false;                    a.b.c; } // error
+  if (a.b) { null ?? f();                     a.b.c; } // error
+  if (a.b) { f() ?? true;                     a.b.c; } // error
+  // … the ternary operator…
+  if (a.b) { p ? f() : 0;                     a.b.c; } // TODO error
+  if (a.b) { p ? 1 : f();                     a.b.c; } // TODO error
+  if (a.b) { f() ? 1 : 0;                     a.b.c; } // error
+  // … and if/else.
+  if (a.b) { if (p) f();                      a.b.c; } // TODO error
+  if (a.b) { if (p); else f();                a.b.c; } // TODO error
+  if (a.b) { if (f());                        a.b.c; } // error
+
+  // Switch statements.
+  if (a.b) { switch (p) { case true: f(); }        a.b.c; } // TODO error
+  if (a.b) { switch (p) { case true: f(); break; } a.b.c; } // error
+  if (a.b) { switch (p) { default: f(); }          a.b.c; } // error
+  if (a.b) { switch (p) { default: f(); break; }   a.b.c; } // error
+  if (a.b) { switch (f()) {}                       a.b.c; } // error
+  if (a.b) { switch (f()) { case true: }           a.b.c; } // error
+  if (a.b) { switch (f()) { case true: break; }    a.b.c; } // error
+  if (a.b) { switch (f()) { default: }             a.b.c; } // error
+  if (a.b) { switch (f()) { default: break; }      a.b.c; } // error
+
+  // Loop constructs.
+  let i;
+  if (a.b) { while (p) f();                   a.b.c; } // TODO error
+  if (a.b) { while (f());                     a.b.c; } // error
+  if (a.b) { do f(); while (p);               a.b.c; } // error
+  if (a.b) { do; while (f());                 a.b.c; } // error
+  if (a.b) { for (; p;) f();                  a.b.c; } // TODO error
+  if (a.b) { for (; p; f());                  a.b.c; } // TODO error
+  if (a.b) { for (; f(););                    a.b.c; } // error
+  if (a.b) { for (f(); p;);                   a.b.c; } // error
+  if (a.b) { for (i in y) f();                a.b.c; } // TODO error
+  if (a.b) { for (i in ff());                 a.b.c; } // TODO error
+  if (a.b) { for (i of y) f();                a.b.c; } // TODO error
+  if (a.b) { for (i of ff());                 a.b.c; } // TODO error
+
+  // Loop constructs with an abrupt completion / abnormal control flow.
+  // while…
+  if (a.b) { while (p) { f(); continue; }     a.b.c; } // TODO error
+  if (a.b) { while (p) { f(); break;    }     a.b.c; } // TODO error
+  if (a.b) { while (p) { f(); return;   }     a.b.c; } // ideally ok, error acceptable
+  if (a.b) { while (f()) { continue; }        a.b.c; } // error
+  if (a.b) { while (f()) { break;    }        a.b.c; } // error
+  if (a.b) { while (f()) { return;   }        a.b.c; } // error
+  // … do-while…
+  if (a.b) { do { f(); continue; } while (p); a.b.c; } // TODO error
+  if (a.b) { do { f(); break;    } while (p); a.b.c; } // TODO error
+  if (a.b) { do { f(); return;   } while (p); a.b.c; } // error[unreachable-code]
+  if (a.b) { do { continue; } while (f());    a.b.c; } // TODO error
+  if (a.b) { do { break;    } while (f());    a.b.c; } // ideally ok, error acceptable
+  if (a.b) { do { return;   } while (f());    a.b.c; } // error[unreachable-code]
+  // … for…
+  if (a.b) { for (; p;) { f(); continue; }    a.b.c; } // TODO error
+  if (a.b) { for (; p;) { f(); break;    }    a.b.c; } // TODO error
+  if (a.b) { for (; p;) { f(); return;   }    a.b.c; } // ideally ok, error acceptable
+  if (a.b) { for (; p; f()) continue;         a.b.c; } // TODO error
+  if (a.b) { for (; p; f()) break;            a.b.c; } // ideally ok, error acceptable
+  if (a.b) { for (; p; f()) return;           a.b.c; } // ideally ok, error acceptable
+  if (a.b) { for (; f();) continue;           a.b.c; } // error
+  if (a.b) { for (; f();) break;              a.b.c; } // error
+  if (a.b) { for (; f();) return;             a.b.c; } // error
+  if (a.b) { for (f(); p;) continue;          a.b.c; } // error
+  if (a.b) { for (f(); p;) break;             a.b.c; } // error
+  if (a.b) { for (f(); p;) return;            a.b.c; } // error
+  // … for-in…
+  if (a.b) { for (i in y) { f(); continue; }  a.b.c; } // TODO error
+  if (a.b) { for (i in y) { f(); break;    }  a.b.c; } // TODO error
+  if (a.b) { for (i in y) { f(); return;   }  a.b.c; } // ideally ok, error acceptable
+  if (a.b) { for (i in ff()) continue;        a.b.c; } // TODO error
+  if (a.b) { for (i in ff()) break;           a.b.c; } // TODO error
+  if (a.b) { for (i in ff()) return;          a.b.c; } // TODO error
+  // … for-of.
+  if (a.b) { for (i of y) { f(); continue; }  a.b.c; } // TODO error
+  if (a.b) { for (i of y) { f(); break;    }  a.b.c; } // TODO error
+  if (a.b) { for (i of y) { f(); return;   }  a.b.c; } // ideally ok, error acceptable
+  if (a.b) { for (i of ff()) continue;        a.b.c; } // TODO error
+  if (a.b) { for (i of ff()) break;           a.b.c; } // TODO error
+  if (a.b) { for (i of ff()) return;          a.b.c; } // TODO error
+}
+
+// Heap refinements on `a.b`, cont'd.
+// (As a separate function just to avoid a perf issue.)
+(a: A) => {
+  let i;
+
+  // Labelled break, to labelled statements that have no "break"
+  // semantics of their own (i.e. not loops or `switch`.)
+  if (a.b) { l: { f(); }                           a.b.c; } // error
+  if (a.b) { l: { f(); break l; }                  a.b.c; } // TODO error
+  if (a.b) { l: if (p) { f(); break l; }           a.b.c; } // TODO error
+  l: if (a.b) { if (p) { f(); break l; }           a.b.c; } // ideally ok, error acceptable
+  l: if (a.b) { f(); break l;                      a.b.c; } // error[unreachable-code]
+
+  // Labelled break to `switch`.
+  if (a.b) { l: switch (p) { case true: f(); break l; } a.b.c; } // TODO error
+  if (a.b) { l: switch (p) { default: f(); break l; }   a.b.c; } // TODO error
+  if (a.b) { l: switch (f()) { case true: break l; }    a.b.c; } // error
+  if (a.b) { l: switch (f()) { default: break l; }      a.b.c; } // error
+
+  // Labelled break and continue, to loop constructs.
+  // while…
+  if (a.b) { l: while (p) { f(); continue l; }     a.b.c; } // TODO error
+  if (a.b) { l: while (p) { f(); break l;    }     a.b.c; } // TODO error
+  if (a.b) { l: while (f()) { continue l; }        a.b.c; } // error
+  if (a.b) { l: while (f()) { break l;    }        a.b.c; } // error
+  // … do-while…
+  if (a.b) { l: do { f(); continue l; } while (p); a.b.c; } // TODO error
+  if (a.b) { l: do { f(); break l;    } while (p); a.b.c; } // TODO error
+  if (a.b) { l: do { continue l; } while (f());    a.b.c; } // TODO error
+  if (a.b) { l: do { break l;    } while (f());    a.b.c; } // ideally ok, error acceptable
+  // … for…
+  if (a.b) { l: for (; p;) { f(); continue l; }    a.b.c; } // TODO error
+  if (a.b) { l: for (; p;) { f(); break l;    }    a.b.c; } // TODO error
+  if (a.b) { l: for (; p; f()) continue l;         a.b.c; } // TODO error
+  if (a.b) { l: for (; p; f()) break l;            a.b.c; } // ideally ok, error acceptable
+  if (a.b) { l: for (; f();) continue l;           a.b.c; } // error
+  if (a.b) { l: for (; f();) break l;              a.b.c; } // error
+  if (a.b) { l: for (f(); p;) continue l;          a.b.c; } // error
+  if (a.b) { l: for (f(); p;) break l;             a.b.c; } // error
+  // … for-in…
+  if (a.b) { l: for (i in y) { f(); continue l; }  a.b.c; } // TODO error
+  if (a.b) { l: for (i in y) { f(); break l;    }  a.b.c; } // TODO error
+  if (a.b) { l: for (i in ff()) continue l;        a.b.c; } // TODO error
+  if (a.b) { l: for (i in ff()) break l;           a.b.c; } // TODO error
+  // … for-of.
+  if (a.b) { l: for (i of y) { f(); continue l; }  a.b.c; } // TODO error
+  if (a.b) { l: for (i of y) { f(); break l;    }  a.b.c; } // TODO error
+  if (a.b) { l: for (i of ff()) continue l;        a.b.c; } // TODO error
+  if (a.b) { l: for (i of ff()) break l;           a.b.c; } // TODO error
+}
+
+// Heap refinements, again on `a.b` where `a` is local,
+// invalidated by a write to property `b` on some other heap object.
+declare var x: { b?: { ... } };
+(a: A) => {
+  // Here's an error, a refinement that fixes it,
+  // and a write correctly invalidating the refinement.
+  if (a.b)                                    a.b.c;   // ok
+  if (a.b) { delete x.b;                      a.b.c; } // error
+  if (a.b) { x.b = y;                         a.b.c; } // error
+
+  // The refinement should stay invalidated anywhere that the control
+  // flow could reach after the write (without passing through
+  // somewhere it gets refined again.)
+
+  // Conditional constructs: the short-circuiting operators…
+  if (a.b) { true && delete x.b;              a.b.c; } // TODO error
+  if (a.b) { delete x.b && true;              a.b.c; } // error
+  if (a.b) { true && (x.b = y);               a.b.c; } // TODO error
+  if (a.b) { (x.b = y) && true;               a.b.c; } // error
+  // (From here, we forget `delete` and just use assignment.)
+  if (a.b) { false || (x.b = y);              a.b.c; } // TODO error
+  if (a.b) { (x.b = y) || false;              a.b.c; } // error
+  if (a.b) { null ?? (x.b = y);               a.b.c; } // error
+  if (a.b) { (x.b = y) ?? true;               a.b.c; } // error
+  // … the ternary operator…
+  if (a.b) { p ? (x.b = y) : 0;               a.b.c; } // TODO error
+  if (a.b) { p ? 1 : (x.b = y);               a.b.c; } // TODO error
+  if (a.b) { (x.b = y) ? 1 : 0;               a.b.c; } // error
+  // … and if/else.
+  if (a.b) { if (p) x.b = y;                  a.b.c; } // TODO error
+  if (a.b) { if (p); else x.b = y;            a.b.c; } // TODO error
+  if (a.b) { if (x.b = y);                    a.b.c; } // error
+
+  // Switch statements.
+  if (a.b) { switch (p) { case true: x.b = y; }        a.b.c; } // TODO error
+  if (a.b) { switch (p) { case true: x.b = y; break; } a.b.c; } // error
+  if (a.b) { switch (p) { default: x.b = y; }          a.b.c; } // error
+  if (a.b) { switch (p) { default: x.b = y; break; }   a.b.c; } // error
+  if (a.b) { switch (x.b = y) {}                       a.b.c; } // error
+  if (a.b) { switch (x.b = y) { case true: }           a.b.c; } // error
+  if (a.b) { switch (x.b = y) { case true: break; }    a.b.c; } // error
+  if (a.b) { switch (x.b = y) { default: }             a.b.c; } // error
+  if (a.b) { switch (x.b = y) { default: break; }      a.b.c; } // error
+
+  // Loop constructs.
+  let i;
+  if (a.b) { while (p) x.b = y;               a.b.c; } // TODO error
+  if (a.b) { while (x.b = y);                 a.b.c; } // error
+  if (a.b) { do x.b = y; while (p);           a.b.c; } // error
+  if (a.b) { do; while (x.b = y);             a.b.c; } // error
+  if (a.b) { for (; p;) x.b = y;              a.b.c; } // TODO error
+  if (a.b) { for (; p; x.b = y);              a.b.c; } // TODO error
+  if (a.b) { for (; x.b = y;);                a.b.c; } // error
+  if (a.b) { for (x.b = y; p;);               a.b.c; } // error
+  if (a.b) { for (i in y) x.b = y;            a.b.c; } // TODO error
+  if (a.b) { for (i in x.b = y);              a.b.c; } // TODO error
+  if (a.b) { for (i of y) x.b = y;            a.b.c; } // TODO error
+  if (a.b) { for (i of x.b = y);              a.b.c; } // TODO error
+
+  // We'll skip running through the other variations in this version:
+  // continue, break, return, and labelled break and continue.
+}
+
+declare var f: mixed => boolean;
+declare var p: boolean;
+
+declare var y: { ... } & Iterator<mixed>;
+declare var ff: mixed => { ... } & Iterator<mixed>;

--- a/tests/refinements/refinements.exp
+++ b/tests/refinements/refinements.exp
@@ -874,6 +874,884 @@ References:
                              ^ [2]
 
 
+Error -------------------------------------------------------------------------------------------- invalidation.js:45:51
+
+Cannot get `a.b.c` because property `c` is missing in undefined [1]. [incompatible-use]
+
+   invalidation.js:45:51
+   45|   if (1)                                      a.b.c;   // error
+                                                         ^
+
+References:
+   invalidation.js:38:15
+   38| type A = {b?: {c: boolean}};
+                     ^^^^^^^^^^^^ [1]
+
+
+Error -------------------------------------------------------------------------------------------- invalidation.js:47:51
+
+Cannot get `a.b.c` because property `c` is missing in undefined [1]. [incompatible-use]
+
+   invalidation.js:47:51
+   47|   if (a.b) { f();                             a.b.c; } // error
+                                                         ^
+
+References:
+   invalidation.js:38:15
+   38| type A = {b?: {c: boolean}};
+                     ^^^^^^^^^^^^ [1]
+
+
+Error -------------------------------------------------------------------------------------------- invalidation.js:55:51
+
+Cannot get `a.b.c` because property `c` is missing in undefined [1]. [incompatible-use]
+
+   invalidation.js:55:51
+   55|   if (a.b) { f() && true;                     a.b.c; } // error
+                                                         ^
+
+References:
+   invalidation.js:38:15
+   38| type A = {b?: {c: boolean}};
+                     ^^^^^^^^^^^^ [1]
+
+
+Error -------------------------------------------------------------------------------------------- invalidation.js:57:51
+
+Cannot get `a.b.c` because property `c` is missing in undefined [1]. [incompatible-use]
+
+   invalidation.js:57:51
+   57|   if (a.b) { f() || false;                    a.b.c; } // error
+                                                         ^
+
+References:
+   invalidation.js:38:15
+   38| type A = {b?: {c: boolean}};
+                     ^^^^^^^^^^^^ [1]
+
+
+Error -------------------------------------------------------------------------------------------- invalidation.js:58:51
+
+Cannot get `a.b.c` because property `c` is missing in undefined [1]. [incompatible-use]
+
+   invalidation.js:58:51
+   58|   if (a.b) { null ?? f();                     a.b.c; } // error
+                                                         ^
+
+References:
+   invalidation.js:38:15
+   38| type A = {b?: {c: boolean}};
+                     ^^^^^^^^^^^^ [1]
+
+
+Error -------------------------------------------------------------------------------------------- invalidation.js:59:51
+
+Cannot get `a.b.c` because property `c` is missing in undefined [1]. [incompatible-use]
+
+   invalidation.js:59:51
+   59|   if (a.b) { f() ?? true;                     a.b.c; } // error
+                                                         ^
+
+References:
+   invalidation.js:38:15
+   38| type A = {b?: {c: boolean}};
+                     ^^^^^^^^^^^^ [1]
+
+
+Error -------------------------------------------------------------------------------------------- invalidation.js:63:51
+
+Cannot get `a.b.c` because property `c` is missing in undefined [1]. [incompatible-use]
+
+   invalidation.js:63:51
+   63|   if (a.b) { f() ? 1 : 0;                     a.b.c; } // error
+                                                         ^
+
+References:
+   invalidation.js:38:15
+   38| type A = {b?: {c: boolean}};
+                     ^^^^^^^^^^^^ [1]
+
+
+Error -------------------------------------------------------------------------------------------- invalidation.js:67:51
+
+Cannot get `a.b.c` because property `c` is missing in undefined [1]. [incompatible-use]
+
+   invalidation.js:67:51
+   67|   if (a.b) { if (f());                        a.b.c; } // error
+                                                         ^
+
+References:
+   invalidation.js:38:15
+   38| type A = {b?: {c: boolean}};
+                     ^^^^^^^^^^^^ [1]
+
+
+Error -------------------------------------------------------------------------------------------- invalidation.js:71:56
+
+Cannot get `a.b.c` because property `c` is missing in undefined [1]. [incompatible-use]
+
+   invalidation.js:71:56
+   71|   if (a.b) { switch (p) { case true: f(); break; } a.b.c; } // error
+                                                              ^
+
+References:
+   invalidation.js:38:15
+   38| type A = {b?: {c: boolean}};
+                     ^^^^^^^^^^^^ [1]
+
+
+Error -------------------------------------------------------------------------------------------- invalidation.js:72:56
+
+Cannot get `a.b.c` because property `c` is missing in undefined [1]. [incompatible-use]
+
+   invalidation.js:72:56
+   72|   if (a.b) { switch (p) { default: f(); }          a.b.c; } // error
+                                                              ^
+
+References:
+   invalidation.js:38:15
+   38| type A = {b?: {c: boolean}};
+                     ^^^^^^^^^^^^ [1]
+
+
+Error -------------------------------------------------------------------------------------------- invalidation.js:73:56
+
+Cannot get `a.b.c` because property `c` is missing in undefined [1]. [incompatible-use]
+
+   invalidation.js:73:56
+   73|   if (a.b) { switch (p) { default: f(); break; }   a.b.c; } // error
+                                                              ^
+
+References:
+   invalidation.js:38:15
+   38| type A = {b?: {c: boolean}};
+                     ^^^^^^^^^^^^ [1]
+
+
+Error -------------------------------------------------------------------------------------------- invalidation.js:74:56
+
+Cannot get `a.b.c` because property `c` is missing in undefined [1]. [incompatible-use]
+
+   invalidation.js:74:56
+   74|   if (a.b) { switch (f()) {}                       a.b.c; } // error
+                                                              ^
+
+References:
+   invalidation.js:38:15
+   38| type A = {b?: {c: boolean}};
+                     ^^^^^^^^^^^^ [1]
+
+
+Error -------------------------------------------------------------------------------------------- invalidation.js:75:56
+
+Cannot get `a.b.c` because property `c` is missing in undefined [1]. [incompatible-use]
+
+   invalidation.js:75:56
+   75|   if (a.b) { switch (f()) { case true: }           a.b.c; } // error
+                                                              ^
+
+References:
+   invalidation.js:38:15
+   38| type A = {b?: {c: boolean}};
+                     ^^^^^^^^^^^^ [1]
+
+
+Error -------------------------------------------------------------------------------------------- invalidation.js:76:56
+
+Cannot get `a.b.c` because property `c` is missing in undefined [1]. [incompatible-use]
+
+   invalidation.js:76:56
+   76|   if (a.b) { switch (f()) { case true: break; }    a.b.c; } // error
+                                                              ^
+
+References:
+   invalidation.js:38:15
+   38| type A = {b?: {c: boolean}};
+                     ^^^^^^^^^^^^ [1]
+
+
+Error -------------------------------------------------------------------------------------------- invalidation.js:77:56
+
+Cannot get `a.b.c` because property `c` is missing in undefined [1]. [incompatible-use]
+
+   invalidation.js:77:56
+   77|   if (a.b) { switch (f()) { default: }             a.b.c; } // error
+                                                              ^
+
+References:
+   invalidation.js:38:15
+   38| type A = {b?: {c: boolean}};
+                     ^^^^^^^^^^^^ [1]
+
+
+Error -------------------------------------------------------------------------------------------- invalidation.js:78:56
+
+Cannot get `a.b.c` because property `c` is missing in undefined [1]. [incompatible-use]
+
+   invalidation.js:78:56
+   78|   if (a.b) { switch (f()) { default: break; }      a.b.c; } // error
+                                                              ^
+
+References:
+   invalidation.js:38:15
+   38| type A = {b?: {c: boolean}};
+                     ^^^^^^^^^^^^ [1]
+
+
+Error -------------------------------------------------------------------------------------------- invalidation.js:83:51
+
+Cannot get `a.b.c` because property `c` is missing in undefined [1]. [incompatible-use]
+
+   invalidation.js:83:51
+   83|   if (a.b) { while (f());                     a.b.c; } // error
+                                                         ^
+
+References:
+   invalidation.js:38:15
+   38| type A = {b?: {c: boolean}};
+                     ^^^^^^^^^^^^ [1]
+
+
+Error -------------------------------------------------------------------------------------------- invalidation.js:84:51
+
+Cannot get `a.b.c` because property `c` is missing in undefined [1]. [incompatible-use]
+
+   invalidation.js:84:51
+   84|   if (a.b) { do f(); while (p);               a.b.c; } // error
+                                                         ^
+
+References:
+   invalidation.js:38:15
+   38| type A = {b?: {c: boolean}};
+                     ^^^^^^^^^^^^ [1]
+
+
+Error -------------------------------------------------------------------------------------------- invalidation.js:85:51
+
+Cannot get `a.b.c` because property `c` is missing in undefined [1]. [incompatible-use]
+
+   invalidation.js:85:51
+   85|   if (a.b) { do; while (f());                 a.b.c; } // error
+                                                         ^
+
+References:
+   invalidation.js:38:15
+   38| type A = {b?: {c: boolean}};
+                     ^^^^^^^^^^^^ [1]
+
+
+Error -------------------------------------------------------------------------------------------- invalidation.js:88:51
+
+Cannot get `a.b.c` because property `c` is missing in undefined [1]. [incompatible-use]
+
+   invalidation.js:88:51
+   88|   if (a.b) { for (; f(););                    a.b.c; } // error
+                                                         ^
+
+References:
+   invalidation.js:38:15
+   38| type A = {b?: {c: boolean}};
+                     ^^^^^^^^^^^^ [1]
+
+
+Error -------------------------------------------------------------------------------------------- invalidation.js:89:51
+
+Cannot get `a.b.c` because property `c` is missing in undefined [1]. [incompatible-use]
+
+   invalidation.js:89:51
+   89|   if (a.b) { for (f(); p;);                   a.b.c; } // error
+                                                         ^
+
+References:
+   invalidation.js:38:15
+   38| type A = {b?: {c: boolean}};
+                     ^^^^^^^^^^^^ [1]
+
+
+Error ------------------------------------------------------------------------------------------- invalidation.js:100:51
+
+Cannot get `a.b.c` because property `c` is missing in undefined [1]. [incompatible-use]
+
+   invalidation.js:100:51
+   100|   if (a.b) { while (f()) { continue; }        a.b.c; } // error
+                                                          ^
+
+References:
+   invalidation.js:38:15
+    38| type A = {b?: {c: boolean}};
+                      ^^^^^^^^^^^^ [1]
+
+
+Error ------------------------------------------------------------------------------------------- invalidation.js:101:51
+
+Cannot get `a.b.c` because property `c` is missing in undefined [1]. [incompatible-use]
+
+   invalidation.js:101:51
+   101|   if (a.b) { while (f()) { break;    }        a.b.c; } // error
+                                                          ^
+
+References:
+   invalidation.js:38:15
+    38| type A = {b?: {c: boolean}};
+                      ^^^^^^^^^^^^ [1]
+
+
+Error ------------------------------------------------------------------------------------------- invalidation.js:102:51
+
+Cannot get `a.b.c` because property `c` is missing in undefined [1]. [incompatible-use]
+
+   invalidation.js:102:51
+   102|   if (a.b) { while (f()) { return;   }        a.b.c; } // error
+                                                          ^
+
+References:
+   invalidation.js:38:15
+    38| type A = {b?: {c: boolean}};
+                      ^^^^^^^^^^^^ [1]
+
+
+Error ------------------------------------------------------------------------------------------- invalidation.js:106:47
+
+Unreachable code. [unreachable-code]
+
+   106|   if (a.b) { do { f(); return;   } while (p); a.b.c; } // error[unreachable-code]
+                                                      ^^^^^^
+
+
+Error ------------------------------------------------------------------------------------------- invalidation.js:109:47
+
+Unreachable code. [unreachable-code]
+
+   109|   if (a.b) { do { return;   } while (f());    a.b.c; } // error[unreachable-code]
+                                                      ^^^^^^
+
+
+Error ------------------------------------------------------------------------------------------- invalidation.js:117:51
+
+Cannot get `a.b.c` because property `c` is missing in undefined [1]. [incompatible-use]
+
+   invalidation.js:117:51
+   117|   if (a.b) { for (; f();) continue;           a.b.c; } // error
+                                                          ^
+
+References:
+   invalidation.js:38:15
+    38| type A = {b?: {c: boolean}};
+                      ^^^^^^^^^^^^ [1]
+
+
+Error ------------------------------------------------------------------------------------------- invalidation.js:118:51
+
+Cannot get `a.b.c` because property `c` is missing in undefined [1]. [incompatible-use]
+
+   invalidation.js:118:51
+   118|   if (a.b) { for (; f();) break;              a.b.c; } // error
+                                                          ^
+
+References:
+   invalidation.js:38:15
+    38| type A = {b?: {c: boolean}};
+                      ^^^^^^^^^^^^ [1]
+
+
+Error ------------------------------------------------------------------------------------------- invalidation.js:119:51
+
+Cannot get `a.b.c` because property `c` is missing in undefined [1]. [incompatible-use]
+
+   invalidation.js:119:51
+   119|   if (a.b) { for (; f();) return;             a.b.c; } // error
+                                                          ^
+
+References:
+   invalidation.js:38:15
+    38| type A = {b?: {c: boolean}};
+                      ^^^^^^^^^^^^ [1]
+
+
+Error ------------------------------------------------------------------------------------------- invalidation.js:120:51
+
+Cannot get `a.b.c` because property `c` is missing in undefined [1]. [incompatible-use]
+
+   invalidation.js:120:51
+   120|   if (a.b) { for (f(); p;) continue;          a.b.c; } // error
+                                                          ^
+
+References:
+   invalidation.js:38:15
+    38| type A = {b?: {c: boolean}};
+                      ^^^^^^^^^^^^ [1]
+
+
+Error ------------------------------------------------------------------------------------------- invalidation.js:121:51
+
+Cannot get `a.b.c` because property `c` is missing in undefined [1]. [incompatible-use]
+
+   invalidation.js:121:51
+   121|   if (a.b) { for (f(); p;) break;             a.b.c; } // error
+                                                          ^
+
+References:
+   invalidation.js:38:15
+    38| type A = {b?: {c: boolean}};
+                      ^^^^^^^^^^^^ [1]
+
+
+Error ------------------------------------------------------------------------------------------- invalidation.js:122:51
+
+Cannot get `a.b.c` because property `c` is missing in undefined [1]. [incompatible-use]
+
+   invalidation.js:122:51
+   122|   if (a.b) { for (f(); p;) return;            a.b.c; } // error
+                                                          ^
+
+References:
+   invalidation.js:38:15
+    38| type A = {b?: {c: boolean}};
+                      ^^^^^^^^^^^^ [1]
+
+
+Error ------------------------------------------------------------------------------------------- invalidation.js:146:56
+
+Cannot get `a.b.c` because property `c` is missing in undefined [1]. [incompatible-use]
+
+   invalidation.js:146:56
+   146|   if (a.b) { l: { f(); }                           a.b.c; } // error
+                                                               ^
+
+References:
+   invalidation.js:38:15
+    38| type A = {b?: {c: boolean}};
+                      ^^^^^^^^^^^^ [1]
+
+
+Error ------------------------------------------------------------------------------------------- invalidation.js:150:52
+
+Unreachable code. [unreachable-code]
+
+   150|   l: if (a.b) { f(); break l;                      a.b.c; } // error[unreachable-code]
+                                                           ^^^^^^
+
+
+Error ------------------------------------------------------------------------------------------- invalidation.js:155:61
+
+Cannot get `a.b.c` because property `c` is missing in undefined [1]. [incompatible-use]
+
+   invalidation.js:155:61
+   155|   if (a.b) { l: switch (f()) { case true: break l; }    a.b.c; } // error
+                                                                    ^
+
+References:
+   invalidation.js:38:15
+    38| type A = {b?: {c: boolean}};
+                      ^^^^^^^^^^^^ [1]
+
+
+Error ------------------------------------------------------------------------------------------- invalidation.js:156:61
+
+Cannot get `a.b.c` because property `c` is missing in undefined [1]. [incompatible-use]
+
+   invalidation.js:156:61
+   156|   if (a.b) { l: switch (f()) { default: break l; }      a.b.c; } // error
+                                                                    ^
+
+References:
+   invalidation.js:38:15
+    38| type A = {b?: {c: boolean}};
+                      ^^^^^^^^^^^^ [1]
+
+
+Error ------------------------------------------------------------------------------------------- invalidation.js:162:56
+
+Cannot get `a.b.c` because property `c` is missing in undefined [1]. [incompatible-use]
+
+   invalidation.js:162:56
+   162|   if (a.b) { l: while (f()) { continue l; }        a.b.c; } // error
+                                                               ^
+
+References:
+   invalidation.js:38:15
+    38| type A = {b?: {c: boolean}};
+                      ^^^^^^^^^^^^ [1]
+
+
+Error ------------------------------------------------------------------------------------------- invalidation.js:163:56
+
+Cannot get `a.b.c` because property `c` is missing in undefined [1]. [incompatible-use]
+
+   invalidation.js:163:56
+   163|   if (a.b) { l: while (f()) { break l;    }        a.b.c; } // error
+                                                               ^
+
+References:
+   invalidation.js:38:15
+    38| type A = {b?: {c: boolean}};
+                      ^^^^^^^^^^^^ [1]
+
+
+Error ------------------------------------------------------------------------------------------- invalidation.js:174:56
+
+Cannot get `a.b.c` because property `c` is missing in undefined [1]. [incompatible-use]
+
+   invalidation.js:174:56
+   174|   if (a.b) { l: for (; f();) continue l;           a.b.c; } // error
+                                                               ^
+
+References:
+   invalidation.js:38:15
+    38| type A = {b?: {c: boolean}};
+                      ^^^^^^^^^^^^ [1]
+
+
+Error ------------------------------------------------------------------------------------------- invalidation.js:175:56
+
+Cannot get `a.b.c` because property `c` is missing in undefined [1]. [incompatible-use]
+
+   invalidation.js:175:56
+   175|   if (a.b) { l: for (; f();) break l;              a.b.c; } // error
+                                                               ^
+
+References:
+   invalidation.js:38:15
+    38| type A = {b?: {c: boolean}};
+                      ^^^^^^^^^^^^ [1]
+
+
+Error ------------------------------------------------------------------------------------------- invalidation.js:176:56
+
+Cannot get `a.b.c` because property `c` is missing in undefined [1]. [incompatible-use]
+
+   invalidation.js:176:56
+   176|   if (a.b) { l: for (f(); p;) continue l;          a.b.c; } // error
+                                                               ^
+
+References:
+   invalidation.js:38:15
+    38| type A = {b?: {c: boolean}};
+                      ^^^^^^^^^^^^ [1]
+
+
+Error ------------------------------------------------------------------------------------------- invalidation.js:177:56
+
+Cannot get `a.b.c` because property `c` is missing in undefined [1]. [incompatible-use]
+
+   invalidation.js:177:56
+   177|   if (a.b) { l: for (f(); p;) break l;             a.b.c; } // error
+                                                               ^
+
+References:
+   invalidation.js:38:15
+    38| type A = {b?: {c: boolean}};
+                      ^^^^^^^^^^^^ [1]
+
+
+Error ------------------------------------------------------------------------------------------- invalidation.js:197:51
+
+Cannot get `a.b.c` because property `c` is missing in undefined [1]. [incompatible-use]
+
+   invalidation.js:197:51
+   197|   if (a.b) { delete x.b;                      a.b.c; } // error
+                                                          ^
+
+References:
+   invalidation.js:38:15
+    38| type A = {b?: {c: boolean}};
+                      ^^^^^^^^^^^^ [1]
+
+
+Error ------------------------------------------------------------------------------------------- invalidation.js:198:51
+
+Cannot get `a.b.c` because property `c` is missing in undefined [1]. [incompatible-use]
+
+   invalidation.js:198:51
+   198|   if (a.b) { x.b = y;                         a.b.c; } // error
+                                                          ^
+
+References:
+   invalidation.js:38:15
+    38| type A = {b?: {c: boolean}};
+                      ^^^^^^^^^^^^ [1]
+
+
+Error ------------------------------------------------------------------------------------------- invalidation.js:206:51
+
+Cannot get `a.b.c` because property `c` is missing in undefined [1]. [incompatible-use]
+
+   invalidation.js:206:51
+   206|   if (a.b) { delete x.b && true;              a.b.c; } // error
+                                                          ^
+
+References:
+   invalidation.js:38:15
+    38| type A = {b?: {c: boolean}};
+                      ^^^^^^^^^^^^ [1]
+
+
+Error ------------------------------------------------------------------------------------------- invalidation.js:208:51
+
+Cannot get `a.b.c` because property `c` is missing in undefined [1]. [incompatible-use]
+
+   invalidation.js:208:51
+   208|   if (a.b) { (x.b = y) && true;               a.b.c; } // error
+                                                          ^
+
+References:
+   invalidation.js:38:15
+    38| type A = {b?: {c: boolean}};
+                      ^^^^^^^^^^^^ [1]
+
+
+Error ------------------------------------------------------------------------------------------- invalidation.js:211:51
+
+Cannot get `a.b.c` because property `c` is missing in undefined [1]. [incompatible-use]
+
+   invalidation.js:211:51
+   211|   if (a.b) { (x.b = y) || false;              a.b.c; } // error
+                                                          ^
+
+References:
+   invalidation.js:38:15
+    38| type A = {b?: {c: boolean}};
+                      ^^^^^^^^^^^^ [1]
+
+
+Error ------------------------------------------------------------------------------------------- invalidation.js:212:51
+
+Cannot get `a.b.c` because property `c` is missing in undefined [1]. [incompatible-use]
+
+   invalidation.js:212:51
+   212|   if (a.b) { null ?? (x.b = y);               a.b.c; } // error
+                                                          ^
+
+References:
+   invalidation.js:38:15
+    38| type A = {b?: {c: boolean}};
+                      ^^^^^^^^^^^^ [1]
+
+
+Error ------------------------------------------------------------------------------------------- invalidation.js:213:51
+
+Cannot get `a.b.c` because property `c` is missing in undefined [1]. [incompatible-use]
+
+   invalidation.js:213:51
+   213|   if (a.b) { (x.b = y) ?? true;               a.b.c; } // error
+                                                          ^
+
+References:
+   invalidation.js:38:15
+    38| type A = {b?: {c: boolean}};
+                      ^^^^^^^^^^^^ [1]
+
+
+Error ------------------------------------------------------------------------------------------- invalidation.js:217:51
+
+Cannot get `a.b.c` because property `c` is missing in undefined [1]. [incompatible-use]
+
+   invalidation.js:217:51
+   217|   if (a.b) { (x.b = y) ? 1 : 0;               a.b.c; } // error
+                                                          ^
+
+References:
+   invalidation.js:38:15
+    38| type A = {b?: {c: boolean}};
+                      ^^^^^^^^^^^^ [1]
+
+
+Error ------------------------------------------------------------------------------------------- invalidation.js:221:51
+
+Cannot get `a.b.c` because property `c` is missing in undefined [1]. [incompatible-use]
+
+   invalidation.js:221:51
+   221|   if (a.b) { if (x.b = y);                    a.b.c; } // error
+                                                          ^
+
+References:
+   invalidation.js:38:15
+    38| type A = {b?: {c: boolean}};
+                      ^^^^^^^^^^^^ [1]
+
+
+Error ------------------------------------------------------------------------------------------- invalidation.js:225:60
+
+Cannot get `a.b.c` because property `c` is missing in undefined [1]. [incompatible-use]
+
+   invalidation.js:225:60
+   225|   if (a.b) { switch (p) { case true: x.b = y; break; } a.b.c; } // error
+                                                                   ^
+
+References:
+   invalidation.js:38:15
+    38| type A = {b?: {c: boolean}};
+                      ^^^^^^^^^^^^ [1]
+
+
+Error ------------------------------------------------------------------------------------------- invalidation.js:226:60
+
+Cannot get `a.b.c` because property `c` is missing in undefined [1]. [incompatible-use]
+
+   invalidation.js:226:60
+   226|   if (a.b) { switch (p) { default: x.b = y; }          a.b.c; } // error
+                                                                   ^
+
+References:
+   invalidation.js:38:15
+    38| type A = {b?: {c: boolean}};
+                      ^^^^^^^^^^^^ [1]
+
+
+Error ------------------------------------------------------------------------------------------- invalidation.js:227:60
+
+Cannot get `a.b.c` because property `c` is missing in undefined [1]. [incompatible-use]
+
+   invalidation.js:227:60
+   227|   if (a.b) { switch (p) { default: x.b = y; break; }   a.b.c; } // error
+                                                                   ^
+
+References:
+   invalidation.js:38:15
+    38| type A = {b?: {c: boolean}};
+                      ^^^^^^^^^^^^ [1]
+
+
+Error ------------------------------------------------------------------------------------------- invalidation.js:228:60
+
+Cannot get `a.b.c` because property `c` is missing in undefined [1]. [incompatible-use]
+
+   invalidation.js:228:60
+   228|   if (a.b) { switch (x.b = y) {}                       a.b.c; } // error
+                                                                   ^
+
+References:
+   invalidation.js:38:15
+    38| type A = {b?: {c: boolean}};
+                      ^^^^^^^^^^^^ [1]
+
+
+Error ------------------------------------------------------------------------------------------- invalidation.js:229:60
+
+Cannot get `a.b.c` because property `c` is missing in undefined [1]. [incompatible-use]
+
+   invalidation.js:229:60
+   229|   if (a.b) { switch (x.b = y) { case true: }           a.b.c; } // error
+                                                                   ^
+
+References:
+   invalidation.js:38:15
+    38| type A = {b?: {c: boolean}};
+                      ^^^^^^^^^^^^ [1]
+
+
+Error ------------------------------------------------------------------------------------------- invalidation.js:230:60
+
+Cannot get `a.b.c` because property `c` is missing in undefined [1]. [incompatible-use]
+
+   invalidation.js:230:60
+   230|   if (a.b) { switch (x.b = y) { case true: break; }    a.b.c; } // error
+                                                                   ^
+
+References:
+   invalidation.js:38:15
+    38| type A = {b?: {c: boolean}};
+                      ^^^^^^^^^^^^ [1]
+
+
+Error ------------------------------------------------------------------------------------------- invalidation.js:231:60
+
+Cannot get `a.b.c` because property `c` is missing in undefined [1]. [incompatible-use]
+
+   invalidation.js:231:60
+   231|   if (a.b) { switch (x.b = y) { default: }             a.b.c; } // error
+                                                                   ^
+
+References:
+   invalidation.js:38:15
+    38| type A = {b?: {c: boolean}};
+                      ^^^^^^^^^^^^ [1]
+
+
+Error ------------------------------------------------------------------------------------------- invalidation.js:232:60
+
+Cannot get `a.b.c` because property `c` is missing in undefined [1]. [incompatible-use]
+
+   invalidation.js:232:60
+   232|   if (a.b) { switch (x.b = y) { default: break; }      a.b.c; } // error
+                                                                   ^
+
+References:
+   invalidation.js:38:15
+    38| type A = {b?: {c: boolean}};
+                      ^^^^^^^^^^^^ [1]
+
+
+Error ------------------------------------------------------------------------------------------- invalidation.js:237:51
+
+Cannot get `a.b.c` because property `c` is missing in undefined [1]. [incompatible-use]
+
+   invalidation.js:237:51
+   237|   if (a.b) { while (x.b = y);                 a.b.c; } // error
+                                                          ^
+
+References:
+   invalidation.js:38:15
+    38| type A = {b?: {c: boolean}};
+                      ^^^^^^^^^^^^ [1]
+
+
+Error ------------------------------------------------------------------------------------------- invalidation.js:238:51
+
+Cannot get `a.b.c` because property `c` is missing in undefined [1]. [incompatible-use]
+
+   invalidation.js:238:51
+   238|   if (a.b) { do x.b = y; while (p);           a.b.c; } // error
+                                                          ^
+
+References:
+   invalidation.js:38:15
+    38| type A = {b?: {c: boolean}};
+                      ^^^^^^^^^^^^ [1]
+
+
+Error ------------------------------------------------------------------------------------------- invalidation.js:239:51
+
+Cannot get `a.b.c` because property `c` is missing in undefined [1]. [incompatible-use]
+
+   invalidation.js:239:51
+   239|   if (a.b) { do; while (x.b = y);             a.b.c; } // error
+                                                          ^
+
+References:
+   invalidation.js:38:15
+    38| type A = {b?: {c: boolean}};
+                      ^^^^^^^^^^^^ [1]
+
+
+Error ------------------------------------------------------------------------------------------- invalidation.js:242:51
+
+Cannot get `a.b.c` because property `c` is missing in undefined [1]. [incompatible-use]
+
+   invalidation.js:242:51
+   242|   if (a.b) { for (; x.b = y;);                a.b.c; } // error
+                                                          ^
+
+References:
+   invalidation.js:38:15
+    38| type A = {b?: {c: boolean}};
+                      ^^^^^^^^^^^^ [1]
+
+
+Error ------------------------------------------------------------------------------------------- invalidation.js:243:51
+
+Cannot get `a.b.c` because property `c` is missing in undefined [1]. [incompatible-use]
+
+   invalidation.js:243:51
+   243|   if (a.b) { for (x.b = y; p;);               a.b.c; } // error
+                                                          ^
+
+References:
+   invalidation.js:38:15
+    38| type A = {b?: {c: boolean}};
+                      ^^^^^^^^^^^^ [1]
+
+
 Error ---------------------------------------------------------------------------------------------- issue-7103.js:15:15
 
 Cannot cast `box` to empty because object literal [1] is incompatible with empty [2]. [incompatible-cast]
@@ -3941,7 +4819,7 @@ Cannot perform arithmetic operation because undefined [1] is not a number. [unsa
 
 
 
-Found 259 errors
+Found 323 errors
 
 Only showing the most relevant union/intersection branches.
 To see all branches, re-run Flow with --show-all-branches


### PR DESCRIPTION
This commit adds tests for a cluster of four issues:
  https://github.com/facebook/flow/issues/8251
  https://github.com/facebook/flow/issues/8777
  https://github.com/facebook/flow/issues/8778
  https://github.com/facebook/flow/issues/8779
among a set of test cases that try to systematically exercise
remembering refinement invalidations after each form of control-flow
statement and expression.

In total there are 137 test cases added here, of which just over half
(71) are failing, marked with TODO.

The number of cases may look like overkill.  But after fixing issues
8251 and 8777, I wrote some more test cases just to try to be
thorough, and discovered some of them failed.  And after fixing 8778,
a few test cases showed there's still at least one more bug; I've
filed 8779 for those.  So it seems like the level of completeness
needed is at least as much as in these tests, possibly more.

And conversely I've tried to keep these compact, so it's easy to scan
through by eye and compare different cases, while remaining readable;
each case fits on a line, making the whole file about 250 lines long.
It also adds <100ms to the total test runtime.

I'll send my fixes (for 8251, 8777, and 8778; I haven't figured out
8779) as separate followup PRs, to make it easy to read which fixes
correspond to which test cases.
