### PR TITLE
Add definition of Performance.eventCounts according to the W3C standard

### DIFF
--- a/lib/bom.js
+++ b/lib/bom.js
@@ -469,7 +469,28 @@ declare type PerformanceMeasureOptions = {|
   duration?: number,
 |};
 
+
+type EventCountsForEachCallbackType =
+  | (() => void)
+  | ((value: number) => void)
+  | ((value: number, key: string) => void)
+  | ((value: number, key: string, map: Map<string, number>) => void);
+
+// https://www.w3.org/TR/event-timing/#eventcounts
+declare interface EventCounts {
+  size: number;
+
+  entries(): Iterator<[string, number]>;
+  forEach(callback: EventCountsForEachCallbackType): void;
+  get(key: string): ?number;
+  has(key: string): boolean;
+  keys(): Iterator<string>;
+  values(): Iterator<number>;
+}
+
 declare class Performance {
+    eventCounts: EventCounts;
+
     // deprecated
     navigation: PerformanceNavigation;
     timing: PerformanceTiming;

--- a/tests/bom/bom.exp
+++ b/tests/bom/bom.exp
@@ -8,8 +8,8 @@ Cannot call `FormData` with empty string bound to `form` because string [1] is i
                      ^^ [1]
 
 References:
-   <BUILTINS>/bom.js:559:24
-   559|     constructor(form?: HTMLFormElement): void;
+   <BUILTINS>/bom.js:580:24
+   580|     constructor(form?: HTMLFormElement): void;
                                ^^^^^^^^^^^^^^^ [2]
 
 
@@ -26,8 +26,8 @@ References:
    <BUILTINS>/dom.js:1125:70
    1125|   createElement(tagName: 'input', options?: ElementCreationOptions): HTMLInputElement;
                                                                               ^^^^^^^^^^^^^^^^ [1]
-   <BUILTINS>/bom.js:559:24
-    559|     constructor(form?: HTMLFormElement): void;
+   <BUILTINS>/bom.js:580:24
+    580|     constructor(form?: HTMLFormElement): void;
                                 ^^^^^^^^^^^^^^^ [2]
 
 
@@ -40,8 +40,8 @@ Cannot assign `a.get(...)` to `d` because null or undefined [1] is incompatible 
                           ^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/bom.js:562:24
-   562|     get(name: string): ?FormDataEntryValue;
+   <BUILTINS>/bom.js:583:24
+   583|     get(name: string): ?FormDataEntryValue;
                                ^^^^^^^^^^^^^^^^^^^ [1]
    FormData.js:14:10
     14| const d: string = a.get('foo'); // incorrect
@@ -57,8 +57,8 @@ Cannot assign `a.get(...)` to `d` because `File` [1] is incompatible with string
                           ^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/bom.js:562:25
-   562|     get(name: string): ?FormDataEntryValue;
+   <BUILTINS>/bom.js:583:25
+   583|     get(name: string): ?FormDataEntryValue;
                                 ^^^^^^^^^^^^^^^^^^ [1]
    FormData.js:14:10
     14| const d: string = a.get('foo'); // incorrect
@@ -74,8 +74,8 @@ Cannot assign `a.get(...)` to `e` because null or undefined [1] is incompatible 
                         ^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/bom.js:562:24
-   562|     get(name: string): ?FormDataEntryValue;
+   <BUILTINS>/bom.js:583:24
+   583|     get(name: string): ?FormDataEntryValue;
                                ^^^^^^^^^^^^^^^^^^^ [1]
    FormData.js:15:10
     15| const e: Blob = a.get('foo'); // incorrect
@@ -91,8 +91,8 @@ Cannot assign `a.get(...)` to `e` because string [1] is incompatible with `Blob`
                         ^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/bom.js:562:25
-   562|     get(name: string): ?FormDataEntryValue;
+   <BUILTINS>/bom.js:583:25
+   583|     get(name: string): ?FormDataEntryValue;
                                 ^^^^^^^^^^^^^^^^^^ [1]
    FormData.js:15:10
     15| const e: Blob = a.get('foo'); // incorrect
@@ -108,8 +108,8 @@ Cannot call `a.get` with `2` bound to `name` because number [1] is incompatible 
               ^ [1]
 
 References:
-   <BUILTINS>/bom.js:562:15
-   562|     get(name: string): ?FormDataEntryValue;
+   <BUILTINS>/bom.js:583:15
+   583|     get(name: string): ?FormDataEntryValue;
                       ^^^^^^ [2]
 
 
@@ -126,8 +126,8 @@ References:
    FormData.js:21:33
     21| const a2: Array<string | File | number> = a.getAll('foo'); // incorrect
                                         ^^^^^^ [1]
-   <BUILTINS>/bom.js:556:27
-   556| type FormDataEntryValue = string | File
+   <BUILTINS>/bom.js:577:27
+   577| type FormDataEntryValue = string | File
                                   ^^^^^^ [2]
 
 
@@ -144,8 +144,8 @@ References:
    FormData.js:22:26
     22| const a3: Array<string | Blob | File> = a.getAll('foo'); // incorrect
                                  ^^^^ [1]
-   <BUILTINS>/bom.js:556:36
-   556| type FormDataEntryValue = string | File
+   <BUILTINS>/bom.js:577:36
+   577| type FormDataEntryValue = string | File
                                            ^^^^ [2]
 
 
@@ -158,8 +158,8 @@ Cannot call `a.getAll` with `23` bound to `name` because number [1] is incompati
                  ^^ [1]
 
 References:
-   <BUILTINS>/bom.js:563:18
-   563|     getAll(name: string): Array<FormDataEntryValue>;
+   <BUILTINS>/bom.js:584:18
+   584|     getAll(name: string): Array<FormDataEntryValue>;
                          ^^^^^^ [2]
 
 
@@ -177,11 +177,11 @@ References:
    FormData.js:27:14
     27| a.set('foo', {}); // incorrect
                      ^^ [1]
-   <BUILTINS>/bom.js:566:30
-   566|     set(name: string, value: Blob, filename?: string): void;
+   <BUILTINS>/bom.js:587:30
+   587|     set(name: string, value: Blob, filename?: string): void;
                                      ^^^^ [2]
-   <BUILTINS>/bom.js:567:30
-   567|     set(name: string, value: File, filename?: string): void;
+   <BUILTINS>/bom.js:588:30
+   588|     set(name: string, value: File, filename?: string): void;
                                      ^^^^ [3]
 
 
@@ -200,14 +200,14 @@ References:
    FormData.js:28:7
     28| a.set(2, 'bar'); // incorrect
               ^ [1]
-   <BUILTINS>/bom.js:565:15
-   565|     set(name: string, value: string): void;
+   <BUILTINS>/bom.js:586:15
+   586|     set(name: string, value: string): void;
                       ^^^^^^ [2]
-   <BUILTINS>/bom.js:566:15
-   566|     set(name: string, value: Blob, filename?: string): void;
+   <BUILTINS>/bom.js:587:15
+   587|     set(name: string, value: Blob, filename?: string): void;
                       ^^^^^^ [3]
-   <BUILTINS>/bom.js:567:15
-   567|     set(name: string, value: File, filename?: string): void;
+   <BUILTINS>/bom.js:588:15
+   588|     set(name: string, value: File, filename?: string): void;
                       ^^^^^^ [4]
 
 
@@ -225,11 +225,11 @@ References:
    FormData.js:29:14
     29| a.set('foo', 'bar', 'baz'); // incorrect
                      ^^^^^ [1]
-   <BUILTINS>/bom.js:566:30
-   566|     set(name: string, value: Blob, filename?: string): void;
+   <BUILTINS>/bom.js:587:30
+   587|     set(name: string, value: Blob, filename?: string): void;
                                      ^^^^ [2]
-   <BUILTINS>/bom.js:567:30
-   567|     set(name: string, value: File, filename?: string): void;
+   <BUILTINS>/bom.js:588:30
+   588|     set(name: string, value: File, filename?: string): void;
                                      ^^^^ [3]
 
 
@@ -247,11 +247,11 @@ References:
    FormData.js:32:33
     32| a.set('bar', new File([], 'q'), 2) // incorrect
                                         ^ [1]
-   <BUILTINS>/bom.js:566:47
-   566|     set(name: string, value: Blob, filename?: string): void;
+   <BUILTINS>/bom.js:587:47
+   587|     set(name: string, value: Blob, filename?: string): void;
                                                       ^^^^^^ [2]
-   <BUILTINS>/bom.js:567:47
-   567|     set(name: string, value: File, filename?: string): void;
+   <BUILTINS>/bom.js:588:47
+   588|     set(name: string, value: File, filename?: string): void;
                                                       ^^^^^^ [3]
 
 
@@ -267,8 +267,8 @@ References:
    FormData.js:35:24
     35| a.set('bar', new Blob, 2) // incorrect
                                ^ [1]
-   <BUILTINS>/bom.js:566:47
-   566|     set(name: string, value: Blob, filename?: string): void;
+   <BUILTINS>/bom.js:587:47
+   587|     set(name: string, value: Blob, filename?: string): void;
                                                       ^^^^^^ [2]
 
 
@@ -286,11 +286,11 @@ References:
    FormData.js:39:17
     39| a.append('foo', {}); // incorrect
                         ^^ [1]
-   <BUILTINS>/bom.js:570:33
-   570|     append(name: string, value: Blob, filename?: string): void;
+   <BUILTINS>/bom.js:591:33
+   591|     append(name: string, value: Blob, filename?: string): void;
                                         ^^^^ [2]
-   <BUILTINS>/bom.js:571:33
-   571|     append(name: string, value: File, filename?: string): void;
+   <BUILTINS>/bom.js:592:33
+   592|     append(name: string, value: File, filename?: string): void;
                                         ^^^^ [3]
 
 
@@ -309,14 +309,14 @@ References:
    FormData.js:40:10
     40| a.append(2, 'bar'); // incorrect
                  ^ [1]
-   <BUILTINS>/bom.js:569:18
-   569|     append(name: string, value: string): void;
+   <BUILTINS>/bom.js:590:18
+   590|     append(name: string, value: string): void;
                          ^^^^^^ [2]
-   <BUILTINS>/bom.js:570:18
-   570|     append(name: string, value: Blob, filename?: string): void;
+   <BUILTINS>/bom.js:591:18
+   591|     append(name: string, value: Blob, filename?: string): void;
                          ^^^^^^ [3]
-   <BUILTINS>/bom.js:571:18
-   571|     append(name: string, value: File, filename?: string): void;
+   <BUILTINS>/bom.js:592:18
+   592|     append(name: string, value: File, filename?: string): void;
                          ^^^^^^ [4]
 
 
@@ -334,11 +334,11 @@ References:
    FormData.js:41:17
     41| a.append('foo', 'bar', 'baz'); // incorrect
                         ^^^^^ [1]
-   <BUILTINS>/bom.js:570:33
-   570|     append(name: string, value: Blob, filename?: string): void;
+   <BUILTINS>/bom.js:591:33
+   591|     append(name: string, value: Blob, filename?: string): void;
                                         ^^^^ [2]
-   <BUILTINS>/bom.js:571:33
-   571|     append(name: string, value: File, filename?: string): void;
+   <BUILTINS>/bom.js:592:33
+   592|     append(name: string, value: File, filename?: string): void;
                                         ^^^^ [3]
 
 
@@ -356,11 +356,11 @@ References:
    FormData.js:45:36
     45| a.append('bar', new File([], 'q'), 2) // incorrect
                                            ^ [1]
-   <BUILTINS>/bom.js:570:50
-   570|     append(name: string, value: Blob, filename?: string): void;
+   <BUILTINS>/bom.js:591:50
+   591|     append(name: string, value: Blob, filename?: string): void;
                                                          ^^^^^^ [2]
-   <BUILTINS>/bom.js:571:50
-   571|     append(name: string, value: File, filename?: string): void;
+   <BUILTINS>/bom.js:592:50
+   592|     append(name: string, value: File, filename?: string): void;
                                                          ^^^^^^ [3]
 
 
@@ -376,8 +376,8 @@ References:
    FormData.js:48:27
     48| a.append('bar', new Blob, 2) // incorrect
                                   ^ [1]
-   <BUILTINS>/bom.js:570:50
-   570|     append(name: string, value: Blob, filename?: string): void;
+   <BUILTINS>/bom.js:591:50
+   591|     append(name: string, value: Blob, filename?: string): void;
                                                          ^^^^^^ [2]
 
 
@@ -390,8 +390,8 @@ Cannot call `a.delete` with `3` bound to `name` because number [1] is incompatib
                  ^ [1]
 
 References:
-   <BUILTINS>/bom.js:573:18
-   573|     delete(name: string): void;
+   <BUILTINS>/bom.js:594:18
+   594|     delete(name: string): void;
                          ^^^^^^ [2]
 
 
@@ -404,8 +404,8 @@ Cannot assign `x` to `x` because string [1] is incompatible with number [2]. [in
                               ^^^^^^^^
 
 References:
-   <BUILTINS>/bom.js:575:22
-   575|     keys(): Iterator<string>;
+   <BUILTINS>/bom.js:596:22
+   596|     keys(): Iterator<string>;
                              ^^^^^^ [1]
    FormData.js:56:13
     56| for (let x: number of a.keys()) {} // incorrect
@@ -425,8 +425,8 @@ References:
    FormData.js:64:43
     64| for (let [x, y]: [string, string | File | Blob] of a.entries()) {} // incorrect
                                                   ^^^^ [1]
-   <BUILTINS>/bom.js:556:36
-   556| type FormDataEntryValue = string | File
+   <BUILTINS>/bom.js:577:36
+   577| type FormDataEntryValue = string | File
                                            ^^^^ [2]
 
 
@@ -440,8 +440,8 @@ Cannot assign for-of element to destructuring because string [1] is incompatible
                                              ^^^^^^^^^^^
 
 References:
-   <BUILTINS>/bom.js:577:26
-   577|     entries(): Iterator<[string, FormDataEntryValue]>;
+   <BUILTINS>/bom.js:598:26
+   598|     entries(): Iterator<[string, FormDataEntryValue]>;
                                  ^^^^^^ [1]
    FormData.js:65:19
     65| for (let [x, y]: [number, string] of a.entries()) {} // incorrect
@@ -458,8 +458,8 @@ Cannot assign for-of element to destructuring because `File` [1] is incompatible
                                              ^^^^^^^^^^^
 
 References:
-   <BUILTINS>/bom.js:577:34
-   577|     entries(): Iterator<[string, FormDataEntryValue]>;
+   <BUILTINS>/bom.js:598:34
+   598|     entries(): Iterator<[string, FormDataEntryValue]>;
                                          ^^^^^^^^^^^^^^^^^^ [1]
    FormData.js:65:27
     65| for (let [x, y]: [number, string] of a.entries()) {} // incorrect
@@ -476,8 +476,8 @@ Cannot assign for-of element to destructuring because `File` [1] is incompatible
                                              ^^^^^^^^^^^
 
 References:
-   <BUILTINS>/bom.js:577:34
-   577|     entries(): Iterator<[string, FormDataEntryValue]>;
+   <BUILTINS>/bom.js:598:34
+   598|     entries(): Iterator<[string, FormDataEntryValue]>;
                                          ^^^^^^^^^^^^^^^^^^ [1]
    FormData.js:66:27
     66| for (let [x, y]: [string, number] of a.entries()) {} // incorrect
@@ -494,8 +494,8 @@ Cannot assign for-of element to destructuring because string [1] is incompatible
                                              ^^^^^^^^^^^
 
 References:
-   <BUILTINS>/bom.js:577:34
-   577|     entries(): Iterator<[string, FormDataEntryValue]>;
+   <BUILTINS>/bom.js:598:34
+   598|     entries(): Iterator<[string, FormDataEntryValue]>;
                                          ^^^^^^^^^^^^^^^^^^ [1]
    FormData.js:66:27
     66| for (let [x, y]: [string, number] of a.entries()) {} // incorrect
@@ -515,8 +515,8 @@ References:
    FormData.js:66:27
     66| for (let [x, y]: [string, number] of a.entries()) {} // incorrect
                                   ^^^^^^ [1]
-   <BUILTINS>/bom.js:556:27
-   556| type FormDataEntryValue = string | File
+   <BUILTINS>/bom.js:577:27
+   577| type FormDataEntryValue = string | File
                                   ^^^^^^ [2]
 
 
@@ -530,8 +530,8 @@ Cannot assign for-of element to destructuring because string [1] is incompatible
                                              ^^^^^^^^^^^
 
 References:
-   <BUILTINS>/bom.js:577:26
-   577|     entries(): Iterator<[string, FormDataEntryValue]>;
+   <BUILTINS>/bom.js:598:26
+   598|     entries(): Iterator<[string, FormDataEntryValue]>;
                                  ^^^^^^ [1]
    FormData.js:67:19
     67| for (let [x, y]: [number, number] of a.entries()) {} // incorrect
@@ -548,8 +548,8 @@ Cannot assign for-of element to destructuring because `File` [1] is incompatible
                                              ^^^^^^^^^^^
 
 References:
-   <BUILTINS>/bom.js:577:34
-   577|     entries(): Iterator<[string, FormDataEntryValue]>;
+   <BUILTINS>/bom.js:598:34
+   598|     entries(): Iterator<[string, FormDataEntryValue]>;
                                          ^^^^^^^^^^^^^^^^^^ [1]
    FormData.js:67:27
     67| for (let [x, y]: [number, number] of a.entries()) {} // incorrect
@@ -566,8 +566,8 @@ Cannot assign for-of element to destructuring because string [1] is incompatible
                                              ^^^^^^^^^^^
 
 References:
-   <BUILTINS>/bom.js:577:34
-   577|     entries(): Iterator<[string, FormDataEntryValue]>;
+   <BUILTINS>/bom.js:598:34
+   598|     entries(): Iterator<[string, FormDataEntryValue]>;
                                          ^^^^^^^^^^^^^^^^^^ [1]
    FormData.js:67:27
     67| for (let [x, y]: [number, number] of a.entries()) {} // incorrect
@@ -587,8 +587,8 @@ References:
    FormData.js:67:27
     67| for (let [x, y]: [number, number] of a.entries()) {} // incorrect
                                   ^^^^^^ [1]
-   <BUILTINS>/bom.js:556:27
-   556| type FormDataEntryValue = string | File
+   <BUILTINS>/bom.js:577:27
+   577| type FormDataEntryValue = string | File
                                   ^^^^^^ [2]
 
 
@@ -601,8 +601,8 @@ Cannot assign `headers.get(...)` to `b` because null [1] is incompatible with st
                            ^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/bom.js:1501:24
-   1501|     get(name: string): null | string;
+   <BUILTINS>/bom.js:1522:24
+   1522|     get(name: string): null | string;
                                 ^^^^ [1]
    Headers.js:8:10
       8| const b: string = headers.get('foo'); // incorrect
@@ -633,8 +633,8 @@ Cannot call `MutationObserver` because function [1] requires another argument. [
             ^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/bom.js:606:5
-   606|     constructor(callback: (arr: Array<MutationRecord>, observer: MutationObserver) => mixed): void;
+   <BUILTINS>/bom.js:627:5
+   627|     constructor(callback: (arr: Array<MutationRecord>, observer: MutationObserver) => mixed): void;
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 
@@ -648,8 +648,8 @@ Cannot call `MutationObserver` with `42` bound to `callback` because number [1] 
                              ^^ [1]
 
 References:
-   <BUILTINS>/bom.js:606:27
-   606|     constructor(callback: (arr: Array<MutationRecord>, observer: MutationObserver) => mixed): void;
+   <BUILTINS>/bom.js:627:27
+   627|     constructor(callback: (arr: Array<MutationRecord>, observer: MutationObserver) => mixed): void;
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [2]
 
 
@@ -663,8 +663,8 @@ in the first parameter. [incompatible-call]
                                  ^^^^^^ [1]
 
 References:
-   <BUILTINS>/bom.js:606:33
-   606|     constructor(callback: (arr: Array<MutationRecord>, observer: MutationObserver) => mixed): void;
+   <BUILTINS>/bom.js:627:33
+   627|     constructor(callback: (arr: Array<MutationRecord>, observer: MutationObserver) => mixed): void;
                                         ^^^^^^^^^^^^^^^^^^^^^ [2]
 
 
@@ -677,8 +677,8 @@ Cannot call `o.observe` because function [1] requires another argument. [incompa
           ^^^^^^^
 
 References:
-   <BUILTINS>/bom.js:607:5
-   607|     observe(target: Node, options: MutationObserverInit): void;
+   <BUILTINS>/bom.js:628:5
+   628|     observe(target: Node, options: MutationObserverInit): void;
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 
@@ -697,14 +697,14 @@ References:
    MutationObserver.js:18:1
     18| o.observe(); // incorrect
         ^^^^^^^^^^^ [1]
-   <BUILTINS>/bom.js:593:7
-   593|     | { childList: true, ... }
+   <BUILTINS>/bom.js:614:7
+   614|     | { childList: true, ... }
               ^^^^^^^^^^^^^^^^^^^^^^^^ [2]
-   <BUILTINS>/bom.js:594:7
-   594|     | { attributes: true, ... }
+   <BUILTINS>/bom.js:615:7
+   615|     | { attributes: true, ... }
               ^^^^^^^^^^^^^^^^^^^^^^^^^ [3]
-   <BUILTINS>/bom.js:595:7
-   595|     | { characterData: true, ... }
+   <BUILTINS>/bom.js:616:7
+   616|     | { characterData: true, ... }
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [4]
 
 
@@ -717,8 +717,8 @@ Cannot call `o.observe` because function [1] requires another argument. [incompa
           ^^^^^^^
 
 References:
-   <BUILTINS>/bom.js:607:5
-   607|     observe(target: Node, options: MutationObserverInit): void;
+   <BUILTINS>/bom.js:628:5
+   628|     observe(target: Node, options: MutationObserverInit): void;
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 
@@ -737,14 +737,14 @@ References:
    MutationObserver.js:19:1
     19| o.observe('invalid'); // incorrect
         ^^^^^^^^^^^^^^^^^^^^ [1]
-   <BUILTINS>/bom.js:593:7
-   593|     | { childList: true, ... }
+   <BUILTINS>/bom.js:614:7
+   614|     | { childList: true, ... }
               ^^^^^^^^^^^^^^^^^^^^^^^^ [2]
-   <BUILTINS>/bom.js:594:7
-   594|     | { attributes: true, ... }
+   <BUILTINS>/bom.js:615:7
+   615|     | { attributes: true, ... }
               ^^^^^^^^^^^^^^^^^^^^^^^^^ [3]
-   <BUILTINS>/bom.js:595:7
-   595|     | { characterData: true, ... }
+   <BUILTINS>/bom.js:616:7
+   616|     | { characterData: true, ... }
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [4]
 
 
@@ -758,8 +758,8 @@ Cannot call `o.observe` with `'invalid'` bound to `target` because string [1] is
                   ^^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/bom.js:607:21
-   607|     observe(target: Node, options: MutationObserverInit): void;
+   <BUILTINS>/bom.js:628:21
+   628|     observe(target: Node, options: MutationObserverInit): void;
                             ^^^^ [2]
 
 
@@ -772,8 +772,8 @@ Cannot call `o.observe` because function [1] requires another argument. [incompa
           ^^^^^^^
 
 References:
-   <BUILTINS>/bom.js:607:5
-   607|     observe(target: Node, options: MutationObserverInit): void;
+   <BUILTINS>/bom.js:628:5
+   628|     observe(target: Node, options: MutationObserverInit): void;
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 
@@ -792,14 +792,14 @@ References:
    MutationObserver.js:20:1
     20| o.observe(div); // incorrect
         ^^^^^^^^^^^^^^ [1]
-   <BUILTINS>/bom.js:593:7
-   593|     | { childList: true, ... }
+   <BUILTINS>/bom.js:614:7
+   614|     | { childList: true, ... }
               ^^^^^^^^^^^^^^^^^^^^^^^^ [2]
-   <BUILTINS>/bom.js:594:7
-   594|     | { attributes: true, ... }
+   <BUILTINS>/bom.js:615:7
+   615|     | { attributes: true, ... }
               ^^^^^^^^^^^^^^^^^^^^^^^^^ [3]
-   <BUILTINS>/bom.js:595:7
-   595|     | { characterData: true, ... }
+   <BUILTINS>/bom.js:616:7
+   616|     | { characterData: true, ... }
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [4]
 
 
@@ -815,14 +815,14 @@ Cannot call `o.observe` with object literal bound to `options` because: [incompa
                        ^^ [1]
 
 References:
-   <BUILTINS>/bom.js:593:7
-   593|     | { childList: true, ... }
+   <BUILTINS>/bom.js:614:7
+   614|     | { childList: true, ... }
               ^^^^^^^^^^^^^^^^^^^^^^^^ [2]
-   <BUILTINS>/bom.js:594:7
-   594|     | { attributes: true, ... }
+   <BUILTINS>/bom.js:615:7
+   615|     | { attributes: true, ... }
               ^^^^^^^^^^^^^^^^^^^^^^^^^ [3]
-   <BUILTINS>/bom.js:595:7
-   595|     | { characterData: true, ... }
+   <BUILTINS>/bom.js:616:7
+   616|     | { characterData: true, ... }
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [4]
 
 
@@ -838,14 +838,14 @@ Cannot call `o.observe` with object literal bound to `options` because: [incompa
                        ^^^^^^^^^^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/bom.js:593:7
-   593|     | { childList: true, ... }
+   <BUILTINS>/bom.js:614:7
+   614|     | { childList: true, ... }
               ^^^^^^^^^^^^^^^^^^^^^^^^ [2]
-   <BUILTINS>/bom.js:594:7
-   594|     | { attributes: true, ... }
+   <BUILTINS>/bom.js:615:7
+   615|     | { attributes: true, ... }
               ^^^^^^^^^^^^^^^^^^^^^^^^^ [3]
-   <BUILTINS>/bom.js:595:7
-   595|     | { characterData: true, ... }
+   <BUILTINS>/bom.js:616:7
+   616|     | { characterData: true, ... }
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [4]
 
 
@@ -859,8 +859,8 @@ in property `attributeFilter`. [incompatible-call]
                                                             ^^^^ [1]
 
 References:
-   <BUILTINS>/bom.js:601:21
-   601|   attributeFilter?: Array<string>,
+   <BUILTINS>/bom.js:622:21
+   622|   attributeFilter?: Array<string>,
                             ^^^^^^^^^^^^^ [2]
 
 
@@ -873,8 +873,8 @@ Cannot assign `params.get(...)` to `b` because null [1] is incompatible with str
                            ^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/bom.js:1515:24
-   1515|     get(name: string): null | string;
+   <BUILTINS>/bom.js:1536:24
+   1536|     get(name: string): null | string;
                                 ^^^^ [1]
    URLSearchParams.js:8:10
       8| const b: string = params.get('foo'); // incorrect

--- a/tests/fetch/fetch.exp
+++ b/tests/fetch/fetch.exp
@@ -8,8 +8,8 @@ Cannot assign `fetch(...)` to `b` because `Response` [1] is incompatible with st
                                     ^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/bom.js:1627:76
-   1627| declare function fetch(input: RequestInfo, init?: RequestOptions): Promise<Response>;
+   <BUILTINS>/bom.js:1648:76
+   1648| declare function fetch(input: RequestInfo, init?: RequestOptions): Promise<Response>;
                                                                                     ^^^^^^^^ [1]
    fetch.js:12:18
      12| const b: Promise<string> = fetch(myRequest); // incorrect
@@ -32,8 +32,8 @@ References:
    fetch.js:25:18
      25| const d: Promise<Blob> = fetch('image.png'); // incorrect
                           ^^^^ [1]
-   <BUILTINS>/bom.js:1627:76
-   1627| declare function fetch(input: RequestInfo, init?: RequestOptions): Promise<Response>;
+   <BUILTINS>/bom.js:1648:76
+   1648| declare function fetch(input: RequestInfo, init?: RequestOptions): Promise<Response>;
                                                                                     ^^^^^^^^ [2]
    <BUILTINS>/core.js:1841:24
    1841| declare class Promise<+R = mixed> {
@@ -52,14 +52,14 @@ Cannot call `Headers` with `''Content-T...'` bound to `init` because: [incompati
                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/bom.js:1489:20
-   1489| type HeadersInit = Headers | Array<[string, string]> | { [key: string]: string, ... };
+   <BUILTINS>/bom.js:1510:20
+   1510| type HeadersInit = Headers | Array<[string, string]> | { [key: string]: string, ... };
                             ^^^^^^^ [2]
-   <BUILTINS>/bom.js:1489:30
-   1489| type HeadersInit = Headers | Array<[string, string]> | { [key: string]: string, ... };
+   <BUILTINS>/bom.js:1510:30
+   1510| type HeadersInit = Headers | Array<[string, string]> | { [key: string]: string, ... };
                                       ^^^^^^^^^^^^^^^^^^^^^^^ [3]
-   <BUILTINS>/bom.js:1489:56
-   1489| type HeadersInit = Headers | Array<[string, string]> | { [key: string]: string, ... };
+   <BUILTINS>/bom.js:1510:56
+   1510| type HeadersInit = Headers | Array<[string, string]> | { [key: string]: string, ... };
                                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [4]
 
 
@@ -76,8 +76,8 @@ References:
    headers.js:4:24
       4| const b = new Headers(['Content-Type', 'image/jpeg']); // not correct
                                 ^^^^^^^^^^^^^^ [1]
-   <BUILTINS>/bom.js:1489:36
-   1489| type HeadersInit = Headers | Array<[string, string]> | { [key: string]: string, ... };
+   <BUILTINS>/bom.js:1510:36
+   1510| type HeadersInit = Headers | Array<[string, string]> | { [key: string]: string, ... };
                                             ^^^^^^^^^^^^^^^^ [2]
 
 
@@ -90,8 +90,8 @@ Cannot call `e.append` because function [1] requires another argument. [incompat
            ^^^^^^
 
 References:
-   <BUILTINS>/bom.js:1497:5
-   1497|     append(name: string, value: string): void;
+   <BUILTINS>/bom.js:1518:5
+   1518|     append(name: string, value: string): void;
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 
@@ -104,8 +104,8 @@ Cannot call `e.append` because function [1] requires another argument. [incompat
            ^^^^^^
 
 References:
-   <BUILTINS>/bom.js:1497:5
-   1497|     append(name: string, value: string): void;
+   <BUILTINS>/bom.js:1518:5
+   1518|     append(name: string, value: string): void;
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 
@@ -119,8 +119,8 @@ Cannot call `e.append` with object literal bound to `name` because object litera
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/bom.js:1497:18
-   1497|     append(name: string, value: string): void;
+   <BUILTINS>/bom.js:1518:18
+   1518|     append(name: string, value: string): void;
                           ^^^^^^ [2]
 
 
@@ -133,8 +133,8 @@ Cannot call `e.set` because function [1] requires another argument. [incompatibl
            ^^^
 
 References:
-   <BUILTINS>/bom.js:1504:5
-   1504|     set(name: string, value: string): void;
+   <BUILTINS>/bom.js:1525:5
+   1525|     set(name: string, value: string): void;
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 
@@ -147,8 +147,8 @@ Cannot call `e.set` because function [1] requires another argument. [incompatibl
            ^^^
 
 References:
-   <BUILTINS>/bom.js:1504:5
-   1504|     set(name: string, value: string): void;
+   <BUILTINS>/bom.js:1525:5
+   1525|     set(name: string, value: string): void;
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 
@@ -162,8 +162,8 @@ Cannot call `e.set` with object literal bound to `name` because object literal [
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/bom.js:1504:15
-   1504|     set(name: string, value: string): void;
+   <BUILTINS>/bom.js:1525:15
+   1525|     set(name: string, value: string): void;
                        ^^^^^^ [2]
 
 
@@ -176,8 +176,8 @@ Cannot assign `e.append(...)` to `f` because undefined [1] is incompatible with 
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/bom.js:1497:42
-   1497|     append(name: string, value: string): void;
+   <BUILTINS>/bom.js:1518:42
+   1518|     append(name: string, value: string): void;
                                                   ^^^^ [1]
    headers.js:15:10
      15| const f: Headers = e.append('Content-Type', 'image/jpeg'); // not correct
@@ -193,8 +193,8 @@ Cannot assign `e.get(...)` to `g` because null [1] is incompatible with string [
                            ^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/bom.js:1501:24
-   1501|     get(name: string): null | string;
+   <BUILTINS>/bom.js:1522:24
+   1522|     get(name: string): null | string;
                                 ^^^^ [1]
    headers.js:17:10
      17| const g: string = e.get('Content-Type'); // correct
@@ -210,8 +210,8 @@ Cannot assign `e.get(...)` to `h` because null [1] is incompatible with number [
                            ^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/bom.js:1501:24
-   1501|     get(name: string): null | string;
+   <BUILTINS>/bom.js:1522:24
+   1522|     get(name: string): null | string;
                                 ^^^^ [1]
    headers.js:18:10
      18| const h: number = e.get('Content-Type'); // not correct
@@ -227,8 +227,8 @@ Cannot assign `e.get(...)` to `h` because string [1] is incompatible with number
                            ^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/bom.js:1501:31
-   1501|     get(name: string): null | string;
+   <BUILTINS>/bom.js:1522:31
+   1522|     get(name: string): null | string;
                                        ^^^^^^ [1]
    headers.js:18:10
      18| const h: number = e.get('Content-Type'); // not correct
@@ -264,14 +264,14 @@ References:
    request.js:2:20
       2| const a: Request = new Request(); // incorrect
                             ^^^^^^^^^^^^^ [1]
-   <BUILTINS>/bom.js:1536:20
-   1536| type RequestInfo = Request | URL | string;
+   <BUILTINS>/bom.js:1557:20
+   1557| type RequestInfo = Request | URL | string;
                             ^^^^^^^ [2]
-   <BUILTINS>/bom.js:1536:30
-   1536| type RequestInfo = Request | URL | string;
+   <BUILTINS>/bom.js:1557:30
+   1557| type RequestInfo = Request | URL | string;
                                       ^^^ [3]
-   <BUILTINS>/bom.js:1536:36
-   1536| type RequestInfo = Request | URL | string;
+   <BUILTINS>/bom.js:1557:36
+   1557| type RequestInfo = Request | URL | string;
                                             ^^^^^^ [4]
 
 
@@ -289,8 +289,8 @@ References:
    request.js:4:10
       4| const c: Request = new Request(b); // correct
                   ^^^^^^^ [1]
-   <BUILTINS>/bom.js:1589:44
-   1589|     constructor(input: RequestInfo, init?: RequestOptions): void;
+   <BUILTINS>/bom.js:1610:44
+   1610|     constructor(input: RequestInfo, init?: RequestOptions): void;
                                                     ^^^^^^^^^^^^^^ [2]
 
 
@@ -307,8 +307,8 @@ References:
    request.js:4:10
       4| const c: Request = new Request(b); // correct
                   ^^^^^^^ [1]
-   <BUILTINS>/bom.js:1589:44
-   1589|     constructor(input: RequestInfo, init?: RequestOptions): void;
+   <BUILTINS>/bom.js:1610:44
+   1610|     constructor(input: RequestInfo, init?: RequestOptions): void;
                                                     ^^^^^^^^^^^^^^ [2]
 
 
@@ -322,11 +322,11 @@ Cannot call `Request` with `c` bound to `init` because literal union [1] is inco
                                            ^
 
 References:
-   <BUILTINS>/bom.js:1594:12
-   1594|     cache: CacheType;
+   <BUILTINS>/bom.js:1615:12
+   1615|     cache: CacheType;
                     ^^^^^^^^^ [1]
-   <BUILTINS>/bom.js:1540:11
-   1540|   cache?: CacheType,
+   <BUILTINS>/bom.js:1561:11
+   1561|   cache?: CacheType,
                    ^^^^^^^^^ [2]
 
 
@@ -340,11 +340,11 @@ Cannot call `Request` with `c` bound to `init` because literal union [1] is inco
                                            ^
 
 References:
-   <BUILTINS>/bom.js:1595:18
-   1595|     credentials: CredentialsType;
+   <BUILTINS>/bom.js:1616:18
+   1616|     credentials: CredentialsType;
                           ^^^^^^^^^^^^^^^ [1]
-   <BUILTINS>/bom.js:1541:17
-   1541|   credentials?: CredentialsType,
+   <BUILTINS>/bom.js:1562:17
+   1562|   credentials?: CredentialsType,
                          ^^^^^^^^^^^^^^^ [2]
 
 
@@ -358,11 +358,11 @@ Cannot call `Request` with `c` bound to `init` because `Headers` [1] is incompat
                                            ^
 
 References:
-   <BUILTINS>/bom.js:1596:14
-   1596|     headers: Headers;
+   <BUILTINS>/bom.js:1617:14
+   1617|     headers: Headers;
                       ^^^^^^^ [1]
-   <BUILTINS>/bom.js:1542:13
-   1542|   headers?: HeadersInit,
+   <BUILTINS>/bom.js:1563:13
+   1563|   headers?: HeadersInit,
                      ^^^^^^^^^^^ [2]
 
 
@@ -376,11 +376,11 @@ Cannot call `Request` with `c` bound to `init` because `Headers` [1] is incompat
                                            ^
 
 References:
-   <BUILTINS>/bom.js:1596:14
-   1596|     headers: Headers;
+   <BUILTINS>/bom.js:1617:14
+   1617|     headers: Headers;
                       ^^^^^^^ [1]
-   <BUILTINS>/bom.js:1542:13
-   1542|   headers?: HeadersInit,
+   <BUILTINS>/bom.js:1563:13
+   1563|   headers?: HeadersInit,
                      ^^^^^^^^^^^ [2]
 
 
@@ -394,11 +394,11 @@ Cannot call `Request` with `c` bound to `init` because `Headers` [1] is incompat
                                            ^
 
 References:
-   <BUILTINS>/bom.js:1596:14
-   1596|     headers: Headers;
+   <BUILTINS>/bom.js:1617:14
+   1617|     headers: Headers;
                       ^^^^^^^ [1]
-   <BUILTINS>/bom.js:1542:13
-   1542|   headers?: HeadersInit,
+   <BUILTINS>/bom.js:1563:13
+   1563|   headers?: HeadersInit,
                      ^^^^^^^^^^^ [2]
 
 
@@ -412,11 +412,11 @@ Cannot call `Request` with `c` bound to `init` because string [1] is incompatibl
                                            ^
 
 References:
-   <BUILTINS>/bom.js:1597:16
-   1597|     integrity: string;
+   <BUILTINS>/bom.js:1618:16
+   1618|     integrity: string;
                         ^^^^^^ [1]
-   <BUILTINS>/bom.js:1543:15
-   1543|   integrity?: string,
+   <BUILTINS>/bom.js:1564:15
+   1564|   integrity?: string,
                        ^^^^^^ [2]
 
 
@@ -430,11 +430,11 @@ Cannot call `Request` with `c` bound to `init` because string [1] is incompatibl
                                            ^
 
 References:
-   <BUILTINS>/bom.js:1598:13
-   1598|     method: string;
+   <BUILTINS>/bom.js:1619:13
+   1619|     method: string;
                      ^^^^^^ [1]
-   <BUILTINS>/bom.js:1545:12
-   1545|   method?: string,
+   <BUILTINS>/bom.js:1566:12
+   1566|   method?: string,
                     ^^^^^^ [2]
 
 
@@ -448,11 +448,11 @@ Cannot call `Request` with `c` bound to `init` because literal union [1] is inco
                                            ^
 
 References:
-   <BUILTINS>/bom.js:1599:11
-   1599|     mode: ModeType;
+   <BUILTINS>/bom.js:1620:11
+   1620|     mode: ModeType;
                    ^^^^^^^^ [1]
-   <BUILTINS>/bom.js:1546:10
-   1546|   mode?: ModeType,
+   <BUILTINS>/bom.js:1567:10
+   1567|   mode?: ModeType,
                   ^^^^^^^^ [2]
 
 
@@ -466,11 +466,11 @@ Cannot call `Request` with `c` bound to `init` because literal union [1] is inco
                                            ^
 
 References:
-   <BUILTINS>/bom.js:1600:15
-   1600|     redirect: RedirectType;
+   <BUILTINS>/bom.js:1621:15
+   1621|     redirect: RedirectType;
                        ^^^^^^^^^^^^ [1]
-   <BUILTINS>/bom.js:1547:14
-   1547|   redirect?: RedirectType,
+   <BUILTINS>/bom.js:1568:14
+   1568|   redirect?: RedirectType,
                       ^^^^^^^^^^^^ [2]
 
 
@@ -484,11 +484,11 @@ Cannot call `Request` with `c` bound to `init` because string [1] is incompatibl
                                            ^
 
 References:
-   <BUILTINS>/bom.js:1601:15
-   1601|     referrer: string;
+   <BUILTINS>/bom.js:1622:15
+   1622|     referrer: string;
                        ^^^^^^ [1]
-   <BUILTINS>/bom.js:1548:14
-   1548|   referrer?: string,
+   <BUILTINS>/bom.js:1569:14
+   1569|   referrer?: string,
                       ^^^^^^ [2]
 
 
@@ -502,11 +502,11 @@ Cannot call `Request` with `c` bound to `init` because literal union [1] is inco
                                            ^
 
 References:
-   <BUILTINS>/bom.js:1602:21
-   1602|     referrerPolicy: ReferrerPolicyType;
+   <BUILTINS>/bom.js:1623:21
+   1623|     referrerPolicy: ReferrerPolicyType;
                              ^^^^^^^^^^^^^^^^^^ [1]
-   <BUILTINS>/bom.js:1549:20
-   1549|   referrerPolicy?: ReferrerPolicyType,
+   <BUILTINS>/bom.js:1570:20
+   1570|   referrerPolicy?: ReferrerPolicyType,
                             ^^^^^^^^^^^^^^^^^^ [2]
 
 
@@ -521,11 +521,11 @@ Cannot call `Request` with object literal bound to `input` because: [incompatibl
                                         ^^ [1]
 
 References:
-   <BUILTINS>/bom.js:1536:20
-   1536| type RequestInfo = Request | URL | string;
+   <BUILTINS>/bom.js:1557:20
+   1557| type RequestInfo = Request | URL | string;
                             ^^^^^^^ [2]
-   <BUILTINS>/bom.js:1536:30
-   1536| type RequestInfo = Request | URL | string;
+   <BUILTINS>/bom.js:1557:30
+   1557| type RequestInfo = Request | URL | string;
                                       ^^^ [3]
 
 
@@ -542,8 +542,8 @@ References:
    request.js:24:19
      24| h.text().then((t: Buffer) => t); // incorrect
                            ^^^^^^ [1]
-   <BUILTINS>/bom.js:1612:21
-   1612|     text(): Promise<string>;
+   <BUILTINS>/bom.js:1633:21
+   1633|     text(): Promise<string>;
                              ^^^^^^ [2]
 
 
@@ -557,8 +557,8 @@ Cannot call `h.arrayBuffer().then` because `ArrayBuffer` [1] is incompatible wit
                          ^^^^
 
 References:
-   <BUILTINS>/bom.js:1608:28
-   1608|     arrayBuffer(): Promise<ArrayBuffer>;
+   <BUILTINS>/bom.js:1629:28
+   1629|     arrayBuffer(): Promise<ArrayBuffer>;
                                     ^^^^^^^^^^^ [1]
    request.js:26:27
      26| h.arrayBuffer().then((ab: Buffer) => ab); // incorrect
@@ -577,14 +577,14 @@ Cannot call `Request` with object literal bound to `init` because in property `h
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/bom.js:1489:20
-   1489| type HeadersInit = Headers | Array<[string, string]> | { [key: string]: string, ... };
+   <BUILTINS>/bom.js:1510:20
+   1510| type HeadersInit = Headers | Array<[string, string]> | { [key: string]: string, ... };
                             ^^^^^^^ [2]
-   <BUILTINS>/bom.js:1489:30
-   1489| type HeadersInit = Headers | Array<[string, string]> | { [key: string]: string, ... };
+   <BUILTINS>/bom.js:1510:30
+   1510| type HeadersInit = Headers | Array<[string, string]> | { [key: string]: string, ... };
                                       ^^^^^^^^^^^^^^^^^^^^^^^ [3]
-   <BUILTINS>/bom.js:1489:56
-   1489| type HeadersInit = Headers | Array<[string, string]> | { [key: string]: string, ... };
+   <BUILTINS>/bom.js:1510:56
+   1510| type HeadersInit = Headers | Array<[string, string]> | { [key: string]: string, ... };
                                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [4]
 
 
@@ -598,8 +598,8 @@ Cannot call `Request` with object literal bound to `init` because null [1] is in
                                     ^^^^ [1]
 
 References:
-   <BUILTINS>/bom.js:1545:12
-   1545|   method?: string,
+   <BUILTINS>/bom.js:1566:12
+   1566|   method?: string,
                     ^^^^^^ [2]
 
 
@@ -613,8 +613,8 @@ property `status`. [incompatible-call]
                                     ^^^^^ [1]
 
 References:
-   <BUILTINS>/bom.js:1556:12
-   1556|   status?: number,
+   <BUILTINS>/bom.js:1577:12
+   1577|   status?: number,
                     ^^^^^^ [2]
 
 
@@ -628,8 +628,8 @@ Cannot call `Response` with object literal bound to `init` because null [1] is i
                                     ^^^^ [1]
 
 References:
-   <BUILTINS>/bom.js:1556:12
-   1556|   status?: number,
+   <BUILTINS>/bom.js:1577:12
+   1577|   status?: number,
                     ^^^^^^ [2]
 
 
@@ -645,14 +645,14 @@ Cannot call `Response` with object literal bound to `init` because in property `
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/bom.js:1489:20
-   1489| type HeadersInit = Headers | Array<[string, string]> | { [key: string]: string, ... };
+   <BUILTINS>/bom.js:1510:20
+   1510| type HeadersInit = Headers | Array<[string, string]> | { [key: string]: string, ... };
                             ^^^^^^^ [2]
-   <BUILTINS>/bom.js:1489:30
-   1489| type HeadersInit = Headers | Array<[string, string]> | { [key: string]: string, ... };
+   <BUILTINS>/bom.js:1510:30
+   1510| type HeadersInit = Headers | Array<[string, string]> | { [key: string]: string, ... };
                                       ^^^^^^^^^^^^^^^^^^^^^^^ [3]
-   <BUILTINS>/bom.js:1489:56
-   1489| type HeadersInit = Headers | Array<[string, string]> | { [key: string]: string, ... };
+   <BUILTINS>/bom.js:1510:56
+   1510| type HeadersInit = Headers | Array<[string, string]> | { [key: string]: string, ... };
                                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [4]
 
 
@@ -680,17 +680,17 @@ Cannot call `Response` with object literal bound to `input` because: [incompatib
          ^ [1]
 
 References:
-   <BUILTINS>/bom.js:1534:26
-   1534| type BodyInit = string | URLSearchParams | FormData | Blob | ArrayBuffer | $ArrayBufferView | ReadableStream;
+   <BUILTINS>/bom.js:1555:26
+   1555| type BodyInit = string | URLSearchParams | FormData | Blob | ArrayBuffer | $ArrayBufferView | ReadableStream;
                                   ^^^^^^^^^^^^^^^ [2]
-   <BUILTINS>/bom.js:1534:44
-   1534| type BodyInit = string | URLSearchParams | FormData | Blob | ArrayBuffer | $ArrayBufferView | ReadableStream;
+   <BUILTINS>/bom.js:1555:44
+   1555| type BodyInit = string | URLSearchParams | FormData | Blob | ArrayBuffer | $ArrayBufferView | ReadableStream;
                                                     ^^^^^^^^ [3]
-   <BUILTINS>/bom.js:1534:55
-   1534| type BodyInit = string | URLSearchParams | FormData | Blob | ArrayBuffer | $ArrayBufferView | ReadableStream;
+   <BUILTINS>/bom.js:1555:55
+   1555| type BodyInit = string | URLSearchParams | FormData | Blob | ArrayBuffer | $ArrayBufferView | ReadableStream;
                                                                ^^^^ [4]
-   <BUILTINS>/bom.js:1534:62
-   1534| type BodyInit = string | URLSearchParams | FormData | Blob | ArrayBuffer | $ArrayBufferView | ReadableStream;
+   <BUILTINS>/bom.js:1555:62
+   1555| type BodyInit = string | URLSearchParams | FormData | Blob | ArrayBuffer | $ArrayBufferView | ReadableStream;
                                                                       ^^^^^^^^^^^ [5]
    <BUILTINS>/core.js:1961:20
    1961| type $TypedArray = $TypedArrayNumber | BigInt64Array | BigUint64Array;
@@ -704,8 +704,8 @@ References:
    <BUILTINS>/core.js:1957:39
    1957| type $ArrayBufferView = $TypedArray | DataView;
                                                ^^^^^^^^ [9]
-   <BUILTINS>/bom.js:1534:95
-   1534| type BodyInit = string | URLSearchParams | FormData | Blob | ArrayBuffer | $ArrayBufferView | ReadableStream;
+   <BUILTINS>/bom.js:1555:95
+   1555| type BodyInit = string | URLSearchParams | FormData | Blob | ArrayBuffer | $ArrayBufferView | ReadableStream;
                                                                                                        ^^^^^^^^^^^^^^ [10]
 
 
@@ -722,8 +722,8 @@ References:
    response.js:42:19
      42| h.text().then((t: Buffer) => t); // incorrect
                            ^^^^^^ [1]
-   <BUILTINS>/bom.js:1585:21
-   1585|     text(): Promise<string>;
+   <BUILTINS>/bom.js:1606:21
+   1606|     text(): Promise<string>;
                              ^^^^^^ [2]
 
 
@@ -737,8 +737,8 @@ Cannot call `h.arrayBuffer().then` because `ArrayBuffer` [1] is incompatible wit
                          ^^^^
 
 References:
-   <BUILTINS>/bom.js:1581:28
-   1581|     arrayBuffer(): Promise<ArrayBuffer>;
+   <BUILTINS>/bom.js:1602:28
+   1602|     arrayBuffer(): Promise<ArrayBuffer>;
                                     ^^^^^^^^^^^ [1]
    response.js:44:27
      44| h.arrayBuffer().then((ab: Buffer) => ab); // incorrect
@@ -758,8 +758,8 @@ References:
    urlsearchparams.js:4:32
       4| const b = new URLSearchParams(['key1', 'value1']); // not correct
                                         ^^^^^^ [1]
-   <BUILTINS>/bom.js:1510:58
-   1510|     constructor(query?: string | URLSearchParams | Array<[string, string]> | { [string]: string, ... } ): void;
+   <BUILTINS>/bom.js:1531:58
+   1531|     constructor(query?: string | URLSearchParams | Array<[string, string]> | { [string]: string, ... } ): void;
                                                                   ^^^^^^^^^^^^^^^^ [2]
 
 
@@ -772,8 +772,8 @@ Cannot call `e.append` because function [1] requires another argument. [incompat
            ^^^^^^
 
 References:
-   <BUILTINS>/bom.js:1511:5
-   1511|     append(name: string, value: string): void;
+   <BUILTINS>/bom.js:1532:5
+   1532|     append(name: string, value: string): void;
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 
@@ -786,8 +786,8 @@ Cannot call `e.append` because function [1] requires another argument. [incompat
            ^^^^^^
 
 References:
-   <BUILTINS>/bom.js:1511:5
-   1511|     append(name: string, value: string): void;
+   <BUILTINS>/bom.js:1532:5
+   1532|     append(name: string, value: string): void;
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 
@@ -801,8 +801,8 @@ Cannot call `e.append` with object literal bound to `name` because object litera
                   ^^^^^^^^^^^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/bom.js:1511:18
-   1511|     append(name: string, value: string): void;
+   <BUILTINS>/bom.js:1532:18
+   1532|     append(name: string, value: string): void;
                           ^^^^^^ [2]
 
 
@@ -815,8 +815,8 @@ Cannot call `e.set` because function [1] requires another argument. [incompatibl
            ^^^
 
 References:
-   <BUILTINS>/bom.js:1519:5
-   1519|     set(name: string, value: string): void;
+   <BUILTINS>/bom.js:1540:5
+   1540|     set(name: string, value: string): void;
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 
@@ -829,8 +829,8 @@ Cannot call `e.set` because function [1] requires another argument. [incompatibl
            ^^^
 
 References:
-   <BUILTINS>/bom.js:1519:5
-   1519|     set(name: string, value: string): void;
+   <BUILTINS>/bom.js:1540:5
+   1540|     set(name: string, value: string): void;
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 
@@ -844,8 +844,8 @@ Cannot call `e.set` with object literal bound to `name` because object literal [
                ^^^^^^^^^^^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/bom.js:1519:15
-   1519|     set(name: string, value: string): void;
+   <BUILTINS>/bom.js:1540:15
+   1540|     set(name: string, value: string): void;
                        ^^^^^^ [2]
 
 
@@ -859,8 +859,8 @@ Cannot assign `e.append(...)` to `f` because undefined [1] is incompatible with 
                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/bom.js:1511:42
-   1511|     append(name: string, value: string): void;
+   <BUILTINS>/bom.js:1532:42
+   1532|     append(name: string, value: string): void;
                                                   ^^^^ [1]
    urlsearchparams.js:15:10
      15| const f: URLSearchParams = e.append('key1', 'value1'); // not correct
@@ -876,8 +876,8 @@ Cannot assign `e.get(...)` to `g` because null [1] is incompatible with string [
                            ^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/bom.js:1515:24
-   1515|     get(name: string): null | string;
+   <BUILTINS>/bom.js:1536:24
+   1536|     get(name: string): null | string;
                                 ^^^^ [1]
    urlsearchparams.js:17:10
      17| const g: string = e.get('key1'); // correct
@@ -893,8 +893,8 @@ Cannot assign `e.get(...)` to `h` because null [1] is incompatible with number [
                            ^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/bom.js:1515:24
-   1515|     get(name: string): null | string;
+   <BUILTINS>/bom.js:1536:24
+   1536|     get(name: string): null | string;
                                 ^^^^ [1]
    urlsearchparams.js:18:10
      18| const h: number = e.get('key1'); // not correct
@@ -910,8 +910,8 @@ Cannot assign `e.get(...)` to `h` because string [1] is incompatible with number
                            ^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/bom.js:1515:31
-   1515|     get(name: string): null | string;
+   <BUILTINS>/bom.js:1536:31
+   1536|     get(name: string): null | string;
                                        ^^^^^^ [1]
    urlsearchparams.js:18:10
      18| const h: number = e.get('key1'); // not correct


### PR DESCRIPTION
Summary:
Expand the `Performance` typing with the `eventCounts`, [according to the W3C standard](https://www.w3.org/TR/event-timing/#sec-event-counts) (more detailed API description [can be found here](https://developer.mozilla.org/en-US/docs/Web/API/EventCounts)).

This is something that is implemented for web, and now we have it implemented in React Native as well, with the goal to be used in the performance APIs migrated from Comet.

Differential Revision: D44059718

