### PR TITLE
libdef update: updated AbortController and AbortSignal

### DIFF
--- a/lib/bom.js
+++ b/lib/bom.js
@@ -1602,12 +1602,13 @@ declare class Request {
 declare class AbortController {
     constructor(): void;
     +signal: AbortSignal;
-    abort(): void;
+    abort(reason?: any): void;
 }
 
 declare class AbortSignal extends EventTarget {
     +aborted: boolean;
     onabort: (event: any) => mixed;
+    throwIfAborted(): void;
 }
 
 declare function fetch(input: RequestInfo, init?: RequestOptions): Promise<Response>;


### PR DESCRIPTION
libdef update:

Added optional `reason` argument to `AbortController.abort()` function.
See doc at: https://developer.mozilla.org/en-US/docs/Web/API/AbortController/AbortController

Added new `AbortSignal.throwIfAborted()` function.
See doc at: https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal/throwIfAborted

This should fix https://github.com/facebook/flow/issues/8970.