### PR TITLE
Bump macos environment in Circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,10 +46,9 @@ executors:
     working_directory: ~/flow
   mac:
     macos:
-      xcode: "13.4.1"
+      xcode: "13.4"
     environment:
       <<: *opam_env
-      MACOSX_DEPLOYMENT_TARGET: 11.3
     working_directory: ~/flow
   curl:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ executors:
       xcode: "13.4.1"
     environment:
       <<: *opam_env
-      MACOSX_DEPLOYMENT_TARGET: 12
+      MACOSX_DEPLOYMENT_TARGET: 11.3
     working_directory: ~/flow
   curl:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,10 +46,10 @@ executors:
     working_directory: ~/flow
   mac:
     macos:
-      xcode: "12.1.0"
+      xcode: "13.4.1"
     environment:
       <<: *opam_env
-      MACOSX_DEPLOYMENT_TARGET: 10.13
+      MACOSX_DEPLOYMENT_TARGET: 12
     working_directory: ~/flow
   curl:
     docker:


### PR DESCRIPTION
Changelog: [internal]

Bump versions since the xcode version seems to be unsupported in Circle CI now.