### PR TITLE
Optimize saved state loading

### DIFF
--- a/src/server/command_handler/commandHandler.ml
+++ b/src/server/command_handler/commandHandler.ml
@@ -843,8 +843,8 @@ let get_imports ~options ~reader module_names =
    * flow. *)
   List.fold_left add_to_results (SMap.empty, SSet.empty) module_names
 
-let save_state ~saved_state_filename ~genv ~env ~profiling =
-  let%lwt () = Saved_state.save ~saved_state_filename ~genv ~env ~profiling in
+let save_state ~saved_state_filename ~options ~env ~profiling =
+  let%lwt () = Saved_state.save ~saved_state_filename ~options ~profiling env in
   Lwt.return (Ok ())
 
 let handle_autocomplete ~trigger_character ~reader ~options ~profiling ~env ~input ~cursor ~imports
@@ -1006,9 +1006,9 @@ let handle_status ~reader ~options ~profiling ~env =
   let (status_response, lazy_stats) = get_status ~profiling ~reader ~options env in
   Lwt.return (env, ServerProt.Response.STATUS { status_response; lazy_stats }, None)
 
-let handle_save_state ~saved_state_filename ~genv ~profiling ~env =
+let handle_save_state ~saved_state_filename ~options ~profiling ~env =
   let%lwt result =
-    try_with_lwt (fun () -> save_state ~saved_state_filename ~genv ~env ~profiling)
+    try_with_lwt (fun () -> save_state ~saved_state_filename ~options ~env ~profiling)
   in
   Lwt.return (env, ServerProt.Response.SAVE_STATE result, None)
 
@@ -1269,7 +1269,7 @@ let get_ephemeral_handler genv command =
   | ServerProt.Request.SAVE_STATE { outfile } ->
     (* save-state can take awhile to run. Furthermore, you probably don't want to run this with out
      * of date data. So save-state is not parallelizable *)
-    Handle_nonparallelizable (handle_save_state ~saved_state_filename:outfile ~genv)
+    Handle_nonparallelizable (handle_save_state ~saved_state_filename:outfile ~options)
 
 let send_finished_status_update profiling cmd_str =
   let event =

--- a/src/services/inference/types_js.ml
+++ b/src/services/inference/types_js.ml
@@ -1971,78 +1971,23 @@ let mk_init_env
 let init_from_saved_state ~profiling ~workers ~saved_state ~updates options =
   let%lwt (env, libs_ok) =
     with_transaction @@ fun transaction reader ->
-    let file_options = Options.file_options options in
-    (* We don't want to walk the file system for the checked in files. But we still need to find the
-     * flowlibs *)
-    let (ordered_flowlib_libs, _) = Files.init ~flowlibs_only:true file_options in
     let {
-      Saved_state.flowconfig_hash = _;
-      parsed_heaps;
-      unparsed_heaps;
-      package_heaps;
+      Saved_state.parsed;
+      unparsed;
+      package_json_files;
       ordered_non_flowlib_libs;
+      node_modules_containers;
+      dependency_info;
       local_errors;
       warnings;
-      node_modules_containers;
-      dependency_graph;
+      dirty_modules;
     } =
       saved_state
     in
-    let root = Options.root options |> Path.to_string in
+
     Files.node_modules_containers := node_modules_containers;
-    (* Restore PackageHeap and the ReversePackageHeap *)
-    FilenameMap.iter (fun fn -> Module_js.add_package (File_key.to_string fn)) package_heaps;
 
-    let restore_parsed (fns, dirty_modules) (fn, parsed_file_data) =
-      let { Saved_state.module_name; normalized_file_data } = parsed_file_data in
-      let { Saved_state.hash; exports; resolved_requires } =
-        Saved_state.denormalize_file_data ~root normalized_file_data
-      in
-
-      (* Restore the FileHeap *)
-      let ms =
-        Parsing_heaps.From_saved_state.add_parsed fn hash module_name exports resolved_requires
-      in
-
-      (FilenameSet.add fn fns, Modulename.Set.union ms dirty_modules)
-    in
-
-    let restore_unparsed (fns, dirty_modules) (fn, unparsed_file_data) =
-      let { Saved_state.unparsed_module_name; unparsed_hash } = unparsed_file_data in
-
-      (* Restore the FileHeap *)
-      let ms = Parsing_heaps.From_saved_state.add_unparsed fn unparsed_hash unparsed_module_name in
-
-      (FilenameSet.add fn fns, Modulename.Set.union ms dirty_modules)
-    in
-
-    Hh_logger.info "Restoring heaps";
-    let%lwt (parsed, unparsed, dirty_modules) =
-      Memory_utils.with_memory_timer_lwt ~options "RestoreHeaps" profiling (fun () ->
-          let neutral = (FilenameSet.empty, Modulename.Set.empty) in
-          let merge (a1, a2) (b1, b2) = (FilenameSet.union a1 b1, Modulename.Set.union a2 b2) in
-          let%lwt (parsed, dirty_modules_parsed) =
-            MultiWorkerLwt.call
-              workers
-              ~job:(List.fold_left restore_parsed)
-              ~merge
-              ~neutral
-              ~next:(MultiWorkerLwt.next workers parsed_heaps)
-          in
-          let%lwt (unparsed, dirty_modules_unparsed) =
-            MultiWorkerLwt.call
-              workers
-              ~job:(List.fold_left restore_unparsed)
-              ~merge
-              ~neutral
-              ~next:(MultiWorkerLwt.next workers unparsed_heaps)
-          in
-          let dirty_modules = Modulename.Set.union dirty_modules_parsed dirty_modules_unparsed in
-          Lwt.return (parsed, unparsed, dirty_modules)
-      )
-    in
     Hh_logger.info "Loading libraries";
-
     (* We actually parse and typecheck the libraries, even though we're loading from saved state.
      * We'd need to check them anyway, as soon as any file is checked, since we don't track
      * dependents for libraries. And we don't really support incrementally checking libraries
@@ -2054,16 +1999,19 @@ let init_from_saved_state ~profiling ~workers ~saved_state ~updates options =
      * 1. The builtin libraries are merged first
      * 2. The non-builtin libraries are merged in the same order as before
      *)
-    let ordered_libs = List.rev_append (List.rev ordered_flowlib_libs) ordered_non_flowlib_libs in
+    let ordered_libs =
+      let file_options = Options.file_options options in
+      let (ordered_flowlib_libs, _) = Files.init ~flowlibs_only:true file_options in
+      List.rev_append (List.rev ordered_flowlib_libs) ordered_non_flowlib_libs
+    in
     let libs = SSet.of_list ordered_libs in
     let%lwt (libs_ok, local_errors, warnings, suppressions, lib_exports) =
       let suppressions = Error_suppressions.empty in
       init_libs ~options ~profiling ~local_errors ~warnings ~suppressions ~reader ordered_libs
     in
+
     Hh_logger.info "Resolving dependencies";
     MonitorRPC.status_update ~event:ServerStatus.Resolving_dependencies_progress;
