### PR TITLE
Use more maintained ocaml-opam/opam-repository-mingw in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -387,7 +387,7 @@ jobs:
           name: Init opam
           shell: C:/tools/cygwin/bin/bash.exe -leo pipefail
           command: |
-            opam init default 'https://github.com/fdopen/opam-repository-mingw.git#opam2' --bare --disable-sandboxing --no-setup
+            opam init default 'https://github.com/ocaml-opam/opam-repository-mingw.git#opam2' --bare --disable-sandboxing --no-setup
       - run:
           name: Create opam switch
           shell: C:/tools/cygwin/bin/bash.exe -leo pipefail


### PR DESCRIPTION
The fdopen one has not been updated since Nov 22, and the OCaml community has forked it. That one has been updated more regularly, and supports OCaml 4.14.1 and 5.