### PR TITLE
[lib] Add missing PerformanceServerTiming definition

### DIFF
--- a/lib/bom.js
+++ b/lib/bom.js
@@ -411,7 +411,16 @@ declare class PerformanceEntry {
     toJSON(): string;
 }
 
+// https://w3c.github.io/server-timing/#the-performanceservertiming-interface
+declare class PerformanceServerTiming {
+  description: string;
+  duration: DOMHighResTimeStamp;
+  name: string;
+  toJSON(): string;
+}
+
 // https://www.w3.org/TR/resource-timing-2/#sec-performanceresourcetiming
+// https://w3c.github.io/server-timing/#extension-to-the-performanceresourcetiming-interface
 declare class PerformanceResourceTiming extends PerformanceEntry {
     initiatorType: string;
     nextHopProtocol: string;
@@ -430,6 +439,7 @@ declare class PerformanceResourceTiming extends PerformanceEntry {
     transferSize: string;
     encodedBodySize: number;
     decodedBodySize: number;
+    serverTiming: Array<PerformanceServerTiming>;
 }
 
 // https://www.w3.org/TR/navigation-timing-2/

--- a/tests/bom/bom.exp
+++ b/tests/bom/bom.exp
@@ -8,8 +8,8 @@ Cannot call `FormData` with empty string bound to `form` because string [1] is i
                      ^^ [1]
 
 References:
-   <BUILTINS>/bom.js:536:24
-   536|     constructor(form?: HTMLFormElement): void;
+   <BUILTINS>/bom.js:546:24
+   546|     constructor(form?: HTMLFormElement): void;
                                ^^^^^^^^^^^^^^^ [2]
 
 
@@ -26,8 +26,8 @@ References:
    <BUILTINS>/dom.js:1125:70
    1125|   createElement(tagName: 'input', options?: ElementCreationOptions): HTMLInputElement;
                                                                               ^^^^^^^^^^^^^^^^ [1]
-   <BUILTINS>/bom.js:536:24
-    536|     constructor(form?: HTMLFormElement): void;
+   <BUILTINS>/bom.js:546:24
+    546|     constructor(form?: HTMLFormElement): void;
                                 ^^^^^^^^^^^^^^^ [2]
 
 
@@ -40,8 +40,8 @@ Cannot assign `a.get(...)` to `d` because null or undefined [1] is incompatible 
                           ^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/bom.js:539:24
-   539|     get(name: string): ?FormDataEntryValue;
+   <BUILTINS>/bom.js:549:24
+   549|     get(name: string): ?FormDataEntryValue;
                                ^^^^^^^^^^^^^^^^^^^ [1]
    FormData.js:14:10
     14| const d: string = a.get('foo'); // incorrect
@@ -57,8 +57,8 @@ Cannot assign `a.get(...)` to `d` because `File` [1] is incompatible with string
                           ^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/bom.js:539:25
-   539|     get(name: string): ?FormDataEntryValue;
+   <BUILTINS>/bom.js:549:25
+   549|     get(name: string): ?FormDataEntryValue;
                                 ^^^^^^^^^^^^^^^^^^ [1]
    FormData.js:14:10
     14| const d: string = a.get('foo'); // incorrect
@@ -74,8 +74,8 @@ Cannot assign `a.get(...)` to `e` because null or undefined [1] is incompatible 
                         ^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/bom.js:539:24
-   539|     get(name: string): ?FormDataEntryValue;
+   <BUILTINS>/bom.js:549:24
+   549|     get(name: string): ?FormDataEntryValue;
                                ^^^^^^^^^^^^^^^^^^^ [1]
    FormData.js:15:10
     15| const e: Blob = a.get('foo'); // incorrect
@@ -91,8 +91,8 @@ Cannot assign `a.get(...)` to `e` because string [1] is incompatible with `Blob`
                         ^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/bom.js:539:25
-   539|     get(name: string): ?FormDataEntryValue;
+   <BUILTINS>/bom.js:549:25
+   549|     get(name: string): ?FormDataEntryValue;
                                 ^^^^^^^^^^^^^^^^^^ [1]
    FormData.js:15:10
     15| const e: Blob = a.get('foo'); // incorrect
@@ -108,8 +108,8 @@ Cannot call `a.get` with `2` bound to `name` because number [1] is incompatible 
               ^ [1]
 
 References:
-   <BUILTINS>/bom.js:539:15
-   539|     get(name: string): ?FormDataEntryValue;
+   <BUILTINS>/bom.js:549:15
+   549|     get(name: string): ?FormDataEntryValue;
                       ^^^^^^ [2]
 
 
@@ -126,8 +126,8 @@ References:
    FormData.js:21:33
     21| const a2: Array<string | File | number> = a.getAll('foo'); // incorrect
                                         ^^^^^^ [1]
-   <BUILTINS>/bom.js:533:27
-   533| type FormDataEntryValue = string | File
+   <BUILTINS>/bom.js:543:27
+   543| type FormDataEntryValue = string | File
                                   ^^^^^^ [2]
 
 
@@ -144,8 +144,8 @@ References:
    FormData.js:22:26
     22| const a3: Array<string | Blob | File> = a.getAll('foo'); // incorrect
                                  ^^^^ [1]
-   <BUILTINS>/bom.js:533:36
-   533| type FormDataEntryValue = string | File
+   <BUILTINS>/bom.js:543:36
+   543| type FormDataEntryValue = string | File
                                            ^^^^ [2]
 
 
@@ -158,8 +158,8 @@ Cannot call `a.getAll` with `23` bound to `name` because number [1] is incompati
                  ^^ [1]
 
 References:
-   <BUILTINS>/bom.js:540:18
-   540|     getAll(name: string): Array<FormDataEntryValue>;
+   <BUILTINS>/bom.js:550:18
+   550|     getAll(name: string): Array<FormDataEntryValue>;
                          ^^^^^^ [2]
 
 
@@ -177,11 +177,11 @@ References:
    FormData.js:27:14
     27| a.set('foo', {}); // incorrect
                      ^^ [1]
-   <BUILTINS>/bom.js:543:30
-   543|     set(name: string, value: Blob, filename?: string): void;
+   <BUILTINS>/bom.js:553:30
+   553|     set(name: string, value: Blob, filename?: string): void;
                                      ^^^^ [2]
-   <BUILTINS>/bom.js:544:30
-   544|     set(name: string, value: File, filename?: string): void;
+   <BUILTINS>/bom.js:554:30
+   554|     set(name: string, value: File, filename?: string): void;
                                      ^^^^ [3]
 
 
@@ -200,14 +200,14 @@ References:
    FormData.js:28:7
     28| a.set(2, 'bar'); // incorrect
               ^ [1]
-   <BUILTINS>/bom.js:542:15
-   542|     set(name: string, value: string): void;
+   <BUILTINS>/bom.js:552:15
+   552|     set(name: string, value: string): void;
                       ^^^^^^ [2]
-   <BUILTINS>/bom.js:543:15
-   543|     set(name: string, value: Blob, filename?: string): void;
+   <BUILTINS>/bom.js:553:15
+   553|     set(name: string, value: Blob, filename?: string): void;
                       ^^^^^^ [3]
-   <BUILTINS>/bom.js:544:15
-   544|     set(name: string, value: File, filename?: string): void;
+   <BUILTINS>/bom.js:554:15
+   554|     set(name: string, value: File, filename?: string): void;
                       ^^^^^^ [4]
 
 
@@ -225,11 +225,11 @@ References:
    FormData.js:29:14
     29| a.set('foo', 'bar', 'baz'); // incorrect
                      ^^^^^ [1]
-   <BUILTINS>/bom.js:543:30
-   543|     set(name: string, value: Blob, filename?: string): void;
+   <BUILTINS>/bom.js:553:30
+   553|     set(name: string, value: Blob, filename?: string): void;
                                      ^^^^ [2]
-   <BUILTINS>/bom.js:544:30
-   544|     set(name: string, value: File, filename?: string): void;
+   <BUILTINS>/bom.js:554:30
+   554|     set(name: string, value: File, filename?: string): void;
                                      ^^^^ [3]
 
 
@@ -247,11 +247,11 @@ References:
    FormData.js:32:33
     32| a.set('bar', new File([], 'q'), 2) // incorrect
                                         ^ [1]
-   <BUILTINS>/bom.js:543:47
-   543|     set(name: string, value: Blob, filename?: string): void;
+   <BUILTINS>/bom.js:553:47
+   553|     set(name: string, value: Blob, filename?: string): void;
                                                       ^^^^^^ [2]
-   <BUILTINS>/bom.js:544:47
-   544|     set(name: string, value: File, filename?: string): void;
+   <BUILTINS>/bom.js:554:47
+   554|     set(name: string, value: File, filename?: string): void;
                                                       ^^^^^^ [3]
 
 
@@ -267,8 +267,8 @@ References:
    FormData.js:35:24
     35| a.set('bar', new Blob, 2) // incorrect
                                ^ [1]
-   <BUILTINS>/bom.js:543:47
-   543|     set(name: string, value: Blob, filename?: string): void;
+   <BUILTINS>/bom.js:553:47
+   553|     set(name: string, value: Blob, filename?: string): void;
                                                       ^^^^^^ [2]
 
 
@@ -286,11 +286,11 @@ References:
    FormData.js:39:17
     39| a.append('foo', {}); // incorrect
                         ^^ [1]
-   <BUILTINS>/bom.js:547:33
-   547|     append(name: string, value: Blob, filename?: string): void;
+   <BUILTINS>/bom.js:557:33
+   557|     append(name: string, value: Blob, filename?: string): void;
                                         ^^^^ [2]
-   <BUILTINS>/bom.js:548:33
-   548|     append(name: string, value: File, filename?: string): void;
+   <BUILTINS>/bom.js:558:33
+   558|     append(name: string, value: File, filename?: string): void;
                                         ^^^^ [3]
 
 
@@ -309,14 +309,14 @@ References:
    FormData.js:40:10
     40| a.append(2, 'bar'); // incorrect
                  ^ [1]
-   <BUILTINS>/bom.js:546:18
-   546|     append(name: string, value: string): void;
+   <BUILTINS>/bom.js:556:18
+   556|     append(name: string, value: string): void;
                          ^^^^^^ [2]
-   <BUILTINS>/bom.js:547:18
-   547|     append(name: string, value: Blob, filename?: string): void;
+   <BUILTINS>/bom.js:557:18
+   557|     append(name: string, value: Blob, filename?: string): void;
                          ^^^^^^ [3]
-   <BUILTINS>/bom.js:548:18
-   548|     append(name: string, value: File, filename?: string): void;
+   <BUILTINS>/bom.js:558:18
+   558|     append(name: string, value: File, filename?: string): void;
                          ^^^^^^ [4]
 
 
@@ -334,11 +334,11 @@ References:
    FormData.js:41:17
     41| a.append('foo', 'bar', 'baz'); // incorrect
                         ^^^^^ [1]
-   <BUILTINS>/bom.js:547:33
-   547|     append(name: string, value: Blob, filename?: string): void;
+   <BUILTINS>/bom.js:557:33
+   557|     append(name: string, value: Blob, filename?: string): void;
                                         ^^^^ [2]
-   <BUILTINS>/bom.js:548:33
-   548|     append(name: string, value: File, filename?: string): void;
+   <BUILTINS>/bom.js:558:33
+   558|     append(name: string, value: File, filename?: string): void;
                                         ^^^^ [3]
 
 
@@ -356,11 +356,11 @@ References:
    FormData.js:45:36
     45| a.append('bar', new File([], 'q'), 2) // incorrect
                                            ^ [1]
-   <BUILTINS>/bom.js:547:50
-   547|     append(name: string, value: Blob, filename?: string): void;
+   <BUILTINS>/bom.js:557:50
+   557|     append(name: string, value: Blob, filename?: string): void;
                                                          ^^^^^^ [2]
-   <BUILTINS>/bom.js:548:50
-   548|     append(name: string, value: File, filename?: string): void;
+   <BUILTINS>/bom.js:558:50
+   558|     append(name: string, value: File, filename?: string): void;
                                                          ^^^^^^ [3]
 
 
@@ -376,8 +376,8 @@ References:
    FormData.js:48:27
     48| a.append('bar', new Blob, 2) // incorrect
                                   ^ [1]
-   <BUILTINS>/bom.js:547:50
-   547|     append(name: string, value: Blob, filename?: string): void;
+   <BUILTINS>/bom.js:557:50
+   557|     append(name: string, value: Blob, filename?: string): void;
                                                          ^^^^^^ [2]
 
 
@@ -390,8 +390,8 @@ Cannot call `a.delete` with `3` bound to `name` because number [1] is incompatib
                  ^ [1]
 
 References:
-   <BUILTINS>/bom.js:550:18
-   550|     delete(name: string): void;
+   <BUILTINS>/bom.js:560:18
+   560|     delete(name: string): void;
                          ^^^^^^ [2]
 
 
@@ -404,8 +404,8 @@ Cannot assign `x` to `x` because string [1] is incompatible with number [2]. [in
                               ^^^^^^^^
 
 References:
-   <BUILTINS>/bom.js:552:22
-   552|     keys(): Iterator<string>;
+   <BUILTINS>/bom.js:562:22
+   562|     keys(): Iterator<string>;
                              ^^^^^^ [1]
    FormData.js:56:13
     56| for (let x: number of a.keys()) {} // incorrect
@@ -425,8 +425,8 @@ References:
    FormData.js:64:43
     64| for (let [x, y]: [string, string | File | Blob] of a.entries()) {} // incorrect
                                                   ^^^^ [1]
-   <BUILTINS>/bom.js:533:36
-   533| type FormDataEntryValue = string | File
+   <BUILTINS>/bom.js:543:36
+   543| type FormDataEntryValue = string | File
                                            ^^^^ [2]
 
 
@@ -440,8 +440,8 @@ Cannot assign for-of element to destructuring because string [1] is incompatible
                                              ^^^^^^^^^^^
 
 References:
-   <BUILTINS>/bom.js:554:26
-   554|     entries(): Iterator<[string, FormDataEntryValue]>;
+   <BUILTINS>/bom.js:564:26
+   564|     entries(): Iterator<[string, FormDataEntryValue]>;
                                  ^^^^^^ [1]
    FormData.js:65:19
     65| for (let [x, y]: [number, string] of a.entries()) {} // incorrect
@@ -458,8 +458,8 @@ Cannot assign for-of element to destructuring because `File` [1] is incompatible
                                              ^^^^^^^^^^^
 
 References:
-   <BUILTINS>/bom.js:554:34
-   554|     entries(): Iterator<[string, FormDataEntryValue]>;
+   <BUILTINS>/bom.js:564:34
+   564|     entries(): Iterator<[string, FormDataEntryValue]>;
                                          ^^^^^^^^^^^^^^^^^^ [1]
    FormData.js:65:27
     65| for (let [x, y]: [number, string] of a.entries()) {} // incorrect
@@ -476,8 +476,8 @@ Cannot assign for-of element to destructuring because `File` [1] is incompatible
                                              ^^^^^^^^^^^
 
 References:
-   <BUILTINS>/bom.js:554:34
-   554|     entries(): Iterator<[string, FormDataEntryValue]>;
+   <BUILTINS>/bom.js:564:34
+   564|     entries(): Iterator<[string, FormDataEntryValue]>;
                                          ^^^^^^^^^^^^^^^^^^ [1]
    FormData.js:66:27
     66| for (let [x, y]: [string, number] of a.entries()) {} // incorrect
@@ -494,8 +494,8 @@ Cannot assign for-of element to destructuring because string [1] is incompatible
                                              ^^^^^^^^^^^
 
 References:
-   <BUILTINS>/bom.js:554:34
-   554|     entries(): Iterator<[string, FormDataEntryValue]>;
+   <BUILTINS>/bom.js:564:34
+   564|     entries(): Iterator<[string, FormDataEntryValue]>;
                                          ^^^^^^^^^^^^^^^^^^ [1]
    FormData.js:66:27
     66| for (let [x, y]: [string, number] of a.entries()) {} // incorrect
@@ -515,8 +515,8 @@ References:
    FormData.js:66:27
     66| for (let [x, y]: [string, number] of a.entries()) {} // incorrect
                                   ^^^^^^ [1]
-   <BUILTINS>/bom.js:533:27
-   533| type FormDataEntryValue = string | File
+   <BUILTINS>/bom.js:543:27
+   543| type FormDataEntryValue = string | File
                                   ^^^^^^ [2]
 
 
@@ -530,8 +530,8 @@ Cannot assign for-of element to destructuring because string [1] is incompatible
                                              ^^^^^^^^^^^
 
 References:
-   <BUILTINS>/bom.js:554:26
-   554|     entries(): Iterator<[string, FormDataEntryValue]>;
+   <BUILTINS>/bom.js:564:26
+   564|     entries(): Iterator<[string, FormDataEntryValue]>;
                                  ^^^^^^ [1]
    FormData.js:67:19
     67| for (let [x, y]: [number, number] of a.entries()) {} // incorrect
@@ -548,8 +548,8 @@ Cannot assign for-of element to destructuring because `File` [1] is incompatible
                                              ^^^^^^^^^^^
 
 References:
-   <BUILTINS>/bom.js:554:34
-   554|     entries(): Iterator<[string, FormDataEntryValue]>;
+   <BUILTINS>/bom.js:564:34
+   564|     entries(): Iterator<[string, FormDataEntryValue]>;
                                          ^^^^^^^^^^^^^^^^^^ [1]
    FormData.js:67:27
     67| for (let [x, y]: [number, number] of a.entries()) {} // incorrect
@@ -566,8 +566,8 @@ Cannot assign for-of element to destructuring because string [1] is incompatible
                                              ^^^^^^^^^^^
 
 References:
-   <BUILTINS>/bom.js:554:34
-   554|     entries(): Iterator<[string, FormDataEntryValue]>;
+   <BUILTINS>/bom.js:564:34
+   564|     entries(): Iterator<[string, FormDataEntryValue]>;
                                          ^^^^^^^^^^^^^^^^^^ [1]
    FormData.js:67:27
     67| for (let [x, y]: [number, number] of a.entries()) {} // incorrect
@@ -587,8 +587,8 @@ References:
    FormData.js:67:27
     67| for (let [x, y]: [number, number] of a.entries()) {} // incorrect
                                   ^^^^^^ [1]
-   <BUILTINS>/bom.js:533:27
-   533| type FormDataEntryValue = string | File
+   <BUILTINS>/bom.js:543:27
+   543| type FormDataEntryValue = string | File
                                   ^^^^^^ [2]
 
 
@@ -601,8 +601,8 @@ Cannot assign `headers.get(...)` to `b` because null [1] is incompatible with st
                            ^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/bom.js:1478:24
-   1478|     get(name: string): null | string;
+   <BUILTINS>/bom.js:1488:24
+   1488|     get(name: string): null | string;
                                 ^^^^ [1]
    Headers.js:8:10
       8| const b: string = headers.get('foo'); // incorrect
@@ -633,8 +633,8 @@ Cannot call `MutationObserver` because function [1] requires another argument. [
             ^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/bom.js:583:5
-   583|     constructor(callback: (arr: Array<MutationRecord>, observer: MutationObserver) => mixed): void;
+   <BUILTINS>/bom.js:593:5
+   593|     constructor(callback: (arr: Array<MutationRecord>, observer: MutationObserver) => mixed): void;
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 
@@ -648,8 +648,8 @@ Cannot call `MutationObserver` with `42` bound to `callback` because number [1] 
                              ^^ [1]
 
 References:
-   <BUILTINS>/bom.js:583:27
-   583|     constructor(callback: (arr: Array<MutationRecord>, observer: MutationObserver) => mixed): void;
+   <BUILTINS>/bom.js:593:27
+   593|     constructor(callback: (arr: Array<MutationRecord>, observer: MutationObserver) => mixed): void;
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [2]
 
 
@@ -663,8 +663,8 @@ in the first parameter. [incompatible-call]
                                  ^^^^^^ [1]
 
 References:
-   <BUILTINS>/bom.js:583:33
-   583|     constructor(callback: (arr: Array<MutationRecord>, observer: MutationObserver) => mixed): void;
+   <BUILTINS>/bom.js:593:33
+   593|     constructor(callback: (arr: Array<MutationRecord>, observer: MutationObserver) => mixed): void;
                                         ^^^^^^^^^^^^^^^^^^^^^ [2]
 
 
@@ -677,8 +677,8 @@ Cannot call `o.observe` because function [1] requires another argument. [incompa
           ^^^^^^^
 
 References:
-   <BUILTINS>/bom.js:584:5
-   584|     observe(target: Node, options: MutationObserverInit): void;
+   <BUILTINS>/bom.js:594:5
+   594|     observe(target: Node, options: MutationObserverInit): void;
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 
@@ -697,14 +697,14 @@ References:
    MutationObserver.js:18:1
     18| o.observe(); // incorrect
         ^^^^^^^^^^^ [1]
-   <BUILTINS>/bom.js:570:7
-   570|     | { childList: true, ... }
+   <BUILTINS>/bom.js:580:7
+   580|     | { childList: true, ... }
               ^^^^^^^^^^^^^^^^^^^^^^^^ [2]
-   <BUILTINS>/bom.js:571:7
-   571|     | { attributes: true, ... }
+   <BUILTINS>/bom.js:581:7
+   581|     | { attributes: true, ... }
               ^^^^^^^^^^^^^^^^^^^^^^^^^ [3]
-   <BUILTINS>/bom.js:572:7
-   572|     | { characterData: true, ... }
+   <BUILTINS>/bom.js:582:7
+   582|     | { characterData: true, ... }
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [4]
 
 
@@ -717,8 +717,8 @@ Cannot call `o.observe` because function [1] requires another argument. [incompa
           ^^^^^^^
 
 References:
-   <BUILTINS>/bom.js:584:5
-   584|     observe(target: Node, options: MutationObserverInit): void;
+   <BUILTINS>/bom.js:594:5
+   594|     observe(target: Node, options: MutationObserverInit): void;
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 
@@ -737,14 +737,14 @@ References:
    MutationObserver.js:19:1
     19| o.observe('invalid'); // incorrect
         ^^^^^^^^^^^^^^^^^^^^ [1]
-   <BUILTINS>/bom.js:570:7
-   570|     | { childList: true, ... }
+   <BUILTINS>/bom.js:580:7
+   580|     | { childList: true, ... }
               ^^^^^^^^^^^^^^^^^^^^^^^^ [2]
-   <BUILTINS>/bom.js:571:7
-   571|     | { attributes: true, ... }
+   <BUILTINS>/bom.js:581:7
+   581|     | { attributes: true, ... }
               ^^^^^^^^^^^^^^^^^^^^^^^^^ [3]
-   <BUILTINS>/bom.js:572:7
-   572|     | { characterData: true, ... }
+   <BUILTINS>/bom.js:582:7
+   582|     | { characterData: true, ... }
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [4]
 
 
@@ -758,8 +758,8 @@ Cannot call `o.observe` with `'invalid'` bound to `target` because string [1] is
                   ^^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/bom.js:584:21
-   584|     observe(target: Node, options: MutationObserverInit): void;
+   <BUILTINS>/bom.js:594:21
+   594|     observe(target: Node, options: MutationObserverInit): void;
                             ^^^^ [2]
 
 
@@ -772,8 +772,8 @@ Cannot call `o.observe` because function [1] requires another argument. [incompa
           ^^^^^^^
 
 References:
-   <BUILTINS>/bom.js:584:5
-   584|     observe(target: Node, options: MutationObserverInit): void;
+   <BUILTINS>/bom.js:594:5
+   594|     observe(target: Node, options: MutationObserverInit): void;
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 
@@ -792,14 +792,14 @@ References:
    MutationObserver.js:20:1
     20| o.observe(div); // incorrect
         ^^^^^^^^^^^^^^ [1]
-   <BUILTINS>/bom.js:570:7
-   570|     | { childList: true, ... }
+   <BUILTINS>/bom.js:580:7
+   580|     | { childList: true, ... }
               ^^^^^^^^^^^^^^^^^^^^^^^^ [2]
-   <BUILTINS>/bom.js:571:7
-   571|     | { attributes: true, ... }
+   <BUILTINS>/bom.js:581:7
+   581|     | { attributes: true, ... }
               ^^^^^^^^^^^^^^^^^^^^^^^^^ [3]
-   <BUILTINS>/bom.js:572:7
-   572|     | { characterData: true, ... }
+   <BUILTINS>/bom.js:582:7
+   582|     | { characterData: true, ... }
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [4]
 
 
@@ -815,14 +815,14 @@ Cannot call `o.observe` with object literal bound to `options` because: [incompa
                        ^^ [1]
 
 References:
-   <BUILTINS>/bom.js:570:7
-   570|     | { childList: true, ... }
+   <BUILTINS>/bom.js:580:7
+   580|     | { childList: true, ... }
               ^^^^^^^^^^^^^^^^^^^^^^^^ [2]
-   <BUILTINS>/bom.js:571:7
-   571|     | { attributes: true, ... }
+   <BUILTINS>/bom.js:581:7
+   581|     | { attributes: true, ... }
               ^^^^^^^^^^^^^^^^^^^^^^^^^ [3]
-   <BUILTINS>/bom.js:572:7
-   572|     | { characterData: true, ... }
+   <BUILTINS>/bom.js:582:7
+   582|     | { characterData: true, ... }
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [4]
 
 
@@ -838,14 +838,14 @@ Cannot call `o.observe` with object literal bound to `options` because: [incompa
                        ^^^^^^^^^^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/bom.js:570:7
-   570|     | { childList: true, ... }
+   <BUILTINS>/bom.js:580:7
+   580|     | { childList: true, ... }
               ^^^^^^^^^^^^^^^^^^^^^^^^ [2]
-   <BUILTINS>/bom.js:571:7
-   571|     | { attributes: true, ... }
+   <BUILTINS>/bom.js:581:7
+   581|     | { attributes: true, ... }
               ^^^^^^^^^^^^^^^^^^^^^^^^^ [3]
-   <BUILTINS>/bom.js:572:7
-   572|     | { characterData: true, ... }
+   <BUILTINS>/bom.js:582:7
+   582|     | { characterData: true, ... }
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [4]
 
 
@@ -859,8 +859,8 @@ in property `attributeFilter`. [incompatible-call]
                                                             ^^^^ [1]
 
 References:
-   <BUILTINS>/bom.js:578:21
-   578|   attributeFilter?: Array<string>,
+   <BUILTINS>/bom.js:588:21
+   588|   attributeFilter?: Array<string>,
                             ^^^^^^^^^^^^^ [2]
 
 
@@ -873,8 +873,8 @@ Cannot assign `params.get(...)` to `b` because null [1] is incompatible with str
                            ^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/bom.js:1492:24
-   1492|     get(name: string): null | string;
+   <BUILTINS>/bom.js:1502:24
+   1502|     get(name: string): null | string;
                                 ^^^^ [1]
    URLSearchParams.js:8:10
       8| const b: string = params.get('foo'); // incorrect

--- a/tests/fetch/fetch.exp
+++ b/tests/fetch/fetch.exp
@@ -8,8 +8,8 @@ Cannot assign `fetch(...)` to `b` because `Response` [1] is incompatible with st
                                     ^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/bom.js:1603:76
-   1603| declare function fetch(input: RequestInfo, init?: RequestOptions): Promise<Response>;
+   <BUILTINS>/bom.js:1613:76
+   1613| declare function fetch(input: RequestInfo, init?: RequestOptions): Promise<Response>;
                                                                                     ^^^^^^^^ [1]
    fetch.js:12:18
      12| const b: Promise<string> = fetch(myRequest); // incorrect
@@ -32,8 +32,8 @@ References:
    fetch.js:25:18
      25| const d: Promise<Blob> = fetch('image.png'); // incorrect
                           ^^^^ [1]
-   <BUILTINS>/bom.js:1603:76
-   1603| declare function fetch(input: RequestInfo, init?: RequestOptions): Promise<Response>;
+   <BUILTINS>/bom.js:1613:76
+   1613| declare function fetch(input: RequestInfo, init?: RequestOptions): Promise<Response>;
                                                                                     ^^^^^^^^ [2]
    <BUILTINS>/core.js:1815:24
    1815| declare class Promise<+R> {
@@ -52,14 +52,14 @@ Cannot call `Headers` with `''Content-T...'` bound to `init` because: [incompati
                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/bom.js:1466:20
-   1466| type HeadersInit = Headers | Array<[string, string]> | { [key: string]: string, ... };
+   <BUILTINS>/bom.js:1476:20
+   1476| type HeadersInit = Headers | Array<[string, string]> | { [key: string]: string, ... };
                             ^^^^^^^ [2]
-   <BUILTINS>/bom.js:1466:30
-   1466| type HeadersInit = Headers | Array<[string, string]> | { [key: string]: string, ... };
+   <BUILTINS>/bom.js:1476:30
+   1476| type HeadersInit = Headers | Array<[string, string]> | { [key: string]: string, ... };
                                       ^^^^^^^^^^^^^^^^^^^^^^^ [3]
-   <BUILTINS>/bom.js:1466:56
-   1466| type HeadersInit = Headers | Array<[string, string]> | { [key: string]: string, ... };
+   <BUILTINS>/bom.js:1476:56
+   1476| type HeadersInit = Headers | Array<[string, string]> | { [key: string]: string, ... };
                                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [4]
 
 
@@ -73,8 +73,8 @@ element. [incompatible-call]
                                 ^^^^^^^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/bom.js:1466:36
-   1466| type HeadersInit = Headers | Array<[string, string]> | { [key: string]: string, ... };
+   <BUILTINS>/bom.js:1476:36
+   1476| type HeadersInit = Headers | Array<[string, string]> | { [key: string]: string, ... };
                                             ^^^^^^^^^^^^^^^^ [2]
 
 
@@ -88,8 +88,8 @@ element. [incompatible-call]
                                                 ^^^^^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/bom.js:1466:36
-   1466| type HeadersInit = Headers | Array<[string, string]> | { [key: string]: string, ... };
+   <BUILTINS>/bom.js:1476:36
+   1476| type HeadersInit = Headers | Array<[string, string]> | { [key: string]: string, ... };
                                             ^^^^^^^^^^^^^^^^ [2]
 
 
@@ -102,8 +102,8 @@ Cannot call `e.append` because function [1] requires another argument. [incompat
            ^^^^^^
 
 References:
-   <BUILTINS>/bom.js:1474:5
-   1474|     append(name: string, value: string): void;
+   <BUILTINS>/bom.js:1484:5
+   1484|     append(name: string, value: string): void;
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 
@@ -116,8 +116,8 @@ Cannot call `e.append` because function [1] requires another argument. [incompat
            ^^^^^^
 
 References:
-   <BUILTINS>/bom.js:1474:5
-   1474|     append(name: string, value: string): void;
+   <BUILTINS>/bom.js:1484:5
+   1484|     append(name: string, value: string): void;
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 
@@ -131,8 +131,8 @@ Cannot call `e.append` with object literal bound to `name` because object litera
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/bom.js:1474:18
-   1474|     append(name: string, value: string): void;
+   <BUILTINS>/bom.js:1484:18
+   1484|     append(name: string, value: string): void;
                           ^^^^^^ [2]
 
 
@@ -145,8 +145,8 @@ Cannot call `e.set` because function [1] requires another argument. [incompatibl
            ^^^
 
 References:
-   <BUILTINS>/bom.js:1481:5
-   1481|     set(name: string, value: string): void;
+   <BUILTINS>/bom.js:1491:5
+   1491|     set(name: string, value: string): void;
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 
@@ -159,8 +159,8 @@ Cannot call `e.set` because function [1] requires another argument. [incompatibl
            ^^^
 
 References:
-   <BUILTINS>/bom.js:1481:5
-   1481|     set(name: string, value: string): void;
+   <BUILTINS>/bom.js:1491:5
+   1491|     set(name: string, value: string): void;
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 
@@ -174,8 +174,8 @@ Cannot call `e.set` with object literal bound to `name` because object literal [
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/bom.js:1481:15
-   1481|     set(name: string, value: string): void;
+   <BUILTINS>/bom.js:1491:15
+   1491|     set(name: string, value: string): void;
                        ^^^^^^ [2]
 
 
@@ -188,8 +188,8 @@ Cannot assign `e.append(...)` to `f` because undefined [1] is incompatible with 
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/bom.js:1474:42
-   1474|     append(name: string, value: string): void;
+   <BUILTINS>/bom.js:1484:42
+   1484|     append(name: string, value: string): void;
                                                   ^^^^ [1]
    headers.js:15:10
      15| const f: Headers = e.append('Content-Type', 'image/jpeg'); // not correct
@@ -205,8 +205,8 @@ Cannot assign `e.get(...)` to `g` because null [1] is incompatible with string [
                            ^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/bom.js:1478:24
-   1478|     get(name: string): null | string;
+   <BUILTINS>/bom.js:1488:24
+   1488|     get(name: string): null | string;
                                 ^^^^ [1]
    headers.js:17:10
      17| const g: string = e.get('Content-Type'); // correct
@@ -222,8 +222,8 @@ Cannot assign `e.get(...)` to `h` because null [1] is incompatible with number [
                            ^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/bom.js:1478:24
-   1478|     get(name: string): null | string;
+   <BUILTINS>/bom.js:1488:24
+   1488|     get(name: string): null | string;
                                 ^^^^ [1]
    headers.js:18:10
      18| const h: number = e.get('Content-Type'); // not correct
@@ -239,8 +239,8 @@ Cannot assign `e.get(...)` to `h` because string [1] is incompatible with number
                            ^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/bom.js:1478:31
-   1478|     get(name: string): null | string;
+   <BUILTINS>/bom.js:1488:31
+   1488|     get(name: string): null | string;
                                        ^^^^^^ [1]
    headers.js:18:10
      18| const h: number = e.get('Content-Type'); // not correct
@@ -276,14 +276,14 @@ References:
    request.js:2:20
       2| const a: Request = new Request(); // incorrect
                             ^^^^^^^^^^^^^ [1]
-   <BUILTINS>/bom.js:1513:20
-   1513| type RequestInfo = Request | URL | string;
+   <BUILTINS>/bom.js:1523:20
+   1523| type RequestInfo = Request | URL | string;
                             ^^^^^^^ [2]
-   <BUILTINS>/bom.js:1513:30
-   1513| type RequestInfo = Request | URL | string;
+   <BUILTINS>/bom.js:1523:30
+   1523| type RequestInfo = Request | URL | string;
                                       ^^^ [3]
-   <BUILTINS>/bom.js:1513:36
-   1513| type RequestInfo = Request | URL | string;
+   <BUILTINS>/bom.js:1523:36
+   1523| type RequestInfo = Request | URL | string;
                                             ^^^^^^ [4]
 
 
@@ -301,8 +301,8 @@ References:
    request.js:4:10
       4| const c: Request = new Request(b); // correct
                   ^^^^^^^ [1]
-   <BUILTINS>/bom.js:1566:44
-   1566|     constructor(input: RequestInfo, init?: RequestOptions): void;
+   <BUILTINS>/bom.js:1576:44
+   1576|     constructor(input: RequestInfo, init?: RequestOptions): void;
                                                     ^^^^^^^^^^^^^^ [2]
 
 
@@ -319,8 +319,8 @@ References:
    request.js:4:10
       4| const c: Request = new Request(b); // correct
                   ^^^^^^^ [1]
-   <BUILTINS>/bom.js:1566:44
-   1566|     constructor(input: RequestInfo, init?: RequestOptions): void;
+   <BUILTINS>/bom.js:1576:44
+   1576|     constructor(input: RequestInfo, init?: RequestOptions): void;
                                                     ^^^^^^^^^^^^^^ [2]
 
 
@@ -334,11 +334,11 @@ Cannot call `Request` with `c` bound to `init` because literal union [1] is inco
                                            ^
 
 References:
-   <BUILTINS>/bom.js:1571:12
-   1571|     cache: CacheType;
+   <BUILTINS>/bom.js:1581:12
+   1581|     cache: CacheType;
                     ^^^^^^^^^ [1]
-   <BUILTINS>/bom.js:1517:11
-   1517|   cache?: CacheType,
+   <BUILTINS>/bom.js:1527:11
+   1527|   cache?: CacheType,
                    ^^^^^^^^^ [2]
 
 
@@ -352,11 +352,11 @@ Cannot call `Request` with `c` bound to `init` because literal union [1] is inco
                                            ^
 
 References:
-   <BUILTINS>/bom.js:1572:18
-   1572|     credentials: CredentialsType;
+   <BUILTINS>/bom.js:1582:18
+   1582|     credentials: CredentialsType;
                           ^^^^^^^^^^^^^^^ [1]
-   <BUILTINS>/bom.js:1518:17
-   1518|   credentials?: CredentialsType,
+   <BUILTINS>/bom.js:1528:17
+   1528|   credentials?: CredentialsType,
                          ^^^^^^^^^^^^^^^ [2]
 
 
@@ -370,11 +370,11 @@ Cannot call `Request` with `c` bound to `init` because `Headers` [1] is incompat
                                            ^
 
 References:
-   <BUILTINS>/bom.js:1573:14
-   1573|     headers: Headers;
+   <BUILTINS>/bom.js:1583:14
+   1583|     headers: Headers;
                       ^^^^^^^ [1]
-   <BUILTINS>/bom.js:1519:13
-   1519|   headers?: HeadersInit,
+   <BUILTINS>/bom.js:1529:13
+   1529|   headers?: HeadersInit,
                      ^^^^^^^^^^^ [2]
 
 
@@ -388,11 +388,11 @@ Cannot call `Request` with `c` bound to `init` because `Headers` [1] is incompat
                                            ^
 
 References:
-   <BUILTINS>/bom.js:1573:14
-   1573|     headers: Headers;
+   <BUILTINS>/bom.js:1583:14
+   1583|     headers: Headers;
                       ^^^^^^^ [1]
-   <BUILTINS>/bom.js:1519:13
-   1519|   headers?: HeadersInit,
+   <BUILTINS>/bom.js:1529:13
+   1529|   headers?: HeadersInit,
                      ^^^^^^^^^^^ [2]
 
 
@@ -406,11 +406,11 @@ Cannot call `Request` with `c` bound to `init` because `Headers` [1] is incompat
                                            ^
 
 References:
-   <BUILTINS>/bom.js:1573:14
-   1573|     headers: Headers;
+   <BUILTINS>/bom.js:1583:14
+   1583|     headers: Headers;
                       ^^^^^^^ [1]
-   <BUILTINS>/bom.js:1519:13
-   1519|   headers?: HeadersInit,
+   <BUILTINS>/bom.js:1529:13
+   1529|   headers?: HeadersInit,
                      ^^^^^^^^^^^ [2]
 
 
@@ -424,11 +424,11 @@ Cannot call `Request` with `c` bound to `init` because string [1] is incompatibl
                                            ^
 
 References:
-   <BUILTINS>/bom.js:1574:16
-   1574|     integrity: string;
+   <BUILTINS>/bom.js:1584:16
+   1584|     integrity: string;
                         ^^^^^^ [1]
-   <BUILTINS>/bom.js:1520:15
-   1520|   integrity?: string,
+   <BUILTINS>/bom.js:1530:15
+   1530|   integrity?: string,
                        ^^^^^^ [2]
 
 
@@ -442,11 +442,11 @@ Cannot call `Request` with `c` bound to `init` because string [1] is incompatibl
                                            ^
 
 References:
-   <BUILTINS>/bom.js:1575:13
-   1575|     method: string;
+   <BUILTINS>/bom.js:1585:13
+   1585|     method: string;
                      ^^^^^^ [1]
-   <BUILTINS>/bom.js:1522:12
-   1522|   method?: string,
+   <BUILTINS>/bom.js:1532:12
+   1532|   method?: string,
                     ^^^^^^ [2]
 
 
@@ -460,11 +460,11 @@ Cannot call `Request` with `c` bound to `init` because literal union [1] is inco
                                            ^
 
 References:
-   <BUILTINS>/bom.js:1576:11
-   1576|     mode: ModeType;
+   <BUILTINS>/bom.js:1586:11
+   1586|     mode: ModeType;
                    ^^^^^^^^ [1]
-   <BUILTINS>/bom.js:1523:10
-   1523|   mode?: ModeType,
+   <BUILTINS>/bom.js:1533:10
+   1533|   mode?: ModeType,
                   ^^^^^^^^ [2]
 
 
@@ -478,11 +478,11 @@ Cannot call `Request` with `c` bound to `init` because literal union [1] is inco
                                            ^
 
 References:
-   <BUILTINS>/bom.js:1577:15
-   1577|     redirect: RedirectType;
+   <BUILTINS>/bom.js:1587:15
+   1587|     redirect: RedirectType;
                        ^^^^^^^^^^^^ [1]
-   <BUILTINS>/bom.js:1524:14
-   1524|   redirect?: RedirectType,
+   <BUILTINS>/bom.js:1534:14
+   1534|   redirect?: RedirectType,
                       ^^^^^^^^^^^^ [2]
 
 
@@ -496,11 +496,11 @@ Cannot call `Request` with `c` bound to `init` because string [1] is incompatibl
                                            ^
 
 References:
-   <BUILTINS>/bom.js:1578:15
-   1578|     referrer: string;
+   <BUILTINS>/bom.js:1588:15
+   1588|     referrer: string;
                        ^^^^^^ [1]
-   <BUILTINS>/bom.js:1525:14
-   1525|   referrer?: string,
+   <BUILTINS>/bom.js:1535:14
+   1535|   referrer?: string,
                       ^^^^^^ [2]
 
 
@@ -514,11 +514,11 @@ Cannot call `Request` with `c` bound to `init` because literal union [1] is inco
                                            ^
 
 References:
-   <BUILTINS>/bom.js:1579:21
-   1579|     referrerPolicy: ReferrerPolicyType;
+   <BUILTINS>/bom.js:1589:21
+   1589|     referrerPolicy: ReferrerPolicyType;
                              ^^^^^^^^^^^^^^^^^^ [1]
-   <BUILTINS>/bom.js:1526:20
-   1526|   referrerPolicy?: ReferrerPolicyType,
+   <BUILTINS>/bom.js:1536:20
+   1536|   referrerPolicy?: ReferrerPolicyType,
                             ^^^^^^^^^^^^^^^^^^ [2]
 
 
@@ -533,11 +533,11 @@ Cannot call `Request` with object literal bound to `input` because: [incompatibl
                                         ^^ [1]
 
 References:
-   <BUILTINS>/bom.js:1513:20
-   1513| type RequestInfo = Request | URL | string;
+   <BUILTINS>/bom.js:1523:20
+   1523| type RequestInfo = Request | URL | string;
                             ^^^^^^^ [2]
-   <BUILTINS>/bom.js:1513:30
-   1513| type RequestInfo = Request | URL | string;
+   <BUILTINS>/bom.js:1523:30
+   1523| type RequestInfo = Request | URL | string;
                                       ^^^ [3]
 
 
@@ -554,8 +554,8 @@ References:
    request.js:24:19
      24| h.text().then((t: Buffer) => t); // incorrect
                            ^^^^^^ [1]
-   <BUILTINS>/bom.js:1589:21
-   1589|     text(): Promise<string>;
+   <BUILTINS>/bom.js:1599:21
+   1599|     text(): Promise<string>;
                              ^^^^^^ [2]
 
 
@@ -569,8 +569,8 @@ Cannot call `h.arrayBuffer().then` because `ArrayBuffer` [1] is incompatible wit
                          ^^^^
 
 References:
-   <BUILTINS>/bom.js:1585:28
-   1585|     arrayBuffer(): Promise<ArrayBuffer>;
+   <BUILTINS>/bom.js:1595:28
+   1595|     arrayBuffer(): Promise<ArrayBuffer>;
                                     ^^^^^^^^^^^ [1]
    request.js:26:27
      26| h.arrayBuffer().then((ab: Buffer) => ab); // incorrect
@@ -589,14 +589,14 @@ Cannot call `Request` with object literal bound to `init` because in property `h
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/bom.js:1466:20
-   1466| type HeadersInit = Headers | Array<[string, string]> | { [key: string]: string, ... };
+   <BUILTINS>/bom.js:1476:20
+   1476| type HeadersInit = Headers | Array<[string, string]> | { [key: string]: string, ... };
                             ^^^^^^^ [2]
-   <BUILTINS>/bom.js:1466:30
-   1466| type HeadersInit = Headers | Array<[string, string]> | { [key: string]: string, ... };
+   <BUILTINS>/bom.js:1476:30
+   1476| type HeadersInit = Headers | Array<[string, string]> | { [key: string]: string, ... };
                                       ^^^^^^^^^^^^^^^^^^^^^^^ [3]
-   <BUILTINS>/bom.js:1466:56
-   1466| type HeadersInit = Headers | Array<[string, string]> | { [key: string]: string, ... };
+   <BUILTINS>/bom.js:1476:56
+   1476| type HeadersInit = Headers | Array<[string, string]> | { [key: string]: string, ... };
                                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [4]
 
 
@@ -610,8 +610,8 @@ Cannot call `Request` with object literal bound to `init` because null [1] is in
                                     ^^^^ [1]
 
 References:
-   <BUILTINS>/bom.js:1522:12
-   1522|   method?: string,
+   <BUILTINS>/bom.js:1532:12
+   1532|   method?: string,
                     ^^^^^^ [2]
 
 
@@ -625,8 +625,8 @@ property `status`. [incompatible-call]
                                     ^^^^^ [1]
 
 References:
-   <BUILTINS>/bom.js:1533:12
-   1533|   status?: number,
+   <BUILTINS>/bom.js:1543:12
+   1543|   status?: number,
                     ^^^^^^ [2]
 
 
@@ -640,8 +640,8 @@ Cannot call `Response` with object literal bound to `init` because null [1] is i
                                     ^^^^ [1]
 
 References:
-   <BUILTINS>/bom.js:1533:12
-   1533|   status?: number,
+   <BUILTINS>/bom.js:1543:12
+   1543|   status?: number,
                     ^^^^^^ [2]
 
 
@@ -657,14 +657,14 @@ Cannot call `Response` with object literal bound to `init` because in property `
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/bom.js:1466:20
-   1466| type HeadersInit = Headers | Array<[string, string]> | { [key: string]: string, ... };
+   <BUILTINS>/bom.js:1476:20
+   1476| type HeadersInit = Headers | Array<[string, string]> | { [key: string]: string, ... };
                             ^^^^^^^ [2]
-   <BUILTINS>/bom.js:1466:30
-   1466| type HeadersInit = Headers | Array<[string, string]> | { [key: string]: string, ... };
+   <BUILTINS>/bom.js:1476:30
+   1476| type HeadersInit = Headers | Array<[string, string]> | { [key: string]: string, ... };
                                       ^^^^^^^^^^^^^^^^^^^^^^^ [3]
-   <BUILTINS>/bom.js:1466:56
-   1466| type HeadersInit = Headers | Array<[string, string]> | { [key: string]: string, ... };
+   <BUILTINS>/bom.js:1476:56
+   1476| type HeadersInit = Headers | Array<[string, string]> | { [key: string]: string, ... };
                                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [4]
 
 
@@ -690,17 +690,17 @@ Cannot call `Response` with object literal bound to `input` because: [incompatib
          ^ [1]
 
 References:
-   <BUILTINS>/bom.js:1511:26
-   1511| type BodyInit = string | URLSearchParams | FormData | Blob | ArrayBuffer | $ArrayBufferView | ReadableStream;
+   <BUILTINS>/bom.js:1521:26
+   1521| type BodyInit = string | URLSearchParams | FormData | Blob | ArrayBuffer | $ArrayBufferView | ReadableStream;
                                   ^^^^^^^^^^^^^^^ [2]
-   <BUILTINS>/bom.js:1511:44
-   1511| type BodyInit = string | URLSearchParams | FormData | Blob | ArrayBuffer | $ArrayBufferView | ReadableStream;
+   <BUILTINS>/bom.js:1521:44
+   1521| type BodyInit = string | URLSearchParams | FormData | Blob | ArrayBuffer | $ArrayBufferView | ReadableStream;
                                                     ^^^^^^^^ [3]
-   <BUILTINS>/bom.js:1511:55
-   1511| type BodyInit = string | URLSearchParams | FormData | Blob | ArrayBuffer | $ArrayBufferView | ReadableStream;
+   <BUILTINS>/bom.js:1521:55
+   1521| type BodyInit = string | URLSearchParams | FormData | Blob | ArrayBuffer | $ArrayBufferView | ReadableStream;
                                                                ^^^^ [4]
-   <BUILTINS>/bom.js:1511:62
-   1511| type BodyInit = string | URLSearchParams | FormData | Blob | ArrayBuffer | $ArrayBufferView | ReadableStream;
+   <BUILTINS>/bom.js:1521:62
+   1521| type BodyInit = string | URLSearchParams | FormData | Blob | ArrayBuffer | $ArrayBufferView | ReadableStream;
                                                                       ^^^^^^^^^^^ [5]
    <BUILTINS>/core.js:1931:25
    1931| type $ArrayBufferView = $TypedArray | DataView;
@@ -708,8 +708,8 @@ References:
    <BUILTINS>/core.js:1931:39
    1931| type $ArrayBufferView = $TypedArray | DataView;
                                                ^^^^^^^^ [7]
-   <BUILTINS>/bom.js:1511:95
-   1511| type BodyInit = string | URLSearchParams | FormData | Blob | ArrayBuffer | $ArrayBufferView | ReadableStream;
+   <BUILTINS>/bom.js:1521:95
+   1521| type BodyInit = string | URLSearchParams | FormData | Blob | ArrayBuffer | $ArrayBufferView | ReadableStream;
                                                                                                        ^^^^^^^^^^^^^^ [8]
 
 
@@ -726,8 +726,8 @@ References:
    response.js:42:19
      42| h.text().then((t: Buffer) => t); // incorrect
                            ^^^^^^ [1]
-   <BUILTINS>/bom.js:1562:21
-   1562|     text(): Promise<string>;
+   <BUILTINS>/bom.js:1572:21
+   1572|     text(): Promise<string>;
                              ^^^^^^ [2]
 
 
@@ -741,8 +741,8 @@ Cannot call `h.arrayBuffer().then` because `ArrayBuffer` [1] is incompatible wit
                          ^^^^
 
 References:
-   <BUILTINS>/bom.js:1558:28
-   1558|     arrayBuffer(): Promise<ArrayBuffer>;
+   <BUILTINS>/bom.js:1568:28
+   1568|     arrayBuffer(): Promise<ArrayBuffer>;
                                     ^^^^^^^^^^^ [1]
    response.js:44:27
      44| h.arrayBuffer().then((ab: Buffer) => ab); // incorrect
@@ -759,8 +759,8 @@ in array element. [incompatible-call]
                                         ^^^^^^ [1]
 
 References:
-   <BUILTINS>/bom.js:1487:58
-   1487|     constructor(query?: string | URLSearchParams | Array<[string, string]> | { [string]: string, ... } ): void;
+   <BUILTINS>/bom.js:1497:58
+   1497|     constructor(query?: string | URLSearchParams | Array<[string, string]> | { [string]: string, ... } ): void;
                                                                   ^^^^^^^^^^^^^^^^ [2]
 
 
@@ -774,8 +774,8 @@ in array element. [incompatible-call]
                                                 ^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/bom.js:1487:58
-   1487|     constructor(query?: string | URLSearchParams | Array<[string, string]> | { [string]: string, ... } ): void;
+   <BUILTINS>/bom.js:1497:58
+   1497|     constructor(query?: string | URLSearchParams | Array<[string, string]> | { [string]: string, ... } ): void;
                                                                   ^^^^^^^^^^^^^^^^ [2]
 
 
@@ -788,8 +788,8 @@ Cannot call `e.append` because function [1] requires another argument. [incompat
            ^^^^^^
 
 References:
-   <BUILTINS>/bom.js:1488:5
-   1488|     append(name: string, value: string): void;
+   <BUILTINS>/bom.js:1498:5
+   1498|     append(name: string, value: string): void;
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 
@@ -802,8 +802,8 @@ Cannot call `e.append` because function [1] requires another argument. [incompat
            ^^^^^^
 
 References:
-   <BUILTINS>/bom.js:1488:5
-   1488|     append(name: string, value: string): void;
+   <BUILTINS>/bom.js:1498:5
+   1498|     append(name: string, value: string): void;
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 
@@ -817,8 +817,8 @@ Cannot call `e.append` with object literal bound to `name` because object litera
                   ^^^^^^^^^^^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/bom.js:1488:18
-   1488|     append(name: string, value: string): void;
+   <BUILTINS>/bom.js:1498:18
+   1498|     append(name: string, value: string): void;
                           ^^^^^^ [2]
 
 
@@ -831,8 +831,8 @@ Cannot call `e.set` because function [1] requires another argument. [incompatibl
            ^^^
 
 References:
-   <BUILTINS>/bom.js:1496:5
-   1496|     set(name: string, value: string): void;
+   <BUILTINS>/bom.js:1506:5
+   1506|     set(name: string, value: string): void;
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 
@@ -845,8 +845,8 @@ Cannot call `e.set` because function [1] requires another argument. [incompatibl
            ^^^
 
 References:
-   <BUILTINS>/bom.js:1496:5
-   1496|     set(name: string, value: string): void;
+   <BUILTINS>/bom.js:1506:5
+   1506|     set(name: string, value: string): void;
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 
@@ -860,8 +860,8 @@ Cannot call `e.set` with object literal bound to `name` because object literal [
                ^^^^^^^^^^^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/bom.js:1496:15
-   1496|     set(name: string, value: string): void;
+   <BUILTINS>/bom.js:1506:15
+   1506|     set(name: string, value: string): void;
                        ^^^^^^ [2]
 
 
@@ -875,8 +875,8 @@ Cannot assign `e.append(...)` to `f` because undefined [1] is incompatible with 
                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/bom.js:1488:42
-   1488|     append(name: string, value: string): void;
+   <BUILTINS>/bom.js:1498:42
+   1498|     append(name: string, value: string): void;
                                                   ^^^^ [1]
    urlsearchparams.js:15:10
      15| const f: URLSearchParams = e.append('key1', 'value1'); // not correct
@@ -892,8 +892,8 @@ Cannot assign `e.get(...)` to `g` because null [1] is incompatible with string [
                            ^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/bom.js:1492:24
-   1492|     get(name: string): null | string;
+   <BUILTINS>/bom.js:1502:24
+   1502|     get(name: string): null | string;
                                 ^^^^ [1]
    urlsearchparams.js:17:10
      17| const g: string = e.get('key1'); // correct
@@ -909,8 +909,8 @@ Cannot assign `e.get(...)` to `h` because null [1] is incompatible with number [
                            ^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/bom.js:1492:24
-   1492|     get(name: string): null | string;
+   <BUILTINS>/bom.js:1502:24
+   1502|     get(name: string): null | string;
                                 ^^^^ [1]
    urlsearchparams.js:18:10
      18| const h: number = e.get('key1'); // not correct
@@ -926,8 +926,8 @@ Cannot assign `e.get(...)` to `h` because string [1] is incompatible with number
                            ^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/bom.js:1492:31
-   1492|     get(name: string): null | string;
+   <BUILTINS>/bom.js:1502:31
+   1502|     get(name: string): null | string;
                                        ^^^^^^ [1]
    urlsearchparams.js:18:10
      18| const h: number = e.get('key1'); // not correct


### PR DESCRIPTION
Flow's is missing the definition of PerformanceServerTiming. 
The exported definition of PerformanceResourceTiming is missing the serverTiming attribute.

PerformanceServerTiming definition : https://www.w3.org/TR/resource-timing-2/#sec-performanceresourcetiming
PerformanceResourceTiming extension: https://w3c.github.io/server-timing/#extension-to-the-performanceresourcetiming-interface