### PR TITLE
Update dom.js to include `rel` as part of the `HTMLFormElement` type declaration

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -3356,6 +3356,7 @@ declare class HTMLFormElement extends HTMLElement {
   length: number;
   method: string;
   name: string;
+  rel: string;
   target: string;
 
   checkValidity(): boolean;


### PR DESCRIPTION
`rel` is a [valid attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel) on the `<form>` element and should be included in the type declaration.