### PR TITLE
pin to core_kernel 0.14.x

### DIFF
--- a/flowtype.opam
+++ b/flowtype.opam
@@ -12,7 +12,7 @@ depends: [
   "base" {>= "v0.14.1"}
   "base-unix"
   "base-bytes"
-  "core_kernel" {>= "v0.14.1"}
+  "core_kernel" {>= "v0.14.1" & < "v0.15.0"}
   "dtoa" {>= "0.3.2"}
   "ocamlbuild" {build}
   "ocamlfind" {build}


### PR DESCRIPTION
Summary:
core_kernel 0.15 adds a deprecation warning about being renamed to Core, which we treat as an error.

since we're pinned on 0.14 internally, i'm doing the same on github for now. ideally, we'd use an opam lock file to pin all of our dependencies.

Differential Revision: D35283155

