### PR TITLE
Fix tool_test_win job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ aliases:
         ignore: /.*/
 
 orbs:
-  win: circleci/windows@4.1.1
+  win: circleci/windows@2.4.0
 
   opam_windows:
     commands:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -508,7 +508,6 @@ jobs:
             yarn install --ignore-scripts --pure-lockfile
       - run:
           name: Run tool tests
-          shell: C:/tools/cygwin/bin/bash.exe -leo pipefail
           command: |
             cd "$CIRCLE_WORKING_DIRECTORY"
             ./tool test --bin bin/win64/flow.exe --parallelism 1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -508,7 +508,7 @@ jobs:
             yarn install --ignore-scripts --pure-lockfile
       - run:
           name: Run tool tests
-          shell: bash
+          shell: C:/tools/cygwin/bin/bash.exe -leo pipefail
           command: |
             cd "$CIRCLE_WORKING_DIRECTORY"
             ./tool test --bin bin/win64/flow.exe --parallelism 1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -374,7 +374,6 @@ jobs:
           name: Create cache breaker
           shell: C:/tools/cygwin/bin/bash.exe -leo pipefail
           command: |
-            cd "$CIRCLE_WORKING_DIRECTORY"
             /usr/bin/make print-switch > /cygdrive/c/tmp/flow/opamcachebreaker
             /usr/local/bin/opam --version >> /cygdrive/c/tmp/flow/opamcachebreaker
             /usr/bin/cat flowtype.opam >> /cygdrive/c/tmp/flow/opamcachebreaker
@@ -393,9 +392,7 @@ jobs:
           shell: C:/tools/cygwin/bin/bash.exe -leo pipefail
           environment:
             PATH: /usr/local/bin:/usr/bin:/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/Wbem:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0
-          command: |
-             cd "$CIRCLE_WORKING_DIRECTORY"
-             make deps
+          command: make deps
       - save_cache:
           key: opam-cache-{{ arch }}-{{ checksum "C:/tmp/flow/opamcachebreaker" }}
           paths:
@@ -407,7 +404,6 @@ jobs:
           environment:
             PATH: /usr/local/bin:/usr/bin:/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/Wbem:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0
           command: |
-             cd "$CIRCLE_WORKING_DIRECTORY"
              eval $(opam env)
              make bin/flow.exe dist/flow.zip
              mkdir -p bin/win64 && cp bin/flow.exe bin/win64/flow.exe
@@ -418,7 +414,6 @@ jobs:
           environment:
             PATH: /usr/local/bin:/usr/bin:/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/Wbem:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0
           command: |
-            cd "$CIRCLE_WORKING_DIRECTORY"
             eval $(opam env)
             dune build src/parser/test/run_tests.exe
             cp _build/default/src/parser/test/run_tests.exe bin/win64/run_parser_tests.exe
@@ -508,9 +503,7 @@ jobs:
             yarn install --ignore-scripts --pure-lockfile
       - run:
           name: Run tool tests
-          command: |
-            cd $(Resolve-Path .)
-            node packages/flow-dev-tools/bin/tool test --bin bin/win64/flow.exe --parallelism 1
+          command: node packages/flow-dev-tools/bin/tool test --bin bin/win64/flow.exe --parallelism 1
 
   ounit_test_linux:
     executor: linux-opam

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -510,7 +510,7 @@ jobs:
           name: Run tool tests
           command: |
             cd "$CIRCLE_WORKING_DIRECTORY"
-            ./tool test --bin bin/win64/flow.exe --parallelism 1
+            node packages/flow-dev-tools/bin/tool test --bin bin/win64/flow.exe --parallelism 1
 
   ounit_test_linux:
     executor: linux-opam

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -509,7 +509,7 @@ jobs:
       - run:
           name: Run tool tests
           command: |
-            cd $(Resolve-Path "$CIRCLE_WORKING_DIRECTORY")
+            cd $(Resolve-Path .)
             node packages/flow-dev-tools/bin/tool test --bin bin/win64/flow.exe --parallelism 1
 
   ounit_test_linux:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -508,9 +508,7 @@ jobs:
             yarn install --ignore-scripts --pure-lockfile
       - run:
           name: Run tool tests
-          command: |
-            cd "$CIRCLE_WORKING_DIRECTORY"
-            node packages/flow-dev-tools/bin/tool test --bin bin/win64/flow.exe --parallelism 1
+          command: node packages/flow-dev-tools/bin/tool test --bin bin/win64/flow.exe --parallelism 1
 
   ounit_test_linux:
     executor: linux-opam

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -508,7 +508,9 @@ jobs:
             yarn install --ignore-scripts --pure-lockfile
       - run:
           name: Run tool tests
