### PR TITLE
Update lib defs for Node's `v8` module

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -2852,6 +2852,13 @@ declare module "assert" {
   }
 }
 
+type HeapCodeStatistics = {
+  code_and_metadata_size: number,
+  bytecode_and_metadata_size: number,
+  external_script_source_size: number,
+  ...
+};
+
 type HeapStatistics = {
   total_heap_size: number,
   total_heap_size_executable: number,
@@ -2861,9 +2868,11 @@ type HeapStatistics = {
   heap_size_limit: number,
   malloced_memory: number,
   peak_malloced_memory: number,
-  does_zap_garbage: number,
+  does_zap_garbage: 0 | 1,
+  number_of_native_contexts: number,
+  number_of_detached_contexts: number,
   ...
-}
+};
 
 type HeapSpaceStatistics = {
   space_name: string,
@@ -2872,13 +2881,167 @@ type HeapSpaceStatistics = {
   space_available_size: number,
   physical_space_size: number,
   ...
+};
+
+// Adapted from DefinitelyTyped for Node v14:
+// https://github.com/DefinitelyTyped/DefinitelyTyped/blob/dea4d99dc302a0b0a25270e46e72c1fe9b741a17/types/node/v14/v8.d.ts
+declare module 'v8' {
+  /**
+   * Returns an integer representing a "version tag" derived from the V8 version, command line flags and detected CPU features.
+   * This is useful for determining whether a vm.Script cachedData buffer is compatible with this instance of V8.
+   */
+  declare function cachedDataVersionTag(): number;
+
+  /**
+   * Generates a snapshot of the current V8 heap and returns a Readable
+   * Stream that may be used to read the JSON serialized representation.
+   * This conversation was marked as resolved by joyeecheung
+   * This JSON stream format is intended to be used with tools such as
+   * Chrome DevTools. The JSON schema is undocumented and specific to the
+   * V8 engine, and may change from one version of V8 to the next.
+   */
+  declare function getHeapSnapshot(): stream$Readable;
+
+  /**
+   *
+   * @param fileName The file path where the V8 heap snapshot is to be
+   * saved. If not specified, a file name with the pattern
+   * `'Heap-${yyyymmdd}-${hhmmss}-${pid}-${thread_id}.heapsnapshot'` will be
+   * generated, where `{pid}` will be the PID of the Node.js process,
+   * `{thread_id}` will be `0` when `writeHeapSnapshot()` is called from
+   * the main Node.js thread or the id of a worker thread.
+   */
+  declare function writeHeapSnapshot(fileName?: string): string;
+
+  declare function getHeapCodeStatistics(): HeapCodeStatistics;
+
+  declare function getHeapStatistics(): HeapStatistics;
+  declare function getHeapSpaceStatistics(): Array<HeapSpaceStatistics>;
+  declare function setFlagsFromString(flags: string): void;
+
+  declare class Serializer {
+    constructor(): void;
+
+    /**
+     * Writes out a header, which includes the serialization format version.
+     */
+    writeHeader(): void;
+
+    /**
+     * Serializes a JavaScript value and adds the serialized representation to the internal buffer.
+     * This throws an error if value cannot be serialized.
+     */
+    writeValue(val: any): boolean;
+
+    /**
+     * Returns the stored internal buffer.
+     * This serializer should not be used once the buffer is released.
+     * Calling this method results in undefined behavior if a previous write has failed.
+     */
+    releaseBuffer(): Buffer;
+
+    /**
+     * Marks an ArrayBuffer as having its contents transferred out of band.\
+     * Pass the corresponding ArrayBuffer in the deserializing context to deserializer.transferArrayBuffer().
+     */
+    transferArrayBuffer(id: number, arrayBuffer: ArrayBuffer): void;
+
+    /**
+     * Write a raw 32-bit unsigned integer.
+     */
+    writeUint32(value: number): void;
+
+    /**
+     * Write a raw 64-bit unsigned integer, split into high and low 32-bit parts.
+     */
+    writeUint64(hi: number, lo: number): void;
+
+    /**
+     * Write a JS number value.
+     */
+    writeDouble(value: number): void;
+
+    /**
+     * Write raw bytes into the serializer’s internal buffer.
+     * The deserializer will require a way to compute the length of the buffer.
+     */
+    writeRawBytes(buffer: Buffer | $TypedArray | DataView): void;
+  }
+
+  /**
+   * A subclass of `Serializer` that serializes `TypedArray` (in particular `Buffer`) and `DataView` objects as host objects,
+   * and only stores the part of their underlying `ArrayBuffers` that they are referring to.
+   */
+  declare class DefaultSerializer extends Serializer {}
+
+  declare class Deserializer {
+    constructor(data: Buffer | $TypedArray | DataView): void;
+
+    /**
+     * Reads and validates a header (including the format version).
+     * May, for example, reject an invalid or unsupported wire format.
+     * In that case, an Error is thrown.
+     */
+    readHeader(): boolean;
+
+    /**
+     * Deserializes a JavaScript value from the buffer and returns it.
+     */
+    readValue(): any;
+
+    /**
+     * Marks an ArrayBuffer as having its contents transferred out of band.
+     * Pass the corresponding `ArrayBuffer` in the serializing context to serializer.transferArrayBuffer()
+     * (or return the id from serializer._getSharedArrayBufferId() in the case of SharedArrayBuffers).
+     */
+    transferArrayBuffer(id: number, arrayBuffer: ArrayBuffer): void;
+
+    /**
+     * Reads the underlying wire format version.
+     * Likely mostly to be useful to legacy code reading old wire format versions.
+     * May not be called before .readHeader().
+     */
+    getWireFormatVersion(): number;
+
+    /**
+     * Read a raw 32-bit unsigned integer and return it.
+     */
+    readUint32(): number;
+
+    /**
+     * Read a raw 64-bit unsigned integer and return it as an array [hi, lo] with two 32-bit unsigned integer entries.
+     */
+    readUint64(): [number, number];
+
+    /**
+     * Read a JS number value.
+     */
+    readDouble(): number;
+
+    /**
+     * Read raw bytes from the deserializer’s internal buffer.
+     * The length parameter must correspond to the length of the buffer that was passed to serializer.writeRawBytes().
+     */
+    readRawBytes(length: number): Buffer;
+  }
+
+  /**
+   * A subclass of `Serializer` that serializes `TypedArray` (in particular `Buffer`) and `DataView` objects as host objects,
+   * and only stores the part of their underlying `ArrayBuffers` that they are referring to.
+   */
+  declare class DefaultDeserializer extends Deserializer {}
+
+  /**
+   * Uses a `DefaultSerializer` to serialize value into a buffer.
+   */
+  declare function serialize(value: any): Buffer;
+
+  /**
+   * Uses a `DefaultDeserializer` with default options to read a JS value from a buffer.
+   */
+  declare function deserialize(data: Buffer | $TypedArray | DataView): any;
 }
 
-declare module "v8" {
-  declare function getHeapStatistics() : HeapStatistics;
-  declare function getHeapSpaceStatistics() : Array<HeapSpaceStatistics>
-  declare function setFlagsFromString(flags: string) : void;
-}
 
 type repl$DefineCommandOptions =
   | (...args: Array<any>) => void

--- a/tests/node_tests/node_tests.exp
+++ b/tests/node_tests/node_tests.exp
@@ -1570,8 +1570,8 @@ Cannot call `inspector.open` with `'8080'` bound to `port` because string [1] is
                         ^^^^^^ [1]
 
 References:
-   <BUILTINS>/node.js:2930:12
-   2930|     port?: number,
+   <BUILTINS>/node.js:3093:12
+   3093|     port?: number,
                     ^^^^^^ [2]
 
 
@@ -1585,8 +1585,8 @@ Cannot call `inspector.open` with `127001` bound to `host` because number [1] is
                               ^^^^^^ [1]
 
 References:
-   <BUILTINS>/node.js:2931:12
-   2931|     host?: string,
+   <BUILTINS>/node.js:3094:12
+   3094|     host?: string,
                     ^^^^^^ [2]
 
 
@@ -1600,8 +1600,8 @@ Cannot call `inspector.open` with `1000` bound to `wait` because number [1] is i
                                                   ^^^^ [1]
 
 References:
-   <BUILTINS>/node.js:2932:12
-   2932|     wait?: boolean
+   <BUILTINS>/node.js:3095:12
+   3095|     wait?: boolean
                     ^^^^^^^ [2]
 
 
@@ -1614,8 +1614,8 @@ Cannot cast `inspector.open()` to string because undefined [1] is incompatible w
           ^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/node.js:2933:6
-   2933|   ): void;
+   <BUILTINS>/node.js:3096:6
+   3096|   ): void;
               ^^^^ [1]
    inspector/inspector.js:16:21
      16| (inspector.open() : string); // error
