### PR TITLE
more accurate to say `number` than `int`

### DIFF
--- a/website/en/docs/usage.md
+++ b/website/en/docs/usage.md
@@ -69,7 +69,7 @@ function foo(x: ?number): string {
 }
 ```
 
-Notice the types added to the parameter of the function along with a return type at the end of the function. You might be able to tell from looking at this code that there is an error in the return type since the function can also return an `int`. However, you do not need to visually inspect the code since the Flow background process will be able to catch this error for you when you [check your code](#toc-check-your-code).
+Notice the types added to the parameter of the function along with a return type at the end of the function. You might be able to tell from looking at this code that there is an error in the return type since the function can also return a `number`. However, you do not need to visually inspect the code since the Flow background process will be able to catch this error for you when you [check your code](#toc-check-your-code).
 
 ### Check Your Code <a class="toc" id="toc-check-your-code" href="#toc-check-your-code"></a>
 


### PR DESCRIPTION
1. there is no type `int` but it is `number`, IEEE 754
2. it is more descriptive to say it can return 1 or return 1.23... not just strictly integers

<!--
  If this is a change to library defintions, please include links to relevant documentation.
  If this is a documentation change, please prefix the title with [DOCS].

  If this is neither, ensure you opened a discussion issue and link it in the PR description.
-->
