### PR TITLE
Export ReactSetStateFunction type

### DIFF
--- a/lib/react.js
+++ b/lib/react.js
@@ -310,7 +310,7 @@ declare module react {
   ): React$AbstractComponent<Config, Instance>;
 
   declare type MaybeCleanUpFn = void | (() => void);
-  declare type ReactSetStateFunction<S> = ((S => S) | S) => void;
+  declare export type ReactSetStateFunction<S> = ((S => S) | S) => void;
 
   declare export function useContext<T>(context: React$Context<T>): T;
 


### PR DESCRIPTION
With current the declaration we can't access the new type. ESM declarations requires the `export` keyword for public types.
From the changelog it looks like it was meant to be shared?   

Either `import type { ReactSetStateFunction } from 'react'` or `import * as React from 'react'` doesn't work. 
