### PR TITLE
Adding ELI5 video to the home page

### DIFF
--- a/website/_data/i18n/en.yml
+++ b/website/_data/i18n/en.yml
@@ -63,6 +63,7 @@ homepage_featurettes:
       existing workflow and toolchain.
 
 homepage_ready_to_get_going: "Ready to get going?"
+homepage_watch_intro_video: "Watch Introductory Video"
 
 navbar_getting_started: "Getting Started"
 navbar_documentation: "Docs"

--- a/website/_layouts/pages/homepage.html
+++ b/website/_layouts/pages/homepage.html
@@ -137,6 +137,16 @@ layout: default
     <h2 class="feature-heading">
       {{i18n.homepage_ready_to_get_going}}
     </h2>
+    <h2>{{i18n.homepage_watch_intro_video}}</h2>
+      <iframe
+        width="560"
+        height="315"
+        src="https://www.youtube.com/embed/r_6cW_Mxy5U"
+        title="Explain Like I'm 5: Flow"
+        frameBorder="0"
+        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+        allowFullScreen
+        ></iframe>
     <div class="mt-2">
       <a class="feature-btn" href="{{url_base}}/docs/getting-started/"><span>{{i18n.homepage_get_started}}</span></a>
       <a class="feature-btn mr-0 hidden-sm-down" href="{{url_base}}/docs/install/"><span>{{i18n.homepage_install_flow}}</span></a>


### PR DESCRIPTION
## Summary
Here at Meta Open Source, we've been creating short-form videos to explain Meta OSS projects in the simplest terms possible. We started embedding these videos into project pages as you can see in [Docusaurus home page](https://docusaurus.io/), [Jest](https://jestjs.io/), [Litho](https://fblitho.com/), [Hydra](https://hydra.cc/), etc.

## Test plan

![image](https://user-images.githubusercontent.com/12485205/155028397-c1a93b6a-67a2-42aa-8efe-78230afdac07.png)
