### PR TITLE
Fix OSS tool_test_win step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -494,9 +494,11 @@ jobs:
           at: .
       - run:
           name: Install Yarn
-          command: npm install --global yarn
+          shell: bash
+          command: choco install yarn -y
       - run:
           name: Install tool deps from yarn
+          shell: bash
           command: |
             cd packages/flow-dev-tools
             yarn install --ignore-scripts --pure-lockfile

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -494,7 +494,7 @@ jobs:
           at: .
       - run:
           name: Install Yarn
-          command: choco install yarn -y
+          command: choco install yarn -y -v
       - run:
           name: Install tool deps from yarn
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -494,9 +494,7 @@ jobs:
           at: .
       - run:
           name: Install Yarn
-          command: |
-            choco install nodejs-lts -y
-            choco install yarn -y
+          command: npm install --global yarn
       - run:
           name: Install tool deps from yarn
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -509,7 +509,9 @@ jobs:
       - run:
           name: Run tool tests
           shell: bash
-          command: ./tool test --bin bin/win64/flow.exe --parallelism 1
+          command: |
+            cd "$CIRCLE_WORKING_DIRECTORY"
+            ./tool test --bin bin/win64/flow.exe --parallelism 1
 
   ounit_test_linux:
     executor: linux-opam

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ aliases:
         ignore: /.*/
 
 orbs:
-  win: circleci/windows@4.2.0
+  win: circleci/windows@5.0.0
 
   opam_windows:
     commands:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -494,9 +494,7 @@ jobs:
           at: .
       - run:
           name: Install Yarn
-          command: |
-            choco install yarn -y
-            yarn --version
+          command: choco install yarn -y
       - run:
           name: Install tool deps from yarn
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ aliases:
         ignore: /.*/
 
 orbs:
-  win: circleci/windows@4.1.0
+  win: circleci/windows@5.0.0
 
   opam_windows:
     commands:
@@ -495,7 +495,7 @@ jobs:
       - run:
           name: Install Yarn
           command: |
-            corepack enable
+            choco install yarn -y
             yarn --version
       - run:
           name: Install tool deps from yarn

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -495,7 +495,8 @@ jobs:
       - run:
           name: Install Yarn
           command: |
-            choco install yarn -y --source https://chocolatey.org/api/v2/
+            choco install nodejs -y
+            choco install yarn -y
             yarn --version
       - run:
           name: Install tool deps from yarn

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -494,12 +494,11 @@ jobs:
           at: .
       - run:
           name: Install Yarn
-          shell: bash
           command: choco install yarn -y
       - run:
           name: Install tool deps from yarn
-          shell: bash
           command: |
+            refreshenv
             cd packages/flow-dev-tools
             yarn install --ignore-scripts --pure-lockfile
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -498,7 +498,7 @@ jobs:
       - run:
           name: Install tool deps from yarn
           command: |
-            refreshenv
+            Import-Module $env:ChocolateyInstall\helpers\chocolateyProfile.psm1
             cd packages/flow-dev-tools
             yarn install --ignore-scripts --pure-lockfile
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -494,7 +494,7 @@ jobs:
           at: .
       - run:
           name: Install Yarn
-          command: choco install yarn
+          command: choco install yarn -y
       - run:
           name: Install tool deps from yarn
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -495,8 +495,7 @@ jobs:
       - run:
           name: Install Yarn
           command: |
-            choco install nodejs-lts --force -y
-            choco install yarn -y
+            corepack enable
             yarn --version
       - run:
           name: Install tool deps from yarn

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -495,7 +495,7 @@ jobs:
       - run:
           name: Install Yarn
           command: |
-            choco install nodejs -y
+            choco install nodejs-lts --force -y
             choco install yarn -y
             yarn --version
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ aliases:
         ignore: /.*/
 
 orbs:
-  win: circleci/windows@5.0.0
+  win: circleci/windows@4.1.0
 
   opam_windows:
     commands:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -494,12 +494,12 @@ jobs:
           at: .
       - run:
           name: Install Yarn
-          command: choco install yarn -y -v
+          command: choco install yarn -y
       - run:
           name: Install tool deps from yarn
           command: |
             cd packages/flow-dev-tools
-            yarn install --ignore-scripts --pure-lockfile
+            yarn.cmd install --ignore-scripts --pure-lockfile
       - run:
           name: Run tool tests
           shell: bash

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -494,7 +494,9 @@ jobs:
           at: .
       - run:
           name: Install Yarn
-          command: choco install yarn -y
+          command: |
+            choco install nodejs-lts -y
+            choco install yarn -y
       - run:
           name: Install tool deps from yarn
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -493,8 +493,14 @@ jobs:
       - attach_workspace:
           at: .
       - run:
-          name: Install Yarn
-          command: choco install yarn -y
+          name: Turn off nvm
+          command: nvm off
+      - run:
+          name: Install Node LTS
+          command: choco install nodejs-lts -y
+      - run:
+          name: Enable Corepack
+          command: corepack enable
       - run:
           name: Install tool deps from yarn
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ aliases:
         ignore: /.*/
 
 orbs:
-  win: circleci/windows@4.1.0
+  win: circleci/windows@4.2.0
 
   opam_windows:
     commands:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -505,7 +505,7 @@ jobs:
           name: Install tool deps from yarn
           command: |
             cd packages/flow-dev-tools
-            yarn.cmd install --ignore-scripts --pure-lockfile
+            yarn install --ignore-scripts --pure-lockfile
       - run:
           name: Run tool tests
           shell: bash

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -494,11 +494,12 @@ jobs:
           at: .
       - run:
           name: Install Yarn
-          command: choco install yarn -y
+          command: |
+            choco install yarn -y
+            Import-Module $env:ChocolateyInstall\helpers\chocolateyProfile.psm1
       - run:
           name: Install tool deps from yarn
           command: |
-            Import-Module $env:ChocolateyInstall\helpers\chocolateyProfile.psm1
             cd packages/flow-dev-tools
             yarn install --ignore-scripts --pure-lockfile
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -495,8 +495,8 @@ jobs:
       - run:
           name: Install Yarn
           command: |
-            choco install yarn -y
-            Import-Module $env:ChocolateyInstall\helpers\chocolateyProfile.psm1
+            choco install yarn -y --source https://chocolatey.org/api/v2/
+            yarn --version
       - run:
           name: Install tool deps from yarn
           command: |


### PR DESCRIPTION
Steal it from https://github.com/facebook/react-native/blob/50638714f5cbf110300aa2a3ecd63a3a25a9ac00/.circleci/config.yml#L1370-L1383

I still have not figured out why the current step breaks. Oh windows