-
-    (* This will restore InfoHeap, NameHeap, & all_providers hashtable *)
     let%lwt (_changed_modules, duplicate_providers) =
       commit_modules
         ~transaction
@@ -2073,15 +2021,10 @@ let init_from_saved_state ~profiling ~workers ~saved_state ~updates options =
         ~duplicate_providers:SMap.empty
         dirty_modules
     in
+
     let errors =
       let merge_errors = FilenameMap.empty in
       { ServerEnv.local_errors; duplicate_providers; merge_errors; warnings; suppressions }
-    in
-
-    let%lwt dependency_info =
-      Memory_utils.with_memory_timer_lwt ~options "RestoreDependencyInfo" profiling (fun () ->
-          Lwt.return (Dependency_info.of_map dependency_graph)
-      )
     in
 
     Hh_logger.info "Indexing files";
@@ -2095,7 +2038,7 @@ let init_from_saved_state ~profiling ~workers ~saved_state ~updates options =
       mk_init_env
         ~files:parsed
         ~unparsed
-        ~package_json_files:(FilenameMap.keys package_heaps)
+        ~package_json_files
         ~dependency_info
         ~ordered_libs
         ~libs
@@ -2269,7 +2212,7 @@ let exit_if_no_fallback ?msg options =
   if Options.saved_state_no_fallback options then Exit.(exit ?msg Invalid_saved_state)
 
 (* Does a best-effort job to load a saved state. If it fails, returns None *)
-let load_saved_state ~profiling ~workers options =
+let load_saved_state ~profiling options =
   let%lwt (fetch_profiling, fetch_result) =
     match Options.saved_state_fetcher options with
     | Options.Dummy_fetcher -> Saved_state_dummy_fetcher.fetch ~options
@@ -2288,9 +2231,7 @@ let load_saved_state ~profiling ~workers options =
   | Saved_state_fetcher.Saved_state { saved_state_filename; changed_files } ->
     let changed_files_count = SSet.cardinal changed_files in
     (try%lwt
-       let%lwt (load_profiling, saved_state) =
-         Saved_state.load ~workers ~saved_state_filename ~options
-       in
+       let%lwt (load_profiling, saved_state) = Saved_state.load ~saved_state_filename ~options in
        Profiling_js.merge ~from:load_profiling ~into:profiling;
 
        let updates =
@@ -2328,7 +2269,7 @@ let load_saved_state ~profiling ~workers options =
 let init ~profiling ~workers options =
   let start_time = Unix.gettimeofday () in
   let%lwt (env, libs_ok) =
-    match%lwt load_saved_state ~profiling ~workers options with
+    match%lwt load_saved_state ~profiling options with
     | None ->
       (* Either there is no saved state or we failed to load it for some reason *)
       init_from_scratch ~profiling ~workers options

--- a/src/services/saved_state/saved_state.ml
+++ b/src/services/saved_state/saved_state.ml
@@ -5,83 +5,101 @@
  * LICENSE file in the root directory of this source tree.
  *)
 
-open Utils_js
+(* # Saving and loading saved states:
+ *
+ * ## Relative / absolute paths
+ *
+ * Flow stores absolute paths, but the server loading a saved state might store
+ * the repo root at a different location. To handle this, we convert all
+ * absolute paths to root-relative paths in the saved state, then convert those
+ * back into absolute paths when we load the saved state.
+ *
+ * ## Dealing with balanced trees
+ *
+ * Flow stores many collections as balanced trees. When loading, we would like
+ * to re-construct these balanced trees efficiently, avoiding comparisons and
+ * rebalancing operations.
+ *
+ * When storing, we convert balanced trees to arrays, ensuring that the arrays
+ * are sorted with respect to the keys. During load, we can use the unsafe API
+ * `of_increasing_iterator_unchecked` to efficiently build maps.
+ *
+ * ## Balanced trees sorted by absolute path
+ *
+ * Sometimes the keys of the balanced trees are absolute file names. We can
+ * safely re-construct these trees, even when the repo root is in a different
+ * directory.
+ *
+ * Consider two absolute paths, A1 and A2, so that A1 < A2. If we convert these
+ * to paths R1 and R2 relative to directory D1, then convert them back
+ * into absolute paths A1' and A2' relative to directory D2, then A1' < A2'.
+ *)
 
