### PR TITLE
fix dune build

### DIFF
--- a/src/analysis/dune
+++ b/src/analysis/dune
@@ -1,0 +1,8 @@
+(library
+ (name flow_analysis)
+ (wrapped false)
+ (libraries
+    flow_common_utils_loc_utils
+    flow_parser_utils)
+ (preprocess
+  (pps ppx_let ppx_deriving.std)))

--- a/src/analysis/env_builder/dune
+++ b/src/analysis/env_builder/dune
@@ -1,0 +1,9 @@
+(library
+ (name flow_env_builder)
+ (wrapped false)
+ (libraries
+    flow_analysis
+    flow_typing_type
+    flow_typing_errors)
+ (preprocess
+  (pps ppx_deriving.std)))

--- a/src/commands/config/dune
+++ b/src/commands/config/dune
@@ -7,4 +7,5 @@
     semver
     xx
   )
+   (preprocess (pps ppx_let))
 )

--- a/src/common/lz4/dune
+++ b/src/common/lz4/dune
@@ -1,0 +1,8 @@
+(library
+ (name common_lz4)
+ (wrapped false)
+ (foreign_stubs
+  (language c)
+  (names lz4_stubs)
+  (flags
+   (:standard -I../../../src/third-party/lz4))))

--- a/src/hack_forked/dfind/dune
+++ b/src/hack_forked/dfind/dune
@@ -4,6 +4,7 @@
   (libraries
     avl
     collections
+    flow_logging_stubs
     fsnotify
     logging_common
     lwt

--- a/src/hack_forked/watchman/dune
+++ b/src/hack_forked/watchman/dune
@@ -4,6 +4,7 @@
   (libraries
     base
     flow_common_lwt
+    flow_logging_stubs
     flow_vcs
     buffered_line_reader_lwt
     hh_json

--- a/src/heap/dune
+++ b/src/heap/dune
@@ -7,10 +7,20 @@
   (names hh_shared)
   (flags
    (:standard -I../../src/third-party/lz4)))
- (c_library_flags (-latomic))
+ (c_library_flags (:include heap_libc_flags.txt))
  (preprocess
   (pps ppx_deriving.std visitors.ppx))
  (libraries utils_core))
+
+(rule
+  (target heap_libc_flags.txt)
+  (enabled_if (= %{system} "linux"))
+  (action (with-stdout-to %{target} (echo "(-latomic)"))))
+
+(rule
+  (target heap_libc_flags.txt)
+  (enabled_if (<> %{system} "linux"))
+  (action (with-stdout-to %{target} (echo "()"))))
 
 (library
  (name heap_ident)
@@ -26,7 +36,12 @@
  (modules prefix sharedMem)
  (preprocess
   (pps ppx_deriving.std visitors.ppx))
- (libraries heap_libc logging_common utils_core worker_cancel))
+ (libraries
+  common_lz4
+  heap_libc
+  logging_common
+  utils_core
+  worker_cancel))
 
 (library
  (name worker_cancel)

--- a/src/parser_utils/dune
+++ b/src/parser_utils/dune
@@ -1,9 +1,11 @@
 (library
  (name flow_parser_utils)
  (wrapped false)
+ (modules (:standard \ flow_ast_visitor file_sig file_sig_sig))
  (libraries
   cycle_hash
   dtoa
+  flow_ast_visitor
   flow_common
   flow_common_utils
   flow_common_utils_loc_utils
@@ -12,8 +14,24 @@
   flow_parser_utils_signature_builder
   flow_typing_polarity
   hh_json ; hack
-  flow_typing_type
-  flow_typing_errors
   )
  (preprocess
   (pps ppx_let ppx_deriving.std)))
+
+(library
+ (name flow_ast_visitor)
+ (wrapped false)
+ (modules flow_ast_visitor)
+ (libraries
+  flow_parser
+  ))
+
+(library
+ (name flow_file_sig)
+ (wrapped false)
+ (modules file_sig file_sig_sig)
+ (libraries
+  flow_ast_visitor
+  flow_parser_utils
+  flow_analysis
+  ))

--- a/src/parser_utils/type_sig/dune
+++ b/src/parser_utils/type_sig/dune
@@ -3,7 +3,7 @@
  (wrapped false)
  (foreign_stubs
   (language c)
-  (names type_sig_bin)
+  (names type_sig_bin_stubs)
   (flags
    (:standard -I../../src/third-party/lz4)))
  (libraries

--- a/src/services/code_action/dune
+++ b/src/services/code_action/dune
@@ -8,4 +8,4 @@
   flow_typing
   collections)
  (preprocess
-  (pps lwt_ppx)))
+  (pps lwt_ppx ppx_let)))

--- a/src/services/references/dune
+++ b/src/services/references/dune
@@ -7,5 +7,5 @@
     flow_service_get_def
     flow_state_readers
   )
-  (preprocess (pps lwt_ppx))
+  (preprocess (pps lwt_ppx ppx_let))
 )

--- a/src/state/heaps/parsing/dune
+++ b/src/state/heaps/parsing/dune
@@ -3,6 +3,7 @@
   (wrapped false)
   (libraries
     flow_common
+    flow_file_sig
     flow_parser
     flow_exports
     flow_state_heaps_parsing_exceptions

--- a/src/third-party/fuzzy-path/test/dune
+++ b/src/third-party/fuzzy-path/test/dune
@@ -1,4 +1,4 @@
 (executable
  (name test)
- (libraries fuzzy_path ounit)
+ (libraries fuzzy_path ounit2)
  )

--- a/src/typing/dune
+++ b/src/typing/dune
@@ -60,9 +60,10 @@
 (library
   (name flow_typing)
   (wrapped false)
-  (modules (:standard \ changeset key key_map trust type typeUtil scope source_or_generated_id generic trust_constraint
-    resolvable_type_job))
+  (modules (:standard \ changeset key key_map trust type typeUtil scope source_or_generated_id generic trust_constraint))
   (libraries
+    flow_env_builder
+    flow_file_sig
     flow_common
     flow_common_errors
     flow_common_modulename

--- a/src/typing/errors/dune
+++ b/src/typing/errors/dune
@@ -3,6 +3,7 @@
   (wrapped false)
   (libraries
     flow_common_errors
+    flow_parser_utils
     flow_parser_utils_signature_builder
     flow_typing_scope
     flow_typing_type


### PR DESCRIPTION
not exactly parity with TARGETS (env_builder and typing have many more separate targets than the dune equivalents), but `dune build` works again