### PR TITLE
fix: function name typo

### DIFF
--- a/src/parser/enum_parser.ml
+++ b/src/parser/enum_parser.ml
@@ -303,13 +303,13 @@ end = struct
     | _ when defaulted_len > initialized_len ->
       List.iter
         (fun (loc, _) ->
-          error_at env (loc, Parse_error.EnumStringMemberInconsistentlyInitailized { enum_name }))
+          error_at env (loc, Parse_error.EnumStringMemberInconsistentlyInitialized { enum_name }))
         string_members;
       defaulted_body ()
     | _ ->
       List.iter
         (fun (loc, _) ->
-          error_at env (loc, Parse_error.EnumStringMemberInconsistentlyInitailized { enum_name }))
+          error_at env (loc, Parse_error.EnumStringMemberInconsistentlyInitialized { enum_name }))
         defaulted_members;
       initialized_body ()
 

--- a/src/parser/parse_error.ml
+++ b/src/parser/parse_error.ml
@@ -63,7 +63,7 @@ type t =
       enum_name: string;
       member_name: string;
     }
-  | EnumStringMemberInconsistentlyInitailized of { enum_name: string }
+  | EnumStringMemberInconsistentlyInitialized of { enum_name: string }
   | EnumInvalidConstPrefix
   | ExpectedJSXClosingTag of string
   | ExpectedPatternFoundExpression
@@ -309,7 +309,7 @@ module PP = struct
         "Number enum members need to be initialized, e.g. `%s = 1,` in enum `%s`."
         member_name
         enum_name
-    | EnumStringMemberInconsistentlyInitailized { enum_name } ->
+    | EnumStringMemberInconsistentlyInitialized { enum_name } ->
       Printf.sprintf
         "String enum members need to consistently either all use initializers, or use no initializers, in enum %s."
         enum_name


### PR DESCRIPTION
<!--
  If this is a change to library defintions, please include links to relevant documentation.
  If this is a documentation change, please prefix the title with [DOCS].

  If this is neither, ensure you opened a discussion issue and link it in the PR description.
-->
