### PR TITLE
fix generateMap "mappings" attribute is empty

### DIFF
--- a/packages/flow-remove-types/index.js
+++ b/packages/flow-remove-types/index.js
@@ -136,11 +136,17 @@ function resultPrinter(options, source, removedNodes) {
       return (result += source.slice(lastPos));
     },
     generateMap: function () {
+      if(!pretty){
+        console.info('flow-remove-types: "pretty" option is false, '
+          + 'and the current version will generate a sourcemap. previously, '
+          + 'the "mappings" attribute of sourcemap was an empty string.'
+        );
+      }
       return {
         version: 3,
         sources: ['source.js'],
         names: [],
-        mappings: pretty ? generateSourceMappings(removedNodes) : '',
+        mappings: generateSourceMappings(removedNodes),
       };
     },
   };


### PR DESCRIPTION
if pretty option is false, generateMap will return empty string.

![screenshot-20230721-160902](https://github.com/facebook/flow/assets/13808186/6a775dc3-6657-43c0-b4aa-a48634396aa2)

rollup [transform](https://rollupjs.org/plugin-development/#transform) need null or real sourcemap (not empty string), and react build script used generateMap by [this way](https://github.com/facebook/react/blob/main/scripts/rollup/build.js#L372).