### PR TITLE
[dom][node] Update URLSearchParams definitions

### DIFF
--- a/lib/bom.js
+++ b/lib/bom.js
@@ -1537,17 +1537,22 @@ declare class Headers {
 
 declare class URLSearchParams {
     @@iterator(): Iterator<[string, string]>;
-    constructor(query?: string | URLSearchParams | Array<[string, string]> | { [string]: string, ... } ): void;
+
+    size: number;
+
+    constructor(init?: string | URLSearchParams | Array<[string, string]> | { [string]: string, ... } ): void;
     append(name: string, value: string): void;
-    delete(name: string): void;
+    delete(name: string, value?: string): void;
     entries(): Iterator<[string, string]>;
     forEach<This>(callback: (this : This, value: string, name: string, params: URLSearchParams) => mixed, thisArg: This): void;
     get(name: string): null | string;
     getAll(name: string): Array<string>;
-    has(name: string): boolean;
+    has(name: string, value?: string): boolean;
     keys(): Iterator<string>;
     set(name: string, value: string): void;
+    sort(): void;
     values(): Iterator<string>;
+    toString(): string;
 }
 
 type CacheType =  'default' | 'no-store' | 'reload' | 'no-cache' | 'force-cache' | 'only-if-cached';

--- a/lib/node.js
+++ b/lib/node.js
@@ -2437,20 +2437,23 @@ declare module "url" {
   declare function pathToFileURL(path: string): url$urlObject;
   declare function fileURLToPath(path: url$urlObject | string): string;
   declare class URLSearchParams {
-    constructor(init?: string | Array<[string, string]> | { [string]: string, ... } ): void;
+    @@iterator(): Iterator<[string, string]>;
+
+    size: number;
+
+    constructor(init?: string | URLSearchParams | Array<[string, string]> | { [string]: string, ... } ): void;
     append(name: string, value: string): void;
-    delete(name: string): void;
+    delete(name: string, value?: void): void;
     entries(): Iterator<[string, string]>;
-    forEach<This>(fn: (this : This, value: string, name: string, searchParams: URLSearchParams) => void, thisArg?: This): void;
+    forEach<This>(callback: (this : This, value: string, name: string, searchParams: URLSearchParams) => mixed, thisArg?: This): void;
     get(name: string): string | null;
     getAll(name: string): string[];
-    has(name: string): boolean;
+    has(name: string, value?: string): boolean;
     keys(): Iterator<string>;
     set(name: string, value: string): void;
     sort(): void;
-    toString(): string;
     values(): Iterator<string>;
-    @@iterator(): Iterator<[string, string]>;
+    toString(): string;
   }
   declare class URL {
     constructor(input: string, base?: string | URL): void;

--- a/tests/bom/bom.exp
+++ b/tests/bom/bom.exp
@@ -915,8 +915,8 @@ Cannot assign `params.get(...)` to `b` because null [1] is incompatible with str
                            ^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/bom.js:1545:24
-   1545|     get(name: string): null | string;
+   <BUILTINS>/bom.js:1548:24
+   1548|     get(name: string): null | string;
                                 ^^^^ [1]
    URLSearchParams.js:8:10
       8| const b: string = params.get('foo'); // incorrect

--- a/tests/fetch/fetch.exp
+++ b/tests/fetch/fetch.exp
@@ -8,8 +8,8 @@ Cannot assign `fetch(...)` to `b` because `Response` [1] is incompatible with st
                                     ^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/bom.js:1660:76
-   1660| declare function fetch(input: RequestInfo, init?: RequestOptions): Promise<Response>;
+   <BUILTINS>/bom.js:1665:76
+   1665| declare function fetch(input: RequestInfo, init?: RequestOptions): Promise<Response>;
                                                                                     ^^^^^^^^ [1]
    fetch.js:12:18
      12| const b: Promise<string> = fetch(myRequest); // incorrect
@@ -32,8 +32,8 @@ References:
    fetch.js:25:18
      25| const d: Promise<Blob> = fetch('image.png'); // incorrect
                           ^^^^ [1]
-   <BUILTINS>/bom.js:1660:76
-   1660| declare function fetch(input: RequestInfo, init?: RequestOptions): Promise<Response>;
+   <BUILTINS>/bom.js:1665:76
+   1665| declare function fetch(input: RequestInfo, init?: RequestOptions): Promise<Response>;
                                                                                     ^^^^^^^^ [2]
    <BUILTINS>/core.js:1907:24
    1907| declare class Promise<+R = mixed> {
@@ -268,14 +268,14 @@ References:
    request.js:2:20
       2| const a: Request = new Request(); // incorrect
                             ^^^^^^^^^^^^^ [1]
-   <BUILTINS>/bom.js:1566:20
-   1566| type RequestInfo = Request | URL | string;
+   <BUILTINS>/bom.js:1571:20
+   1571| type RequestInfo = Request | URL | string;
                             ^^^^^^^ [2]
-   <BUILTINS>/bom.js:1566:30
-   1566| type RequestInfo = Request | URL | string;
+   <BUILTINS>/bom.js:1571:30
+   1571| type RequestInfo = Request | URL | string;
                                       ^^^ [3]
-   <BUILTINS>/bom.js:1566:36
-   1566| type RequestInfo = Request | URL | string;
+   <BUILTINS>/bom.js:1571:36
+   1571| type RequestInfo = Request | URL | string;
                                             ^^^^^^ [4]
 
 
@@ -293,8 +293,8 @@ References:
    request.js:4:10
       4| const c: Request = new Request(b); // correct
                   ^^^^^^^ [1]
-   <BUILTINS>/bom.js:1619:44
-   1619|     constructor(input: RequestInfo, init?: RequestOptions): void;
+   <BUILTINS>/bom.js:1624:44
+   1624|     constructor(input: RequestInfo, init?: RequestOptions): void;
                                                     ^^^^^^^^^^^^^^ [2]
 
 
@@ -311,8 +311,8 @@ References:
    request.js:4:10
       4| const c: Request = new Request(b); // correct
                   ^^^^^^^ [1]
-   <BUILTINS>/bom.js:1619:44
-   1619|     constructor(input: RequestInfo, init?: RequestOptions): void;
+   <BUILTINS>/bom.js:1624:44
+   1624|     constructor(input: RequestInfo, init?: RequestOptions): void;
                                                     ^^^^^^^^^^^^^^ [2]
 
 
@@ -327,11 +327,11 @@ https://flow.org/en/docs/faq/#why-cant-i-pass-a-string-to-a-function-that-takes-
                                            ^
 
 References:
-   <BUILTINS>/bom.js:1570:11
-   1570|   cache?: CacheType,
+   <BUILTINS>/bom.js:1575:11
+   1575|   cache?: CacheType,
                    ^^^^^^^^^ [1]
-   <BUILTINS>/bom.js:1624:12
-   1624|     cache: CacheType;
+   <BUILTINS>/bom.js:1629:12
+   1629|     cache: CacheType;
                     ^^^^^^^^^ [2]
 
 
@@ -346,11 +346,11 @@ https://flow.org/en/docs/faq/#why-cant-i-pass-a-string-to-a-function-that-takes-
                                            ^
 
 References:
-   <BUILTINS>/bom.js:1571:17
-   1571|   credentials?: CredentialsType,
+   <BUILTINS>/bom.js:1576:17
+   1576|   credentials?: CredentialsType,
                          ^^^^^^^^^^^^^^^ [1]
-   <BUILTINS>/bom.js:1625:18
-   1625|     credentials: CredentialsType;
+   <BUILTINS>/bom.js:1630:18
+   1630|     credentials: CredentialsType;
                           ^^^^^^^^^^^^^^^ [2]
 
 
@@ -365,11 +365,11 @@ https://flow.org/en/docs/faq/#why-cant-i-pass-a-string-to-a-function-that-takes-
                                            ^
 
 References:
-   <BUILTINS>/bom.js:1572:13
-   1572|   headers?: HeadersInit,
+   <BUILTINS>/bom.js:1577:13
+   1577|   headers?: HeadersInit,
                      ^^^^^^^^^^^ [1]
-   <BUILTINS>/bom.js:1626:14
-   1626|     headers: Headers;
+   <BUILTINS>/bom.js:1631:14
+   1631|     headers: Headers;
                       ^^^^^^^ [2]
 
 
@@ -384,11 +384,11 @@ https://flow.org/en/docs/faq/#why-cant-i-pass-a-string-to-a-function-that-takes-
                                            ^
 
 References:
-   <BUILTINS>/bom.js:1572:13
-   1572|   headers?: HeadersInit,
+   <BUILTINS>/bom.js:1577:13
+   1577|   headers?: HeadersInit,
                      ^^^^^^^^^^^ [1]
-   <BUILTINS>/bom.js:1626:14
-   1626|     headers: Headers;
+   <BUILTINS>/bom.js:1631:14
+   1631|     headers: Headers;
                       ^^^^^^^ [2]
 
 
@@ -403,11 +403,11 @@ https://flow.org/en/docs/faq/#why-cant-i-pass-a-string-to-a-function-that-takes-
                                            ^
 
 References:
-   <BUILTINS>/bom.js:1572:13
-   1572|   headers?: HeadersInit,
+   <BUILTINS>/bom.js:1577:13
+   1577|   headers?: HeadersInit,
                      ^^^^^^^^^^^ [1]
-   <BUILTINS>/bom.js:1626:14
-   1626|     headers: Headers;
+   <BUILTINS>/bom.js:1631:14
+   1631|     headers: Headers;
                       ^^^^^^^ [2]
 
 
@@ -422,11 +422,11 @@ https://flow.org/en/docs/faq/#why-cant-i-pass-a-string-to-a-function-that-takes-
                                            ^
 
 References:
-   <BUILTINS>/bom.js:1573:15
-   1573|   integrity?: string,
+   <BUILTINS>/bom.js:1578:15
+   1578|   integrity?: string,
                        ^^^^^^ [1]
-   <BUILTINS>/bom.js:1627:16
-   1627|     integrity: string;
+   <BUILTINS>/bom.js:1632:16
+   1632|     integrity: string;
                         ^^^^^^ [2]
 
 
@@ -441,11 +441,11 @@ https://flow.org/en/docs/faq/#why-cant-i-pass-a-string-to-a-function-that-takes-
                                            ^
 
 References:
-   <BUILTINS>/bom.js:1575:12
-   1575|   method?: string,
+   <BUILTINS>/bom.js:1580:12
+   1580|   method?: string,
                     ^^^^^^ [1]
-   <BUILTINS>/bom.js:1628:13
-   1628|     method: string;
+   <BUILTINS>/bom.js:1633:13
+   1633|     method: string;
                      ^^^^^^ [2]
 
 
@@ -460,11 +460,11 @@ https://flow.org/en/docs/faq/#why-cant-i-pass-a-string-to-a-function-that-takes-
                                            ^
 
 References:
-   <BUILTINS>/bom.js:1576:10
-   1576|   mode?: ModeType,
+   <BUILTINS>/bom.js:1581:10
+   1581|   mode?: ModeType,
                   ^^^^^^^^ [1]
-   <BUILTINS>/bom.js:1629:11
-   1629|     mode: ModeType;
+   <BUILTINS>/bom.js:1634:11
+   1634|     mode: ModeType;
                    ^^^^^^^^ [2]
 
 
@@ -479,11 +479,11 @@ https://flow.org/en/docs/faq/#why-cant-i-pass-a-string-to-a-function-that-takes-
                                            ^
 
 References:
-   <BUILTINS>/bom.js:1577:14
-   1577|   redirect?: RedirectType,
+   <BUILTINS>/bom.js:1582:14
+   1582|   redirect?: RedirectType,
                       ^^^^^^^^^^^^ [1]
-   <BUILTINS>/bom.js:1630:15
-   1630|     redirect: RedirectType;
+   <BUILTINS>/bom.js:1635:15
+   1635|     redirect: RedirectType;
                        ^^^^^^^^^^^^ [2]
 
 
@@ -498,11 +498,11 @@ https://flow.org/en/docs/faq/#why-cant-i-pass-a-string-to-a-function-that-takes-
                                            ^
 
 References:
-   <BUILTINS>/bom.js:1578:14
-   1578|   referrer?: string,
+   <BUILTINS>/bom.js:1583:14
+   1583|   referrer?: string,
                       ^^^^^^ [1]
-   <BUILTINS>/bom.js:1631:15
-   1631|     referrer: string;
+   <BUILTINS>/bom.js:1636:15
+   1636|     referrer: string;
                        ^^^^^^ [2]
 
 
@@ -517,11 +517,11 @@ https://flow.org/en/docs/faq/#why-cant-i-pass-a-string-to-a-function-that-takes-
                                            ^
 
 References:
-   <BUILTINS>/bom.js:1579:20
-   1579|   referrerPolicy?: ReferrerPolicyType,
+   <BUILTINS>/bom.js:1584:20
+   1584|   referrerPolicy?: ReferrerPolicyType,
                             ^^^^^^^^^^^^^^^^^^ [1]
-   <BUILTINS>/bom.js:1632:21
-   1632|     referrerPolicy: ReferrerPolicyType;
+   <BUILTINS>/bom.js:1637:21
+   1637|     referrerPolicy: ReferrerPolicyType;
                              ^^^^^^^^^^^^^^^^^^ [2]
 
 
@@ -536,11 +536,11 @@ Cannot call `Request` with object literal bound to `input` because: [incompatibl
                                         ^^ [1]
 
 References:
-   <BUILTINS>/bom.js:1566:20
-   1566| type RequestInfo = Request | URL | string;
+   <BUILTINS>/bom.js:1571:20
+   1571| type RequestInfo = Request | URL | string;
                             ^^^^^^^ [2]
-   <BUILTINS>/bom.js:1566:30
-   1566| type RequestInfo = Request | URL | string;
+   <BUILTINS>/bom.js:1571:30
+   1571| type RequestInfo = Request | URL | string;
                                       ^^^ [3]
 
 
@@ -558,8 +558,8 @@ References:
    request.js:24:19
      24| h.text().then((t: Buffer) => t); // incorrect
                            ^^^^^^ [1]
-   <BUILTINS>/bom.js:1642:21
-   1642|     text(): Promise<string>;
+   <BUILTINS>/bom.js:1647:21
+   1647|     text(): Promise<string>;
                              ^^^^^^ [2]
    request.js:24:15
      24| h.text().then((t: Buffer) => t); // incorrect
@@ -580,8 +580,8 @@ Cannot call `h.arrayBuffer().then` because: [incompatible-call]
                          ^^^^
 
 References:
-   <BUILTINS>/bom.js:1638:28
-   1638|     arrayBuffer(): Promise<ArrayBuffer>;
+   <BUILTINS>/bom.js:1643:28
+   1643|     arrayBuffer(): Promise<ArrayBuffer>;
                                     ^^^^^^^^^^^ [1]
    request.js:26:27
      26| h.arrayBuffer().then((ab: Buffer) => ab); // incorrect
@@ -627,8 +627,8 @@ Cannot call `Request` with object literal bound to `init` because null [1] is in
                                     ^^^^ [1]
 
 References:
-   <BUILTINS>/bom.js:1575:12
-   1575|   method?: string,
+   <BUILTINS>/bom.js:1580:12
+   1580|   method?: string,
                     ^^^^^^ [2]
 
 
@@ -642,8 +642,8 @@ property `status`. [incompatible-call]
                                     ^^^^^ [1]
 
 References:
-   <BUILTINS>/bom.js:1586:12
-   1586|   status?: number,
+   <BUILTINS>/bom.js:1591:12
+   1591|   status?: number,
                     ^^^^^^ [2]
 
 
@@ -657,8 +657,8 @@ Cannot call `Response` with object literal bound to `init` because null [1] is i
                                     ^^^^ [1]
 
 References:
-   <BUILTINS>/bom.js:1586:12
-   1586|   status?: number,
+   <BUILTINS>/bom.js:1591:12
+   1591|   status?: number,
                     ^^^^^^ [2]
 
 
@@ -709,17 +709,17 @@ Cannot call `Response` with object literal bound to `input` because: [incompatib
          ^ [1]
 
 References:
-   <BUILTINS>/bom.js:1564:26
-   1564| type BodyInit = string | URLSearchParams | FormData | Blob | ArrayBuffer | $ArrayBufferView | ReadableStream;
+   <BUILTINS>/bom.js:1569:26
+   1569| type BodyInit = string | URLSearchParams | FormData | Blob | ArrayBuffer | $ArrayBufferView | ReadableStream;
                                   ^^^^^^^^^^^^^^^ [2]
-   <BUILTINS>/bom.js:1564:44
-   1564| type BodyInit = string | URLSearchParams | FormData | Blob | ArrayBuffer | $ArrayBufferView | ReadableStream;
+   <BUILTINS>/bom.js:1569:44
+   1569| type BodyInit = string | URLSearchParams | FormData | Blob | ArrayBuffer | $ArrayBufferView | ReadableStream;
                                                     ^^^^^^^^ [3]
-   <BUILTINS>/bom.js:1564:55
-   1564| type BodyInit = string | URLSearchParams | FormData | Blob | ArrayBuffer | $ArrayBufferView | ReadableStream;
+   <BUILTINS>/bom.js:1569:55
+   1569| type BodyInit = string | URLSearchParams | FormData | Blob | ArrayBuffer | $ArrayBufferView | ReadableStream;
                                                                ^^^^ [4]
-   <BUILTINS>/bom.js:1564:62
-   1564| type BodyInit = string | URLSearchParams | FormData | Blob | ArrayBuffer | $ArrayBufferView | ReadableStream;
+   <BUILTINS>/bom.js:1569:62
+   1569| type BodyInit = string | URLSearchParams | FormData | Blob | ArrayBuffer | $ArrayBufferView | ReadableStream;
                                                                       ^^^^^^^^^^^ [5]
    <BUILTINS>/core.js:2035:20
    2035| type $TypedArray = $TypedArrayNumber | BigInt64Array | BigUint64Array;
@@ -733,8 +733,8 @@ References:
    <BUILTINS>/core.js:2031:39
    2031| type $ArrayBufferView = $TypedArray | DataView;
                                                ^^^^^^^^ [9]
-   <BUILTINS>/bom.js:1564:95
-   1564| type BodyInit = string | URLSearchParams | FormData | Blob | ArrayBuffer | $ArrayBufferView | ReadableStream;
+   <BUILTINS>/bom.js:1569:95
+   1569| type BodyInit = string | URLSearchParams | FormData | Blob | ArrayBuffer | $ArrayBufferView | ReadableStream;
                                                                                                        ^^^^^^^^^^^^^^ [10]
 
 
@@ -752,8 +752,8 @@ References:
    response.js:42:19
      42| h.text().then((t: Buffer) => t); // incorrect
                            ^^^^^^ [1]
-   <BUILTINS>/bom.js:1615:21
-   1615|     text(): Promise<string>;
+   <BUILTINS>/bom.js:1620:21
+   1620|     text(): Promise<string>;
                              ^^^^^^ [2]
    response.js:42:15
      42| h.text().then((t: Buffer) => t); // incorrect
@@ -774,8 +774,8 @@ Cannot call `h.arrayBuffer().then` because: [incompatible-call]
                          ^^^^
 
 References:
-   <BUILTINS>/bom.js:1611:28
-   1611|     arrayBuffer(): Promise<ArrayBuffer>;
+   <BUILTINS>/bom.js:1616:28
+   1616|     arrayBuffer(): Promise<ArrayBuffer>;
                                     ^^^^^^^^^^^ [1]
    response.js:44:27
      44| h.arrayBuffer().then((ab: Buffer) => ab); // incorrect
@@ -790,7 +790,7 @@ References:
 
 Error ------------------------------------------------------------------------------------------ urlsearchparams.js:4:31
 
-Cannot call `URLSearchParams` with array literal bound to `query` because: [incompatible-call]
+Cannot call `URLSearchParams` with array literal bound to `init` because: [incompatible-call]
  - Either string [1] is incompatible with tuple type [2] in array element.
  - Or array literal [3] is incompatible with object type [4].
 
@@ -802,12 +802,12 @@ References:
    urlsearchparams.js:4:32
       4| const b = new URLSearchParams(['key1', 'value1']); // not correct
                                         ^^^^^^ [1]
-   <BUILTINS>/bom.js:1540:58
-   1540|     constructor(query?: string | URLSearchParams | Array<[string, string]> | { [string]: string, ... } ): void;
-                                                                  ^^^^^^^^^^^^^^^^ [2]
-   <BUILTINS>/bom.js:1540:78
-   1540|     constructor(query?: string | URLSearchParams | Array<[string, string]> | { [string]: string, ... } ): void;
-                                                                                      ^^^^^^^^^^^^^^^^^^^^^^^^^ [4]
+   <BUILTINS>/bom.js:1543:57
+   1543|     constructor(init?: string | URLSearchParams | Array<[string, string]> | { [string]: string, ... } ): void;
+                                                                 ^^^^^^^^^^^^^^^^ [2]
+   <BUILTINS>/bom.js:1543:77
+   1543|     constructor(init?: string | URLSearchParams | Array<[string, string]> | { [string]: string, ... } ): void;
+                                                                                     ^^^^^^^^^^^^^^^^^^^^^^^^^ [4]
 
 
 Error ------------------------------------------------------------------------------------------- urlsearchparams.js:9:3
@@ -819,8 +819,8 @@ Cannot call `e.append` because function [1] requires another argument. [incompat
            ^^^^^^
 
 References:
-   <BUILTINS>/bom.js:1541:5
-   1541|     append(name: string, value: string): void;
+   <BUILTINS>/bom.js:1544:5
+   1544|     append(name: string, value: string): void;
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 
@@ -833,8 +833,8 @@ Cannot call `e.append` because function [1] requires another argument. [incompat
            ^^^^^^
 
 References:
-   <BUILTINS>/bom.js:1541:5
-   1541|     append(name: string, value: string): void;
+   <BUILTINS>/bom.js:1544:5
+   1544|     append(name: string, value: string): void;
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 
@@ -848,8 +848,8 @@ Cannot call `e.append` with object literal bound to `name` because object litera
                   ^^^^^^^^^^^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/bom.js:1541:18
-   1541|     append(name: string, value: string): void;
+   <BUILTINS>/bom.js:1544:18
+   1544|     append(name: string, value: string): void;
                           ^^^^^^ [2]
 
 
@@ -862,8 +862,8 @@ Cannot call `e.set` because function [1] requires another argument. [incompatibl
            ^^^
 
 References:
-   <BUILTINS>/bom.js:1549:5
-   1549|     set(name: string, value: string): void;
+   <BUILTINS>/bom.js:1552:5
+   1552|     set(name: string, value: string): void;
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 
@@ -876,8 +876,8 @@ Cannot call `e.set` because function [1] requires another argument. [incompatibl
            ^^^
 
 References:
-   <BUILTINS>/bom.js:1549:5
-   1549|     set(name: string, value: string): void;
+   <BUILTINS>/bom.js:1552:5
+   1552|     set(name: string, value: string): void;
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 
@@ -891,8 +891,8 @@ Cannot call `e.set` with object literal bound to `name` because object literal [
                ^^^^^^^^^^^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/bom.js:1549:15
-   1549|     set(name: string, value: string): void;
+   <BUILTINS>/bom.js:1552:15
+   1552|     set(name: string, value: string): void;
                        ^^^^^^ [2]
 
 
@@ -906,8 +906,8 @@ Cannot assign `e.append(...)` to `f` because undefined [1] is incompatible with 
                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/bom.js:1541:42
-   1541|     append(name: string, value: string): void;
+   <BUILTINS>/bom.js:1544:42
+   1544|     append(name: string, value: string): void;
                                                   ^^^^ [1]
    urlsearchparams.js:15:10
      15| const f: URLSearchParams = e.append('key1', 'value1'); // not correct
@@ -923,8 +923,8 @@ Cannot assign `e.get(...)` to `g` because null [1] is incompatible with string [
                            ^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/bom.js:1545:24
-   1545|     get(name: string): null | string;
+   <BUILTINS>/bom.js:1548:24
+   1548|     get(name: string): null | string;
                                 ^^^^ [1]
    urlsearchparams.js:17:10
      17| const g: string = e.get('key1'); // correct
@@ -940,8 +940,8 @@ Cannot assign `e.get(...)` to `h` because null [1] is incompatible with number [
                            ^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/bom.js:1545:24
-   1545|     get(name: string): null | string;
+   <BUILTINS>/bom.js:1548:24
+   1548|     get(name: string): null | string;
                                 ^^^^ [1]
    urlsearchparams.js:18:10
      18| const h: number = e.get('key1'); // not correct
@@ -957,8 +957,8 @@ Cannot assign `e.get(...)` to `h` because string [1] is incompatible with number
                            ^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/bom.js:1545:31
-   1545|     get(name: string): null | string;
+   <BUILTINS>/bom.js:1548:31
+   1548|     get(name: string): null | string;
                                        ^^^^^^ [1]
    urlsearchparams.js:18:10
      18| const h: number = e.get('key1'); // not correct

--- a/tests/node_tests/node_tests.exp
+++ b/tests/node_tests/node_tests.exp
@@ -1749,8 +1749,8 @@ Cannot call `inspector.open` with `'8080'` bound to `port` because string [1] is
                         ^^^^^^ [1]
 
 References:
-   <BUILTINS>/node.js:3245:12
-   3245|     port?: number,
+   <BUILTINS>/node.js:3248:12
+   3248|     port?: number,
                     ^^^^^^ [2]
 
 
@@ -1764,8 +1764,8 @@ Cannot call `inspector.open` with `127001` bound to `host` because number [1] is
                               ^^^^^^ [1]
 
 References:
-   <BUILTINS>/node.js:3246:12
-   3246|     host?: string,
+   <BUILTINS>/node.js:3249:12
+   3249|     host?: string,
                     ^^^^^^ [2]
 
 
@@ -1779,8 +1779,8 @@ Cannot call `inspector.open` with `1000` bound to `wait` because number [1] is i
                                                   ^^^^ [1]
 
 References:
-   <BUILTINS>/node.js:3247:12
-   3247|     wait?: boolean
+   <BUILTINS>/node.js:3250:12
+   3250|     wait?: boolean
                     ^^^^^^^ [2]
 
 
@@ -1793,8 +1793,8 @@ Cannot cast `inspector.open()` to string because undefined [1] is incompatible w
           ^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/node.js:3248:6
-   3248|   ): void;
+   <BUILTINS>/node.js:3251:6
+   3251|   ): void;
               ^^^^ [1]
    inspector/inspector.js:16:21
      16| (inspector.open() : string); // error
@@ -1810,8 +1810,8 @@ Cannot cast `inspector.close()` to string because undefined [1] is incompatible 
           ^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/node.js:3250:29
-   3250|   declare function close(): void;
+   <BUILTINS>/node.js:3253:29
+   3253|   declare function close(): void;
                                      ^^^^ [1]
    inspector/inspector.js:24:22
      24| (inspector.close() : string); // error
@@ -1827,8 +1827,8 @@ Cannot cast `inspector.url()` to number because string [1] is incompatible with 
           ^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/node.js:3251:28
-   3251|   declare function url() : string | void;
+   <BUILTINS>/node.js:3254:28
+   3254|   declare function url() : string | void;
                                     ^^^^^^ [1]
    inspector/inspector.js:36:20
      36| (inspector.url() : number); // error
@@ -1844,8 +1844,8 @@ Cannot cast `inspector.url()` to number because undefined [1] is incompatible wi
           ^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/node.js:3251:37
-   3251|   declare function url() : string | void;
+   <BUILTINS>/node.js:3254:37
+   3254|   declare function url() : string | void;
                                              ^^^^ [1]
    inspector/inspector.js:36:20
      36| (inspector.url() : number); // error
@@ -1862,8 +1862,8 @@ Cannot cast `inspector.waitForDebugger()` to number because undefined [1] is inc
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/node.js:3253:39
-   3253|   declare function waitForDebugger(): void;
+   <BUILTINS>/node.js:3256:39
+   3256|   declare function waitForDebugger(): void;
                                                ^^^^ [1]
    inspector/inspector.js:44:32
      44| (inspector.waitForDebugger() : number); // error
@@ -1879,8 +1879,8 @@ Cannot call `inspector.connect` because property `connect` is missing in module 
                     ^^^^^^^
 
 References:
-   <BUILTINS>/node.js:3243:16
-   3243| declare module 'inspector' {
+   <BUILTINS>/node.js:3246:16
+   3246| declare module 'inspector' {
                         ^^^^^^^^^^^ [1]
 
 
@@ -1894,8 +1894,8 @@ Cannot call `inspector.connectToMainThread` because property `connectToMainThrea
                     ^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/node.js:3243:16
-   3243| declare module 'inspector' {
+   <BUILTINS>/node.js:3246:16
+   3246| declare module 'inspector' {
                         ^^^^^^^^^^^ [1]
 
 
@@ -1908,8 +1908,8 @@ Cannot call `inspector.disconnect` because property `disconnect` is missing in m
                     ^^^^^^^^^^
 
 References:
-   <BUILTINS>/node.js:3243:16
-   3243| declare module 'inspector' {
+   <BUILTINS>/node.js:3246:16
+   3246| declare module 'inspector' {
                         ^^^^^^^^^^^ [1]
 
 
@@ -1922,13 +1922,13 @@ Cannot call `session.post` because function [1] requires another argument. [inco
                  ^^^^
 
 References:
-   <BUILTINS>/node.js:3260:5
+   <BUILTINS>/node.js:3263:5
              v----
-   3260|     post(
-   3261|       method: string,
-   3262|       params?: Object,
-   3263|       callback?: Function
-   3264|     ): void;
+   3263|     post(
+   3264|       method: string,
+   3265|       params?: Object,
+   3266|       callback?: Function
+   3267|     ): void;
              ------^ [1]
 
 
@@ -1941,13 +1941,13 @@ Cannot call `session.post` because function [1] requires another argument. [inco
                   ^^^^
 
 References:
-   <BUILTINS>/node.js:3260:5
+   <BUILTINS>/node.js:3263:5
              v----
-   3260|     post(
-   3261|       method: string,
-   3262|       params?: Object,
-   3263|       callback?: Function
-   3264|     ): void;
+   3263|     post(
+   3264|       method: string,
+   3265|       params?: Object,
+   3266|       callback?: Function
+   3267|     ): void;
              ------^ [1]
 
 
@@ -1960,8 +1960,8 @@ Cannot cast `session.post()` to string because undefined [1] is incompatible wit
           ^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/node.js:3264:8
-   3264|     ): void;
+   <BUILTINS>/node.js:3267:8
+   3267|     ): void;
                 ^^^^ [1]
    inspector/inspector.js:90:19
      90| (session.post() : string); // error
@@ -2044,26 +2044,26 @@ References:
    process/emitWarning.js:10:1
      10| process.emitWarning(); // error
          ^^^^^^^^^^^^^^^^^^^^^ [1]
-   <BUILTINS>/node.js:3289:24
-   3289|   emitWarning(warning: string | Error): void;
+   <BUILTINS>/node.js:3292:24
+   3292|   emitWarning(warning: string | Error): void;
                                 ^^^^^^ [2]
-   <BUILTINS>/node.js:3289:33
-   3289|   emitWarning(warning: string | Error): void;
+   <BUILTINS>/node.js:3292:33
+   3292|   emitWarning(warning: string | Error): void;
                                          ^^^^^ [3]
-   <BUILTINS>/node.js:3290:3
-   3290|   emitWarning(warning: string, typeOrCtor: string | (...empty) => mixed): void;
+   <BUILTINS>/node.js:3293:3
+   3293|   emitWarning(warning: string, typeOrCtor: string | (...empty) => mixed): void;
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [4]
-   <BUILTINS>/node.js:3291:3
-   3291|   emitWarning(warning: string, type: string, codeOrCtor: string | (...empty) => mixed): void;
+   <BUILTINS>/node.js:3294:3
+   3294|   emitWarning(warning: string, type: string, codeOrCtor: string | (...empty) => mixed): void;
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [5]
-   <BUILTINS>/node.js:3292:3
+   <BUILTINS>/node.js:3295:3
            v-----------
-   3292|   emitWarning(
-   3293|     warning: string,
-   3294|     type: string,
-   3295|     code: string,
-   3296|     ctor?: (...empty) => mixed
-   3297|   ): void;
+   3295|   emitWarning(
+   3296|     warning: string,
+   3297|     type: string,
+   3298|     code: string,
+   3299|     ctor?: (...empty) => mixed
+   3300|   ): void;
            ------^ [6]
 
 
@@ -2082,14 +2082,14 @@ References:
    process/emitWarning.js:11:21
      11| process.emitWarning(42); // error
                              ^^ [1]
-   <BUILTINS>/node.js:3290:24
-   3290|   emitWarning(warning: string, typeOrCtor: string | (...empty) => mixed): void;
+   <BUILTINS>/node.js:3293:24
+   3293|   emitWarning(warning: string, typeOrCtor: string | (...empty) => mixed): void;
                                 ^^^^^^ [2]
-   <BUILTINS>/node.js:3291:24
-   3291|   emitWarning(warning: string, type: string, codeOrCtor: string | (...empty) => mixed): void;
+   <BUILTINS>/node.js:3294:24
+   3294|   emitWarning(warning: string, type: string, codeOrCtor: string | (...empty) => mixed): void;
                                 ^^^^^^ [3]
-   <BUILTINS>/node.js:3293:14
-   3293|     warning: string,
+   <BUILTINS>/node.js:3296:14
+   3296|     warning: string,
                       ^^^^^^ [4]
 
 
@@ -2107,11 +2107,11 @@ References:
    process/emitWarning.js:12:29
      12| process.emitWarning("blah", 42); // error
                                      ^^ [1]
-   <BUILTINS>/node.js:3291:38
-   3291|   emitWarning(warning: string, type: string, codeOrCtor: string | (...empty) => mixed): void;
+   <BUILTINS>/node.js:3294:38
+   3294|   emitWarning(warning: string, type: string, codeOrCtor: string | (...empty) => mixed): void;
                                               ^^^^^^ [2]
-   <BUILTINS>/node.js:3294:11
-   3294|     type: string,
+   <BUILTINS>/node.js:3297:11
+   3297|     type: string,
                    ^^^^^^ [3]
 
 
@@ -2129,11 +2129,11 @@ References:
    process/emitWarning.js:13:37
      13| process.emitWarning("blah", "blah", 42); // error
                                              ^^ [1]
-   <BUILTINS>/node.js:3295:11
-   3295|     code: string,
+   <BUILTINS>/node.js:3298:11
+   3298|     code: string,
                    ^^^^^^ [2]
-   <BUILTINS>/node.js:3291:58
-   3291|   emitWarning(warning: string, type: string, codeOrCtor: string | (...empty) => mixed): void;
+   <BUILTINS>/node.js:3294:58
+   3294|   emitWarning(warning: string, type: string, codeOrCtor: string | (...empty) => mixed): void;
                                                                   ^^^^^^ [3]
 
 
@@ -2147,8 +2147,8 @@ Cannot cast `process.emitWarning(...)` to string because undefined [1] is incomp
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/node.js:3289:41
-   3289|   emitWarning(warning: string | Error): void;
+   <BUILTINS>/node.js:3292:41
+   3292|   emitWarning(warning: string | Error): void;
                                                  ^^^^ [1]
    process/emitWarning.js:14:31
      14| (process.emitWarning("blah"): string); // error
@@ -2219,8 +2219,8 @@ type [2]. [incompatible-call]
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/node.js:3323:21
-   3323|   nextTick: <T>(cb: (...T) => mixed, ...T) => void;
+   <BUILTINS>/node.js:3326:21
+   3326|   nextTick: <T>(cb: (...T) => mixed, ...T) => void;
                              ^^^^^^^^^^^^^^^ [2]
 
 
@@ -2234,8 +2234,8 @@ Cannot cast `process.allowedNodeEnvironmentFlags` to string because `Set` [1] is
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/node.js:3278:32
-   3278|   allowedNodeEnvironmentFlags: Set<string>;
+   <BUILTINS>/node.js:3281:32
+   3281|   allowedNodeEnvironmentFlags: Set<string>;
                                         ^^^^^^^^^^^ [1]
    process/process.js:5:39
       5| (process.allowedNodeEnvironmentFlags: string); // error
@@ -2589,8 +2589,8 @@ Cannot get `values.invalid` because property `invalid` is missing in `util$Parse
                 ^^^^^^^
 
 References:
-   <BUILTINS>/node.js:2565:13
-   2565|     values: util$ParseArgsOptionsToValues<TOptions>,
+   <BUILTINS>/node.js:2568:13
+   2568|     values: util$ParseArgsOptionsToValues<TOptions>,
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 
@@ -2603,12 +2603,12 @@ Cannot get `parseArgs(...).tokens` because property `tokens` is missing in objec
                        ^^^^^^
 
 References:
-   <BUILTINS>/node.js:2564:8
+   <BUILTINS>/node.js:2567:8
                 v-
-   2564|   |}): {|
-   2565|     values: util$ParseArgsOptionsToValues<TOptions>,
-   2566|     positionals: Array<string>,
-   2567|   |};
+   2567|   |}): {|
+   2568|     values: util$ParseArgsOptionsToValues<TOptions>,
+   2569|     positionals: Array<string>,
+   2570|   |};
            -^ [1]
 
 
@@ -2621,12 +2621,12 @@ Cannot get `parseArgs(...).tokens` because property `tokens` is missing in objec
                                     ^^^^^^
 
 References:
-   <BUILTINS>/node.js:2564:8
+   <BUILTINS>/node.js:2567:8
                 v-
-   2564|   |}): {|
-   2565|     values: util$ParseArgsOptionsToValues<TOptions>,
-   2566|     positionals: Array<string>,
-   2567|   |};
+   2567|   |}): {|
+   2568|     values: util$ParseArgsOptionsToValues<TOptions>,
+   2569|     positionals: Array<string>,
+   2570|   |};
            -^ [1]
 
 


### PR DESCRIPTION
Greetings, 

this add the following missing optional parameter `value` to `delete` and `has` methods.

1. `delete` https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams/delete
2. `has` https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams/has

Also add missing instance property `size`, as well as `toString` and `sort` methods.

1. `size` https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams/size
2. `toString` https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams/toString
3. `sort` https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams/sort

Grab the occasion to harmonize the DOM and Node definitions.

See 
- https://nodejs.org/api/url.html#class-urlsearchparams
- https://url.spec.whatwg.org/#interface-urlsearchparams