@@ -1631,8 +1631,8 @@ Cannot cast `inspector.close()` to string because undefined [1] is incompatible 
           ^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/node.js:2935:29
-   2935|   declare function close(): void;
+   <BUILTINS>/node.js:3098:29
+   3098|   declare function close(): void;
                                      ^^^^ [1]
    inspector/inspector.js:24:22
      24| (inspector.close() : string); // error
@@ -1648,8 +1648,8 @@ Cannot cast `inspector.url()` to number because string [1] is incompatible with 
           ^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/node.js:2936:28
-   2936|   declare function url() : string | void;
+   <BUILTINS>/node.js:3099:28
+   3099|   declare function url() : string | void;
                                     ^^^^^^ [1]
    inspector/inspector.js:36:20
      36| (inspector.url() : number); // error
@@ -1665,8 +1665,8 @@ Cannot cast `inspector.url()` to number because undefined [1] is incompatible wi
           ^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/node.js:2936:37
-   2936|   declare function url() : string | void;
+   <BUILTINS>/node.js:3099:37
+   3099|   declare function url() : string | void;
                                              ^^^^ [1]
    inspector/inspector.js:36:20
      36| (inspector.url() : number); // error
@@ -1683,8 +1683,8 @@ Cannot cast `inspector.waitForDebugger()` to number because undefined [1] is inc
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/node.js:2938:39
-   2938|   declare function waitForDebugger(): void;
+   <BUILTINS>/node.js:3101:39
+   3101|   declare function waitForDebugger(): void;
                                                ^^^^ [1]
    inspector/inspector.js:44:32
      44| (inspector.waitForDebugger() : number); // error
