### PR TITLE
Fix forgotten havoc, part 1: havoc_heap_refinements

### DIFF
--- a/src/typing/scope.ml
+++ b/src/typing/scope.ml
@@ -376,6 +376,9 @@ let remove_entry name scope = scope.entries <- NameUtils.Map.remove name scope.e
 (* get entry from scope, or None *)
 let get_entry name scope = NameUtils.Map.find_opt name scope.entries
 
+(* use passed f to iterate over all scope refis *)
+let iter_refis f scope = Key_map.iter f scope.refis
+
 (* use passed f to update all scope refis *)
 let update_refis f scope = scope.refis <- Key_map.mapi f scope.refis
 

--- a/src/typing/scope.ml
+++ b/src/typing/scope.ml
@@ -406,9 +406,8 @@ let havoc_refis ?name ~private_ scope =
     | Some name -> scope.refis |> filter_refis_using_propname ~private_ name
     | None -> Key_map.empty)
 
-let havoc_all_refis ?name scope =
-  havoc_refis ?name ~private_:false scope;
-  havoc_refis ?name ~private_:true scope
+(* havoc a scope's refinements: clear all its refis *)
+let havoc_all_refis scope = scope.refis <- Key_map.empty
 
 (* havoc a scope:
    - clear all refinements

--- a/src/typing/scope.mli
+++ b/src/typing/scope.mli
@@ -197,7 +197,7 @@ val filter_refis_using_propname : private_:bool -> string -> 'a Key_map.t -> 'a 
 
 val havoc_refis : ?name:string -> private_:bool -> t -> unit
 
-val havoc_all_refis : ?name:string -> t -> unit
+val havoc_all_refis : t -> unit
 
 val havoc : t -> unit
 

--- a/src/typing/scope.mli
+++ b/src/typing/scope.mli
@@ -183,6 +183,8 @@ val remove_entry : Reason.name -> t -> unit
 
 val get_entry : Reason.name -> t -> Entry.t option
 
+val iter_refis : (Key_map.key -> refi_binding -> unit) -> t -> unit
+
 val update_refis : (Key_map.key -> refi_binding -> refi_binding) -> t -> unit
 
 val add_refi : Key_map.key -> refi_binding -> t -> unit

--- a/tests/refinements/invalidation.js
+++ b/tests/refinements/invalidation.js
@@ -11,7 +11,7 @@ const store = (x: mixed) => { v.f = () => x; };
 function coerce8251<A, B>(x: A): B {
   v.f = () => { throw null };  // Refine v.f.
   if (true) store(x);  // Invalidate the refinement.
-  return v.f(); // TODO error: trying to still use the refinement.
+  return v.f(); // error: trying to still use the refinement.
 }
 
 function coerce8777<A, B>(x: A): B {
@@ -51,23 +51,23 @@ type A = {b?: {c: boolean}};
   // somewhere it gets refined again.)
 
   // Conditional constructs: the short-circuiting operators…
-  if (a.b) { true && f();                     a.b.c; } // TODO error
+  if (a.b) { true && f();                     a.b.c; } // error
   if (a.b) { f() && true;                     a.b.c; } // error
-  if (a.b) { false || f();                    a.b.c; } // TODO error
+  if (a.b) { false || f();                    a.b.c; } // error
   if (a.b) { f() || false;                    a.b.c; } // error
   if (a.b) { null ?? f();                     a.b.c; } // error
   if (a.b) { f() ?? true;                     a.b.c; } // error
   // … the ternary operator…
-  if (a.b) { p ? f() : 0;                     a.b.c; } // TODO error
-  if (a.b) { p ? 1 : f();                     a.b.c; } // TODO error
+  if (a.b) { p ? f() : 0;                     a.b.c; } // error
+  if (a.b) { p ? 1 : f();                     a.b.c; } // error
   if (a.b) { f() ? 1 : 0;                     a.b.c; } // error
   // … and if/else.
-  if (a.b) { if (p) f();                      a.b.c; } // TODO error
-  if (a.b) { if (p); else f();                a.b.c; } // TODO error
+  if (a.b) { if (p) f();                      a.b.c; } // error
+  if (a.b) { if (p); else f();                a.b.c; } // error
   if (a.b) { if (f());                        a.b.c; } // error
 
   // Switch statements.
-  if (a.b) { switch (p) { case true: f(); }        a.b.c; } // TODO error
+  if (a.b) { switch (p) { case true: f(); }        a.b.c; } // error
   if (a.b) { switch (p) { case true: f(); break; } a.b.c; } // error
   if (a.b) { switch (p) { default: f(); }          a.b.c; } // error
   if (a.b) { switch (p) { default: f(); break; }   a.b.c; } // error
@@ -95,7 +95,7 @@ type A = {b?: {c: boolean}};
   // Loop constructs with an abrupt completion / abnormal control flow.
   // while…
   if (a.b) { while (p) { f(); continue; }     a.b.c; } // TODO error
-  if (a.b) { while (p) { f(); break;    }     a.b.c; } // TODO error
+  if (a.b) { while (p) { f(); break;    }     a.b.c; } // error
   if (a.b) { while (p) { f(); return;   }     a.b.c; } // ideally ok, error acceptable
   if (a.b) { while (f()) { continue; }        a.b.c; } // error
   if (a.b) { while (f()) { break;    }        a.b.c; } // error
@@ -109,7 +109,7 @@ type A = {b?: {c: boolean}};
   if (a.b) { do { return;   } while (f());    a.b.c; } // error[unreachable-code]
   // … for…
   if (a.b) { for (; p;) { f(); continue; }    a.b.c; } // TODO error
-  if (a.b) { for (; p;) { f(); break;    }    a.b.c; } // TODO error
+  if (a.b) { for (; p;) { f(); break;    }    a.b.c; } // error
   if (a.b) { for (; p;) { f(); return;   }    a.b.c; } // ideally ok, error acceptable
   if (a.b) { for (; p; f()) continue;         a.b.c; } // TODO error
   if (a.b) { for (; p; f()) break;            a.b.c; } // ideally ok, error acceptable
@@ -122,17 +122,17 @@ type A = {b?: {c: boolean}};
   if (a.b) { for (f(); p;) return;            a.b.c; } // error
   // … for-in…
   if (a.b) { for (i in y) { f(); continue; }  a.b.c; } // TODO error
-  if (a.b) { for (i in y) { f(); break;    }  a.b.c; } // TODO error
+  if (a.b) { for (i in y) { f(); break;    }  a.b.c; } // error
   if (a.b) { for (i in y) { f(); return;   }  a.b.c; } // ideally ok, error acceptable
   if (a.b) { for (i in ff()) continue;        a.b.c; } // TODO error
-  if (a.b) { for (i in ff()) break;           a.b.c; } // TODO error
+  if (a.b) { for (i in ff()) break;           a.b.c; } // error
   if (a.b) { for (i in ff()) return;          a.b.c; } // TODO error
   // … for-of.
   if (a.b) { for (i of y) { f(); continue; }  a.b.c; } // TODO error
-  if (a.b) { for (i of y) { f(); break;    }  a.b.c; } // TODO error
+  if (a.b) { for (i of y) { f(); break;    }  a.b.c; } // error
   if (a.b) { for (i of y) { f(); return;   }  a.b.c; } // ideally ok, error acceptable
   if (a.b) { for (i of ff()) continue;        a.b.c; } // TODO error
-  if (a.b) { for (i of ff()) break;           a.b.c; } // TODO error
+  if (a.b) { for (i of ff()) break;           a.b.c; } // error
   if (a.b) { for (i of ff()) return;          a.b.c; } // TODO error
 }
 
@@ -145,20 +145,20 @@ type A = {b?: {c: boolean}};
   // semantics of their own (i.e. not loops or `switch`.)
   if (a.b) { l: { f(); }                           a.b.c; } // error
   if (a.b) { l: { f(); break l; }                  a.b.c; } // TODO error
-  if (a.b) { l: if (p) { f(); break l; }           a.b.c; } // TODO error
+  if (a.b) { l: if (p) { f(); break l; }           a.b.c; } // error
   l: if (a.b) { if (p) { f(); break l; }           a.b.c; } // ideally ok, error acceptable
   l: if (a.b) { f(); break l;                      a.b.c; } // error[unreachable-code]
 
   // Labelled break to `switch`.
-  if (a.b) { l: switch (p) { case true: f(); break l; } a.b.c; } // TODO error
-  if (a.b) { l: switch (p) { default: f(); break l; }   a.b.c; } // TODO error
+  if (a.b) { l: switch (p) { case true: f(); break l; } a.b.c; } // error
+  if (a.b) { l: switch (p) { default: f(); break l; }   a.b.c; } // error
   if (a.b) { l: switch (f()) { case true: break l; }    a.b.c; } // error
   if (a.b) { l: switch (f()) { default: break l; }      a.b.c; } // error
 
   // Labelled break and continue, to loop constructs.
   // while…
-  if (a.b) { l: while (p) { f(); continue l; }     a.b.c; } // TODO error
-  if (a.b) { l: while (p) { f(); break l;    }     a.b.c; } // TODO error
+  if (a.b) { l: while (p) { f(); continue l; }     a.b.c; } // error
+  if (a.b) { l: while (p) { f(); break l;    }     a.b.c; } // error
   if (a.b) { l: while (f()) { continue l; }        a.b.c; } // error
   if (a.b) { l: while (f()) { break l;    }        a.b.c; } // error
   // … do-while…
@@ -167,8 +167,8 @@ type A = {b?: {c: boolean}};
   if (a.b) { l: do { continue l; } while (f());    a.b.c; } // TODO error
   if (a.b) { l: do { break l;    } while (f());    a.b.c; } // ideally ok, error acceptable
   // … for…
-  if (a.b) { l: for (; p;) { f(); continue l; }    a.b.c; } // TODO error
-  if (a.b) { l: for (; p;) { f(); break l;    }    a.b.c; } // TODO error
+  if (a.b) { l: for (; p;) { f(); continue l; }    a.b.c; } // error
+  if (a.b) { l: for (; p;) { f(); break l;    }    a.b.c; } // error
   if (a.b) { l: for (; p; f()) continue l;         a.b.c; } // TODO error
   if (a.b) { l: for (; p; f()) break l;            a.b.c; } // ideally ok, error acceptable
   if (a.b) { l: for (; f();) continue l;           a.b.c; } // error
@@ -176,15 +176,15 @@ type A = {b?: {c: boolean}};
   if (a.b) { l: for (f(); p;) continue l;          a.b.c; } // error
   if (a.b) { l: for (f(); p;) break l;             a.b.c; } // error
   // … for-in…
-  if (a.b) { l: for (i in y) { f(); continue l; }  a.b.c; } // TODO error
-  if (a.b) { l: for (i in y) { f(); break l;    }  a.b.c; } // TODO error
-  if (a.b) { l: for (i in ff()) continue l;        a.b.c; } // TODO error
-  if (a.b) { l: for (i in ff()) break l;           a.b.c; } // TODO error
+  if (a.b) { l: for (i in y) { f(); continue l; }  a.b.c; } // error
+  if (a.b) { l: for (i in y) { f(); break l;    }  a.b.c; } // error
+  if (a.b) { l: for (i in ff()) continue l;        a.b.c; } // error
+  if (a.b) { l: for (i in ff()) break l;           a.b.c; } // error
   // … for-of.
   if (a.b) { l: for (i of y) { f(); continue l; }  a.b.c; } // TODO error
-  if (a.b) { l: for (i of y) { f(); break l;    }  a.b.c; } // TODO error
+  if (a.b) { l: for (i of y) { f(); break l;    }  a.b.c; } // error
   if (a.b) { l: for (i of ff()) continue l;        a.b.c; } // TODO error
-  if (a.b) { l: for (i of ff()) break l;           a.b.c; } // TODO error
+  if (a.b) { l: for (i of ff()) break l;           a.b.c; } // error
 }
 
 // Heap refinements, again on `a.b` where `a` is local,

--- a/tests/refinements/refinements.exp
+++ b/tests/refinements/refinements.exp
@@ -874,6 +874,34 @@ References:
                              ^ [2]
 
 
+Error -------------------------------------------------------------------------------------------- invalidation.js:14:12
+
+Cannot call `v.f` because mixed [1] is not a function. [not-a-function]
+
+   invalidation.js:14:12
+   14|   return v.f(); // error: trying to still use the refinement.
+                  ^
+
+References:
+   invalidation.js:7:16
+    7| const v: { f?: mixed } = {};
+                      ^^^^^ [1]
+
+
+Error -------------------------------------------------------------------------------------------- invalidation.js:14:12
+
+Cannot call `v.f` because undefined [1] is not a function. [not-a-function]
+
+   invalidation.js:14:12
+   14|   return v.f(); // error: trying to still use the refinement.
+                  ^
+
+References:
+   invalidation.js:7:16
+    7| const v: { f?: mixed } = {};
+                      ^^^^^ [1]
+
+
 Error -------------------------------------------------------------------------------------------- invalidation.js:45:51
 
 Cannot get `a.b.c` because property `c` is missing in undefined [1]. [incompatible-use]
@@ -902,12 +930,40 @@ References:
                      ^^^^^^^^^^^^ [1]
 
 
+Error -------------------------------------------------------------------------------------------- invalidation.js:54:51
+
+Cannot get `a.b.c` because property `c` is missing in undefined [1]. [incompatible-use]
+
+   invalidation.js:54:51
+   54|   if (a.b) { true && f();                     a.b.c; } // error
+                                                         ^
+
+References:
+   invalidation.js:38:15
+   38| type A = {b?: {c: boolean}};
+                     ^^^^^^^^^^^^ [1]
+
+
 Error -------------------------------------------------------------------------------------------- invalidation.js:55:51
 
 Cannot get `a.b.c` because property `c` is missing in undefined [1]. [incompatible-use]
 
    invalidation.js:55:51
    55|   if (a.b) { f() && true;                     a.b.c; } // error
+                                                         ^
+
+References:
+   invalidation.js:38:15
+   38| type A = {b?: {c: boolean}};
+                     ^^^^^^^^^^^^ [1]
+
+
+Error -------------------------------------------------------------------------------------------- invalidation.js:56:51
+
+Cannot get `a.b.c` because property `c` is missing in undefined [1]. [incompatible-use]
+
+   invalidation.js:56:51
+   56|   if (a.b) { false || f();                    a.b.c; } // error
                                                          ^
 
 References:
@@ -958,12 +1014,68 @@ References:
                      ^^^^^^^^^^^^ [1]
 
 
+Error -------------------------------------------------------------------------------------------- invalidation.js:61:51
+
+Cannot get `a.b.c` because property `c` is missing in undefined [1]. [incompatible-use]
+
+   invalidation.js:61:51
+   61|   if (a.b) { p ? f() : 0;                     a.b.c; } // error
+                                                         ^
+
+References:
+   invalidation.js:38:15
+   38| type A = {b?: {c: boolean}};
+                     ^^^^^^^^^^^^ [1]
+
+
+Error -------------------------------------------------------------------------------------------- invalidation.js:62:51
+
+Cannot get `a.b.c` because property `c` is missing in undefined [1]. [incompatible-use]
+
+   invalidation.js:62:51
+   62|   if (a.b) { p ? 1 : f();                     a.b.c; } // error
+                                                         ^
+
+References:
+   invalidation.js:38:15
+   38| type A = {b?: {c: boolean}};
+                     ^^^^^^^^^^^^ [1]
+
+
 Error -------------------------------------------------------------------------------------------- invalidation.js:63:51
 
 Cannot get `a.b.c` because property `c` is missing in undefined [1]. [incompatible-use]
 
    invalidation.js:63:51
    63|   if (a.b) { f() ? 1 : 0;                     a.b.c; } // error
+                                                         ^
+
+References:
+   invalidation.js:38:15
+   38| type A = {b?: {c: boolean}};
+                     ^^^^^^^^^^^^ [1]
+
+
+Error -------------------------------------------------------------------------------------------- invalidation.js:65:51
+
+Cannot get `a.b.c` because property `c` is missing in undefined [1]. [incompatible-use]
+
+   invalidation.js:65:51
+   65|   if (a.b) { if (p) f();                      a.b.c; } // error
+                                                         ^
+
+References:
+   invalidation.js:38:15
+   38| type A = {b?: {c: boolean}};
+                     ^^^^^^^^^^^^ [1]
+
+
+Error -------------------------------------------------------------------------------------------- invalidation.js:66:51
+
+Cannot get `a.b.c` because property `c` is missing in undefined [1]. [incompatible-use]
+
+   invalidation.js:66:51
+   66|   if (a.b) { if (p); else f();                a.b.c; } // error
                                                          ^
 
 References:
@@ -979,6 +1091,20 @@ Cannot get `a.b.c` because property `c` is missing in undefined [1]. [incompatib
    invalidation.js:67:51
    67|   if (a.b) { if (f());                        a.b.c; } // error
                                                          ^
+
+References:
+   invalidation.js:38:15
+   38| type A = {b?: {c: boolean}};
+                     ^^^^^^^^^^^^ [1]
+
+
+Error -------------------------------------------------------------------------------------------- invalidation.js:70:56
+
+Cannot get `a.b.c` because property `c` is missing in undefined [1]. [incompatible-use]
+
+   invalidation.js:70:56
+   70|   if (a.b) { switch (p) { case true: f(); }        a.b.c; } // error
+                                                              ^
 
 References:
    invalidation.js:38:15
@@ -1168,6 +1294,20 @@ References:
                      ^^^^^^^^^^^^ [1]
 
 
+Error -------------------------------------------------------------------------------------------- invalidation.js:98:51
+
+Cannot get `a.b.c` because property `c` is missing in undefined [1]. [incompatible-use]
+
+   invalidation.js:98:51
+   98|   if (a.b) { while (p) { f(); break;    }     a.b.c; } // error
+                                                         ^
+
+References:
+   invalidation.js:38:15
+   38| type A = {b?: {c: boolean}};
+                     ^^^^^^^^^^^^ [1]
+
+
 Error ------------------------------------------------------------------------------------------- invalidation.js:100:51
 
 Cannot get `a.b.c` because property `c` is missing in undefined [1]. [incompatible-use]
@@ -1224,6 +1364,20 @@ Unreachable code. [unreachable-code]
 
    109|   if (a.b) { do { return;   } while (f());    a.b.c; } // error[unreachable-code]
                                                       ^^^^^^
+
+
+Error ------------------------------------------------------------------------------------------- invalidation.js:112:51
+
+Cannot get `a.b.c` because property `c` is missing in undefined [1]. [incompatible-use]
+
+   invalidation.js:112:51
+   112|   if (a.b) { for (; p;) { f(); break;    }    a.b.c; } // error
+                                                          ^
+
+References:
+   invalidation.js:38:15
+    38| type A = {b?: {c: boolean}};
+                      ^^^^^^^^^^^^ [1]
 
 
 Error ------------------------------------------------------------------------------------------- invalidation.js:117:51
@@ -1310,6 +1464,62 @@ References:
                       ^^^^^^^^^^^^ [1]
 
 
+Error ------------------------------------------------------------------------------------------- invalidation.js:125:51
+
+Cannot get `a.b.c` because property `c` is missing in undefined [1]. [incompatible-use]
+
+   invalidation.js:125:51
+   125|   if (a.b) { for (i in y) { f(); break;    }  a.b.c; } // error
+                                                          ^
+
+References:
+   invalidation.js:38:15
+    38| type A = {b?: {c: boolean}};
+                      ^^^^^^^^^^^^ [1]
+
+
+Error ------------------------------------------------------------------------------------------- invalidation.js:128:51
+
+Cannot get `a.b.c` because property `c` is missing in undefined [1]. [incompatible-use]
+
+   invalidation.js:128:51
+   128|   if (a.b) { for (i in ff()) break;           a.b.c; } // error
+                                                          ^
+
+References:
+   invalidation.js:38:15
+    38| type A = {b?: {c: boolean}};
+                      ^^^^^^^^^^^^ [1]
+
+
+Error ------------------------------------------------------------------------------------------- invalidation.js:132:51
+
+Cannot get `a.b.c` because property `c` is missing in undefined [1]. [incompatible-use]
+
+   invalidation.js:132:51
+   132|   if (a.b) { for (i of y) { f(); break;    }  a.b.c; } // error
+                                                          ^
+
+References:
+   invalidation.js:38:15
+    38| type A = {b?: {c: boolean}};
+                      ^^^^^^^^^^^^ [1]
+
+
+Error ------------------------------------------------------------------------------------------- invalidation.js:135:51
+
+Cannot get `a.b.c` because property `c` is missing in undefined [1]. [incompatible-use]
+
+   invalidation.js:135:51
+   135|   if (a.b) { for (i of ff()) break;           a.b.c; } // error
+                                                          ^
+
+References:
+   invalidation.js:38:15
+    38| type A = {b?: {c: boolean}};
+                      ^^^^^^^^^^^^ [1]
+
+
 Error ------------------------------------------------------------------------------------------- invalidation.js:146:56
 
 Cannot get `a.b.c` because property `c` is missing in undefined [1]. [incompatible-use]
@@ -1324,12 +1534,68 @@ References:
                       ^^^^^^^^^^^^ [1]
 
 
+Error ------------------------------------------------------------------------------------------- invalidation.js:148:56
+
+Cannot get `a.b.c` because property `c` is missing in undefined [1]. [incompatible-use]
+
+   invalidation.js:148:56
+   148|   if (a.b) { l: if (p) { f(); break l; }           a.b.c; } // error
+                                                               ^
+
+References:
+   invalidation.js:38:15
+    38| type A = {b?: {c: boolean}};
+                      ^^^^^^^^^^^^ [1]
+
+
+Error ------------------------------------------------------------------------------------------- invalidation.js:149:56
+
+Cannot get `a.b.c` because property `c` is missing in undefined [1]. [incompatible-use]
+
+   invalidation.js:149:56
+   149|   l: if (a.b) { if (p) { f(); break l; }           a.b.c; } // ideally ok, error acceptable
+                                                               ^
+
+References:
+   invalidation.js:38:15
+    38| type A = {b?: {c: boolean}};
+                      ^^^^^^^^^^^^ [1]
+
+
 Error ------------------------------------------------------------------------------------------- invalidation.js:150:52
 
 Unreachable code. [unreachable-code]
 
    150|   l: if (a.b) { f(); break l;                      a.b.c; } // error[unreachable-code]
                                                            ^^^^^^
+
+
+Error ------------------------------------------------------------------------------------------- invalidation.js:153:61
+
+Cannot get `a.b.c` because property `c` is missing in undefined [1]. [incompatible-use]
+
+   invalidation.js:153:61
+   153|   if (a.b) { l: switch (p) { case true: f(); break l; } a.b.c; } // error
+                                                                    ^
+
+References:
+   invalidation.js:38:15
+    38| type A = {b?: {c: boolean}};
+                      ^^^^^^^^^^^^ [1]
+
+
+Error ------------------------------------------------------------------------------------------- invalidation.js:154:61
+
+Cannot get `a.b.c` because property `c` is missing in undefined [1]. [incompatible-use]
+
+   invalidation.js:154:61
+   154|   if (a.b) { l: switch (p) { default: f(); break l; }   a.b.c; } // error
+                                                                    ^
+
+References:
+   invalidation.js:38:15
+    38| type A = {b?: {c: boolean}};
+                      ^^^^^^^^^^^^ [1]
 
 
 Error ------------------------------------------------------------------------------------------- invalidation.js:155:61
@@ -1360,6 +1626,34 @@ References:
                       ^^^^^^^^^^^^ [1]
 
 
+Error ------------------------------------------------------------------------------------------- invalidation.js:160:56
+
+Cannot get `a.b.c` because property `c` is missing in undefined [1]. [incompatible-use]
+
+   invalidation.js:160:56
+   160|   if (a.b) { l: while (p) { f(); continue l; }     a.b.c; } // error
+                                                               ^
+
+References:
+   invalidation.js:38:15
+    38| type A = {b?: {c: boolean}};
+                      ^^^^^^^^^^^^ [1]
+
+
+Error ------------------------------------------------------------------------------------------- invalidation.js:161:56
+
+Cannot get `a.b.c` because property `c` is missing in undefined [1]. [incompatible-use]
+
+   invalidation.js:161:56
+   161|   if (a.b) { l: while (p) { f(); break l;    }     a.b.c; } // error
+                                                               ^
+
+References:
+   invalidation.js:38:15
+    38| type A = {b?: {c: boolean}};
+                      ^^^^^^^^^^^^ [1]
+
+
 Error ------------------------------------------------------------------------------------------- invalidation.js:162:56
 
 Cannot get `a.b.c` because property `c` is missing in undefined [1]. [incompatible-use]
@@ -1380,6 +1674,34 @@ Cannot get `a.b.c` because property `c` is missing in undefined [1]. [incompatib
 
    invalidation.js:163:56
    163|   if (a.b) { l: while (f()) { break l;    }        a.b.c; } // error
+                                                               ^
+
+References:
+   invalidation.js:38:15
+    38| type A = {b?: {c: boolean}};
+                      ^^^^^^^^^^^^ [1]
+
+
+Error ------------------------------------------------------------------------------------------- invalidation.js:170:56
+
+Cannot get `a.b.c` because property `c` is missing in undefined [1]. [incompatible-use]
+
+   invalidation.js:170:56
+   170|   if (a.b) { l: for (; p;) { f(); continue l; }    a.b.c; } // error
+                                                               ^
+
+References:
+   invalidation.js:38:15
+    38| type A = {b?: {c: boolean}};
+                      ^^^^^^^^^^^^ [1]
+
+
+Error ------------------------------------------------------------------------------------------- invalidation.js:171:56
+
+Cannot get `a.b.c` because property `c` is missing in undefined [1]. [incompatible-use]
+
+   invalidation.js:171:56
+   171|   if (a.b) { l: for (; p;) { f(); break l;    }    a.b.c; } // error
                                                                ^
 
 References:
@@ -1436,6 +1758,90 @@ Cannot get `a.b.c` because property `c` is missing in undefined [1]. [incompatib
 
    invalidation.js:177:56
    177|   if (a.b) { l: for (f(); p;) break l;             a.b.c; } // error
+                                                               ^
+
+References:
+   invalidation.js:38:15
+    38| type A = {b?: {c: boolean}};
+                      ^^^^^^^^^^^^ [1]
+
+
+Error ------------------------------------------------------------------------------------------- invalidation.js:179:56
+
+Cannot get `a.b.c` because property `c` is missing in undefined [1]. [incompatible-use]
+
+   invalidation.js:179:56
+   179|   if (a.b) { l: for (i in y) { f(); continue l; }  a.b.c; } // error
+                                                               ^
+
+References:
+   invalidation.js:38:15
+    38| type A = {b?: {c: boolean}};
+                      ^^^^^^^^^^^^ [1]
+
+
+Error ------------------------------------------------------------------------------------------- invalidation.js:180:56
+
+Cannot get `a.b.c` because property `c` is missing in undefined [1]. [incompatible-use]
+
+   invalidation.js:180:56
+   180|   if (a.b) { l: for (i in y) { f(); break l;    }  a.b.c; } // error
+                                                               ^
+
+References:
+   invalidation.js:38:15
+    38| type A = {b?: {c: boolean}};
+                      ^^^^^^^^^^^^ [1]
+
+
+Error ------------------------------------------------------------------------------------------- invalidation.js:181:56
+
+Cannot get `a.b.c` because property `c` is missing in undefined [1]. [incompatible-use]
+
+   invalidation.js:181:56
+   181|   if (a.b) { l: for (i in ff()) continue l;        a.b.c; } // error
+                                                               ^
+
+References:
+   invalidation.js:38:15
+    38| type A = {b?: {c: boolean}};
+                      ^^^^^^^^^^^^ [1]
+
+
+Error ------------------------------------------------------------------------------------------- invalidation.js:182:56
+
+Cannot get `a.b.c` because property `c` is missing in undefined [1]. [incompatible-use]
+
+   invalidation.js:182:56
+   182|   if (a.b) { l: for (i in ff()) break l;           a.b.c; } // error
+                                                               ^
+
+References:
+   invalidation.js:38:15
+    38| type A = {b?: {c: boolean}};
+                      ^^^^^^^^^^^^ [1]
+
+
+Error ------------------------------------------------------------------------------------------- invalidation.js:185:56
+
+Cannot get `a.b.c` because property `c` is missing in undefined [1]. [incompatible-use]
+
+   invalidation.js:185:56
+   185|   if (a.b) { l: for (i of y) { f(); break l;    }  a.b.c; } // error
+                                                               ^
+
+References:
+   invalidation.js:38:15
+    38| type A = {b?: {c: boolean}};
+                      ^^^^^^^^^^^^ [1]
+
+
+Error ------------------------------------------------------------------------------------------- invalidation.js:187:56
+
+Cannot get `a.b.c` because property `c` is missing in undefined [1]. [incompatible-use]
+
+   invalidation.js:187:56
+   187|   if (a.b) { l: for (i of ff()) break l;           a.b.c; } // error
                                                                ^
 
 References:
@@ -4819,7 +5225,7 @@ Cannot perform arithmetic operation because undefined [1] is not a number. [unsa
 
 
 
-Found 323 errors
+Found 352 errors
 
 Only showing the most relevant union/intersection branches.
 To see all branches, re-run Flow with --show-all-branches


### PR DESCRIPTION
When there's a branch in the control flow, we rely on some tricky
juggling of state in order to get the right environments (with the
right refinements, initialization states, etc.) at the right places.

A key workhorse of that juggling is Env.merge_env, which we invoke
where control-flow paths join up (at a number of callsites directly in
statement.ml, and several more indirectly through Env.in_refined_env)
in order to merge what happened in two different incoming paths to
produce an appropriate environment for the outgoing path.

The work that Env.merge_env does is all independent between different
bindings and refinements; it iterates through them.  Usually most of
them weren't touched, and are the same on all the paths; so as an
optimization, it relies on being passed a set of bindings and
refinement keys (a Changeset.t) which is supposed to identify all of
the binding-entries and refinements that may differ between the envs.

To make that work, everything in the Env module that mutates the
current environment needs to ensure that the current global changeset
has the appropriate keys.

We had a bug where Env.havoc_heap_refinements, which we use in
particular at function and method calls, wasn't adding the havoced
keys to the changeset.  As a result, when we later merge environments
at the end of some enclosing control-flow construct, we could forget
to propagate the invalidation to the surviving environment.

Fix that by adding the keys for any refis we find here to invalidate.

Along the way, simplify Scope.havoc_all_refis by dropping its unused
`?name` parameter.  There's never been a caller that actually passed
that parameter, and without it the function better matches its name
and becomes very simple, easy to reason about.  The simpler interface
also lets us write a clean, concise comment documenting what it's for.

Fixes: #8251
