### PR TITLE
Add 'navigate' as valid request ModeType

### DIFF
--- a/lib/bom.js
+++ b/lib/bom.js
@@ -1497,7 +1497,7 @@ declare class URLSearchParams {
 
 type CacheType =  'default' | 'no-store' | 'reload' | 'no-cache' | 'force-cache' | 'only-if-cached';
 type CredentialsType = 'omit' | 'same-origin' | 'include';
-type ModeType = 'cors' | 'no-cors' | 'same-origin';
+type ModeType = 'cors' | 'no-cors' | 'same-origin' | 'navigate;
 type RedirectType = 'follow' | 'error' | 'manual';
 type ReferrerPolicyType =
     '' | 'no-referrer' | 'no-referrer-when-downgrade' | 'same-origin' |

--- a/lib/bom.js
+++ b/lib/bom.js
@@ -1497,7 +1497,7 @@ declare class URLSearchParams {
 
 type CacheType =  'default' | 'no-store' | 'reload' | 'no-cache' | 'force-cache' | 'only-if-cached';
 type CredentialsType = 'omit' | 'same-origin' | 'include';
-type ModeType = 'cors' | 'no-cors' | 'same-origin' | 'navigate;
+type ModeType = 'cors' | 'no-cors' | 'same-origin' | 'navigate';
 type RedirectType = 'follow' | 'error' | 'manual';
 type ReferrerPolicyType =
     '' | 'no-referrer' | 'no-referrer-when-downgrade' | 'same-origin' |


### PR DESCRIPTION
Currently, in a SW, checking if the request is a full document reload might be done as request.mode === 'navigate'. However, this raises a flow error.

https://developer.mozilla.org/en-US/docs/Web/API/Request/mode