### PR TITLE
[flow][fuzzy] Make C++ code more portable

### DIFF
--- a/newtests/lsp/completion/autoimports/test.js
+++ b/newtests/lsp/completion/autoimports/test.js
@@ -938,185 +938,93 @@ module.exports = (suite(
                     ],
                   },
                 },
-                ...(process.platform === 'win32'
-                  ? [
+                {
+                  label: 'Function',
+                  kind: 6,
+                  detail: '(global)',
+                  sortText: '00000000000000000009',
+                  insertTextFormat: 1,
+                  textEdit: {
+                    range: {
+                      start: {
+                        line: 2,
+                        character: 0,
+                      },
+                      end: {
+                        line: 2,
+                        character: 1,
+                      },
+                    },
+                    newText: 'Function',
+                  },
+                  command: {
+                    title: '',
+                    command: 'log:org.flow:<PLACEHOLDER_PROJECT_URL>',
+                    arguments: [
+                      'textDocument/completion',
+                      'global',
                       {
-                        label: 'barFoo',
-                        kind: 6,
-                        detail: 'Import from ./bar',
-                        sortText: '00000000000000000009',
-                        insertTextFormat: 1,
-                        textEdit: {
-                          range: {
-                            start: {
-                              line: 2,
-                              character: 0,
-                            },
-                            end: {
-                              line: 2,
-                              character: 1,
-                            },
-                          },
-                          newText: 'barFoo',
+                        token: 'fAUTO332',
+                        index: 9,
+                        session_requests: 1,
+                        typed_length: 1,
+                        completion: 'Function',
+                        ac_type: 'Acid',
+                      },
+                    ],
+                  },
+                },
+                {
+                  label: 'barFoo',
+                  kind: 6,
+                  detail: 'Import from ./bar',
+                  sortText: '00000000000000000010',
+                  insertTextFormat: 1,
+                  textEdit: {
+                    range: {
+                      start: {
+                        line: 2,
+                        character: 0,
+                      },
+                      end: {
+                        line: 2,
+                        character: 1,
+                      },
+                    },
+                    newText: 'barFoo',
+                  },
+                  additionalTextEdits: [
+                    {
+                      range: {
+                        start: {
+                          line: 2,
+                          character: 0,
                         },
-                        additionalTextEdits: [
-                          {
-                            range: {
-                              start: {
-                                line: 2,
-                                character: 0,
-                              },
-                              end: {
-                                line: 2,
-                                character: 0,
-                              },
-                            },
-                            newText: 'import { barFoo } from "./bar";\n\n',
-                          },
-                        ],
-                        command: {
-                          title: '',
-                          command: 'log:org.flow:<PLACEHOLDER_PROJECT_URL>',
-                          arguments: [
-                            'textDocument/completion',
-                            'autoimport',
-                            {
-                              token: 'fAUTO332',
-                              index: 9,
-                              session_requests: 1,
-                              typed_length: 1,
-                              completion: 'barFoo',
-                              ac_type: 'Acid',
-                            },
-                          ],
+                        end: {
+                          line: 2,
+                          character: 0,
                         },
                       },
+                      newText: 'import { barFoo } from "./bar";\n\n',
+                    },
+                  ],
+                  command: {
+                    title: '',
+                    command: 'log:org.flow:<PLACEHOLDER_PROJECT_URL>',
+                    arguments: [
+                      'textDocument/completion',
+                      'autoimport',
                       {
-                        label: 'Function',
-                        kind: 6,
-                        detail: '(global)',
-                        sortText: '00000000000000000010',
-                        insertTextFormat: 1,
-                        textEdit: {
-                          range: {
-                            start: {
-                              line: 2,
-                              character: 0,
-                            },
-                            end: {
-                              line: 2,
-                              character: 1,
-                            },
-                          },
-                          newText: 'Function',
-                        },
-                        command: {
-                          title: '',
-                          command: 'log:org.flow:<PLACEHOLDER_PROJECT_URL>',
-                          arguments: [
-                            'textDocument/completion',
-                            'global',
-                            {
-                              token: 'fAUTO332',
-                              index: 10,
-                              session_requests: 1,
-                              typed_length: 1,
-                              completion: 'Function',
-                              ac_type: 'Acid',
-                            },
-                          ],
-                        },
+                        token: 'fAUTO332',
+                        index: 10,
+                        session_requests: 1,
+                        typed_length: 1,
+                        completion: 'barFoo',
+                        ac_type: 'Acid',
                       },
-                    ]
-                  : [
-                      {
-                        label: 'Function',
-                        kind: 6,
-                        detail: '(global)',
-                        sortText: '00000000000000000009',
-                        insertTextFormat: 1,
-                        textEdit: {
-                          range: {
-                            start: {
-                              line: 2,
-                              character: 0,
-                            },
-                            end: {
-                              line: 2,
-                              character: 1,
-                            },
-                          },
-                          newText: 'Function',
-                        },
-                        command: {
-                          title: '',
-                          command: 'log:org.flow:<PLACEHOLDER_PROJECT_URL>',
-                          arguments: [
-                            'textDocument/completion',
-                            'global',
-                            {
-                              token: 'fAUTO332',
-                              index: 9,
-                              session_requests: 1,
-                              typed_length: 1,
-                              completion: 'Function',
-                              ac_type: 'Acid',
-                            },
-                          ],
-                        },
-                      },
-                      {
-                        label: 'barFoo',
-                        kind: 6,
-                        detail: 'Import from ./bar',
-                        sortText: '00000000000000000010',
-                        insertTextFormat: 1,
-                        textEdit: {
-                          range: {
-                            start: {
-                              line: 2,
-                              character: 0,
-                            },
-                            end: {
-                              line: 2,
-                              character: 1,
-                            },
-                          },
-                          newText: 'barFoo',
-                        },
-                        additionalTextEdits: [
-                          {
-                            range: {
-                              start: {
-                                line: 2,
-                                character: 0,
-                              },
-                              end: {
-                                line: 2,
-                                character: 0,
-                              },
-                            },
-                            newText: 'import { barFoo } from "./bar";\n\n',
-                          },
-                        ],
-                        command: {
-                          title: '',
-                          command: 'log:org.flow:<PLACEHOLDER_PROJECT_URL>',
-                          arguments: [
-                            'textDocument/completion',
-                            'autoimport',
-                            {
-                              token: 'fAUTO332',
-                              index: 10,
-                              session_requests: 1,
-                              typed_length: 1,
-                              completion: 'barFoo',
-                              ac_type: 'Acid',
-                            },
-                          ],
-                        },
-                      },
-                    ]),
+                    ],
+                  },
+                },
               ],
             },
           },

