### PR TITLE
(fix) Remove `flow suggest` from CLI docs

### DIFF
--- a/new_website/docs/cli/index.md
+++ b/new_website/docs/cli/index.md
@@ -49,7 +49,6 @@ Valid values for COMMAND:
   start            Starts a Flow server
   status           (default) Shows current Flow errors by asking the Flow server
   stop             Stops a Flow server
-  suggest          Provides type annotation suggestions for a given program
   type-at-pos      Shows the type at a given file and position
   version          Print version information
 

--- a/website/en/docs/cli/index.md
+++ b/website/en/docs/cli/index.md
@@ -48,7 +48,6 @@ Valid values for COMMAND:
   start            Starts a Flow server
   status           (default) Shows current Flow errors by asking the Flow server
   stop             Stops a Flow server
-  suggest          Provides type annotation suggestions for a given program
   type-at-pos      Shows the type at a given file and position
   version          Print version information
 


### PR DESCRIPTION
`flow suggest` and `flow autofix suggest` were removed in https://github.com/facebook/flow/commit/d2985638a29033a3358cbbc1774c461651aacd09 but we never updated the docs