### PR TITLE
[core] Add Array copying methods definitions

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -889,9 +889,38 @@ declare class $ReadOnlyArray<+T> {
      */
     some<This>(callbackfn: (this : This, value: T, index: number, array: $ReadOnlyArray<T>) => mixed, thisArg: This): boolean;
     /**
+     * Returns a new array with the elements in reversed order.
+     * It is the copying counterpart of the reverse() method.
+     */
+    toReversed(): Array<T>;
+    /**
+     * Returns a new array with the elements sorted in ascending order.
+     * It is the copying counterpart of the sort() method.
+     * @param compareFn Specifies a function that defines the sort order. 
+     * If omitted, the array elements are converted to strings, then sorted according 
+     * to each character's Unicode code point value.
+     */
+    toSorted(compareFn?: (a: T, b: T) => number): Array<T>;
+    /**
+     * Returns a new array with some elements removed and/or replaced at a given index.
+     * It is the copying counterpart of the splice() method. 
+     * @param start Zero-based index at which to start changing the array, converted to an integer.
+     * @param deleteCount An integer indicating the number of elements in the array to remove from start.
+     * @param items The elements to add to the array, beginning from start.
+     */
+    toSpliced<S, Item: $ReadOnlyArray<S> | S>(start: number, deleteCount?: number, ...items: Array<Item>): Array<T | S>;
+    /**
      * Returns an iterable of values in the array
      */
     values(): Iterator<T>;
+    /**
+     * Returns a new array with the element at the given index replaced with the given value.
+     * It is the copying version of using the bracket notation to change the value of a given index.
+     * @param index Zero-based index at which to change the array, converted to an integer.
+     * @param value Any value to be assigned to the given index.
+     */
+    with(index: number, value: T): Array<T>;
+
     +[key: number]: T;
     /**
      * Gets the length of the array. This is a number one higher than the highest element defined in an array.

--- a/tests/arraylib/arraylib.exp
+++ b/tests/arraylib/arraylib.exp
@@ -107,8 +107,8 @@ References:
    array_lib.js:46:4
      46|   [""].reduce((acc, str) => acc * str.length); // error, string ~> number
             ^^ [1]
-   <BUILTINS>/core.js:1319:13
-   1319|     length: number;
+   <BUILTINS>/core.js:1348:13
+   1348|     length: number;
                      ^^^^^^ [2]
 
 
@@ -124,8 +124,8 @@ References:
    array_lib.js:47:4
      47|   [""].reduceRight((acc, str) => acc * str.length); // error, string ~> number
             ^^ [1]
-   <BUILTINS>/core.js:1319:13
-   1319|     length: number;
+   <BUILTINS>/core.js:1348:13
+   1348|     length: number;
                      ^^^^^^ [2]
 
 
@@ -139,8 +139,8 @@ Cannot cast `Array.from(...)` to array type because string [1] is incompatible w
             ^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:1104:37
-   1104|     static from(str: string): Array<string>;
+   <BUILTINS>/core.js:1133:37
+   1133|     static from(str: string): Array<string>;
                                              ^^^^^^ [1]
    array_lib.js:59:30
      59|   (Array.from("abcd"): Array<empty>); // ERROR

--- a/tests/arrows/arrows.exp
+++ b/tests/arrows/arrows.exp
@@ -42,8 +42,8 @@ return value. [incompatible-call]
                                             ^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:1052:38
-   1052|     sort(compareFn?: (a: T, b: T) => number): Array<T>;
+   <BUILTINS>/core.js:1081:38
+   1081|     sort(compareFn?: (a: T, b: T) => number): Array<T>;
                                               ^^^^^^ [2]
 
 

--- a/tests/async/async.exp
+++ b/tests/async/async.exp
@@ -10,8 +10,8 @@ References:
    async.js:9:30
       9| async function f1(): Promise<boolean> {
                                       ^^^^^^^ [2]
-   <BUILTINS>/core.js:1878:24
-   1878| declare class Promise<+R = mixed> {
+   <BUILTINS>/core.js:1907:24
+   1907| declare class Promise<+R = mixed> {
                                 ^ [3]
 
 
@@ -31,8 +31,8 @@ References:
    async.js:28:48
      28| async function f4(p: Promise<number>): Promise<boolean> {
                                                         ^^^^^^^ [2]
-   <BUILTINS>/core.js:1878:24
-   1878| declare class Promise<+R = mixed> {
+   <BUILTINS>/core.js:1907:24
+   1907| declare class Promise<+R = mixed> {
                                 ^ [3]
 
 
@@ -99,8 +99,8 @@ undefined in type argument `R` [2]. [incompatible-return]
                      ^^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:1878:24
-   1878| declare class Promise<+R = mixed> {
+   <BUILTINS>/core.js:1907:24
+   1907| declare class Promise<+R = mixed> {
                                 ^ [2]
 
 
@@ -142,8 +142,8 @@ References:
    async_return_void.js:1:32
       1| async function foo1(): Promise<string> {
                                         ^^^^^^ [2]
-   <BUILTINS>/core.js:1878:24
-   1878| declare class Promise<+R = mixed> {
+   <BUILTINS>/core.js:1907:24
+   1907| declare class Promise<+R = mixed> {
                                 ^ [3]
 
 
@@ -160,8 +160,8 @@ References:
    async_return_void.js:5:32
       5| async function foo2(): Promise<string> {
                                         ^^^^^^ [2]
-   <BUILTINS>/core.js:1878:24
-   1878| declare class Promise<+R = mixed> {
+   <BUILTINS>/core.js:1907:24
+   1907| declare class Promise<+R = mixed> {
                                 ^ [3]
 
 
@@ -181,8 +181,8 @@ References:
    async_return_void.js:9:32
       9| async function foo3(): Promise<string> {
                                         ^^^^^^ [2]
-   <BUILTINS>/core.js:1878:24
-   1878| declare class Promise<+R = mixed> {
+   <BUILTINS>/core.js:1907:24
+   1907| declare class Promise<+R = mixed> {
                                 ^ [3]
 
 

--- a/tests/async_iteration/async_iteration.exp
+++ b/tests/async_iteration/async_iteration.exp
@@ -113,8 +113,8 @@ Cannot cast `result.value` to string because undefined [1] is incompatible with 
               ^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:1689:14
-   1689|     +value?: Return,
+   <BUILTINS>/core.js:1718:14
+   1718|     +value?: Return,
                       ^^^^^^ [1]
    return.js:20:20
      20|     (result.value: string); // error: number | void ~> string

--- a/tests/autocomplete/autocomplete.exp
+++ b/tests/autocomplete/autocomplete.exp
@@ -1032,8 +1032,18 @@ Flags: --pretty
       "type":"void | ((start: number, deleteCount?: number, ...items: Array<T>) => Array<T>)"
     },
     {"name":"?.toLocaleString","type":"void | (() => string)"},
+    {"name":"?.toReversed","type":"void | (() => Array<T>)"},
+    {
+      "name":"?.toSorted",
+      "type":"void | ((compareFn?: (a: T, b: T) => number) => Array<T>)"
+    },
+    {
+      "name":"?.toSpliced",
+      "type":"void | (<S, Item: ($ReadOnlyArray<S> | S)>(start: number, deleteCount?: number, ...items: Array<Item>) => Array<(T | S)>)"
+    },
     {"name":"?.unshift","type":"void | ((...items: Array<T>) => number)"},
-    {"name":"?.values","type":"void | (() => Iterator<T>)"}
+    {"name":"?.values","type":"void | (() => Iterator<T>)"},
+    {"name":"?.with","type":"void | ((index: number, value: T) => Array<T>)"}
   ]
 }
 
@@ -1124,8 +1134,15 @@ Flags: --pretty
       "type":"(start: number, deleteCount?: number, ...items: Array<T>) => Array<T>"
     },
     {"name":"toLocaleString","type":"() => string"},
+    {"name":"toReversed","type":"() => Array<T>"},
+    {"name":"toSorted","type":"(compareFn?: (a: T, b: T) => number) => Array<T>"},
+    {
+      "name":"toSpliced",
+      "type":"<S, Item: ($ReadOnlyArray<S> | S)>(start: number, deleteCount?: number, ...items: Array<Item>) => Array<(T | S)>"
+    },
     {"name":"unshift","type":"(...items: Array<T>) => number"},
-    {"name":"values","type":"() => Iterator<T>"}
+    {"name":"values","type":"() => Iterator<T>"},
+    {"name":"with","type":"(index: number, value: T) => Array<T>"}
   ]
 }
 

--- a/tests/babel_loose_array_spread/babel_loose_array_spread.exp
+++ b/tests/babel_loose_array_spread/babel_loose_array_spread.exp
@@ -10,13 +10,13 @@ References:
    apply.js:3:11
       3| const it: Iterable<number> = [7,8,9];
                    ^^^^^^^^^^^^^^^^ [1]
-   <BUILTINS>/core.js:1112:22
+   <BUILTINS>/core.js:1141:22
                               v----------
-   1112| type $ArrayLike<T> = interface {
-   1113|   +[indexer: number]: T;
-   1114|   @@iterator(): Iterator<T>;
-   1115|   length: number;
-   1116| }
+   1141| type $ArrayLike<T> = interface {
+   1142|   +[indexer: number]: T;
+   1143|   @@iterator(): Iterator<T>;
+   1144|   length: number;
+   1145| }
          ^ [2]
 
 

--- a/tests/bigint/bigint.exp
+++ b/tests/bigint/bigint.exp
@@ -30,23 +30,23 @@ Cannot call `BigInt` with `null` bound to `value` because: [incompatible-call]
                 ^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:2674:18
-   2674|   static (value: boolean | string | number | bigint | interface {} | $ReadOnlyArray<mixed>): bigint;
+   <BUILTINS>/core.js:2703:18
+   2703|   static (value: boolean | string | number | bigint | interface {} | $ReadOnlyArray<mixed>): bigint;
                           ^^^^^^^ [2]
-   <BUILTINS>/core.js:2674:28
-   2674|   static (value: boolean | string | number | bigint | interface {} | $ReadOnlyArray<mixed>): bigint;
+   <BUILTINS>/core.js:2703:28
+   2703|   static (value: boolean | string | number | bigint | interface {} | $ReadOnlyArray<mixed>): bigint;
                                     ^^^^^^ [3]
-   <BUILTINS>/core.js:2674:37
-   2674|   static (value: boolean | string | number | bigint | interface {} | $ReadOnlyArray<mixed>): bigint;
+   <BUILTINS>/core.js:2703:37
+   2703|   static (value: boolean | string | number | bigint | interface {} | $ReadOnlyArray<mixed>): bigint;
                                              ^^^^^^ [4]
-   <BUILTINS>/core.js:2674:46
-   2674|   static (value: boolean | string | number | bigint | interface {} | $ReadOnlyArray<mixed>): bigint;
+   <BUILTINS>/core.js:2703:46
+   2703|   static (value: boolean | string | number | bigint | interface {} | $ReadOnlyArray<mixed>): bigint;
                                                       ^^^^^^ [5]
-   <BUILTINS>/core.js:2674:55
-   2674|   static (value: boolean | string | number | bigint | interface {} | $ReadOnlyArray<mixed>): bigint;
+   <BUILTINS>/core.js:2703:55
+   2703|   static (value: boolean | string | number | bigint | interface {} | $ReadOnlyArray<mixed>): bigint;
                                                                ^^^^^^^^^^^^ [6]
-   <BUILTINS>/core.js:2674:70
-   2674|   static (value: boolean | string | number | bigint | interface {} | $ReadOnlyArray<mixed>): bigint;
+   <BUILTINS>/core.js:2703:70
+   2703|   static (value: boolean | string | number | bigint | interface {} | $ReadOnlyArray<mixed>): bigint;
                                                                               ^^^^^^^^^^^^^^^^^^^^^ [7]
 
 

--- a/tests/computed_props/computed_props.exp
+++ b/tests/computed_props/computed_props.exp
@@ -198,8 +198,8 @@ Cannot assign `arr[0]()` to `y` because number [1] is incompatible with string [
                            ^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:1061:13
-   1061|     length: number;
+   <BUILTINS>/core.js:1090:13
+   1090|     length: number;
                      ^^^^^^ [1]
    test7.js:5:10
       5| const y: string = arr[0](); // error: number ~> string

--- a/tests/contextual_typing/contextual_typing.exp
+++ b/tests/contextual_typing/contextual_typing.exp
@@ -22,8 +22,8 @@ expression to your expected type. [underconstrained-implicit-instantiation]
                             ^^^
 
 References:
-   <BUILTINS>/core.js:1836:19
-   1836| declare class Set<T> extends $ReadOnlySet<T> {
+   <BUILTINS>/core.js:1865:19
+   1865| declare class Set<T> extends $ReadOnlySet<T> {
                            ^ [1]
    arr_rest.js:9:16
       9| const [...y] = new Set() // still error
@@ -298,8 +298,8 @@ Property `@@iterator` is missing in function [1] but exists in `$Iterable` [2]. 
                 ^^^^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:1704:11
-   1704| interface $Iterable<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:1733:11
+   1733| interface $Iterable<+Yield,+Return,-Next> {
                    ^^^^^^^^^ [2]
 
 
@@ -437,8 +437,8 @@ References:
    implicit_instantiation.js:150:11
     150|   (a: Set<empty>); // error Set<string> ~> Set<empty>
                    ^^^^^ [2]
-   <BUILTINS>/core.js:1836:19
-   1836| declare class Set<T> extends $ReadOnlySet<T> {
+   <BUILTINS>/core.js:1865:19
+   1865| declare class Set<T> extends $ReadOnlySet<T> {
                            ^ [3]
 
 
@@ -457,8 +457,8 @@ References:
    implicit_instantiation.js:151:11
     151|   (b: Set<empty>); // error Set<string> ~> Set<empty>
                    ^^^^^ [2]
-   <BUILTINS>/core.js:1836:19
-   1836| declare class Set<T> extends $ReadOnlySet<T> {
+   <BUILTINS>/core.js:1865:19
+   1865| declare class Set<T> extends $ReadOnlySet<T> {
                            ^ [3]
 
 
@@ -696,8 +696,8 @@ References:
    lits.js:43:26
      43|   (s2.values(): Iterator<string>); // error number ~> string
                                   ^^^^^^ [2]
-   <BUILTINS>/core.js:1702:16
-   1702| type Iterator<+T> = $Iterator<T,void,void>;
+   <BUILTINS>/core.js:1731:16
+   1731| type Iterator<+T> = $Iterator<T,void,void>;
                         ^ [3]
 
 
@@ -1006,8 +1006,8 @@ defined. [method-unbinding]
                                                          ^^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:941:5
-   941|     filter(callbackfn: typeof Boolean): Array<$NonMaybeType<T>>;
+   <BUILTINS>/core.js:970:5
+   970|     filter(callbackfn: typeof Boolean): Array<$NonMaybeType<T>>;
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [2]
 
 

--- a/tests/core_tests/core_tests.exp
+++ b/tests/core_tests/core_tests.exp
@@ -7,33 +7,33 @@ Cannot use `new` on object type [1]. Only classes can be constructed. [invalid-c
              ^^^^
 
 References:
-   <BUILTINS>/core.js:1658:19
+   <BUILTINS>/core.js:1687:19
                            v-
-   1658| declare var JSON: {|
-   1659|     /**
-   1660|      * Converts a JavaScript Object Notation (JSON) string into an object.
-   1661|      * @param text A valid JSON string.
-   1662|      * @param reviver A function that transforms the results. This function is called for each member of the object.
-   1663|      * If a member contains nested objects, the nested objects are transformed before the parent object is.
-   1664|      */
-   1665|     +parse: (text: string, reviver?: (key: any, value: any) => any) => any,
-   1666|     /**
-   1667|      * Converts a JavaScript value to a JavaScript Object Notation (JSON) string.
-   1668|      * @param value A JavaScript value, usually an object or array, to be converted.
-   1669|      * @param replacer A function that transforms the results or an array of strings and numbers that acts as a approved list for selecting the object properties that will be stringified.
-   1670|      * @param space Adds indentation, white space, and line break characters to the return-value JSON text to make it easier to read.
-   1671|      */
-   1672|     +stringify: ((
-   1673|         value: null | string | number | boolean | interface {} | $ReadOnlyArray<mixed>,
-   1674|         replacer?: ?((key: string, value: any) => any) | Array<any>,
-   1675|         space?: string | number
-   1676|       ) => string) &
-   1677|       (
-   1678|         value: mixed,
-   1679|         replacer?: ?((key: string, value: any) => any) | Array<any>,
-   1680|         space?: string | number
-   1681|       ) => string | void,
-   1682| |};
+   1687| declare var JSON: {|
+   1688|     /**
+   1689|      * Converts a JavaScript Object Notation (JSON) string into an object.
+   1690|      * @param text A valid JSON string.
+   1691|      * @param reviver A function that transforms the results. This function is called for each member of the object.
+   1692|      * If a member contains nested objects, the nested objects are transformed before the parent object is.
+   1693|      */
+   1694|     +parse: (text: string, reviver?: (key: any, value: any) => any) => any,
+   1695|     /**
+   1696|      * Converts a JavaScript value to a JavaScript Object Notation (JSON) string.
+   1697|      * @param value A JavaScript value, usually an object or array, to be converted.
+   1698|      * @param replacer A function that transforms the results or an array of strings and numbers that acts as a approved list for selecting the object properties that will be stringified.
+   1699|      * @param space Adds indentation, white space, and line break characters to the return-value JSON text to make it easier to read.
+   1700|      */
+   1701|     +stringify: ((
+   1702|         value: null | string | number | boolean | interface {} | $ReadOnlyArray<mixed>,
+   1703|         replacer?: ?((key: string, value: any) => any) | Array<any>,
+   1704|         space?: string | number
+   1705|       ) => string) &
+   1706|       (
+   1707|         value: mixed,
+   1708|         replacer?: ?((key: string, value: any) => any) | Array<any>,
+   1709|         space?: string | number
+   1710|       ) => string | void,
+   1711| |};
          -^ [1]
 
 
