### PR TITLE
[lib] globalise tls connect options

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -2147,7 +2147,7 @@ declare module "string_decoder" {
   declare var StringDecoder : typeof string_decoder$StringDecoder;
 }
 
-type tls$connectOptions = {
+declare type tls$connectOptions = {
   port?: number,
   host?: string,
   socket?: net$Socket,


### PR DESCRIPTION
<!--
  If this is a change to library defintions, please include links to relevant documentation.
  If this is a documentation change, please prefix the title with [DOCS].

  If this is neither, ensure you opened a discussion issue and link it in the PR description.
-->
I'm trying to type 'pg' library right now but cannot access the type of tls options. Would be great to make it global just like the a lot of the node module. 
