### PR TITLE
make the variables have different name or else the second one causes …

### DIFF
--- a/website/en/docs/lang/nominal-structural.md
+++ b/website/en/docs/lang/nominal-structural.md
@@ -111,8 +111,8 @@ interface Interface {
 class Foo { method(input: string) { /* ... */ } }
 class Bar { method(input: string) { /* ... */ } }
 
-let test: Interface = new Foo(); // Okay.
-let test: Interface = new Bar(); // Okay.
+let test1: Interface = new Foo(); // Okay.
+let test2: Interface = new Bar(); // Okay.
 ```
 
 #### Mixing nominal and structural typing <a class="toc" id="toc-mixing-nominal-and-structural-typing" href="#toc-mixing-nominal-and-structural-typing"></a>


### PR DESCRIPTION
…an error

it's say `test` has already been declared

It seems you new_website has this fixed but new_website is not being used at the moment.

<!--
  If this is a change to library defintions, please include links to relevant documentation.
  If this is a documentation change, please prefix the title with [DOCS].

  If this is neither, ensure you opened a discussion issue and link it in the PR description.
-->