@@ -54,8 +54,8 @@ Cannot cast `JSON.stringify(...)` to string because undefined [1] is incompatibl
           ^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:1681:21
-   1681|       ) => string | void,
+   <BUILTINS>/core.js:1710:21
+   1710|       ) => string | void,
                              ^^^^ [1]
    json_stringify.js:7:24
       7| (JSON.stringify(bad1): string);
@@ -75,11 +75,11 @@ References:
    map.js:21:22
      21|     let x = new Map(['foo', 123]); // error
                               ^^^^^ [1]
-   <BUILTINS>/core.js:1764:38
-   1764|     constructor(iterable?: ?Iterable<[K, V]>): void;
+   <BUILTINS>/core.js:1793:38
+   1793|     constructor(iterable?: ?Iterable<[K, V]>): void;
                                               ^^^^^^ [2]
-   <BUILTINS>/core.js:1698:22
-   1698| interface $Iterator<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:1727:22
+   1727| interface $Iterator<+Yield,+Return,-Next> {
                               ^^^^^ [3]
 
 
@@ -96,11 +96,11 @@ References:
    map.js:21:29
      21|     let x = new Map(['foo', 123]); // error
                                      ^^^ [1]
-   <BUILTINS>/core.js:1764:38
-   1764|     constructor(iterable?: ?Iterable<[K, V]>): void;
+   <BUILTINS>/core.js:1793:38
+   1793|     constructor(iterable?: ?Iterable<[K, V]>): void;
                                               ^^^^^^ [2]
-   <BUILTINS>/core.js:1698:22
-   1698| interface $Iterator<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:1727:22
+   1727| interface $Iterator<+Yield,+Return,-Next> {
                               ^^^^^ [3]
 
 
@@ -120,8 +120,8 @@ References:
    map.js:22:16
      22|     let y: Map<number, string> = new Map([['foo', 123]]); // error
                         ^^^^^^ [2]
-   <BUILTINS>/core.js:1698:22
-   1698| interface $Iterator<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:1727:22
+   1727| interface $Iterator<+Yield,+Return,-Next> {
                               ^^^^^ [3]
 
 
@@ -141,8 +141,8 @@ References:
    map.js:22:24
      22|     let y: Map<number, string> = new Map([['foo', 123]]); // error
                                 ^^^^^^ [2]
-   <BUILTINS>/core.js:1698:22
-   1698| interface $Iterator<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:1727:22
+   1727| interface $Iterator<+Yield,+Return,-Next> {
                               ^^^^^ [3]
 
 
@@ -155,8 +155,8 @@ Cannot cast `x.get(...)` to boolean because undefined [1] is incompatible with b
               ^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:1772:22
-   1772|     get(key: K): V | void;
+   <BUILTINS>/core.js:1801:22
+   1801|     get(key: K): V | void;
                               ^^^^ [1]
    map.js:27:20
      27|     (x.get('foo'): boolean); // error, string | void
@@ -204,8 +204,8 @@ since `z` is not a member of the set. [invalid-charset-type-arg]
                            ^^^ [1]
 
 References:
-   <BUILTINS>/core.js:1118:21
-   1118| type RegExp$flags = $CharSet<"gimsuy">;
+   <BUILTINS>/core.js:1147:21
+   1147| type RegExp$flags = $CharSet<"gimsuy">;
                              ^^^^^^^^^^^^^^^^^^ [2]
 
 
@@ -219,8 +219,8 @@ since `z` is not a member of the set. [invalid-charset-type-arg]
                                ^^^ [1]
 
 References:
-   <BUILTINS>/core.js:1118:21
-   1118| type RegExp$flags = $CharSet<"gimsuy">;
+   <BUILTINS>/core.js:1147:21
+   1147| type RegExp$flags = $CharSet<"gimsuy">;
                              ^^^^^^^^^^^^^^^^^^ [2]
 
 
@@ -236,11 +236,11 @@ Cannot call `WeakRef` because in type argument `T`: [incompatible-call]
                                ^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:1795:26
-   1795| declare class WeakRef<T: interface {} | $ReadOnlyArray<mixed>> {
+   <BUILTINS>/core.js:1824:26
+   1824| declare class WeakRef<T: interface {} | $ReadOnlyArray<mixed>> {
                                   ^^^^^^^^^^^^ [2]
-   <BUILTINS>/core.js:1795:41
-   1795| declare class WeakRef<T: interface {} | $ReadOnlyArray<mixed>> {
+   <BUILTINS>/core.js:1824:41
+   1824| declare class WeakRef<T: interface {} | $ReadOnlyArray<mixed>> {
                                                  ^^^^^^^^^^^^^^^^^^^^^ [3]
 
 
@@ -256,11 +256,11 @@ Cannot call `WeakRef` because in type argument `T`: [incompatible-call]
                                ^^^ [1]
 
 References:
-   <BUILTINS>/core.js:1795:26
-   1795| declare class WeakRef<T: interface {} | $ReadOnlyArray<mixed>> {
+   <BUILTINS>/core.js:1824:26
+   1824| declare class WeakRef<T: interface {} | $ReadOnlyArray<mixed>> {
                                   ^^^^^^^^^^^^ [2]
-   <BUILTINS>/core.js:1795:41
-   1795| declare class WeakRef<T: interface {} | $ReadOnlyArray<mixed>> {
+   <BUILTINS>/core.js:1824:41
+   1824| declare class WeakRef<T: interface {} | $ReadOnlyArray<mixed>> {
                                                  ^^^^^^^^^^^^^^^^^^^^^ [3]
 
 
@@ -276,11 +276,11 @@ Cannot call `WeakRef` because in type argument `T`: [incompatible-call]
                                ^^^^^^^^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:1795:26
-   1795| declare class WeakRef<T: interface {} | $ReadOnlyArray<mixed>> {
+   <BUILTINS>/core.js:1824:26
+   1824| declare class WeakRef<T: interface {} | $ReadOnlyArray<mixed>> {
                                   ^^^^^^^^^^^^ [2]
-   <BUILTINS>/core.js:1795:41
-   1795| declare class WeakRef<T: interface {} | $ReadOnlyArray<mixed>> {
+   <BUILTINS>/core.js:1824:41
+   1824| declare class WeakRef<T: interface {} | $ReadOnlyArray<mixed>> {
                                                  ^^^^^^^^^^^^^^^^^^^^^ [3]
 
 
@@ -296,11 +296,11 @@ Cannot call `WeakSet` because in type argument `T`: [incompatible-call]
                                 ^ [1]
 
 References:
-   <BUILTINS>/core.js:1865:26
-   1865| declare class WeakSet<T: interface {} | $ReadOnlyArray<mixed>> extends $ReadOnlyWeakSet<T> {
+   <BUILTINS>/core.js:1894:26
+   1894| declare class WeakSet<T: interface {} | $ReadOnlyArray<mixed>> extends $ReadOnlyWeakSet<T> {
                                   ^^^^^^^^^^^^ [2]
-   <BUILTINS>/core.js:1865:41
-   1865| declare class WeakSet<T: interface {} | $ReadOnlyArray<mixed>> extends $ReadOnlyWeakSet<T> {
+   <BUILTINS>/core.js:1894:41
+   1894| declare class WeakSet<T: interface {} | $ReadOnlyArray<mixed>> extends $ReadOnlyWeakSet<T> {
                                                  ^^^^^^^^^^^^^^^^^^^^^ [3]
 
 
@@ -316,11 +316,11 @@ Cannot call `WeakSet` because in type argument `T`: [incompatible-call]
                                    ^ [1]
 
 References:
-   <BUILTINS>/core.js:1865:26
-   1865| declare class WeakSet<T: interface {} | $ReadOnlyArray<mixed>> extends $ReadOnlyWeakSet<T> {
+   <BUILTINS>/core.js:1894:26
+   1894| declare class WeakSet<T: interface {} | $ReadOnlyArray<mixed>> extends $ReadOnlyWeakSet<T> {
                                   ^^^^^^^^^^^^ [2]
-   <BUILTINS>/core.js:1865:41
-   1865| declare class WeakSet<T: interface {} | $ReadOnlyArray<mixed>> extends $ReadOnlyWeakSet<T> {
+   <BUILTINS>/core.js:1894:41
+   1894| declare class WeakSet<T: interface {} | $ReadOnlyArray<mixed>> extends $ReadOnlyWeakSet<T> {
                                                  ^^^^^^^^^^^^^^^^^^^^^ [3]
 
 
@@ -336,11 +336,11 @@ Cannot call `WeakSet` because in type argument `T`: [incompatible-call]
                                       ^ [1]
 
 References:
-   <BUILTINS>/core.js:1865:26
-   1865| declare class WeakSet<T: interface {} | $ReadOnlyArray<mixed>> extends $ReadOnlyWeakSet<T> {
+   <BUILTINS>/core.js:1894:26
+   1894| declare class WeakSet<T: interface {} | $ReadOnlyArray<mixed>> extends $ReadOnlyWeakSet<T> {
                                   ^^^^^^^^^^^^ [2]
-   <BUILTINS>/core.js:1865:41
-   1865| declare class WeakSet<T: interface {} | $ReadOnlyArray<mixed>> extends $ReadOnlyWeakSet<T> {
+   <BUILTINS>/core.js:1894:41
+   1894| declare class WeakSet<T: interface {} | $ReadOnlyArray<mixed>> extends $ReadOnlyWeakSet<T> {
                                                  ^^^^^^^^^^^^^^^^^^^^^ [3]
 
 
@@ -359,11 +359,11 @@ References:
    weakset.js:27:31
      27| function* numbers(): Iterable<number> {
                                        ^^^^^^ [1]
-   <BUILTINS>/core.js:1865:26
-   1865| declare class WeakSet<T: interface {} | $ReadOnlyArray<mixed>> extends $ReadOnlyWeakSet<T> {
+   <BUILTINS>/core.js:1894:26
+   1894| declare class WeakSet<T: interface {} | $ReadOnlyArray<mixed>> extends $ReadOnlyWeakSet<T> {
                                   ^^^^^^^^^^^^ [2]
-   <BUILTINS>/core.js:1865:41
-   1865| declare class WeakSet<T: interface {} | $ReadOnlyArray<mixed>> extends $ReadOnlyWeakSet<T> {
+   <BUILTINS>/core.js:1894:41
+   1894| declare class WeakSet<T: interface {} | $ReadOnlyArray<mixed>> extends $ReadOnlyWeakSet<T> {
                                                  ^^^^^^^^^^^^^^^^^^^^^ [3]
 
 

--- a/tests/date/date.exp
+++ b/tests/date/date.exp
@@ -7,8 +7,8 @@ Cannot assign `d.getTime()` to `x` because number [1] is incompatible with strin
                         ^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:1418:16
-   1418|     getTime(): number;
+   <BUILTINS>/core.js:1447:16
+   1447|     getTime(): number;
                         ^^^^^^ [1]
    date.js:2:7
       2| var x:string = d.getTime(); // expect error
@@ -46,11 +46,11 @@ References:
    date.js:18:10
      18| new Date({});
                   ^^ [1]
-   <BUILTINS>/core.js:1398:23
-   1398|     constructor(date: Date): void;
+   <BUILTINS>/core.js:1427:23
+   1427|     constructor(date: Date): void;
                                ^^^^ [2]
-   <BUILTINS>/core.js:1399:29
-   1399|     constructor(dateString: string): void;
+   <BUILTINS>/core.js:1428:29
+   1428|     constructor(dateString: string): void;
                                      ^^^^^^ [3]
 
 
@@ -68,11 +68,11 @@ References:
    date.js:19:16
      19| new Date(2015, '6');
                         ^^^ [1]
-   <BUILTINS>/core.js:1400:38
-   1400|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
+   <BUILTINS>/core.js:1429:38
+   1429|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
                                               ^^^^^^ [2]
-   <BUILTINS>/core.js:1399:5
-   1399|     constructor(dateString: string): void;
+   <BUILTINS>/core.js:1428:5
+   1428|     constructor(dateString: string): void;
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [3]
 
 
@@ -90,11 +90,11 @@ References:
    date.js:20:19
      20| new Date(2015, 6, '18');
                            ^^^^ [1]
-   <BUILTINS>/core.js:1400:52
-   1400|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
+   <BUILTINS>/core.js:1429:52
+   1429|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
                                                             ^^^^^^ [2]
-   <BUILTINS>/core.js:1399:5
-   1399|     constructor(dateString: string): void;
+   <BUILTINS>/core.js:1428:5
+   1428|     constructor(dateString: string): void;
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [3]
 
 
@@ -112,11 +112,11 @@ References:
    date.js:21:23
      21| new Date(2015, 6, 18, '11');
                                ^^^^ [1]
-   <BUILTINS>/core.js:1400:67
-   1400|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
+   <BUILTINS>/core.js:1429:67
+   1429|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
                                                                            ^^^^^^ [2]
-   <BUILTINS>/core.js:1399:5
-   1399|     constructor(dateString: string): void;
+   <BUILTINS>/core.js:1428:5
+   1428|     constructor(dateString: string): void;
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [3]
 
 
@@ -134,11 +134,11 @@ References:
    date.js:22:27
      22| new Date(2015, 6, 18, 11, '55');
                                    ^^^^ [1]
-   <BUILTINS>/core.js:1400:84
-   1400|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
+   <BUILTINS>/core.js:1429:84
+   1429|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
                                                                                             ^^^^^^ [2]
-   <BUILTINS>/core.js:1399:5
-   1399|     constructor(dateString: string): void;
+   <BUILTINS>/core.js:1428:5
+   1428|     constructor(dateString: string): void;
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [3]
 
 
@@ -156,11 +156,11 @@ References:
    date.js:23:31
      23| new Date(2015, 6, 18, 11, 55, '42');
                                        ^^^^ [1]
-   <BUILTINS>/core.js:1400:101
-   1400|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
+   <BUILTINS>/core.js:1429:101
+   1429|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
                                                                                                              ^^^^^^ [2]
-   <BUILTINS>/core.js:1399:5
-   1399|     constructor(dateString: string): void;
+   <BUILTINS>/core.js:1428:5
+   1428|     constructor(dateString: string): void;
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [3]
 
 
@@ -178,11 +178,11 @@ References:
    date.js:24:35
      24| new Date(2015, 6, 18, 11, 55, 42, '999');
                                            ^^^^^ [1]
-   <BUILTINS>/core.js:1400:123
-   1400|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
+   <BUILTINS>/core.js:1429:123
+   1429|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
                                                                                                                                    ^^^^^^ [2]
-   <BUILTINS>/core.js:1399:5
-   1399|     constructor(dateString: string): void;
+   <BUILTINS>/core.js:1428:5
+   1428|     constructor(dateString: string): void;
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [3]
 
 
@@ -200,20 +200,20 @@ Cannot call `Date` because: [incompatible-call]
              ^^^^
 
 References:
-   <BUILTINS>/core.js:1396:5
-   1396|     constructor(): void;
+   <BUILTINS>/core.js:1425:5
+   1425|     constructor(): void;
              ^^^^^^^^^^^^^^^^^^^ [1]
-   <BUILTINS>/core.js:1397:5
-   1397|     constructor(timestamp: number): void;
+   <BUILTINS>/core.js:1426:5
+   1426|     constructor(timestamp: number): void;
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [2]
-   <BUILTINS>/core.js:1398:5
-   1398|     constructor(date: Date): void;
+   <BUILTINS>/core.js:1427:5
+   1427|     constructor(date: Date): void;
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [3]
-   <BUILTINS>/core.js:1399:5
-   1399|     constructor(dateString: string): void;
+   <BUILTINS>/core.js:1428:5
+   1428|     constructor(dateString: string): void;
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [4]
-   <BUILTINS>/core.js:1400:5
-   1400|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
+   <BUILTINS>/core.js:1429:5
+   1429|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [5]
 
 
@@ -231,11 +231,11 @@ References:
    date.js:26:10
      26| new Date('2015', 6);
                   ^^^^^^ [1]
-   <BUILTINS>/core.js:1400:23
-   1400|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
+   <BUILTINS>/core.js:1429:23
+   1429|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
                                ^^^^^^ [2]
-   <BUILTINS>/core.js:1399:5
-   1399|     constructor(dateString: string): void;
+   <BUILTINS>/core.js:1428:5
+   1428|     constructor(dateString: string): void;
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [3]
 
 

--- a/tests/enums/enums.exp
+++ b/tests/enums/enums.exp
@@ -1252,8 +1252,8 @@ implicitly-returned undefined in type argument `Return` [2]. [incompatible-retur
                                             ^^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:1709:29
-   1709| interface Generator<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:1738:29
+   1738| interface Generator<+Yield,+Return,-Next> {
                                      ^^^^^^ [2]
 
 
@@ -1282,8 +1282,8 @@ undefined in type argument `R` [2]. [incompatible-return]
                                          ^^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:1878:24
-   1878| declare class Promise<+R = mixed> {
+   <BUILTINS>/core.js:1907:24
+   1907| declare class Promise<+R = mixed> {
                                 ^ [2]
 
 
@@ -1417,8 +1417,8 @@ References:
    exhaustive-check.js:3:6
       3| enum E {
               ^ [2]
-   <BUILTINS>/core.js:2559:3
-   2559|   isValid(this: TEnumObject, input: ?TRepresentation): boolean,
+   <BUILTINS>/core.js:2588:3
+   2588|   isValid(this: TEnumObject, input: ?TRepresentation): boolean,
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [3]
 
 
@@ -2079,15 +2079,15 @@ Cannot get `E.nonExistent` because property `nonExistent` is missing in `$EnumPr
            ^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:2556:56
+   <BUILTINS>/core.js:2585:56
                                                                 v-
-   2556| type $EnumProto<TEnumObject, TEnum, TRepresentation> = {|
-   2557|   cast(this: TEnumObject, input: ?TRepresentation): void | TEnum,
-   2558|   getName(this: TEnumObject, input: TEnum): string,
-   2559|   isValid(this: TEnumObject, input: ?TRepresentation): boolean,
-   2560|   members(this: TEnumObject): Iterator<TEnum>,
-   2561|   __proto__: null,
-   2562| |}
+   2585| type $EnumProto<TEnumObject, TEnum, TRepresentation> = {|
+   2586|   cast(this: TEnumObject, input: ?TRepresentation): void | TEnum,
+   2587|   getName(this: TEnumObject, input: TEnum): string,
+   2588|   isValid(this: TEnumObject, input: ?TRepresentation): boolean,
+   2589|   members(this: TEnumObject): Iterator<TEnum>,
+   2590|   __proto__: null,
+   2591| |}
          -^ [1]
 
 
@@ -2100,15 +2100,15 @@ Cannot call `E.nonExistent` because property `nonExistent` is missing in `$EnumP
            ^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:2556:56
+   <BUILTINS>/core.js:2585:56
                                                                 v-
-   2556| type $EnumProto<TEnumObject, TEnum, TRepresentation> = {|
-   2557|   cast(this: TEnumObject, input: ?TRepresentation): void | TEnum,
-   2558|   getName(this: TEnumObject, input: TEnum): string,
-   2559|   isValid(this: TEnumObject, input: ?TRepresentation): boolean,
-   2560|   members(this: TEnumObject): Iterator<TEnum>,
-   2561|   __proto__: null,
-   2562| |}
+   2585| type $EnumProto<TEnumObject, TEnum, TRepresentation> = {|
+   2586|   cast(this: TEnumObject, input: ?TRepresentation): void | TEnum,
+   2587|   getName(this: TEnumObject, input: TEnum): string,
+   2588|   isValid(this: TEnumObject, input: ?TRepresentation): boolean,
+   2589|   members(this: TEnumObject): Iterator<TEnum>,
+   2590|   __proto__: null,
+   2591| |}
          -^ [1]
 
 
@@ -2135,15 +2135,15 @@ Cannot call `E.A` because property `A` is missing in `$EnumProto` [1]. [prop-mis
            ^
 
 References:
-   <BUILTINS>/core.js:2556:56
+   <BUILTINS>/core.js:2585:56
                                                                 v-
-   2556| type $EnumProto<TEnumObject, TEnum, TRepresentation> = {|
-   2557|   cast(this: TEnumObject, input: ?TRepresentation): void | TEnum,
-   2558|   getName(this: TEnumObject, input: TEnum): string,
-   2559|   isValid(this: TEnumObject, input: ?TRepresentation): boolean,
-   2560|   members(this: TEnumObject): Iterator<TEnum>,
-   2561|   __proto__: null,
-   2562| |}
+   2585| type $EnumProto<TEnumObject, TEnum, TRepresentation> = {|
+   2586|   cast(this: TEnumObject, input: ?TRepresentation): void | TEnum,
+   2587|   getName(this: TEnumObject, input: TEnum): string,
+   2588|   isValid(this: TEnumObject, input: ?TRepresentation): boolean,
+   2589|   members(this: TEnumObject): Iterator<TEnum>,
+   2590|   __proto__: null,
+   2591| |}
          -^ [1]
 
 
@@ -2156,15 +2156,15 @@ Cannot call `E.toString` because property `toString` is missing in `$EnumProto` 
            ^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:2556:56
+   <BUILTINS>/core.js:2585:56
                                                                 v-
-   2556| type $EnumProto<TEnumObject, TEnum, TRepresentation> = {|
-   2557|   cast(this: TEnumObject, input: ?TRepresentation): void | TEnum,
-   2558|   getName(this: TEnumObject, input: TEnum): string,
-   2559|   isValid(this: TEnumObject, input: ?TRepresentation): boolean,
-   2560|   members(this: TEnumObject): Iterator<TEnum>,
-   2561|   __proto__: null,
-   2562| |}
+   2585| type $EnumProto<TEnumObject, TEnum, TRepresentation> = {|
+   2586|   cast(this: TEnumObject, input: ?TRepresentation): void | TEnum,
+   2587|   getName(this: TEnumObject, input: TEnum): string,
+   2588|   isValid(this: TEnumObject, input: ?TRepresentation): boolean,
+   2589|   members(this: TEnumObject): Iterator<TEnum>,
+   2590|   __proto__: null,
+   2591| |}
          -^ [1]
 
 
@@ -2177,8 +2177,8 @@ Cannot cast `E.getName(...)` to boolean because string [1] is incompatible with 
           ^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:2558:45
-   2558|   getName(this: TEnumObject, input: TEnum): string,
+   <BUILTINS>/core.js:2587:45
+   2587|   getName(this: TEnumObject, input: TEnum): string,
                                                      ^^^^^^ [1]
    methods.js:43:18
      43| (E.getName(E.B): boolean); // Error - wrong type

--- a/tests/fetch/fetch.exp
+++ b/tests/fetch/fetch.exp
@@ -14,8 +14,8 @@ References:
    fetch.js:12:18
      12| const b: Promise<string> = fetch(myRequest); // incorrect
                           ^^^^^^ [2]
-   <BUILTINS>/core.js:1878:24
-   1878| declare class Promise<+R = mixed> {
+   <BUILTINS>/core.js:1907:24
+   1907| declare class Promise<+R = mixed> {
                                 ^ [3]
 
 
@@ -35,8 +35,8 @@ References:
    <BUILTINS>/bom.js:1657:76
    1657| declare function fetch(input: RequestInfo, init?: RequestOptions): Promise<Response>;
                                                                                     ^^^^^^^^ [2]
-   <BUILTINS>/core.js:1878:24
-   1878| declare class Promise<+R = mixed> {
+   <BUILTINS>/core.js:1907:24
+   1907| declare class Promise<+R = mixed> {
                                 ^ [3]
 
 
@@ -564,8 +564,8 @@ References:
    request.js:24:15
      24| h.text().then((t: Buffer) => t); // incorrect
                        ^^^^^^^^^^^^^^^^ [3]
-   <BUILTINS>/core.js:1898:18
-   1898|       onFulfill: null | void,
+   <BUILTINS>/core.js:1927:18
+   1927|       onFulfill: null | void,
                           ^^^^^^^^^^^ [4]
 
 
@@ -589,8 +589,8 @@ References:
    request.js:26:22
      26| h.arrayBuffer().then((ab: Buffer) => ab); // incorrect
                               ^^^^^^^^^^^^^^^^^^ [3]
-   <BUILTINS>/core.js:1898:18
-   1898|       onFulfill: null | void,
+   <BUILTINS>/core.js:1927:18
+   1927|       onFulfill: null | void,
                           ^^^^^^^^^^^ [4]
 
 
@@ -721,17 +721,17 @@ References:
    <BUILTINS>/bom.js:1564:62
    1564| type BodyInit = string | URLSearchParams | FormData | Blob | ArrayBuffer | $ArrayBufferView | ReadableStream;
                                                                       ^^^^^^^^^^^ [5]
-   <BUILTINS>/core.js:2006:20
-   2006| type $TypedArray = $TypedArrayNumber | BigInt64Array | BigUint64Array;
+   <BUILTINS>/core.js:2035:20
+   2035| type $TypedArray = $TypedArrayNumber | BigInt64Array | BigUint64Array;
                             ^^^^^^^^^^^^^^^^^ [6]
-   <BUILTINS>/core.js:2006:40
-   2006| type $TypedArray = $TypedArrayNumber | BigInt64Array | BigUint64Array;
+   <BUILTINS>/core.js:2035:40
+   2035| type $TypedArray = $TypedArrayNumber | BigInt64Array | BigUint64Array;
                                                 ^^^^^^^^^^^^^ [7]
-   <BUILTINS>/core.js:2006:56
-   2006| type $TypedArray = $TypedArrayNumber | BigInt64Array | BigUint64Array;
+   <BUILTINS>/core.js:2035:56
+   2035| type $TypedArray = $TypedArrayNumber | BigInt64Array | BigUint64Array;
                                                                 ^^^^^^^^^^^^^^ [8]
-   <BUILTINS>/core.js:2002:39
-   2002| type $ArrayBufferView = $TypedArray | DataView;
+   <BUILTINS>/core.js:2031:39
+   2031| type $ArrayBufferView = $TypedArray | DataView;
                                                ^^^^^^^^ [9]
    <BUILTINS>/bom.js:1564:95
    1564| type BodyInit = string | URLSearchParams | FormData | Blob | ArrayBuffer | $ArrayBufferView | ReadableStream;
@@ -758,8 +758,8 @@ References:
    response.js:42:15
      42| h.text().then((t: Buffer) => t); // incorrect
                        ^^^^^^^^^^^^^^^^ [3]
-   <BUILTINS>/core.js:1898:18
-   1898|       onFulfill: null | void,
+   <BUILTINS>/core.js:1927:18
+   1927|       onFulfill: null | void,
                           ^^^^^^^^^^^ [4]
 
 
@@ -783,8 +783,8 @@ References:
    response.js:44:22
      44| h.arrayBuffer().then((ab: Buffer) => ab); // incorrect
                               ^^^^^^^^^^^^^^^^^^ [3]
-   <BUILTINS>/core.js:1898:18
-   1898|       onFulfill: null | void,
+   <BUILTINS>/core.js:1927:18
+   1927|       onFulfill: null | void,
                           ^^^^^^^^^^^ [4]
 
 

--- a/tests/forof/forof.exp
+++ b/tests/forof/forof.exp
@@ -45,8 +45,8 @@ References:
    forof.js:23:26
      23| function testString(str: string): void {
                                   ^^^^^^ [1]
-   <BUILTINS>/core.js:1704:11
-   1704| interface $Iterable<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:1733:11
+   1733| interface $Iterable<+Yield,+Return,-Next> {
                    ^^^^^^^^^ [2]
 
 
@@ -59,8 +59,8 @@ Cannot cast `elem` to number because tuple type [1] is incompatible with number 
               ^^^^
 
 References:
-   <BUILTINS>/core.js:1763:28
-   1763|     @@iterator(): Iterator<[K, V]>;
+   <BUILTINS>/core.js:1792:28
+   1792|     @@iterator(): Iterator<[K, V]>;
                                     ^^^^^^ [1]
    forof.js:32:12
      32|     (elem: number); // Error - tuple ~> number

--- a/tests/function/function.exp
+++ b/tests/function/function.exp
@@ -24,13 +24,13 @@ it into an object and attempt to use it as a subtype of an interface. [incompati
                         ^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:1112:22
+   <BUILTINS>/core.js:1141:22
                               v----------
-   1112| type $ArrayLike<T> = interface {
-   1113|   +[indexer: number]: T;
-   1114|   @@iterator(): Iterator<T>;
-   1115|   length: number;
-   1116| }
+   1141| type $ArrayLike<T> = interface {
+   1142|   +[indexer: number]: T;
+   1143|   @@iterator(): Iterator<T>;
+   1144|   length: number;
+   1145| }
          ^ [2]
 
 
@@ -93,16 +93,16 @@ Property `length` is missing in `Generator` [1] but exists in `$ArrayLike` [2]. 
                         ^^^^^
 
 References:
-   <BUILTINS>/core.js:1709:11
-   1709| interface Generator<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:1738:11
+   1738| interface Generator<+Yield,+Return,-Next> {
                    ^^^^^^^^^ [1]
-   <BUILTINS>/core.js:1112:22
+   <BUILTINS>/core.js:1141:22
                               v----------
-   1112| type $ArrayLike<T> = interface {
-   1113|   +[indexer: number]: T;
-   1114|   @@iterator(): Iterator<T>;
-   1115|   length: number;
-   1116| }
+   1141| type $ArrayLike<T> = interface {
+   1142|   +[indexer: number]: T;
+   1143|   @@iterator(): Iterator<T>;
+   1144|   length: number;
+   1145| }
          ^ [2]
 
 
@@ -118,13 +118,13 @@ References:
    apply-array-like.js:16:17
      16| function * gen() {
                          ^ [1]
-   <BUILTINS>/core.js:1112:22
+   <BUILTINS>/core.js:1141:22
                               v----------
-   1112| type $ArrayLike<T> = interface {
-   1113|   +[indexer: number]: T;
-   1114|   @@iterator(): Iterator<T>;
-   1115|   length: number;
-   1116| }
+   1141| type $ArrayLike<T> = interface {
+   1142|   +[indexer: number]: T;
+   1143|   @@iterator(): Iterator<T>;
+   1144|   length: number;
+   1145| }
          ^ [2]
 
 
@@ -210,13 +210,13 @@ it into an object and attempt to use it as a subtype of an interface. [incompati
                         ^^^^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:1112:22
+   <BUILTINS>/core.js:1141:22
                               v----------
-   1112| type $ArrayLike<T> = interface {
-   1113|   +[indexer: number]: T;
-   1114|   @@iterator(): Iterator<T>;
-   1115|   length: number;
-   1116| }
+   1141| type $ArrayLike<T> = interface {
+   1142|   +[indexer: number]: T;
+   1143|   @@iterator(): Iterator<T>;
+   1144|   length: number;
+   1145| }
          ^ [2]
 
 

--- a/tests/generators/generators.exp
+++ b/tests/generators/generators.exp
@@ -42,8 +42,8 @@ References:
    class.js:23:39
      23|   *stmt_return_err(): Generator<void, number, void> {
                                                ^^^^^^ [2]
-   <BUILTINS>/core.js:1709:29
-   1709| interface Generator<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:1738:29
+   1738| interface Generator<+Yield,+Return,-Next> {
                                      ^^^^^^ [3]
 
 
@@ -125,14 +125,14 @@ of property `@@iterator`. [incompatible-type-arg]
                     ^^
 
 References:
-   <BUILTINS>/core.js:1702:38
-   1702| type Iterator<+T> = $Iterator<T,void,void>;
+   <BUILTINS>/core.js:1731:38
+   1731| type Iterator<+T> = $Iterator<T,void,void>;
                                               ^^^^ [1]
    class.js:71:71
      71|   *delegate_next_iterable(xs: Array<number>): Generator<number, void, string> {
                                                                                ^^^^^^ [2]
-   <BUILTINS>/core.js:1698:37
-   1698| interface $Iterator<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:1727:37
+   1727| interface $Iterator<+Yield,+Return,-Next> {
                                              ^^^^ [3]
 
 
@@ -374,8 +374,8 @@ References:
    generators.js:22:46
      22| function *stmt_return_err(): Generator<void, number, void> {
                                                       ^^^^^^ [2]
-   <BUILTINS>/core.js:1709:29
-   1709| interface Generator<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:1738:29
+   1738| interface Generator<+Yield,+Return,-Next> {
                                      ^^^^^^ [3]
 
 
@@ -679,8 +679,8 @@ Cannot cast `refuse_return_result.value` to string because undefined [1] is inco
             ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:1689:14
-   1689|     +value?: Return,
+   <BUILTINS>/core.js:1718:14
+   1718|     +value?: Return,
                       ^^^^^^ [1]
    return.js:20:32
      20|   (refuse_return_result.value: string); // error: number | void ~> string

--- a/tests/generic_escape/generic_escape.exp
+++ b/tests/generic_escape/generic_escape.exp
@@ -431,8 +431,8 @@ the expression to your expected type. [underconstrained-implicit-instantiation]
                     ^^^^^
 
 References:
-   <BUILTINS>/core.js:902:21
-   902| declare class Array<T> extends $ReadOnlyArray<T> {
+   <BUILTINS>/core.js:931:21
+   931| declare class Array<T> extends $ReadOnlyArray<T> {
                             ^ [1]
    misc.js:3:9
      3| var e = new Array(10);

--- a/tests/generic_zeroed/generic_zeroed.exp
+++ b/tests/generic_zeroed/generic_zeroed.exp
@@ -77,11 +77,11 @@ References:
    reduce.js:7:22
       7|   return nums.reduce<T>(
                               ^ [2]
-   <BUILTINS>/core.js:1015:5
+   <BUILTINS>/core.js:1044:5
              v------
-   1015|     reduce(
-   1016|       callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: Array<T>) => T,
-   1017|     ): T;
+   1044|     reduce(
+   1045|       callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: Array<T>) => T,
+   1046|     ): T;
              ---^ [3]
 
 

--- a/tests/get_def_enums/get_def_enums.exp
+++ b/tests/get_def_enums/get_def_enums.exp
@@ -28,9 +28,9 @@ library.js:4:3,4:5
 
 main.js:27:13
 Flags:
-[LIB] core.js:2557:3,2557:6
+[LIB] core.js:2586:3,2586:6
 
 main.js:30:13
 Flags:
-[LIB] core.js:2559:3,2559:9
+[LIB] core.js:2588:3,2588:9
 

--- a/tests/interface/interface.exp
+++ b/tests/interface/interface.exp
@@ -782,8 +782,8 @@ References:
    string.js:1:18
       1| declare const s: string;
                           ^^^^^^ [1]
-   <BUILTINS>/core.js:1704:11
-   1704| interface $Iterable<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:1733:11
+   1733| interface $Iterable<+Yield,+Return,-Next> {
                    ^^^^^^^^^ [2]
 
 

--- a/tests/iterable/iterable.exp
+++ b/tests/iterable/iterable.exp
@@ -14,8 +14,8 @@ References:
    array.js:7:19
       7| (["hi"]: Iterable<number>); // Error string ~> number
                            ^^^^^^ [2]
-   <BUILTINS>/core.js:1698:22
-   1698| interface $Iterator<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:1727:22
+   1727| interface $Iterator<+Yield,+Return,-Next> {
                               ^^^^^ [3]
 
 
@@ -35,8 +35,8 @@ References:
    array.js:8:22
       8| (["hi", 1]: Iterable<string>); // Error number ~> string
                               ^^^^^^ [2]
-   <BUILTINS>/core.js:1698:22
-   1698| interface $Iterator<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:1727:22
+   1727| interface $Iterator<+Yield,+Return,-Next> {
                               ^^^^^ [3]
 
 
@@ -56,8 +56,8 @@ References:
    caching_bug.js:21:62
      21| function miss_the_cache(x: Array<string | number>): Iterable<string> { return x; }
                                                                       ^^^^^^ [2]
-   <BUILTINS>/core.js:1698:22
-   1698| interface $Iterator<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:1727:22
+   1727| interface $Iterator<+Yield,+Return,-Next> {
                               ^^^^^ [3]
 
 
@@ -86,13 +86,13 @@ Cannot return object literal because property `value` is missing in object liter
                         ^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:1692:5
+   <BUILTINS>/core.js:1721:5
              v
-   1692|   | {
-   1693|     done: false,
-   1694|     +value: Yield,
-   1695|     ...
-   1696| };
+   1721|   | {
+   1722|     done: false,
+   1723|     +value: Yield,
+   1724|     ...
+   1725| };
          ^ [2]
 
 
@@ -106,14 +106,14 @@ value of property `@@iterator`. [incompatible-return]
                   ^^^
 
 References:
-   <BUILTINS>/core.js:1763:28
-   1763|     @@iterator(): Iterator<[K, V]>;
+   <BUILTINS>/core.js:1792:28
+   1792|     @@iterator(): Iterator<[K, V]>;
                                     ^^^^^^ [1]
    map.js:13:55
      13| function mapTest4(map: Map<number, string>): Iterable<string> {
                                                                ^^^^^^ [2]
-   <BUILTINS>/core.js:1698:22
-   1698| interface $Iterator<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:1727:22
+   1727| interface $Iterator<+Yield,+Return,-Next> {
                               ^^^^^ [3]
 
 
@@ -133,8 +133,8 @@ References:
    set.js:13:47
      13| function setTest4(set: Set<string>): Iterable<number> {
                                                        ^^^^^^ [2]
-   <BUILTINS>/core.js:1698:22
-   1698| interface $Iterator<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:1727:22
+   1727| interface $Iterator<+Yield,+Return,-Next> {
                               ^^^^^ [3]
 
 
@@ -148,14 +148,14 @@ Cannot cast `new String(...)` to `Iterable` because string [1] is incompatible w
           ^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:1134:28
-   1134|     @@iterator(): Iterator<string>;
+   <BUILTINS>/core.js:1163:28
+   1163|     @@iterator(): Iterator<string>;
                                     ^^^^^^ [1]
    string.js:3:29
       3| (new String("hi"): Iterable<number>); // Error - string is a Iterable<string>
                                      ^^^^^^ [2]
-   <BUILTINS>/core.js:1698:22
-   1698| interface $Iterator<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:1727:22
+   1727| interface $Iterator<+Yield,+Return,-Next> {
                               ^^^^^ [3]
 
 

--- a/tests/lib/lib.exp
+++ b/tests/lib/lib.exp
@@ -41,8 +41,8 @@ Cannot assign `(new TypeError()).name` to `z` because string [1] is incompatible
                         ^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:1604:11
-   1604|     name: string;
+   <BUILTINS>/core.js:1633:11
+   1633|     name: string;
                    ^^^^^^ [1]
    libtest.js:3:7
       3| var z:number = new TypeError().name;

--- a/tests/local_inference_annotations/local_inference_annotations.exp
+++ b/tests/local_inference_annotations/local_inference_annotations.exp
@@ -63,8 +63,8 @@ Property `@@iterator` is missing in function [1] but exists in `$Iterable` [2]. 
                 ^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:1704:11
-   1704| interface $Iterable<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:1733:11
+   1733| interface $Iterable<+Yield,+Return,-Next> {
                    ^^^^^^^^^ [2]
 
 
@@ -497,8 +497,8 @@ Property `@@iterator` is missing in function [1] but exists in `$Iterable` [2]. 
                           ^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:1704:11
-   1704| interface $Iterable<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:1733:11
+   1733| interface $Iterable<+Yield,+Return,-Next> {
                    ^^^^^^^^^ [2]
 
 

--- a/tests/lti_friendly_errors/lti_friendly_errors.exp
+++ b/tests/lti_friendly_errors/lti_friendly_errors.exp
@@ -8,14 +8,14 @@ in type argument `R` [3]. [incompatible-cast]
           ^
 
 References:
-   <BUILTINS>/core.js:1878:28
-   1878| declare class Promise<+R = mixed> {
+   <BUILTINS>/core.js:1907:28
+   1907| declare class Promise<+R = mixed> {
                                     ^^^^^ [1]
    reason_of_inferred_targs.js:2:13
       2| (p: Promise<string>); // error
                      ^^^^^^ [2]
-   <BUILTINS>/core.js:1878:24
-   1878| declare class Promise<+R = mixed> {
+   <BUILTINS>/core.js:1907:24
+   1907| declare class Promise<+R = mixed> {
                                 ^ [3]
 
 

--- a/tests/lti_implicit_instantiation/lti_implicit_instantiation.exp
+++ b/tests/lti_implicit_instantiation/lti_implicit_instantiation.exp
@@ -8,8 +8,8 @@ expression to your expected type. [underconstrained-implicit-instantiation]
                   ^^^^^^^^^^^ [2]
 
 References:
-   <BUILTINS>/core.js:1987:25
-   1987| declare function $await<T>(p: Promise<T> | T): T;
+   <BUILTINS>/core.js:2016:25
+   2016| declare function $await<T>(p: Promise<T> | T): T;
                                  ^ [1]
 
 
@@ -205,8 +205,8 @@ the expression to your expected type. [underconstrained-implicit-instantiation]
             ^^^^^
 
 References:
-   <BUILTINS>/core.js:902:21
-   902| declare class Array<T> extends $ReadOnlyArray<T> {
+   <BUILTINS>/core.js:931:21
+   931| declare class Array<T> extends $ReadOnlyArray<T> {
                             ^ [1]
    underconstrained_class_constructor.js:18:1
     18| new Array(1); // Error
@@ -724,8 +724,8 @@ Cannot get `r1.bad` because property `bad` is missing in `Array` [1]. [prop-miss
              ^^^
 
 References:
-   <BUILTINS>/core.js:902:15
-   902| declare class Array<T> extends $ReadOnlyArray<T> {
+   <BUILTINS>/core.js:931:15
+   931| declare class Array<T> extends $ReadOnlyArray<T> {
                       ^^^^^ [1]
 
 
@@ -772,8 +772,8 @@ Cannot get `r2.bad` because property `bad` is missing in `Array` [1]. [prop-miss
              ^^^
 
 References:
-   <BUILTINS>/core.js:902:15
-   902| declare class Array<T> extends $ReadOnlyArray<T> {
+   <BUILTINS>/core.js:931:15
+   931| declare class Array<T> extends $ReadOnlyArray<T> {
                       ^^^^^ [1]
 
 

--- a/tests/mapped_type_utilities/mapped_type_utilities.exp
+++ b/tests/mapped_type_utilities/mapped_type_utilities.exp
@@ -85,8 +85,8 @@ Cannot cast `pickedO1.bar` to string because undefined [1] is incompatible with 
           ^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:2730:62
-   2730| type Pick<O: interface {}, Keys: $Keys<O>> = {[key in Keys]: O[key]};
+   <BUILTINS>/core.js:2759:62
+   2759| type Pick<O: interface {}, Keys: $Keys<O>> = {[key in Keys]: O[key]};
                                                                       ^^^^^^ [1]
    pick.js:9:16
       9| (pickedO1.bar: string); // ERROR bar is optional

--- a/tests/meta_property/meta_property.exp
+++ b/tests/meta_property/meta_property.exp
@@ -8,13 +8,13 @@ Cannot cast `import.meta` to number literal `1` because `Import$Meta` [1] is inc
           ^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:2667:20
+   <BUILTINS>/core.js:2696:20
                             v
-   2667| type Import$Meta = {
-   2668|   [string]: mixed,
-   2669|   url?: string,
-   2670|   ...
-   2671| };
+   2696| type Import$Meta = {
+   2697|   [string]: mixed,
+   2698|   url?: string,
+   2699|   ...
+   2700| };
          ^ [1]
    import_meta.js:5:15
       5| (import.meta: 1); // Error
@@ -31,8 +31,8 @@ Cannot cast `import.meta.XXX` to number literal `1` because mixed [1] is incompa
           ^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:2668:13
-   2668|   [string]: mixed,
+   <BUILTINS>/core.js:2697:13
+   2697|   [string]: mixed,
                      ^^^^^ [1]
    import_meta.js:6:19
       6| (import.meta.XXX: 1); // Error

--- a/tests/new_env/new_env.exp
+++ b/tests/new_env/new_env.exp
@@ -197,12 +197,12 @@ Cannot call `Promise` because function [1] requires another argument. [incompati
                      ^^^^^^^
 
 References:
-   <BUILTINS>/core.js:1879:5
+   <BUILTINS>/core.js:1908:5
              v----------------------
-   1879|     constructor(callback: (
-   1880|       resolve: (result: Promise<R> | R) => void,
-   1881|       reject: (error: any) => void
-   1882|     ) => mixed): void;
+   1908|     constructor(callback: (
+   1909|       resolve: (result: Promise<R> | R) => void,
+   1910|       reject: (error: any) => void
+   1911|     ) => mixed): void;
              ----------------^ [1]
 
 

--- a/tests/new_merge/new_merge.exp
+++ b/tests/new_merge/new_merge.exp
@@ -273,8 +273,8 @@ Cannot cast `f15()` to empty because `Promise` [1] is incompatible with empty [2
           ^^^^^
 
 References:
-   <BUILTINS>/core.js:1878:15
-   1878| declare class Promise<+R = mixed> {
+   <BUILTINS>/core.js:1907:15
+   1907| declare class Promise<+R = mixed> {
                        ^^^^^^^ [1]
    main.js:58:9
      58| (f15(): empty);

--- a/tests/object_api/object_api.exp
+++ b/tests/object_api/object_api.exp
@@ -978,8 +978,8 @@ Cannot assign `x.valueOf` to `xValueOf` because function type [1] is incompatibl
                                  ^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:1559:5
-   1559|     valueOf(): number;
+   <BUILTINS>/core.js:1588:5
+   1588|     valueOf(): number;
              ^^^^^^^^^^^^^^^^^ [1]
    object_prototype.js:122:16
     122| var xValueOf : number = x.valueOf; // error
@@ -996,8 +996,8 @@ Cannot get `x.valueOf` because property `valueOf` [1] cannot be unbound from the
                                    ^^^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:1559:5
-   1559|     valueOf(): number;
+   <BUILTINS>/core.js:1588:5
+   1588|     valueOf(): number;
              ^^^^^^^^^^^^^^^^^ [2]
 
 
@@ -1073,8 +1073,8 @@ Cannot assign `x.toLocaleString` to `xToLocaleString` because function type [1] 
                                         ^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:1547:5
-   1547|     toLocaleString(locales?: string | Array<string>, options?: Intl$DateTimeFormatOptions): string;
+   <BUILTINS>/core.js:1576:5
+   1576|     toLocaleString(locales?: string | Array<string>, options?: Intl$DateTimeFormatOptions): string;
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
    object_prototype.js:150:23
     150| var xToLocaleString : number = x.toLocaleString; // error
@@ -1091,8 +1091,8 @@ defined. [method-unbinding]
                                           ^^^^^^^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:1547:5
-   1547|     toLocaleString(locales?: string | Array<string>, options?: Intl$DateTimeFormatOptions): string;
+   <BUILTINS>/core.js:1576:5
+   1576|     toLocaleString(locales?: string | Array<string>, options?: Intl$DateTimeFormatOptions): string;
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [2]
 
 
@@ -1106,8 +1106,8 @@ value. [incompatible-type]
                                                ^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:1547:93
-   1547|     toLocaleString(locales?: string | Array<string>, options?: Intl$DateTimeFormatOptions): string;
+   <BUILTINS>/core.js:1576:93
+   1576|     toLocaleString(locales?: string | Array<string>, options?: Intl$DateTimeFormatOptions): string;
                                                                                                      ^^^^^^ [1]
    object_prototype.js:151:30
     151| var xToLocaleString2 : () => number = x.toLocaleString; // error
@@ -1124,8 +1124,8 @@ defined. [method-unbinding]
                                                  ^^^^^^^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:1547:5
-   1547|     toLocaleString(locales?: string | Array<string>, options?: Intl$DateTimeFormatOptions): string;
+   <BUILTINS>/core.js:1576:5
+   1576|     toLocaleString(locales?: string | Array<string>, options?: Intl$DateTimeFormatOptions): string;
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [2]
 
 

--- a/tests/overload/overload.exp
+++ b/tests/overload/overload.exp
@@ -29,8 +29,8 @@ Cannot assign `"".match(...)[0]` to `x1` because string [1] is incompatible with
                           ^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:1119:33
-   1119| type RegExp$matchResult = Array<string> & {
+   <BUILTINS>/core.js:1148:33
+   1148| type RegExp$matchResult = Array<string> & {
                                          ^^^^^^ [1]
    overload.js:7:9
       7| var x1: number = "".match(0)[0];
@@ -46,8 +46,8 @@ Cannot get `"".match(...)[0]` because null [1] does not have properties. [incomp
                                       ^
 
 References:
-   <BUILTINS>/core.js:1203:58
-   1203|     match(regexp: string | RegExp): RegExp$matchResult | null;
+   <BUILTINS>/core.js:1232:58
+   1232|     match(regexp: string | RegExp): RegExp$matchResult | null;
                                                                   ^^^^ [1]
 
 
@@ -62,11 +62,11 @@ Cannot call `"".match` with `0` bound to `regexp` because: [incompatible-call]
                                    ^ [1]
 
 References:
-   <BUILTINS>/core.js:1203:19
-   1203|     match(regexp: string | RegExp): RegExp$matchResult | null;
+   <BUILTINS>/core.js:1232:19
+   1232|     match(regexp: string | RegExp): RegExp$matchResult | null;
                            ^^^^^^ [2]
-   <BUILTINS>/core.js:1203:28
-   1203|     match(regexp: string | RegExp): RegExp$matchResult | null;
+   <BUILTINS>/core.js:1232:28
+   1232|     match(regexp: string | RegExp): RegExp$matchResult | null;
                                     ^^^^^^ [3]
 
 
@@ -79,8 +79,8 @@ Cannot assign `"".match(...)[0]` to `x2` because string [1] is incompatible with
                           ^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:1119:33
-   1119| type RegExp$matchResult = Array<string> & {
+   <BUILTINS>/core.js:1148:33
+   1148| type RegExp$matchResult = Array<string> & {
                                          ^^^^^^ [1]
    overload.js:8:9
       8| var x2: number = "".match(/pattern/)[0];
@@ -96,8 +96,8 @@ Cannot get `"".match(...)[0]` because null [1] does not have properties. [incomp
                                               ^
 
 References:
-   <BUILTINS>/core.js:1203:58
-   1203|     match(regexp: string | RegExp): RegExp$matchResult | null;
+   <BUILTINS>/core.js:1232:58
+   1232|     match(regexp: string | RegExp): RegExp$matchResult | null;
                                                                   ^^^^ [1]
 
 
@@ -110,8 +110,8 @@ Cannot assign `"".split(...)[0]` to `x4` because string [1] is incompatible with
                           ^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:1276:63
-   1276|     split(separator?: string | RegExp, limit?: number): Array<string>;
+   <BUILTINS>/core.js:1305:63
+   1305|     split(separator?: string | RegExp, limit?: number): Array<string>;
                                                                        ^^^^^^ [1]
    overload.js:10:9
      10| var x4: number = "".split(/pattern/)[0];

--- a/tests/predicates_declared/predicates_declared.exp
+++ b/tests/predicates_declared/predicates_declared.exp
@@ -95,8 +95,8 @@ Cannot return `Array.isArray(...)` because boolean [1] is incompatible with stri
                                                        ^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:1063:33
-   1063|     static isArray(obj: mixed): boolean;
+   <BUILTINS>/core.js:1092:33
+   1092|     static isArray(obj: mixed): boolean;
                                          ^^^^^^^ [1]
    sanity-return-type.js:1:32
       1| declare function f2(x: mixed): string %checks(Array.isArray(x));

--- a/tests/promises/promises.exp
+++ b/tests/promises/promises.exp
@@ -109,8 +109,8 @@ Cannot call `Promise.all` because function [1] requires another argument. [incom
                  ^^^
 
 References:
-   <BUILTINS>/core.js:1953:5
-   1953|     static all<T: Iterable<mixed>>(promises: T): Promise<$TupleMap<T, typeof $await>>;
+   <BUILTINS>/core.js:1982:5
+   1982|     static all<T: Iterable<mixed>>(promises: T): Promise<$TupleMap<T, typeof $await>>;
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 
@@ -138,8 +138,8 @@ Cannot call `Promise.allSettled` because function [1] requires another argument.
                  ^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:1960:5
-   1960|     static allSettled<T: Iterable<mixed>>(promises: T): Promise<$TupleMap<T, <T>(p: Promise<T> | T) => $SettledPromiseResult<T>>>;
+   <BUILTINS>/core.js:1989:5
+   1989|     static allSettled<T: Iterable<mixed>>(promises: T): Promise<$TupleMap<T, <T>(p: Promise<T> | T) => $SettledPromiseResult<T>>>;
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 
@@ -168,8 +168,8 @@ Cannot cast `first.status` to empty because string literal `rejected` [1] is inc
                 ^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:1982:12
-   1982|   +status: 'rejected',
+   <BUILTINS>/core.js:2011:12
+   2011|   +status: 'rejected',
                     ^^^^^^^^^^ [1]
    allSettled.js:34:22
      34|       (first.status: empty) // Error: 'rejected' case was not covered
@@ -200,8 +200,8 @@ expected type. [underconstrained-implicit-instantiation]
                                     ^^^^^
 
 References:
-   <BUILTINS>/core.js:1987:25
-   1987| declare function $await<T>(p: Promise<T> | T): T;
+   <BUILTINS>/core.js:2016:25
+   2016| declare function $await<T>(p: Promise<T> | T): T;
                                  ^ [1]
    allSettled.js:44:5
      44|     return (second.status: empty); // Spurious underconstrained-implicit-instantiation error in LTI due to lack of empty propagation
@@ -217,8 +217,8 @@ Cannot use function type [1] with fewer than 2 type arguments. [missing-type-arg
          ^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:1975:15
-   1975|     static any<T, Elem: Promise<T> | T>(promises: Iterable<Elem>): Promise<T>;
+   <BUILTINS>/core.js:2004:15
+   2004|     static any<T, Elem: Promise<T> | T>(promises: Iterable<Elem>): Promise<T>;
                        ^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 
@@ -231,8 +231,8 @@ Cannot call `Promise.any` because function [1] requires another argument. [incom
                  ^^^
 
 References:
-   <BUILTINS>/core.js:1975:5
-   1975|     static any<T, Elem: Promise<T> | T>(promises: Iterable<Elem>): Promise<T>;
+   <BUILTINS>/core.js:2004:5
+   2004|     static any<T, Elem: Promise<T> | T>(promises: Iterable<Elem>): Promise<T>;
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 
@@ -245,8 +245,8 @@ Cannot use function type [1] with fewer than 2 type arguments. [missing-type-arg
          ^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:1975:15
-   1975|     static any<T, Elem: Promise<T> | T>(promises: Iterable<Elem>): Promise<T>;
+   <BUILTINS>/core.js:2004:15
+   2004|     static any<T, Elem: Promise<T> | T>(promises: Iterable<Elem>): Promise<T>;
                        ^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 
@@ -261,8 +261,8 @@ an interface. [incompatible-type]
                                    ^ [1]
 
 References:
-   <BUILTINS>/core.js:1975:51
-   1975|     static any<T, Elem: Promise<T> | T>(promises: Iterable<Elem>): Promise<T>;
+   <BUILTINS>/core.js:2004:51
+   2004|     static any<T, Elem: Promise<T> | T>(promises: Iterable<Elem>): Promise<T>;
                                                            ^^^^^^^^^^^^^^ [2]
 
 
@@ -647,8 +647,8 @@ References:
    resolve_void.js:1:29
       1| (Promise.resolve(): Promise<number>); // error
                                      ^^^^^^ [2]
-   <BUILTINS>/core.js:1878:24
-   1878| declare class Promise<+R = mixed> {
+   <BUILTINS>/core.js:1907:24
+   1907| declare class Promise<+R = mixed> {
                                 ^ [3]
 
 
@@ -665,8 +665,8 @@ References:
    resolve_void.js:3:38
       3| (Promise.resolve(undefined): Promise<number>); // error
                                               ^^^^^^ [2]
-   <BUILTINS>/core.js:1878:24
-   1878| declare class Promise<+R = mixed> {
+   <BUILTINS>/core.js:1907:24
+   1907| declare class Promise<+R = mixed> {
                                 ^ [3]
 
 

--- a/tests/react_16_6/react_16_6.exp
+++ b/tests/react_16_6/react_16_6.exp
@@ -76,8 +76,8 @@ References:
    <BUILTINS>/react.js:297:30
     297|     component: () => Promise<{ default: React$AbstractComponent<Config, Instance, React$Node>, ... }>,
                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [2]
-   <BUILTINS>/core.js:1878:24
-   1878| declare class Promise<+R = mixed> {
+   <BUILTINS>/core.js:1907:24
+   1907| declare class Promise<+R = mixed> {
                                 ^ [3]
 
 
@@ -97,8 +97,8 @@ References:
    <BUILTINS>/react.js:297:30
     297|     component: () => Promise<{ default: React$AbstractComponent<Config, Instance, React$Node>, ... }>,
                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [2]
-   <BUILTINS>/core.js:1878:24
-   1878| declare class Promise<+R = mixed> {
+   <BUILTINS>/core.js:1907:24
+   1907| declare class Promise<+R = mixed> {
                                 ^ [3]
 
 

--- a/tests/react_abstract_component/react_abstract_component.exp
+++ b/tests/react_abstract_component/react_abstract_component.exp
@@ -114,8 +114,8 @@ Cannot return `x` because `$Iterable` [1] is incompatible with number [2]. [inco
                   ^
 
 References:
-   <BUILTINS>/core.js:1707:21
-   1707| type Iterable<+T> = $Iterable<T,void,void>;
+   <BUILTINS>/core.js:1736:21
+   1736| type Iterable<+T> = $Iterable<T,void,void>;
                              ^^^^^^^^^^^^^^^^^^^^^^ [1]
    arity.js:20:107
      20| function defaultsErrorMessages(x: React$AbstractComponent<empty>): React$AbstractComponent<empty, number, number> {

--- a/tests/refinements/refinements.exp
+++ b/tests/refinements/refinements.exp
@@ -3040,8 +3040,8 @@ expected type. [underconstrained-implicit-instantiation]
                       ^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:1987:25
-   1987| declare function $await<T>(p: Promise<T> | T): T;
+   <BUILTINS>/core.js:2016:25
+   2016| declare function $await<T>(p: Promise<T> | T): T;
                                  ^ [1]
    issue-7104.js:20:7
      20|       return (box: empty).value; // underconstrained-implicit-instantiation error in LTI due to lack of empty propagation

--- a/tests/regexp/regexp.exp
+++ b/tests/regexp/regexp.exp
@@ -7,8 +7,8 @@ Cannot assign `patt.test(...)` to `match` because boolean [1] is incompatible wi
                             ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:1389:27
-   1389|     test(string: string): boolean;
+   <BUILTINS>/core.js:1418:27
+   1418|     test(string: string): boolean;
                                    ^^^^^^^ [1]
    regexp.js:2:11
       2| var match:number = patt.test("Hello world!");

--- a/tests/resolved_env/resolved_env.exp
+++ b/tests/resolved_env/resolved_env.exp
@@ -36,8 +36,8 @@ expression to your expected type. [underconstrained-implicit-instantiation]
                      ^^^^^^^^^^^^^^^^^ [2]
 
 References:
-   <BUILTINS>/core.js:1987:25
-   1987| declare function $await<T>(p: Promise<T> | T): T;
+   <BUILTINS>/core.js:2016:25
+   2016| declare function $await<T>(p: Promise<T> | T): T;
                                  ^ [1]
 
 
@@ -51,8 +51,8 @@ in `new Number(...))` to turn it into an object and attempt to use it as a subty
                                    ^^ [1]
 
 References:
-   <BUILTINS>/core.js:1726:11
-   1726| interface $AsyncIterable<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:1755:11
+   1755| interface $AsyncIterable<+Yield,+Return,-Next> {
                    ^^^^^^^^^^^^^^ [2]
 
 

--- a/tests/return/return.exp
+++ b/tests/return/return.exp
@@ -40,8 +40,8 @@ undefined in type argument `R` [2]. [incompatible-return]
                                       ^^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:1878:24
-   1878| declare class Promise<+R = mixed> {
+   <BUILTINS>/core.js:1907:24
+   1907| declare class Promise<+R = mixed> {
                                 ^ [2]
 
 

--- a/tests/template/template.exp
+++ b/tests/template/template.exp
@@ -49,8 +49,8 @@ Cannot cast `quasis.raw` to empty because read-only array type [1] is incompatib
               ^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:1127:9
-   1127|   +raw: $ReadOnlyArray<string>;
+   <BUILTINS>/core.js:1156:9
+   1156|   +raw: $ReadOnlyArray<string>;
                  ^^^^^^^^^^^^^^^^^^^^^^ [1]
    tagged_template.js:25:18
      25|     (quasis.raw: empty); // ERROR
@@ -66,8 +66,8 @@ Cannot cast `x` to empty because string [1] is incompatible with empty [2]. [inc
             ^
 
 References:
-   <BUILTINS>/core.js:1336:110
-   1336|     static raw(callSite: interface {+raw: $ReadOnlyArray<string>}, ...substitutions: $ReadOnlyArray<mixed>): string;
+   <BUILTINS>/core.js:1365:110
+   1365|     static raw(callSite: interface {+raw: $ReadOnlyArray<string>}, ...substitutions: $ReadOnlyArray<mixed>): string;
                                                                                                                       ^^^^^^ [1]
    tagged_template.js:34:7
      34|   (x: empty); // ERROR
@@ -85,8 +85,8 @@ subtype of an interface. [incompatible-type]
                       ^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:1336:26
-   1336|     static raw(callSite: interface {+raw: $ReadOnlyArray<string>}, ...substitutions: $ReadOnlyArray<mixed>): string;
+   <BUILTINS>/core.js:1365:26
+   1365|     static raw(callSite: interface {+raw: $ReadOnlyArray<string>}, ...substitutions: $ReadOnlyArray<mixed>): string;
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [2]
 
 
@@ -99,8 +99,8 @@ Cannot cast `x` to empty because string [1] is incompatible with empty [2]. [inc
             ^
 
 References:
-   <BUILTINS>/core.js:1336:110
-   1336|     static raw(callSite: interface {+raw: $ReadOnlyArray<string>}, ...substitutions: $ReadOnlyArray<mixed>): string;
+   <BUILTINS>/core.js:1365:110
+   1365|     static raw(callSite: interface {+raw: $ReadOnlyArray<string>}, ...substitutions: $ReadOnlyArray<mixed>): string;
                                                                                                                       ^^^^^^ [1]
    tagged_template.js:45:7
      45|   (x: empty); // ERROR

--- a/tests/type_guards/type_guards.exp
+++ b/tests/type_guards/type_guards.exp
@@ -801,8 +801,8 @@ Error --------------------------------------------------------------------------
                                         ^^^^^^^^^^^ [2]
 
 References:
-   <BUILTINS>/core.js:1709:11
-   1709| interface Generator<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:1738:11
+   1738| interface Generator<+Yield,+Return,-Next> {
                    ^^^^^^^^^ [1]
 
 
@@ -816,8 +816,8 @@ it into an object and attempt to use it as a subtype of an interface. [incompati
                                         ^^^^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:1704:11
-   1704| interface $Iterable<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:1733:11
+   1733| interface $Iterable<+Yield,+Return,-Next> {
                    ^^^^^^^^^ [2]
 
 
@@ -830,8 +830,8 @@ Cannot return `(typeof x) == "number"` because `Generator` [1] is incompatible w
                   ^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:1709:11
-   1709| interface Generator<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:1738:11
+   1738| interface Generator<+Yield,+Return,-Next> {
                    ^^^^^^^^^ [1]
    invalid.js:19:32
      19| function *generator(x: mixed): x is number { // error
@@ -872,8 +872,8 @@ Cannot return `(typeof x) == "number"` because `Promise` [1] is incompatible wit
                   ^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:1878:15
-   1878| declare class Promise<+R = mixed> {
+   <BUILTINS>/core.js:1907:15
+   1907| declare class Promise<+R = mixed> {
                        ^^^^^^^ [1]
    invalid.js:28:33
      28| async function async(x: mixed): x is number { // error

--- a/tests/union_new/union_new.exp
+++ b/tests/union_new/union_new.exp
@@ -202,8 +202,8 @@ References:
    test20.js:14:2
      14| [""].reduce((acc,str) => acc * str.length);
           ^^ [1]
-   <BUILTINS>/core.js:1319:13
-   1319|     length: number;
+   <BUILTINS>/core.js:1348:13
+   1348|     length: number;
                      ^^^^^^ [2]
 
 


### PR DESCRIPTION
Greetings,

this adds Array copying methods the the `$ReadOnlyArray` class definitions.    
See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array#copying_methods_and_mutating_methods   

They are part of ES2023 and already implemented by most browsers and runtimes.     
https://caniuse.com/mdn-javascript_builtins_array_with   

Namely:    
`toReversed` https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/toReversed
`toSorted` https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/toSorted
`toSpliced` https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/toSpliced
`with` https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/with