--- a/src/third-party/fuzzy-path/src/fuzzy_path_stubs.c
+++ b/src/third-party/fuzzy-path/src/fuzzy_path_stubs.c
@@ -125,7 +125,7 @@ value fuzzy_score(value haystack_v, value needle_v, value boost_full_match_v, va
   bool boost_full_match = Bool_val(boost_full_match_v);
   bool first_match_can_be_weak = Bool_val(first_match_can_be_weak);
 
-  long score = 0;
+  int64_t score = 0;
   bool has_score = fuzzy_score_c(haystack, needle, boost_full_match, first_match_can_be_weak, &score);
 
   if (has_score) {

--- a/src/third-party/fuzzy-path/src/fuzzy_path_wrapper.cpp
+++ b/src/third-party/fuzzy-path/src/fuzzy_path_wrapper.cpp
@@ -134,7 +134,7 @@ bool fuzzy_score_c(
     const char* needle,
     bool boost_full_match,
     bool first_match_can_be_weak,
-    long* result) {
+    int64_t* result) {
   std::string haystack_str(haystack);
   std::string haystack_lower = str_to_lower(haystack_str);
 

--- a/src/third-party/fuzzy-path/src/fuzzy_path_wrapper.h
+++ b/src/third-party/fuzzy-path/src/fuzzy_path_wrapper.h
@@ -14,6 +14,7 @@ extern "C" {
 
 #include <stdlib.h>
 #include <stdbool.h>
+#include <stdint.h>
 
 struct matcher;
 typedef struct matcher matcher_t;
@@ -51,7 +52,7 @@ bool fuzzy_score_c(
     const char* needle,
     bool boost_full_match,
     bool first_match_can_be_weak,
-    long* result);
+    int64_t* result);
 
 #ifdef __cplusplus
 }

--- a/src/third-party/fuzzy-path/vendor/MatcherBase.cpp
+++ b/src/third-party/fuzzy-path/vendor/MatcherBase.cpp
@@ -47,7 +47,7 @@ inline std::string str_to_lower(const std::string &s) {
 // Push a new entry on the heap while ensuring size <= max_results.
 void push_heap(ResultHeap &heap,
                int weight,
-               long score,
+               int64_t score,
                const std::string *value,
                size_t max_results) {
   MatchResult result(weight, score, value);
@@ -92,7 +92,7 @@ void thread_worker(
       continue;
     }
     if ((bitmask & candidate.bitmask) == bitmask) {
-      long score = 0;
+      int64_t score = 0;
       bool has_score = fuzzy_score(
         candidate.value.c_str(),
         candidate.lowercase.c_str(),

--- a/src/third-party/fuzzy-path/vendor/MatcherBase.h
+++ b/src/third-party/fuzzy-path/vendor/MatcherBase.h
@@ -14,7 +14,7 @@ struct MatcherOptions {
 
 struct MatchResult {
   int weight;
-  long score;
+  int64_t score;
   // We can't afford to copy strings around while we're ranking them.
   // These are not guaranteed to last very long and should be copied out ASAP.
   const std::string *value;

--- a/src/third-party/fuzzy-path/vendor/score_match.cpp
+++ b/src/third-party/fuzzy-path/vendor/score_match.cpp
@@ -41,7 +41,7 @@ struct MatchInfo {
   bool first_match_can_be_weak;
 };
 
-const long MAX_SAFE_INTEGER = 9007199254740991;
+const int64_t MAX_SAFE_INTEGER = 9007199254740991;
 
 bool is_separator_at_pos(const char* value, size_t value_len, size_t index) {
   if (index < 0 || index >= value_len) {
@@ -85,7 +85,7 @@ bool is_uppercase_at_pos(size_t pos, const char* word, const char* word_lower) {
 
 // needle is the pattern being searched for
 // haystack is the word being matched against
-long do_score(
+int64_t do_score(
     const MatchInfo& m,
     const size_t haystack_idx,
     const size_t needle_idx,
@@ -104,7 +104,7 @@ long do_score(
     return MIN_SCORE;
   }
 
-  long score;
+  int64_t score;
   bool is_gap_location;
 
   if (word_pos == pattern_pos) {
@@ -200,7 +200,7 @@ void _fillInMaxWordMatchPos(size_t patternLen, size_t wordLen, const char* patte
   }
 }
 
-bool do_fuzzy_score(const MatchInfo& m, long* result) {
+bool do_fuzzy_score(const MatchInfo& m, int64_t* result) {
   bool first_match_can_be_weak = m.first_match_can_be_weak;
 
   // const char* pattern = m.needle;
@@ -242,7 +242,7 @@ bool do_fuzzy_score(const MatchInfo& m, long* result) {
     int nextMaxWordMatchPos = (patternPos + 1 < patternLen ? _maxWordMatchPos[patternPos + 1] : wordLen);
 
     for (column = minWordMatchPos + 1, wordPos = minWordMatchPos; wordPos < nextMaxWordMatchPos; column++, wordPos++) {
-      long score = MIN_SCORE;
+      int64_t score = MIN_SCORE;
       bool canComeDiag = false;
 
       if (wordPos <= maxWordMatchPos) {
@@ -255,17 +255,17 @@ bool do_fuzzy_score(const MatchInfo& m, long* result) {
         );
       }
 
-      long diagScore = 0;
+      int64_t diagScore = 0;
       if (score != MAX_SAFE_INTEGER) {
         canComeDiag = true;
         diagScore = score + _table[row - 1][column - 1];
       }
 
       bool canComeLeft = wordPos > minWordMatchPos;
-      long leftScore = canComeLeft ? _table[row][column - 1] + (_diag[row][column - 1] > 0 ? -5 : 0) : 0; // penalty for a gap start
+      int64_t leftScore = canComeLeft ? _table[row][column - 1] + (_diag[row][column - 1] > 0 ? -5 : 0) : 0; // penalty for a gap start
 
       bool canComeLeftLeft = wordPos > minWordMatchPos + 1 && _diag[row][column - 1] > 0;
-      long leftLeftScore = canComeLeftLeft ? _table[row][column - 2] + (_diag[row][column - 2] > 0 ? -5 : 0) : 0; // penalty for a gap start
+      int64_t leftLeftScore = canComeLeftLeft ? _table[row][column - 2] + (_diag[row][column - 2] > 0 ? -5 : 0) : 0; // penalty for a gap start
 
       if (canComeLeftLeft && (!canComeLeft || leftLeftScore >= leftScore) && (!canComeDiag || leftLeftScore >= diagScore)) {
         // always prefer choosing left left to jump over a diagonal because that means a match is earlier in the word
@@ -303,7 +303,7 @@ bool do_fuzzy_score(const MatchInfo& m, long* result) {
     // Find the column where we go diagonally up
     int diagColumn = column;
     do {
-      long arrow = _arrows[row][diagColumn];
+      int64_t arrow = _arrows[row][diagColumn];
       if (arrow == LeftLeft) {
         diagColumn = diagColumn - 2;
       } else if (arrow == Left) {
@@ -359,7 +359,7 @@ bool fuzzy_score(
     const char* needle,
     const char* needle_lower,
     const MatchOptions& options,
-    long* result) {
+    int64_t* result) {
   if (!*needle) {
     return 1.0;
   }

--- a/src/third-party/fuzzy-path/vendor/score_match.h
+++ b/src/third-party/fuzzy-path/vendor/score_match.h
@@ -16,7 +16,7 @@
 #include <cstddef>
 #include <string>
 
-const long MIN_SCORE = -9007199254740991;
+const int64_t MIN_SCORE = -9007199254740991;
 
 struct MatchOptions {
   bool boost_full_match;
@@ -33,4 +33,4 @@ bool fuzzy_score(
     const char* needle,
     const char* needle_lower,
     const MatchOptions& options,
-    long* result);
+    int64_t* result);


### PR DESCRIPTION
Summary:
`long` has different sizes across different platforms and operating systems. On windows, it causes the following warning:

```
In file included from src/fuzzy_path_wrapper.cpp:14:
src/../vendor/score_match.h:19:24: warning: overflow in conversion from ‘long long int’ to ‘long int’ changes value from ‘-9007199254740991’ to ‘1’ [-Woverflow]
   19 | const long MIN_SCORE = -9007199254740991;
      |                        ^~~~~~~~~~~~~~~~~
x86_64-w64-mingw32-g++ -std=c++11 -Wall -O3 -fPIC   -c -o vendor/MatcherBase.o vendor/MatcherBase.cpp
In file included from vendor/MatcherBase.cpp:4:
vendor/score_match.h:19:24: warning: overflow in conversion from ‘long long int’ to ‘long int’ changes value from ‘-9007199254740991’ to ‘1’ [-Woverflow]
   19 | const long MIN_SCORE = -9007199254740991;
      |                        ^~~~~~~~~~~~~~~~~
x86_64-w64-mingw32-g++ -std=c++11 -Wall -O3 -fPIC   -c -o vendor/score_match.o vendor/score_match.cpp
In file included from vendor/score_match.cpp:14:
vendor/score_match.h:19:24: warning: overflow in conversion from ‘long long int’ to ‘long int’ changes value from ‘-9007199254740991’ to ‘1’ [-Woverflow]
   19 | const long MIN_SCORE = -9007199254740991;
      |                        ^~~~~~~~~~~~~~~~~
vendor/score_match.cpp:44:31: warning: overflow in conversion from ‘long long int’ to ‘long int’ changes value from ‘9007199254740991’ to ‘-1’ [-Woverflow]
   44 | const long MAX_SAFE_INTEGER = 9007199254740991;
      |                               ^~~~~~~~~~~~~~~~
```

Use `int64_h` to be consistent. It probably wouldn't matter in usual cases, but we hard coded an integer that can only fit in int64 here.

Changelog: [internal]

Differential Revision: D48472511

