### PR TITLE
[codemod] Give proper error when run without arguments

### DIFF
--- a/src/commands/codemodCommand.ml
+++ b/src/commands/codemodCommand.ml
@@ -44,7 +44,12 @@ let main (module Runnable : Codemod_runner.RUNNABLE) codemod_flags () =
     codemod_flags
   in
   initialize_environment ();
+  (* Normalizes filepaths (symlinks and shortcuts) *)
   let filenames = CommandUtils.get_filenames_from_input input_file filenames in
+  if filenames = [] then (
+    Printf.eprintf "Error: filenames or --input-file are required\n%!";
+    exit 64 (* EX_USAGE *)
+  );
   let flowconfig_name = base_flags.CommandUtils.Base_flags.flowconfig_name in
   let root =
     match root with
@@ -73,13 +78,7 @@ let main (module Runnable : Codemod_runner.RUNNABLE) codemod_flags () =
       ~options_flags:option_values
       ~saved_state_options_flags
   in
-  (* Normalizes filepaths (symlinks and shortcuts) *)
-  if filenames = [] then (
-    Printf.eprintf "Error: filenames or --input-file are required\n%!";
-    exit 64 (* EX_USAGE *)
-  );
   let file_options = Options.file_options options in
-
   let roots = CommandUtils.expand_file_list ~options:file_options filenames in
   let roots =
     SSet.fold


### PR DESCRIPTION
When a codemod command is run with no arguments, it gives an error,
because it requires a list of filenames.

But rather than a proper error message, it was crashing with an
OCaml traceback:

  Unhandled exception: (Failure hd)
  Raised at file "stdlib.ml", line 29, characters 17-33
  Called from file "list.ml", line 30, characters 10-23
  Called from file "src/commands/commandUtils.ml", line 13, characters 4-32

There was already a conditional intended to provide a helpful error
message for the lack of filenames.  But earlier in the function, if
there's no --root, we were trying to take the first filename in order
to guess the root.  That caused the crash.

The fix is to move that check sooner.  (Nothing touches `filenames`
in between, so this doesn't have any other effect.)  Now the command
fails properly with:

  Error: filenames or --input-file are required

Also move a neighboring comment to the line it looks like it was
intended to apply to.

This fix would be good to backport to a v0.162.2, so that it can
apply to the replace-existentials codemod advertised in the v0.163.0
release notes.

Fixes: https://github.com/facebook/flow/issues/8782