-          command: node packages/flow-dev-tools/bin/tool test --bin bin/win64/flow.exe --parallelism 1
+          command: |
+            cd $(Resolve-Path "$CIRCLE_WORKING_DIRECTORY")
+            node packages/flow-dev-tools/bin/tool test --bin bin/win64/flow.exe --parallelism 1
 
   ounit_test_linux:
     executor: linux-opam

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ aliases:
         ignore: /.*/
 
 orbs:
-  win: circleci/windows@5.0.0
+  win: circleci/windows@4.1.1
 
   opam_windows:
     commands:
@@ -374,6 +374,7 @@ jobs:
           name: Create cache breaker
           shell: C:/tools/cygwin/bin/bash.exe -leo pipefail
           command: |
+            cd "$CIRCLE_WORKING_DIRECTORY"
             /usr/bin/make print-switch > /cygdrive/c/tmp/flow/opamcachebreaker
             /usr/local/bin/opam --version >> /cygdrive/c/tmp/flow/opamcachebreaker
             /usr/bin/cat flowtype.opam >> /cygdrive/c/tmp/flow/opamcachebreaker
@@ -392,7 +393,9 @@ jobs:
           shell: C:/tools/cygwin/bin/bash.exe -leo pipefail
           environment:
             PATH: /usr/local/bin:/usr/bin:/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/Wbem:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0
-          command: make deps
+          command: |
+             cd "$CIRCLE_WORKING_DIRECTORY"
+             make deps
       - save_cache:
           key: opam-cache-{{ arch }}-{{ checksum "C:/tmp/flow/opamcachebreaker" }}
           paths:
@@ -404,6 +407,7 @@ jobs:
           environment:
             PATH: /usr/local/bin:/usr/bin:/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/Wbem:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0
           command: |
+             cd "$CIRCLE_WORKING_DIRECTORY"
              eval $(opam env)
              make bin/flow.exe dist/flow.zip
              mkdir -p bin/win64 && cp bin/flow.exe bin/win64/flow.exe
@@ -414,6 +418,7 @@ jobs:
           environment:
             PATH: /usr/local/bin:/usr/bin:/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/Wbem:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0
           command: |
+            cd "$CIRCLE_WORKING_DIRECTORY"
             eval $(opam env)
             dune build src/parser/test/run_tests.exe
             cp _build/default/src/parser/test/run_tests.exe bin/win64/run_parser_tests.exe
@@ -503,6 +508,7 @@ jobs:
             yarn install --ignore-scripts --pure-lockfile
       - run:
           name: Run tool tests
+          shell: bash
           command: node packages/flow-dev-tools/bin/tool test --bin bin/win64/flow.exe --parallelism 1
 
   ounit_test_linux:

--- a/packages/flow-dev-tools/src/test/builder.js
+++ b/packages/flow-dev-tools/src/test/builder.js
@@ -516,7 +516,6 @@ class TestBuilder {
   sanitizeIncomingLSPMessage(params: any): any {
     // LSP sends back document URLs, to files within the test project
     const dirUrl = this.getDirUrl();
-    console.error(dirUrl);
     const replaceDir = (str: string): string => {
       let out = str;
       let index;
@@ -526,7 +525,6 @@ class TestBuilder {
           '<PLACEHOLDER_PROJECT_URL>' +
           out.substr(index + dirUrl.length);
       }
-      console.log('before\n', out, '\nAfter\n', str);
       return out;
     };
 

--- a/packages/flow-dev-tools/src/test/builder.js
+++ b/packages/flow-dev-tools/src/test/builder.js
@@ -516,6 +516,7 @@ class TestBuilder {
   sanitizeIncomingLSPMessage(params: any): any {
     // LSP sends back document URLs, to files within the test project
     const dirUrl = this.getDirUrl();
+    console.error(dirUrl);
     const replaceDir = (str: string): string => {
       let out = str;
       let index;
@@ -525,6 +526,7 @@ class TestBuilder {
           '<PLACEHOLDER_PROJECT_URL>' +
           out.substr(index + dirUrl.length);
       }
+      console.log('before\n', out, '\nAfter\n', str);
       return out;
     };
 


### PR DESCRIPTION
The latest version has all sorts of issues that are not addressed by circleci (at least I can't find them). One example is https://github.com/CircleCI-Public/windows-orb/issues/50, which is why the job is currently failing.

This diff downgrades it to 2.4.0, which is also the one used by react native.