### PR TITLE
Update React types to use better AbstractComponent<>

### DIFF
--- a/lib/react.js
+++ b/lib/react.js
@@ -277,21 +277,21 @@ declare module react {
     ...
   };
 
-  declare export function forwardRef<Config, Instance>(
+  declare export function forwardRef<Config, Instance, Renders = React$Node>(
     render: (
       props: Config,
       ref: { current: null | Instance, ... } | ((null | Instance) => mixed),
-    ) => React$Node,
-  ): React$AbstractComponent<Config, Instance, React$Node>;
+    ) => Renders,
+  ): React$AbstractComponent<Config, Instance, Renders>;
 
-  declare export function memo<Config, Instance = mixed>(
-    component: React$AbstractComponent<Config, Instance, React$Node>,
+  declare export function memo<Config, Instance = mixed, Renders = React$Node>(
+    component: React$AbstractComponent<Config, Instance, Renders>,
     equal?: (Config, Config) => boolean,
-  ): React$AbstractComponent<Config, Instance, React$Node>;
+  ): React$AbstractComponent<Config, Instance, Renders>;
 
-  declare export function lazy<Config, Instance = mixed>(
-    component: () => Promise<{ default: React$AbstractComponent<Config, Instance, React$Node>, ... }>,
-  ): React$AbstractComponent<Config, Instance, React$Node>;
+  declare export function lazy<Config, Instance = mixed, Renders = React$Node>(
+    component: () => Promise<{ default: React$AbstractComponent<Config, Instance, Renders>, ... }>,
+  ): React$AbstractComponent<Config, Instance, Renders>;
 
   declare type MaybeCleanUpFn = void | (() => void);
   declare export type ReactSetStateFunction<S> = ((S => S) | S) => void;

--- a/tests/react_16_6/react_16_6.exp
+++ b/tests/react_16_6/react_16_6.exp
@@ -38,8 +38,8 @@ References:
      6| function FunctionComponent(x: Props): React.Node { return null }
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
    <BUILTINS>/react.js:293:22
-   293|     component: () => Promise<{ default: React$AbstractComponent<Config, Instance, React$Node>, ... }>,
-                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [2]
+   293|     component: () => Promise<{ default: React$AbstractComponent<Config, Instance, Renders>, ... }>,
+                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [2]
 
 
 Error ---------------------------------------------------------------------------------------------------- lazy.js:10:18
@@ -56,8 +56,8 @@ References:
      7| class ClassComponent extends React.Component<Props> {}
               ^^^^^^^^^^^^^^ [1]
    <BUILTINS>/react.js:293:22
-   293|     component: () => Promise<{ default: React$AbstractComponent<Config, Instance, React$Node>, ... }>,
-                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [2]
+   293|     component: () => Promise<{ default: React$AbstractComponent<Config, Instance, Renders>, ... }>,
+                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [2]
 
 
 Error ---------------------------------------------------------------------------------------------------- lazy.js:11:34
@@ -74,8 +74,8 @@ References:
       6| function FunctionComponent(x: Props): React.Node { return null }
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
    <BUILTINS>/react.js:293:30
-    293|     component: () => Promise<{ default: React$AbstractComponent<Config, Instance, React$Node>, ... }>,
-                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [2]
+    293|     component: () => Promise<{ default: React$AbstractComponent<Config, Instance, Renders>, ... }>,
+                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [2]
    <BUILTINS>/core.js:1878:24
    1878| declare class Promise<+R = mixed> {
                                 ^ [3]
@@ -95,8 +95,8 @@ References:
       7| class ClassComponent extends React.Component<Props> {}
                ^^^^^^^^^^^^^^ [1]
    <BUILTINS>/react.js:293:30
-    293|     component: () => Promise<{ default: React$AbstractComponent<Config, Instance, React$Node>, ... }>,
-                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [2]
+    293|     component: () => Promise<{ default: React$AbstractComponent<Config, Instance, Renders>, ... }>,
+                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [2]
    <BUILTINS>/core.js:1878:24
    1878| declare class Promise<+R = mixed> {
                                 ^ [3]

--- a/tests/type_at_pos_react/type_at_pos_react.exp
+++ b/tests/type_at_pos_react/type_at_pos_react.exp
@@ -1,4 +1,4 @@
-lazy_ref.js:14:9 = {default: React$AbstractComponent<empty, {moo(x: string): void}, React$Node>}
+lazy_ref.js:14:9 = {default: React$AbstractComponent<empty, {moo(x: string): void}, null>}
 lazy_ref.js:14:9,14:9
 lazy_ref.js:19:9 = Promise<{+default: (x: Props) => Element<(x: Props) => Node>}>
 lazy_ref.js:19:9,19:9


### PR DESCRIPTION
Improve the type definitions for `React.forwardRef`, `React.memo` and `React.lazy` by leveraging the third type argument for `AbstractComponent`.

The "return" value of components, i.e. the `Render` type is now maintained.