@@ -1700,32 +1700,32 @@ Cannot call `inspector.connect` because property `connect` is missing in module 
                     ^^^^^^^
 
 References:
-   <BUILTINS>/node.js:2928:1
+   <BUILTINS>/node.js:3091:1
          v---------------------------
-   2928| declare module 'inspector' {
-   2929|   declare function open(
-   2930|     port?: number,
-   2931|     host?: string,
-   2932|     wait?: boolean
-   2933|   ): void;
-   2934|
-   2935|   declare function close(): void;
-   2936|   declare function url() : string | void;
-   2937|   declare var console: Object;
-   2938|   declare function waitForDebugger(): void;
-   2939|
-   2940|   declare class Session extends events$EventEmitter {
-   2941|     constructor(): void;
-   2942|     connect(): void;
-   2943|     connectToMainThread(): void;
-   2944|     disconnect(): void;
-   2945|     post(
-   2946|       method: string,
-   2947|       params?: Object,
-   2948|       callback?: Function
-   2949|     ): void;
-   2950|   }
-   2951| }
+   3091| declare module 'inspector' {
+   3092|   declare function open(
+   3093|     port?: number,
+   3094|     host?: string,
+   3095|     wait?: boolean
+   3096|   ): void;
+   3097|
+   3098|   declare function close(): void;
+   3099|   declare function url() : string | void;
+   3100|   declare var console: Object;
+   3101|   declare function waitForDebugger(): void;
+   3102|
+   3103|   declare class Session extends events$EventEmitter {
+   3104|     constructor(): void;
+   3105|     connect(): void;
+   3106|     connectToMainThread(): void;
+   3107|     disconnect(): void;
+   3108|     post(
+   3109|       method: string,
+   3110|       params?: Object,
+   3111|       callback?: Function
+   3112|     ): void;
+   3113|   }
+   3114| }
          ^ [1]
 
 
