### PR TITLE
fix js exception due to regex flags

### DIFF
--- a/src/parser/flow_parser_js.ml
+++ b/src/parser/flow_parser_js.ml
@@ -30,19 +30,17 @@ end = struct
 
   let null = Js.Unsafe.inject Js.null
 
-  let regexp loc pattern flags =
+  let regexp _loc pattern flags =
     let regexp =
       try
         Js.Unsafe.new_obj (Js.Unsafe.pure_js_expr "RegExp") [| string pattern; string flags |]
       with
       | _ ->
-        translation_errors := (loc, Parse_error.InvalidRegExp) :: !translation_errors;
-
-        (* Invalid RegExp. We already validated the flags, but we've been
-         * too lazy to write a JS regexp parser in Ocaml, so we didn't know
-         * the pattern was invalid. We'll recover with an empty pattern.
-         *)
-        Js.Unsafe.new_obj (Js.Unsafe.pure_js_expr "RegExp") [| string ""; string flags |]
+        (* We don't implement regexp validation other than checking the flags. The regex
+           might be invalid, or the runtime might not support certain flags like y or u
+           or d, which prevents instantiating a native RegExp object. Return `null` instead
+           per https://github.com/estree/estree/blob/master/es5.md#regexpliteral *)
+        Js.null
     in
     Js.Unsafe.inject regexp
 end


### PR DESCRIPTION
Summary:
in ESTree, the `value` property of a regex is an instantiated `RegExp` object. if it can't be represented for some reason, the `value` should be `null`. there is also a `regex` property with the pattern and flags as strings so you can still tell what it was.

JSON doesn't have regexes, so `flow ast` already returns null. `flow_parser.js` runs in a JS engine so it does try to create a `RegExp`. when creating a `RegExp` fatals, we previously tried to recover in a bogus way. it should return `null` instead.

this fixes a crash when the browser engine doesn't support the latest regex flags, like `y`, `u` or `d`.

Fixes https://github.com/facebook/flow/issues/8886

Changelog: [parser] Fix a runtime exception when parsing regexes via the JS version of the parser

Differential Revision: D36754295

