### PR TITLE
[try-flow] Support pragmas in try-flow

### DIFF
--- a/src/__tests__/flow_dot_js_smoke_test.js
+++ b/src/__tests__/flow_dot_js_smoke_test.js
@@ -29,3 +29,14 @@ if (
 ) {
   throw 'Referring to non-existent global should be an error.';
 }
+if (
+  flow.checkContent(
+    'test.js',
+    `// @jsx Foo
+const Bar = '123';
+function Foo(x: string) {}
+<Bar />; // ok`,
+  ).length > 0
+) {
+  throw 'There should be no errors if jsx pragma is correctly parsed.';
+}

--- a/src/dune
+++ b/src/dune
@@ -28,6 +28,7 @@
     flow_file_sig
     flow_parser_js
     flow_parser_utils_aloc
+    flow_parsing_docblock
     flow_typing
     flow_typing_errors
     js_of_ocaml)

--- a/src/parsing/dune
+++ b/src/parsing/dune
@@ -1,11 +1,19 @@
 (library
+ (name flow_parsing_docblock)
+ (wrapped false)
+ (modules docblock_parser)
+ (libraries flow_common))
+
+(library
  (name flow_parsing)
  (wrapped false)
+ (modules (:standard \ docblock_parser))
  (libraries
   flow_common
   flow_monitor_rpc
   flow_exports
   flow_procs
+  flow_parsing_docblock
   flow_service_inference_module
   flow_state_heaps_parsing
   flow_state_readers


### PR DESCRIPTION
Summary: Changelog: [feature] Pragmas (e.g. `// flow strict`, `// Huxpro custom_jsx_fun`) are now supported in try-flow.

Differential Revision: D43060075