@@ -1739,32 +1739,32 @@ Cannot call `inspector.connectToMainThread` because property `connectToMainThrea
                     ^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/node.js:2928:1
+   <BUILTINS>/node.js:3091:1
          v---------------------------
-   2928| declare module 'inspector' {
-   2929|   declare function open(
-   2930|     port?: number,
-   2931|     host?: string,
-   2932|     wait?: boolean
-   2933|   ): void;
-   2934|
-   2935|   declare function close(): void;
-   2936|   declare function url() : string | void;
-   2937|   declare var console: Object;
-   2938|   declare function waitForDebugger(): void;
-   2939|
-   2940|   declare class Session extends events$EventEmitter {
-   2941|     constructor(): void;
-   2942|     connect(): void;
-   2943|     connectToMainThread(): void;
-   2944|     disconnect(): void;
-   2945|     post(
-   2946|       method: string,
-   2947|       params?: Object,
-   2948|       callback?: Function
-   2949|     ): void;
-   2950|   }
-   2951| }
+   3091| declare module 'inspector' {
+   3092|   declare function open(
+   3093|     port?: number,
+   3094|     host?: string,
+   3095|     wait?: boolean
+   3096|   ): void;
+   3097|
+   3098|   declare function close(): void;
+   3099|   declare function url() : string | void;
+   3100|   declare var console: Object;
+   3101|   declare function waitForDebugger(): void;
+   3102|
+   3103|   declare class Session extends events$EventEmitter {
+   3104|     constructor(): void;
+   3105|     connect(): void;
+   3106|     connectToMainThread(): void;
+   3107|     disconnect(): void;
+   3108|     post(
+   3109|       method: string,
+   3110|       params?: Object,
+   3111|       callback?: Function
+   3112|     ): void;
+   3113|   }
+   3114| }
          ^ [1]
 
 
@@ -1777,32 +1777,32 @@ Cannot call `inspector.disconnect` because property `disconnect` is missing in m
                     ^^^^^^^^^^
 
 References:
-   <BUILTINS>/node.js:2928:1
+   <BUILTINS>/node.js:3091:1
          v---------------------------
-   2928| declare module 'inspector' {
-   2929|   declare function open(
-   2930|     port?: number,
-   2931|     host?: string,
-   2932|     wait?: boolean
-   2933|   ): void;
-   2934|
-   2935|   declare function close(): void;
-   2936|   declare function url() : string | void;
-   2937|   declare var console: Object;
-   2938|   declare function waitForDebugger(): void;
-   2939|
-   2940|   declare class Session extends events$EventEmitter {
-   2941|     constructor(): void;
-   2942|     connect(): void;
-   2943|     connectToMainThread(): void;
-   2944|     disconnect(): void;
-   2945|     post(
-   2946|       method: string,
-   2947|       params?: Object,
-   2948|       callback?: Function
-   2949|     ): void;
-   2950|   }
-   2951| }
+   3091| declare module 'inspector' {
+   3092|   declare function open(
+   3093|     port?: number,
+   3094|     host?: string,
+   3095|     wait?: boolean
+   3096|   ): void;
+   3097|
+   3098|   declare function close(): void;
+   3099|   declare function url() : string | void;
+   3100|   declare var console: Object;
+   3101|   declare function waitForDebugger(): void;
+   3102|
+   3103|   declare class Session extends events$EventEmitter {
+   3104|     constructor(): void;
+   3105|     connect(): void;
+   3106|     connectToMainThread(): void;
+   3107|     disconnect(): void;
+   3108|     post(
+   3109|       method: string,
+   3110|       params?: Object,
+   3111|       callback?: Function
+   3112|     ): void;
+   3113|   }
+   3114| }
          ^ [1]
 
 
@@ -1815,13 +1815,13 @@ Cannot call `session.post` because function [1] requires another argument. [inco
                  ^^^^
 
 References:
-   <BUILTINS>/node.js:2945:5
+   <BUILTINS>/node.js:3108:5
              v----
-   2945|     post(
-   2946|       method: string,
-   2947|       params?: Object,
-   2948|       callback?: Function
-   2949|     ): void;
+   3108|     post(
+   3109|       method: string,
+   3110|       params?: Object,
+   3111|       callback?: Function
+   3112|     ): void;
              ------^ [1]
 
 
@@ -1834,13 +1834,13 @@ Cannot call `session.post` because function [1] requires another argument. [inco
                   ^^^^
 
 References:
-   <BUILTINS>/node.js:2945:5
+   <BUILTINS>/node.js:3108:5
              v----
-   2945|     post(
-   2946|       method: string,
-   2947|       params?: Object,
-   2948|       callback?: Function
-   2949|     ): void;
+   3108|     post(
+   3109|       method: string,
+   3110|       params?: Object,
+   3111|       callback?: Function
+   3112|     ): void;
              ------^ [1]
 
 
@@ -1853,8 +1853,8 @@ Cannot cast `session.post()` to string because undefined [1] is incompatible wit
           ^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/node.js:2949:8
-   2949|     ): void;
+   <BUILTINS>/node.js:3112:8
+   3112|     ): void;
                 ^^^^ [1]
    inspector/inspector.js:90:19
      90| (session.post() : string); // error
@@ -1937,26 +1937,26 @@ References:
    process/emitWarning.js:10:1
      10| process.emitWarning(); // error
          ^^^^^^^^^^^^^^^^^^^^^ [1]
-   <BUILTINS>/node.js:2974:24
-   2974|   emitWarning(warning: string | Error): void;
+   <BUILTINS>/node.js:3137:24
+   3137|   emitWarning(warning: string | Error): void;
                                 ^^^^^^ [2]
-   <BUILTINS>/node.js:2974:33
-   2974|   emitWarning(warning: string | Error): void;
+   <BUILTINS>/node.js:3137:33
+   3137|   emitWarning(warning: string | Error): void;
                                          ^^^^^ [3]
-   <BUILTINS>/node.js:2975:3
-   2975|   emitWarning(warning: string, typeOrCtor: string | (...empty) => mixed): void;
+   <BUILTINS>/node.js:3138:3
+   3138|   emitWarning(warning: string, typeOrCtor: string | (...empty) => mixed): void;
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [4]
-   <BUILTINS>/node.js:2976:3
-   2976|   emitWarning(warning: string, type: string, codeOrCtor: string | (...empty) => mixed): void;
+   <BUILTINS>/node.js:3139:3
+   3139|   emitWarning(warning: string, type: string, codeOrCtor: string | (...empty) => mixed): void;
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [5]
-   <BUILTINS>/node.js:2977:3
+   <BUILTINS>/node.js:3140:3
            v-----------
-   2977|   emitWarning(
-   2978|     warning: string,
-   2979|     type: string,
-   2980|     code: string,
-   2981|     ctor?: (...empty) => mixed
-   2982|   ): void;
+   3140|   emitWarning(
+   3141|     warning: string,
+   3142|     type: string,
+   3143|     code: string,
+   3144|     ctor?: (...empty) => mixed
+   3145|   ): void;
            ------^ [6]
 
 
@@ -1975,14 +1975,14 @@ References:
    process/emitWarning.js:11:21
      11| process.emitWarning(42); // error
                              ^^ [1]
-   <BUILTINS>/node.js:2975:24
-   2975|   emitWarning(warning: string, typeOrCtor: string | (...empty) => mixed): void;
+   <BUILTINS>/node.js:3138:24
+   3138|   emitWarning(warning: string, typeOrCtor: string | (...empty) => mixed): void;
                                 ^^^^^^ [2]
-   <BUILTINS>/node.js:2976:24
-   2976|   emitWarning(warning: string, type: string, codeOrCtor: string | (...empty) => mixed): void;
+   <BUILTINS>/node.js:3139:24
+   3139|   emitWarning(warning: string, type: string, codeOrCtor: string | (...empty) => mixed): void;
                                 ^^^^^^ [3]
-   <BUILTINS>/node.js:2978:14
-   2978|     warning: string,
+   <BUILTINS>/node.js:3141:14
+   3141|     warning: string,
                       ^^^^^^ [4]
 
 
@@ -2000,11 +2000,11 @@ References:
    process/emitWarning.js:12:29
      12| process.emitWarning("blah", 42); // error
                                      ^^ [1]
-   <BUILTINS>/node.js:2976:38
-   2976|   emitWarning(warning: string, type: string, codeOrCtor: string | (...empty) => mixed): void;
+   <BUILTINS>/node.js:3139:38
+   3139|   emitWarning(warning: string, type: string, codeOrCtor: string | (...empty) => mixed): void;
                                               ^^^^^^ [2]
-   <BUILTINS>/node.js:2979:11
-   2979|     type: string,
+   <BUILTINS>/node.js:3142:11
+   3142|     type: string,
                    ^^^^^^ [3]
 
 
@@ -2020,8 +2020,8 @@ References:
    process/emitWarning.js:13:37
      13| process.emitWarning("blah", "blah", 42); // error
                                              ^^ [1]
-   <BUILTINS>/node.js:2980:11
-   2980|     code: string,
+   <BUILTINS>/node.js:3143:11
+   3143|     code: string,
                    ^^^^^^ [2]
 
 
@@ -2035,8 +2035,8 @@ Cannot cast `process.emitWarning(...)` to string because undefined [1] is incomp
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/node.js:2974:41
-   2974|   emitWarning(warning: string | Error): void;
+   <BUILTINS>/node.js:3137:41
+   3137|   emitWarning(warning: string | Error): void;
                                                  ^^^^ [1]
    process/emitWarning.js:14:31
      14| (process.emitWarning("blah"): string); // error
@@ -2101,8 +2101,8 @@ References:
    process/nextTick.js:27:3
      27|   (a: string, b: number, c: boolean) => {} // Error: too few arguments
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
-   <BUILTINS>/node.js:3003:21
-   3003|   nextTick: <T>(cb: (...T) => mixed, ...T) => void;
+   <BUILTINS>/node.js:3166:21
+   3166|   nextTick: <T>(cb: (...T) => mixed, ...T) => void;
                              ^^^^^^^^^^^^^^^ [2]
 
 
@@ -2116,8 +2116,8 @@ Cannot cast `process.allowedNodeEnvironmentFlags` to string because `Set` [1] is
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/node.js:2963:32
-   2963|   allowedNodeEnvironmentFlags: Set<string>;
+   <BUILTINS>/node.js:3126:32
+   3126|   allowedNodeEnvironmentFlags: Set<string>;
                                         ^^^^^^^^^^^ [1]
    process/process.js:5:39
       5| (process.allowedNodeEnvironmentFlags: string); // error


### PR DESCRIPTION
Summary:
Updates the built-in definitions for the `v8` module, in particular serialisation APIs.

As the comment notes, these are adapted from [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/dea4d99dc302a0b0a25270e46e72c1fe9b741a17/types/node/v14/v8.d.ts) definitions, which are pretty mature by now.

Differences from TypeScript are
 - `import('stream').Readable` -> `stream$Readable`
 - `NodeJS.TypedArray` -> `Buffer | $TypedArray | DataView`, which matches [Node JS docs](https://nodejs.org/docs/latest-v14.x/api/v8.html#v8_v8_deserialize_buffer) better anyway.

Differential Revision: D36806761

