### PR TITLE
compile fuzzy-path stubs in C11

### DIFF
--- a/src/third-party/fuzzy-path/Makefile
+++ b/src/third-party/fuzzy-path/Makefile
@@ -6,7 +6,7 @@ endif
 
 OCAML_INCLUDES := $(shell ocamlc 2>/dev/null -where || echo /usr/local/lib/ocaml)
 
-CFLAGS= -I $(OCAML_INCLUDES) -fPIC
+CFLAGS= -I $(OCAML_INCLUDES) -std=c11 -fPIC
 
 CXXFLAGS=-std=c++11 -Wall -O3 -fPIC
 


### PR DESCRIPTION
Summary:
we use `for (int i = ...)` which is a c99-ism, but we do not explicitly enable c99. since we already use c++11 for the c++ parts, let's also use c11 for the C stubs.

the release builds are built by the flowtype/flow-ci docker image which is based on centos7, which has gcc 4.8.5. 4.8 defaults to c90, but should support c11 well enough for our purposes ([docs](https://gcc.gnu.org/wiki/C11Status)).

Changelog: [internal]

Differential Revision: D41549820