-type denormalized_file_data = {
-  resolved_requires: Parsing_heaps.resolved_requires;
+module FMap = Utils_js.FilenameMap
+module FSet = Utils_js.FilenameSet
+module FGraph = Utils_js.FilenameGraph
+module MSet = Modulename.Set
+
+type path = {
+  relative: string;
+  mutable absolute: string option;
+}
+
+type file_key =
+  | Source_file of path
+  | Json_file of path
+  | Resource_file of path
+  | Lib_file of path
+
+type modulename =
+  | Haste_module of string
+  | File_module of file_key
+
+type parse = {
   exports: Exports.t;
-  hash: Xx.hash;
+  resolved_modules: (string * modulename) array;
+  phantom_dependencies: modulename array;
 }
 
-type normalized_file_data = denormalized_file_data
-
-(* For each parsed file, this is what we will save *)
-type parsed_file_data = {
-  module_name: string option;
-  normalized_file_data: normalized_file_data;
-}
-
-(* We also need to store the info for unparsed files *)
-type unparsed_file_data = {
-  unparsed_module_name: string option;
-  unparsed_hash: Xx.hash;
-}
-
-type saved_state_dependency_graph =
-  (Utils_js.FilenameSet.t * Utils_js.FilenameSet.t) Utils_js.FilenameMap.t
+type aloc = (ALoc.t, file_key * ALoc.t) Either.t
 
 (* This is the complete saved state data representation *)
-type saved_state_data = {
-  (* The version header should guarantee that a saved state is used by the same version of Flow.
-   * However, config might have changed in a way that invalidates the saved state. In the future,
-   * we probably could allow some config options, whitespace, etc. But for now, let's
-   * invalidate the saved state if the config has changed at all *)
-  flowconfig_hash: Xx.hash;
-  parsed_heaps: (File_key.t * parsed_file_data) list;
-  unparsed_heaps: (File_key.t * unparsed_file_data) list;
-  (* package.json info *)
-  package_heaps: (Package_json.t, unit) result FilenameMap.t;
+type serialized_t =
+  | Saved_state of {
+      (* The version header should guarantee that a saved state is used by the same version of Flow.
+       * However, config might have changed in a way that invalidates the saved state. In the future,
+       * we probably could allow some config options, whitespace, etc. But for now, let's
+       * invalidate the saved state if the config has changed at all *)
+      flowconfig_hash: int64;
+      parsed: (file_key * int64 * string option * parse) array;
+      unparsed: (file_key * int64 * string option) array;
+      package_json: (file_key * (Package_json.t, unit) result) list;
+      rev_non_flowlib_libs: path list;
+      (* Why store local errors and not merge_errors/suppressions/etc? Well, I have a few reasons:
+       *
+       * 1. Much smaller data structure. The whole env.errors data structure can be hundreds of MBs
+       *    when marshal'd, even when there are 0 errors reported to the user)
+       * 2. Saved state is designed to help skip parsing. One of the outputs of parsing are local errors
+       * 3. Local errors should be the same after a lazy init and after a full init. This isn't true
+       *    for the other members of env.errors which are filled in during typechecking
+       *)
+      local_errors: (file_key * aloc Flow_error.t array) array;
+      warnings: (file_key * aloc Flow_error.t array) array;
+      node_modules_containers: (path * SSet.t) array;
+      dependency_graph: (file_key * file_key array * file_key array) array;
+    }
+
+type t = {
+  parsed: Utils_js.FilenameSet.t;
+  unparsed: Utils_js.FilenameSet.t;
+  package_json_files: File_key.t list;
+  node_modules_containers: SSet.t SMap.t;
+  dependency_info: Dependency_info.t;
   ordered_non_flowlib_libs: string list;
-  (* Why store local errors and not merge_errors/suppressions/etc? Well, I have a few reasons:
-   *
-   * 1. Much smaller data structure. The whole env.errors data structure can be hundreds of MBs
-   *    when marshal'd, even when there are 0 errors reported to the user)
-   * 2. Saved state is designed to help skip parsing. One of the outputs of parsing are local errors
-   * 3. Local errors should be the same after a lazy init and after a full init. This isn't true
-   *    for the other members of env.errors which are filled in during typechecking
-   *)
   local_errors: Flow_error.ErrorSet.t Utils_js.FilenameMap.t;
   warnings: Flow_error.ErrorSet.t Utils_js.FilenameMap.t;
-  node_modules_containers: SSet.t SMap.t;
-  dependency_graph: saved_state_dependency_graph;
+  dirty_modules: Modulename.Set.t;
 }
-
-let modulename_map_fn ~f = function
-  | Modulename.Filename fn -> Modulename.Filename (f fn)
-  | Modulename.String _ as module_name -> module_name
-
-let update_dependency_graph_filenames f graph =
-  let update_set set = FilenameSet.map f set in
-  let update_map update_value map =
-    FilenameMap.fold
-      (fun key value new_map ->
-        let key = f key in
-        let value = update_value value in
-        FilenameMap.update
-          key
-          (function
-            | None -> Some value
-            | Some _ -> invalid_arg "Duplicate keys created by mapper function")
-          new_map)
-      map
-      FilenameMap.empty
-  in
-  let update_value (sig_deps, impl_deps) =
-    let sig_deps = update_set sig_deps in
-    let impl_deps = update_set impl_deps in
-    (sig_deps, impl_deps)
-  in
-  update_map update_value graph
 
 (* It's simplest if the build ID is always the same length. Let's use 16, since that happens to
  * be the size of the build ID hash. *)
@@ -101,73 +119,16 @@ let saved_state_version () =
   assert (String.length version = saved_state_version_length);
   version
 
-let with_cache tbl key f =
-  match Hashtbl.find_opt tbl key with
-  | Some result -> result
-  | None ->
-    let result = f key in
-    Hashtbl.add tbl key result;
-    result
+let get_flowconfig_hash ~options =
+  let flowconfig_name = Options.flowconfig_name options in
+  let root = Options.root options in
+  FlowConfig.get_hash (Server_files_js.config_file flowconfig_name root)
 
-(* Saving the saved state generally consists of 3 things:
- *
- * 1. Collecting the various bits of data
- * 2. Normalizing the data so it can be used by other Flow servers. This generally means turning
- *    absolute paths into relative paths
- * 3. Writing the data to the saved state file
- *
- * We care a little bit about the perf of generating saved state, so that any script which
- * generates saved states has an easier time keeping up. But the perf of saving isn't as important
- * as the perf of loading
- *)
-module Save : sig
-  val save :
-    saved_state_filename:Path.t ->
-    genv:ServerEnv.genv ->
-    env:ServerEnv.env ->
-    profiling:Profiling_js.running ->
-    unit Lwt.t
-end = struct
-  module FileNormalizer : sig
-    type t
-
-    val make : root:string -> t
-
-    val normalize_path : t -> string -> string
-
-    val normalize_file_key : t -> File_key.t -> File_key.t
-  end = struct
-    type t = {
-      root: string;
-      file_key_cache: (File_key.t, File_key.t) Hashtbl.t;
-    }
-
-    let make ~root = { root; file_key_cache = Hashtbl.create 16 }
-
-    (* We could also add a cache for this call, to improve sharing of the underlying strings
-     * between file keys and the places that deal with raw paths. Unfortunately, an April 2020 test
-     * of the saved state size of Facebook's largest JS codebase showed that while adding this
-     * cache decreased the pre-compression size, it actually increased the post-compression size.
-     * *)
-    let normalize_path { root; _ } path = Files.relative_path root path
-
-    let normalize_file_key ({ file_key_cache; _ } as normalizer) file_key =
-      with_cache file_key_cache file_key (File_key.map (normalize_path normalizer))
-  end
-
-  let normalize_dependency_graph ~normalizer =
-    update_dependency_graph_filenames (FileNormalizer.normalize_file_key normalizer)
-
-  (* A Flow_error.t is a complicated data structure with Loc.t's hidden everywhere. *)
-  let normalize_error ~normalizer =
-    Flow_error.map_loc_of_error
-      (ALoc.update_source (Base.Option.map ~f:(FileNormalizer.normalize_file_key normalizer)))
-
+module Save = struct
   (* We write the Flow version at the beginning of each saved state file. It's an easy way to assert
    * upon reading the file that the writer and reader are the same version of Flow *)
   let write_version fd =
     let version = saved_state_version () in
-
     let rec loop offset len =
       if len > 0 then
         let%lwt bytes_written = Lwt_unix.write_string fd version offset len in
@@ -179,206 +140,188 @@ end = struct
     in
     loop 0 saved_state_version_length
 
-  let normalize_resolved_requires
-      ~normalizer { Parsing_heaps.resolved_modules; phantom_dependencies; hash } =
-    let phantom_dependencies =
-      Modulename.Set.map
-        (modulename_map_fn ~f:(FileNormalizer.normalize_file_key normalizer))
-        phantom_dependencies
+  let mk_env root =
+    let tbl = Hashtbl.create 0 in
+    let relative_path = Files.relative_path root in
+    fun abs_path ->
+      match Hashtbl.find_opt tbl abs_path with
+      | Some path -> path
+      | None ->
+        let path = { relative = relative_path abs_path; absolute = None } in
+        Hashtbl.add tbl abs_path path;
+        path
+
+  let get_path env = env
+
+  let get_key env = function
+    | File_key.SourceFile path -> Source_file (get_path env path)
+    | File_key.JsonFile path -> Json_file (get_path env path)
+    | File_key.ResourceFile path -> Resource_file (get_path env path)
+    | File_key.LibFile path -> Lib_file (get_path env path)
+
+  let get_module env = function
+    | Modulename.String name -> Haste_module name
+    | Modulename.Filename key -> File_module (get_key env key)
+
+  let collect_parsed env reader file_key acc =
+    let file = Parsing_heaps.get_file_addr_unsafe file_key in
+    let parse = Parsing_heaps.Reader.get_typed_parse_unsafe ~reader file_key file in
+    let { Parsing_heaps.resolved_modules; phantom_dependencies; _ } =
+      Parsing_heaps.Reader.get_resolved_requires_unsafe file_key ~reader parse
     in
     let resolved_modules =
-      SMap.map
-        (modulename_map_fn ~f:(FileNormalizer.normalize_file_key normalizer))
-        resolved_modules
+      SMap.fold (fun mref m acc -> (mref, get_module env m) :: acc) resolved_modules []
+      |> Base.Array.of_list_rev
     in
-    { Parsing_heaps.resolved_modules; phantom_dependencies; hash }
-
-  let normalize_file_data ~normalizer { resolved_requires; exports; hash } =
-    let resolved_requires = normalize_resolved_requires ~normalizer resolved_requires in
-    { resolved_requires; exports; hash }
-
-  let normalize_parsed_data ~normalizer { module_name; normalized_file_data } =
-    let normalized_file_data = normalize_file_data ~normalizer normalized_file_data in
-    { module_name; normalized_file_data }
-
-  (* Collect all the data for a single parsed file *)
-  let collect_normalized_data_for_parsed_file ~normalizer ~reader fn parsed_heaps =
-    let addr = Parsing_heaps.get_file_addr_unsafe fn in
-    let parse = Parsing_heaps.Reader.get_typed_parse_unsafe ~reader fn addr in
-    let resolved_requires = Parsing_heaps.Reader.get_resolved_requires_unsafe fn ~reader parse in
-    let file_data =
-      {
-        module_name = Parsing_heaps.Reader.get_haste_name ~reader addr;
-        normalized_file_data =
-          {
-            resolved_requires;
-            exports = Parsing_heaps.read_exports parse;
-            hash = Parsing_heaps.read_file_hash parse;
-          };
-      }
+    let phantom_dependencies =
+      MSet.fold (fun m acc -> get_module env m :: acc) phantom_dependencies []
+      |> Base.Array.of_list_rev
     in
-    let relative_fn = FileNormalizer.normalize_file_key normalizer fn in
-    let relative_file_data = normalize_parsed_data ~normalizer file_data in
-    (relative_fn, relative_file_data) :: parsed_heaps
+    let file_key = get_key env file_key in
+    let file_hash = Parsing_heaps.read_file_hash parse in
+    let haste_name = Parsing_heaps.Reader.get_haste_name ~reader file in
+    let parse =
+      { exports = Parsing_heaps.read_exports parse; resolved_modules; phantom_dependencies }
+    in
+    (file_key, file_hash, haste_name, parse) :: acc
 
-  let collect_normalized_data_for_package_json_file ~normalizer fn package_heaps =
-    let str = File_key.to_string fn in
+  let collect_unparsed env reader file_key acc =
+    let file = Parsing_heaps.get_file_addr_unsafe file_key in
+    let parse = Parsing_heaps.Reader.get_parse_unsafe ~reader file_key file in
+    let file_key = get_key env file_key in
+    let file_hash = Parsing_heaps.read_file_hash parse in
+    let haste_name = Parsing_heaps.Reader.get_haste_name ~reader file in
+    (file_key, file_hash, haste_name) :: acc
+
+  let collect_package_json env acc file_key =
+    let str = File_key.to_string file_key in
     let package = Package_heaps.For_saved_state.get_package_json_unsafe str in
-    let relative_fn = FileNormalizer.normalize_file_key normalizer fn in
-    FilenameMap.add relative_fn package package_heaps
-
-  (* Collect all the data for a single unparsed file *)
-  let collect_normalized_data_for_unparsed_file ~normalizer ~reader fn unparsed_heaps =
-    let addr = Parsing_heaps.get_file_addr_unsafe fn in
-    let parse = Parsing_heaps.Reader.get_parse_unsafe ~reader fn addr in
-    let relative_file_data =
-      {
-        unparsed_module_name = Parsing_heaps.Reader.get_haste_name ~reader addr;
-        unparsed_hash = Parsing_heaps.read_file_hash parse;
-      }
-    in
-    let relative_fn = FileNormalizer.normalize_file_key normalizer fn in
-    (relative_fn, relative_file_data) :: unparsed_heaps
+    (get_key env file_key, package) :: acc
 
   (* The builtin flowlibs are excluded from the saved state. The server which loads the saved state
    * will extract and typecheck its own builtin flowlibs *)
-  let is_not_in_flowlib ~options =
+  let collect_lib env options =
     let file_options = Options.file_options options in
     let is_in_flowlib = Files.is_in_flowlib file_options in
-    (fun f -> not (is_in_flowlib f))
+    fun acc lib ->
+      if is_in_flowlib lib then
+        acc
+      else
+        get_path env lib :: acc
 
-  let normalize_error_set ~normalizer = Flow_error.ErrorSet.map (normalize_error ~normalizer)
+  let collect_err env =
+    let f loc =
+      match ALoc.source loc with
+      | None -> Either.Left loc
+      | Some file_key ->
+        let file_key = get_key env file_key in
+        let loc = ALoc.update_source (Fun.const None) loc in
+        Either.Right (file_key, loc)
+    in
+    (fun err acc -> Flow_error.map_loc_of_error f err :: acc)
 
-  (* Collect all the data for all the files *)
-  let collect_data ~genv ~env ~profiling =
-    let options = genv.ServerEnv.options in
+  let collect_errs env file_key errs acc =
+    let errs = Flow_error.ErrorSet.fold (collect_err env) errs [] |> Base.Array.of_list_rev in
+    (get_key env file_key, errs) :: acc
+
+  let collect_node_modules_containers env container node_modules acc =
+    (get_path env container, node_modules) :: acc
+
+  let collect ~options ~profiling env =
+    let {
+      ServerEnv.files = parsed;
+      unparsed;
+      package_json_files;
+      ordered_libs;
+      errors = { ServerEnv.local_errors; warnings; _ };
+      dependency_info;
+      _;
+    } =
+      env
+    in
+    let root = Options.root options in
+    let env = mk_env (Path.to_string root) in
     let reader = State_reader.create () in
-    let normalizer =
-      let root = Options.root options |> Path.to_string in
-      FileNormalizer.make ~root
-    in
-    let parsed_heaps =
+    let%lwt parsed =
       Profiling_js.with_timer profiling ~timer:"CollectParsed" ~f:(fun () ->
-          FilenameSet.fold
-            (collect_normalized_data_for_parsed_file ~normalizer ~reader)
-            env.ServerEnv.files
-            []
+          FSet.fold (collect_parsed env reader) parsed [] |> Base.Array.of_list_rev |> Lwt.return
       )
     in
-    let unparsed_heaps =
+    let%lwt unparsed =
       Profiling_js.with_timer profiling ~timer:"CollectUnparsed" ~f:(fun () ->
-          FilenameSet.fold
-            (collect_normalized_data_for_unparsed_file ~normalizer ~reader)
-            env.ServerEnv.unparsed
-            []
+          FSet.fold (collect_unparsed env reader) unparsed []
+          |> Base.Array.of_list_rev
+          |> Lwt.return
       )
     in
-    let package_heaps =
+    let%lwt package_json =
       Profiling_js.with_timer profiling ~timer:"CollectPackageJson" ~f:(fun () ->
-          Base.List.fold
-            ~f:(fun m fn -> collect_normalized_data_for_package_json_file ~normalizer fn m)
-            env.ServerEnv.package_json_files
-            ~init:FilenameMap.empty
+          List.fold_left (collect_package_json env) [] package_json_files |> Lwt.return
       )
     in
-    let ordered_non_flowlib_libs =
-      env.ServerEnv.ordered_libs
-      |> List.filter (is_not_in_flowlib ~options)
-      |> Base.List.map ~f:(FileNormalizer.normalize_path normalizer)
-    in
-    let local_errors =
-      FilenameMap.fold
-        (fun fn error_set acc ->
-          let normalized_fn = FileNormalizer.normalize_file_key normalizer fn in
-          let normalized_error_set = normalize_error_set ~normalizer error_set in
-          FilenameMap.add normalized_fn normalized_error_set acc)
-        env.ServerEnv.errors.ServerEnv.local_errors
-        FilenameMap.empty
-    in
-    let warnings =
-      FilenameMap.fold
-        (fun fn warning_set acc ->
-          let normalized_fn = FileNormalizer.normalize_file_key normalizer fn in
-          let normalized_error_set = normalize_error_set ~normalizer warning_set in
-          FilenameMap.add normalized_fn normalized_error_set acc)
-        env.ServerEnv.errors.ServerEnv.warnings
-        FilenameMap.empty
-    in
+    let rev_non_flowlib_libs = List.fold_left (collect_lib env options) [] ordered_libs in
+    let local_errors = FMap.fold (collect_errs env) local_errors [] |> Base.Array.of_list_rev in
+    let warnings = FMap.fold (collect_errs env) warnings [] |> Base.Array.of_list_rev in
     let node_modules_containers =
-      SMap.fold
-        (fun key value acc -> SMap.add (FileNormalizer.normalize_path normalizer key) value acc)
-        !Files.node_modules_containers
-        SMap.empty
+      SMap.fold (collect_node_modules_containers env) !Files.node_modules_containers []
+      |> Base.Array.of_list_rev
     in
-    let dependency_graph =
-      let dependency_info = env.ServerEnv.dependency_info in
-      let impl_map =
-        dependency_info |> Dependency_info.implementation_dependency_graph |> FilenameGraph.to_map
+    let%lwt dependency_graph =
+      let f dep_key acc = get_key env dep_key :: acc in
+      let f sig_map file_key impl_deps acc =
+        let sig_deps = FMap.find file_key sig_map in
+        let sig_deps = FSet.fold f sig_deps [] |> Base.Array.of_list_rev in
+        let impl_deps = FSet.fold f impl_deps [] |> Base.Array.of_list_rev in
+        (get_key env file_key, sig_deps, impl_deps) :: acc
       in
-      let dependency_graph =
-        let sig_map =
-          dependency_info |> Dependency_info.sig_dependency_graph |> FilenameGraph.to_map
-        in
-        (* The maps should have the same entries. Enforce this by asserting that they have the
-         * same size, and then by using `FilenameMap.find` below to ensure that each `impl_map`
-         * entry has a corresponding `sig_map` entry. *)
-        assert (FilenameMap.cardinal sig_map = FilenameMap.cardinal impl_map);
-        FilenameMap.mapi
-          (fun file impl_deps ->
-            let sig_deps = FilenameMap.find file sig_map in
-            (sig_deps, impl_deps))
-          impl_map
-      in
-
-      normalize_dependency_graph ~normalizer dependency_graph
-    in
-    let flowconfig_hash =
-      FlowConfig.get_hash
-      @@ Server_files_js.config_file (Options.flowconfig_name options)
-      @@ Options.root options
+      Profiling_js.with_timer profiling ~timer:"CollectDependencyInfo" ~f:(fun () ->
+          let impl_map =
+            Dependency_info.implementation_dependency_graph dependency_info |> FGraph.to_map
+          in
+          let sig_map = Dependency_info.sig_dependency_graph dependency_info |> FGraph.to_map in
+          Lwt.return (FMap.fold (f sig_map) impl_map [] |> Base.Array.of_list_rev)
+      )
     in
     Lwt.return
-      {
-        flowconfig_hash;
-        parsed_heaps;
-        unparsed_heaps;
-        package_heaps;
-        ordered_non_flowlib_libs;
-        local_errors;
-        warnings;
-        node_modules_containers;
-        dependency_graph;
-      }
+      (Saved_state
+         {
+           flowconfig_hash = get_flowconfig_hash ~options;
+           parsed;
+           unparsed;
+           package_json;
+           rev_non_flowlib_libs;
+           local_errors;
+           warnings;
+           node_modules_containers;
+           dependency_graph;
+         }
+      )
 
-  let save ~saved_state_filename ~genv ~env ~profiling =
+  let save ~saved_state_filename ~options ~profiling env =
     Hh_logger.info "Collecting data for saved state";
-
-    let%lwt data = collect_data ~genv ~env ~profiling in
+    let%lwt saved_state = collect ~options ~profiling env in
     let filename = Path.to_string saved_state_filename in
     let%lwt fd = Lwt_unix.openfile filename [Unix.O_WRONLY; Unix.O_CREAT; Unix.O_TRUNC] 0o666 in
     let%lwt header_bytes_written = write_version fd in
-    Hh_logger.info "Compressing saved state with lz4";
-    let%lwt saved_state_contents =
+    let%lwt compressed =
       Profiling_js.with_timer_lwt profiling ~timer:"Compress" ~f:(fun () ->
-          Saved_state_compression.(
-            let compressed = marshal_and_compress data in
-            let orig_size = uncompressed_size compressed in
-            let new_size = compressed_size compressed in
-            Hh_logger.info
-              "Compressed from %d bytes to %d bytes (%3.2f%%)"
-              orig_size
-              new_size
-              (100. *. float_of_int new_size /. float_of_int orig_size);
-            Lwt.return compressed
-          )
+          let open Saved_state_compression in
+          Hh_logger.info "Compressing saved state with lz4";
+          let compressed = marshal_and_compress saved_state in
+          let orig_size = uncompressed_size compressed in
+          let new_size = compressed_size compressed in
+          Hh_logger.info
+            "Compressed from %d bytes to %d bytes (%3.2f%%)"
+            orig_size
+            new_size
+            (100. *. float_of_int new_size /. float_of_int orig_size);
+          Lwt.return compressed
       )
     in
     Profiling_js.with_timer_lwt profiling ~timer:"Write" ~f:(fun () ->
         Hh_logger.info "Writing saved-state file at %S" filename;
         let%lwt data_bytes_written =
-          Marshal_tools_lwt.to_fd_with_preamble
-            fd
-            (saved_state_contents : Saved_state_compression.compressed)
+          Marshal_tools_lwt.to_fd_with_preamble fd (compressed : Saved_state_compression.compressed)
         in
         let%lwt () = Lwt_unix.close fd in
         let bytes_written =
@@ -410,57 +353,7 @@ let invalid_reason_to_string = function
 
 exception Invalid_saved_state of invalid_reason
 
-(* Loading the saved state generally consists of 2 things:
- *
- * 1. Loading the saved state from a file
- * 2. Denormalizing the data. This generally means turning relative paths into absolute paths
- *
- * This is on the critical path for starting up a server with saved state. We really care about
- * the perf
- *)
-module Load : sig
-  val load :
-    workers:MultiWorkerLwt.worker list option ->
-    saved_state_filename:Path.t ->
-    options:Options.t ->
-    profiling:Profiling_js.running ->
-    saved_state_data Lwt.t
-
-  val denormalize_file_data : root:string -> normalized_file_data -> denormalized_file_data
-end = struct
-  module FileDenormalizer : sig
-    type t
-
-    val make : root:string -> t
-
-    val denormalize_path : t -> string -> string
-
-    val denormalize_file_key : t -> File_key.t -> File_key.t
-  end = struct
-    type t = {
-      root: string;
-      file_key_cache: (File_key.t, File_key.t) Hashtbl.t;
-    }
-
-    let make ~root = { root; file_key_cache = Hashtbl.create 16 }
-
-    (* This could also have its own cache, but an October 2020 experiment showed that memoizing
-     * these calls does not even save a single word in the denormalized saved state object. *)
-    let denormalize_path { root; _ } path = Files.absolute_path root path
-
-    let denormalize_file_key ({ file_key_cache; _ } as denormalizer) file_key =
-      with_cache file_key_cache file_key (File_key.map (denormalize_path denormalizer))
-  end
-
-  let denormalize_file_key_nocache ~root fn = File_key.map (Files.absolute_path root) fn
-
-  let denormalize_dependency_graph ~denormalizer =
-    update_dependency_graph_filenames (FileDenormalizer.denormalize_file_key denormalizer)
-
-  let denormalize_error ~denormalizer =
-    Flow_error.map_loc_of_error
-      (ALoc.update_source (Base.Option.map ~f:(FileDenormalizer.denormalize_file_key denormalizer)))
-
+module Load = struct
   let verify_version =
     (* Flow_build_id should always be 16 bytes *)
     let rec read_version fd buf offset len =
@@ -491,138 +384,210 @@ end = struct
     fun fd ->
       read_version fd (Bytes.create saved_state_version_length) 0 saved_state_version_length
 
-  let denormalize_resolved_requires
-      ~root { Parsing_heaps.resolved_modules; phantom_dependencies; hash = _ } =
-    (* We do our best to avoid reading the file system (which Path.make will do) *)
-    let phantom_dependencies =
-      Modulename.Set.map
-        (modulename_map_fn ~f:(denormalize_file_key_nocache ~root))
-        phantom_dependencies
+  let mk_env root =
+    let absolute_path = Files.absolute_path root in
+    fun path ->
+      match path.absolute with
+      | Some absolute_path -> absolute_path
+      | None ->
+        let abs_path = absolute_path path.relative in
+        path.absolute <- Some abs_path;
+        abs_path
+
+  let load_path env = env
+
+  let load_key env = function
+    | Source_file path -> File_key.SourceFile (load_path env path)
+    | Json_file path -> File_key.JsonFile (load_path env path)
+    | Resource_file path -> File_key.ResourceFile (load_path env path)
+    | Lib_file path -> File_key.LibFile (load_path env path)
+
+  let load_module env = function
+    | Haste_module name -> Modulename.String name
+    | File_module key -> Modulename.Filename (load_key env key)
+
+  let load_resolved_modules env resolved_modules =
+    let i = ref 0 in
+    let f () =
+      let (mref, m) = resolved_modules.(!i) in
+      incr i;
+      (mref, load_module env m)
     in
-    let resolved_modules =
-      SMap.map (modulename_map_fn ~f:(denormalize_file_key_nocache ~root)) resolved_modules
+    SMap.of_increasing_iterator_unchecked f (Array.length resolved_modules)
+
+  let load_phantom_dependencies env phantom_dependencies =
+    let i = ref 0 in
+    let f () =
+      let path = load_module env phantom_dependencies.(!i) in
+      incr i;
+      path
     in
-    Parsing_heaps.mk_resolved_requires ~resolved_modules ~phantom_dependencies
+    MSet.of_increasing_iterator_unchecked f (Array.length phantom_dependencies)
 
-  (** Turns all the relative paths in a file's data back into absolute paths. *)
-  let denormalize_file_data ~root { resolved_requires; exports; hash } =
-    let resolved_requires = denormalize_resolved_requires ~root resolved_requires in
-    { resolved_requires; exports; hash }
-
-  let progress_fn real_total ~total:_ ~start ~length:_ =
-    MonitorRPC.status_update
-      ~event:ServerStatus.(Load_saved_state_progress { total = Some real_total; finished = start })
-
-  (* Denormalize the data for all the parsed files. This is kind of slow :( *)
-  let denormalize_parsed_heaps ~denormalizer parsed_heaps =
-    Base.List.map
-      ~f:(fun (relative_fn, parsed_file_data) ->
-        let fn = FileDenormalizer.denormalize_file_key denormalizer relative_fn in
-        (fn, parsed_file_data))
-      parsed_heaps
-
-  (* Denormalize the data for all the unparsed files *)
-  let denormalize_unparsed_heaps ~workers ~root ~progress_fn unparsed_heaps =
-    let next = MultiWorkerLwt.next ~progress_fn ~max_size:4000 workers unparsed_heaps in
-    MultiWorkerLwt.call
-      workers
-      ~job:
-        (List.fold_left (fun acc (relative_fn, unparsed_file_data) ->
-             let fn = denormalize_file_key_nocache ~root relative_fn in
-             (fn, unparsed_file_data) :: acc
-         )
-        )
-      ~neutral:[]
-      ~merge:List.rev_append
-      ~next
-
-  let denormalize_error_set ~denormalizer = Flow_error.ErrorSet.map (denormalize_error ~denormalizer)
-
-  (* Denormalize all the data *)
-  let denormalize_data ~workers ~options ~data =
-    let root = Options.root options |> Path.to_string in
-    let denormalizer = FileDenormalizer.make ~root in
-    let {
-      flowconfig_hash;
-      parsed_heaps;
-      unparsed_heaps;
-      package_heaps;
-      ordered_non_flowlib_libs;
-      local_errors;
-      warnings;
-      node_modules_containers;
-      dependency_graph;
-    } =
-      data
+  let load_parse dirty_modules env parsed =
+    let i = ref 0 in
+    let f () =
+      let (file_key, hash, haste_name, parse) = parsed.(!i) in
+      incr i;
+      let { exports; resolved_modules; phantom_dependencies } = parse in
+      let file_key = load_key env file_key in
+      let resolved_modules = load_resolved_modules env resolved_modules in
+      let phantom_dependencies = load_phantom_dependencies env phantom_dependencies in
+      let resolved_requires =
+        Parsing_heaps.mk_resolved_requires ~resolved_modules ~phantom_dependencies
+      in
+      let ms =
+        Parsing_heaps.From_saved_state.add_parsed file_key hash haste_name exports resolved_requires
+      in
+      dirty_modules := MSet.union ms !dirty_modules;
+      file_key
     in
-    let current_flowconfig_hash =
-      let flowconfig_name = Options.flowconfig_name options in
-      FlowConfig.get_hash @@ Server_files_js.config_file flowconfig_name @@ Options.root options
+    FSet.of_increasing_iterator_unchecked f (Array.length parsed)
+
+  let load_unparsed dirty_modules env unparsed =
+    let i = ref 0 in
+    let f () =
+      let (file_key, hash, haste_name) = unparsed.(!i) in
+      incr i;
+      let file_key = load_key env file_key in
+      let ms = Parsing_heaps.From_saved_state.add_unparsed file_key hash haste_name in
+      dirty_modules := MSet.union ms !dirty_modules;
+      file_key
     in
-    if flowconfig_hash <> current_flowconfig_hash then (
+    FSet.of_increasing_iterator_unchecked f (Array.length unparsed)
+
+  let load_errs env errs =
+    let map_err =
+      let f = function
+        | Either.Left loc -> loc
+        | Either.Right (key, loc) ->
+          let f _ = Some (load_key env key) in
+          ALoc.update_source f loc
+      in
+      Flow_error.map_loc_of_error f
+    in
+    let i = ref 0 in
+    let f () =
+      let err = map_err errs.(!i) in
+      incr i;
+      err
+    in
+    Flow_error.ErrorSet.of_increasing_iterator_unchecked f (Array.length errs)
+
+  let load_file_errs env file_errs =
+    let i = ref 0 in
+    let f () =
+      let (file_key, errs) = file_errs.(!i) in
+      incr i;
+      (load_key env file_key, load_errs env errs)
+    in
+    FMap.of_increasing_iterator_unchecked f (Array.length file_errs)
+
+  let load_deps env deps =
+    let i = ref 0 in
+    let f () =
+      let key = load_key env deps.(!i) in
+      incr i;
+      key
+    in
+    FSet.of_increasing_iterator_unchecked f (Array.length deps)
+
+  let load_dependency_info env graph =
+    let i = ref 0 in
+    let f () =
+      let (file_key, sig_deps, impl_deps) = graph.(!i) in
+      incr i;
+      let sig_deps = load_deps env sig_deps in
+      let impl_deps = load_deps env impl_deps in
+      (load_key env file_key, (sig_deps, impl_deps))
+    in
+    FMap.of_increasing_iterator_unchecked f (Array.length graph) |> Dependency_info.of_map
+
+  let load_saved_state ~options ~profiling saved_state =
+    let root = Path.to_string (Options.root options) in
+    let env = mk_env root in
+    let (Saved_state
+          {
+            flowconfig_hash;
+            parsed;
+            unparsed;
+            package_json;
+            rev_non_flowlib_libs;
+            local_errors;
+            warnings;
+            node_modules_containers;
+            dependency_graph;
+          }
+          ) =
+      saved_state
+    in
+
+    if flowconfig_hash <> get_flowconfig_hash ~options then (
       Hh_logger.error
         "Invalid saved state: .flowconfig has changed since this saved state was generated.";
       raise (Invalid_saved_state Flowconfig_mismatch)
     );
 
-    let package_heaps =
-      FilenameMap.fold
-        (fun fn package heap ->
-          FilenameMap.add (FileDenormalizer.denormalize_file_key denormalizer fn) package heap)
-        package_heaps
-        FilenameMap.empty
+    let dirty_modules = ref MSet.empty in
+
+    let%lwt parsed =
+      Profiling_js.with_timer_lwt profiling ~timer:"LoadParsed" ~f:(fun () ->
+          Lwt.return (load_parse dirty_modules env parsed)
+      )
     in
 
-    Hh_logger.info "Denormalizing the data for the parsed files";
-    let parsed_heaps = denormalize_parsed_heaps ~denormalizer parsed_heaps in
-    Hh_logger.info "Denormalizing the data for the unparsed files";
-    let%lwt unparsed_heaps =
-      let progress_fn = progress_fn (List.length unparsed_heaps) in
-      denormalize_unparsed_heaps ~workers ~root ~progress_fn unparsed_heaps
+    let%lwt unparsed =
+      Profiling_js.with_timer_lwt profiling ~timer:"LoadUnparsed" ~f:(fun () ->
+          Lwt.return (load_unparsed dirty_modules env unparsed)
+      )
     in
-    let ordered_non_flowlib_libs =
-      Base.List.map ~f:(FileDenormalizer.denormalize_path denormalizer) ordered_non_flowlib_libs
+
+    let%lwt package_json_files =
+      let f acc (file_key, package) =
+        let file_key = load_key env file_key in
+        Module_js.add_package (File_key.to_string file_key) package;
+        file_key :: acc
+      in
+      Profiling_js.with_timer_lwt profiling ~timer:"LoadPackageJson" ~f:(fun () ->
+          Lwt.return (List.fold_left f [] package_json)
+      )
     in
-    let local_errors =
-      FilenameMap.fold
-        (fun normalized_fn normalized_error_set acc ->
-          let fn = FileDenormalizer.denormalize_file_key denormalizer normalized_fn in
-          let error_set = denormalize_error_set ~denormalizer normalized_error_set in
-          FilenameMap.add fn error_set acc)
-        local_errors
-        FilenameMap.empty
-    in
-    let warnings =
-      FilenameMap.fold
-        (fun normalized_fn normalized_warning_set acc ->
-          let fn = FileDenormalizer.denormalize_file_key denormalizer normalized_fn in
-          let warning_set = denormalize_error_set ~denormalizer normalized_warning_set in
-          FilenameMap.add fn warning_set acc)
-        warnings
-        FilenameMap.empty
-    in
+
+    let ordered_non_flowlib_libs = List.rev_map (load_path env) rev_non_flowlib_libs in
+
     let node_modules_containers =
-      SMap.fold
-        (fun key value acc ->
-          SMap.add (FileDenormalizer.denormalize_path denormalizer key) value acc)
-        node_modules_containers
-        SMap.empty
+      let i = ref 0 in
+      let f () =
+        let (container, node_modules) = node_modules_containers.(!i) in
+        incr i;
+        (load_path env container, node_modules)
+      in
+      SMap.of_increasing_iterator_unchecked f (Array.length node_modules_containers)
     in
-    let dependency_graph = denormalize_dependency_graph ~denormalizer dependency_graph in
+
+    let%lwt dependency_info =
+      Profiling_js.with_timer_lwt profiling ~timer:"LoadDependencyInfo" ~f:(fun () ->
+          Lwt.return (load_dependency_info env dependency_graph)
+      )
+    in
+
+    let local_errors = load_file_errs env local_errors in
+    let warnings = load_file_errs env warnings in
+
     Lwt.return
       {
-        flowconfig_hash;
-        parsed_heaps;
-        unparsed_heaps;
-        package_heaps;
+        parsed;
+        unparsed;
+        package_json_files;
         ordered_non_flowlib_libs;
+        node_modules_containers;
+        dependency_info;
         local_errors;
         warnings;
-        node_modules_containers;
-        dependency_graph;
+        dirty_modules = !dirty_modules;
       }
 
-  let load ~workers ~saved_state_filename ~options ~profiling =
+  let load ~saved_state_filename ~options ~profiling =
     let filename = Path.to_string saved_state_filename in
     Hh_logger.info "Reading saved-state file at %S" filename;
 
@@ -636,7 +601,7 @@ end = struct
         raise (Invalid_saved_state File_does_not_exist)
     in
     let%lwt () = verify_version fd in
-    let%lwt (compressed_data : Saved_state_compression.compressed) =
+    let%lwt (compressed : Saved_state_compression.compressed) =
       Profiling_js.with_timer_lwt profiling ~timer:"Read" ~f:(fun () ->
           try%lwt Marshal_tools_lwt.from_fd_with_preamble fd with
           | exn ->
@@ -646,35 +611,29 @@ end = struct
       )
     in
     let%lwt () = Lwt_unix.close fd in
-    Hh_logger.info "Decompressing saved-state data";
 
-    let%lwt (data : saved_state_data) =
+    Hh_logger.info "Decompressing saved-state data";
+    let%lwt (saved_state : serialized_t) =
       Profiling_js.with_timer_lwt profiling ~timer:"Decompress" ~f:(fun () ->
-          try Lwt.return (Saved_state_compression.decompress_and_unmarshal compressed_data) with
+          try Lwt.return (Saved_state_compression.decompress_and_unmarshal compressed) with
           | exn ->
             let exn = Exception.wrap exn in
             Hh_logger.error ~exn "Failed to decompress saved state";
             raise (Invalid_saved_state Failed_to_decompress)
       )
     in
-    Hh_logger.info "Denormalizing saved-state data";
 
-    let%lwt data =
-      Profiling_js.with_timer_lwt profiling ~timer:"Denormalize" ~f:(fun () ->
-          denormalize_data ~workers ~options ~data
-      )
-    in
+    Hh_logger.info "Loading saved-state data";
+    let%lwt saved_state = load_saved_state ~options ~profiling saved_state in
     Hh_logger.info "Finished loading saved-state";
 
-    Lwt.return data
+    Lwt.return saved_state
 end
 
 let save = Save.save
 
-let load ~workers ~saved_state_filename ~options =
+let load ~saved_state_filename ~options =
   let should_print_summary = Options.should_profile options in
   Profiling_js.with_profiling_lwt ~label:"LoadSavedState" ~should_print_summary (fun profiling ->
-      Load.load ~workers ~saved_state_filename ~options ~profiling
+      Load.load ~saved_state_filename ~options ~profiling
   )
-
-let denormalize_file_data = Load.denormalize_file_data

--- a/src/services/saved_state/saved_state.mli
+++ b/src/services/saved_state/saved_state.mli
@@ -5,37 +5,16 @@
  * LICENSE file in the root directory of this source tree.
  *)
 
-type denormalized_file_data = {
-  resolved_requires: Parsing_heaps.resolved_requires;
-  exports: Exports.t;
-  hash: Xx.hash;
-}
-
-type normalized_file_data
-
-type parsed_file_data = {
-  module_name: string option;
-  normalized_file_data: normalized_file_data;
-}
-
-type unparsed_file_data = {
-  unparsed_module_name: string option;
-  unparsed_hash: Xx.hash;
-}
-
-type saved_state_dependency_graph =
-  (Utils_js.FilenameSet.t * Utils_js.FilenameSet.t) Utils_js.FilenameMap.t
-
-type saved_state_data = {
-  flowconfig_hash: Xx.hash;
-  parsed_heaps: (File_key.t * parsed_file_data) list;
-  unparsed_heaps: (File_key.t * unparsed_file_data) list;
-  package_heaps: (Package_json.t, unit) result Utils_js.FilenameMap.t;
+type t = {
+  parsed: Utils_js.FilenameSet.t;
+  unparsed: Utils_js.FilenameSet.t;
+  package_json_files: File_key.t list;
+  node_modules_containers: SSet.t SMap.t;
+  dependency_info: Dependency_info.t;
   ordered_non_flowlib_libs: string list;
   local_errors: Flow_error.ErrorSet.t Utils_js.FilenameMap.t;
   warnings: Flow_error.ErrorSet.t Utils_js.FilenameMap.t;
-  node_modules_containers: SSet.t SMap.t;
-  dependency_graph: saved_state_dependency_graph;
+  dirty_modules: Modulename.Set.t;
 }
 
 type invalid_reason =
@@ -53,15 +32,9 @@ exception Invalid_saved_state of invalid_reason
 
 val save :
   saved_state_filename:Path.t ->
-  genv:ServerEnv.genv ->
-  env:ServerEnv.env ->
+  options:Options.t ->
   profiling:Profiling_js.running ->
+  ServerEnv.env ->
   unit Lwt.t
 
-val load :
-  workers:MultiWorkerLwt.worker list option ->
-  saved_state_filename:Path.t ->
-  options:Options.t ->
-  (Profiling_js.finished * saved_state_data) Lwt.t
-
-val denormalize_file_data : root:string -> normalized_file_data -> denormalized_file_data
+val load : saved_state_filename:Path.t -> options:Options.t -> (Profiling_js.finished * t) Lwt.t


### PR DESCRIPTION
Summary:
This diff includes a few separate optimizations to speed up loading saved states.

1. We save maps and sets as sorted arrays and load them using an optimized API which avoids comparisons and rebalancing.
2. We ensure that all absolute<->relative paths are de-duplicated, so we only ever need to reconstruct absolute paths once per unique relative path.
3. We also avoid hash table lookups during load by caching the absolute path in a shared record embedded in the saved state directly.

This diff also fuses the RestoreHeaps/RestoreDependency steps into LoadSavedState, which makes the profiling simpler, so we can more easily attribute the cost of loading a saved state.

Changelog: [feature] Optimize initialization from saved state

Reviewed By: mroch

Differential Revision: D36041629

