### PR TITLE
Fix `flow-remove-types/jest` transformer

### DIFF
--- a/packages/flow-remove-types/jest.js
+++ b/packages/flow-remove-types/jest.js
@@ -11,6 +11,8 @@ var flowRemoveTypes = require('./index');
 
 module.exports = {
   process: function (src, filename) {
-    return flowRemoveTypes(src).toString();
+    return {
+      code: flowRemoveTypes(src).toString()
+    }
   },
 };


### PR DESCRIPTION
## Description

Hey! 👋🏼 

This PR updates the `flow-remove-types/jest` transformer to the new format defined by Jest in `v28`.

Related issue: https://github.com/facebook/flow/issues/8914