### PR TITLE
[dom][node] Update URL definitions

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -4222,23 +4222,25 @@ declare class Comment extends CharacterData {
 }
 
 declare class URL {
+  static canParse(url: string, base?: string): boolean;
   static createObjectURL(blob: Blob): string;
   static createObjectURL(mediaSource: MediaSource): string;
-  static createFor(blob: Blob): string;
   static revokeObjectURL(url: string): void;
   constructor(url: string, base?: string | URL): void;
   hash: string;
   host: string;
   hostname: string;
   href: string;
-  origin: string; // readonly
+  +origin: string;
   password: string;
   pathname: string;
   port: string;
   protocol: string;
   search: string;
-  searchParams: URLSearchParams; // readonly
+  +searchParams: URLSearchParams;
   username: string;
+  toString(): string;
+  toJSON(): string;
 }
 
 declare interface MediaSourceHandle {

--- a/lib/node.js
+++ b/lib/node.js
@@ -2456,12 +2456,16 @@ declare module "url" {
     toString(): string;
   }
   declare class URL {
+    static canParse(url: string, base?: string): boolean;
+    static createObjectURL(blob: Blob): string;
+    static createObjectURL(mediaSource: MediaSource): string;
+    static revokeObjectURL(url: string): void;
     constructor(input: string, base?: string | URL): void;
     hash: string;
     host: string;
     hostname: string;
     href: string;
-    origin: string;
+    +origin: string;
     password: string;
     pathname: string;
     port: string;

--- a/tests/dom/dom.exp
+++ b/tests/dom/dom.exp
@@ -1022,11 +1022,11 @@ References:
    traversal.js:188:74
     188|     document.createNodeIterator(document_body, -1, { acceptNode: node => 'accept' }); // invalid
                                                                                   ^^^^^^^^ [1]
-   <BUILTINS>/dom.js:4312:1
+   <BUILTINS>/dom.js:4314:1
          v--------------------------------
-   4312| typeof NodeFilter.FILTER_ACCEPT |
-   4313| typeof NodeFilter.FILTER_REJECT |
-   4314| typeof NodeFilter.FILTER_SKIP;
+   4314| typeof NodeFilter.FILTER_ACCEPT |
+   4315| typeof NodeFilter.FILTER_REJECT |
+   4316| typeof NodeFilter.FILTER_SKIP;
          ----------------------------^ [2]
    traversal.js:188:48
     188|     document.createNodeIterator(document_body, -1, { acceptNode: node => 'accept' }); // invalid
@@ -1398,11 +1398,11 @@ References:
    traversal.js:195:72
     195|     document.createTreeWalker(document_body, -1, { acceptNode: node => 'accept' }); // invalid
                                                                                 ^^^^^^^^ [1]
-   <BUILTINS>/dom.js:4312:1
+   <BUILTINS>/dom.js:4314:1
          v--------------------------------
-   4312| typeof NodeFilter.FILTER_ACCEPT |
-   4313| typeof NodeFilter.FILTER_REJECT |
-   4314| typeof NodeFilter.FILTER_SKIP;
+   4314| typeof NodeFilter.FILTER_ACCEPT |
+   4315| typeof NodeFilter.FILTER_REJECT |
+   4316| typeof NodeFilter.FILTER_SKIP;
          ----------------------------^ [2]
    traversal.js:195:46
     195|     document.createTreeWalker(document_body, -1, { acceptNode: node => 'accept' }); // invalid

--- a/tests/node_tests/node_tests.exp
+++ b/tests/node_tests/node_tests.exp
@@ -1749,8 +1749,8 @@ Cannot call `inspector.open` with `'8080'` bound to `port` because string [1] is
                         ^^^^^^ [1]
 
 References:
-   <BUILTINS>/node.js:3248:12
-   3248|     port?: number,
+   <BUILTINS>/node.js:3252:12
+   3252|     port?: number,
                     ^^^^^^ [2]
 
 
@@ -1764,8 +1764,8 @@ Cannot call `inspector.open` with `127001` bound to `host` because number [1] is
                               ^^^^^^ [1]
 
 References:
-   <BUILTINS>/node.js:3249:12
-   3249|     host?: string,
+   <BUILTINS>/node.js:3253:12
+   3253|     host?: string,
                     ^^^^^^ [2]
 
 
@@ -1779,8 +1779,8 @@ Cannot call `inspector.open` with `1000` bound to `wait` because number [1] is i
                                                   ^^^^ [1]
 
 References:
-   <BUILTINS>/node.js:3250:12
-   3250|     wait?: boolean
+   <BUILTINS>/node.js:3254:12
+   3254|     wait?: boolean
                     ^^^^^^^ [2]
 
 
@@ -1793,8 +1793,8 @@ Cannot cast `inspector.open()` to string because undefined [1] is incompatible w
           ^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/node.js:3251:6
-   3251|   ): void;
+   <BUILTINS>/node.js:3255:6
+   3255|   ): void;
               ^^^^ [1]
    inspector/inspector.js:16:21
      16| (inspector.open() : string); // error
@@ -1810,8 +1810,8 @@ Cannot cast `inspector.close()` to string because undefined [1] is incompatible 
           ^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/node.js:3253:29
-   3253|   declare function close(): void;
+   <BUILTINS>/node.js:3257:29
+   3257|   declare function close(): void;
                                      ^^^^ [1]
    inspector/inspector.js:24:22
      24| (inspector.close() : string); // error
@@ -1827,8 +1827,8 @@ Cannot cast `inspector.url()` to number because string [1] is incompatible with 
           ^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/node.js:3254:28
-   3254|   declare function url() : string | void;
+   <BUILTINS>/node.js:3258:28
+   3258|   declare function url() : string | void;
                                     ^^^^^^ [1]
    inspector/inspector.js:36:20
      36| (inspector.url() : number); // error
@@ -1844,8 +1844,8 @@ Cannot cast `inspector.url()` to number because undefined [1] is incompatible wi
           ^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/node.js:3254:37
-   3254|   declare function url() : string | void;
+   <BUILTINS>/node.js:3258:37
+   3258|   declare function url() : string | void;
                                              ^^^^ [1]
    inspector/inspector.js:36:20
      36| (inspector.url() : number); // error
@@ -1862,8 +1862,8 @@ Cannot cast `inspector.waitForDebugger()` to number because undefined [1] is inc
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/node.js:3256:39
-   3256|   declare function waitForDebugger(): void;
+   <BUILTINS>/node.js:3260:39
+   3260|   declare function waitForDebugger(): void;
                                                ^^^^ [1]
    inspector/inspector.js:44:32
      44| (inspector.waitForDebugger() : number); // error
@@ -1879,8 +1879,8 @@ Cannot call `inspector.connect` because property `connect` is missing in module 
                     ^^^^^^^
 
 References:
-   <BUILTINS>/node.js:3246:16
-   3246| declare module 'inspector' {
+   <BUILTINS>/node.js:3250:16
+   3250| declare module 'inspector' {
                         ^^^^^^^^^^^ [1]
 
 
@@ -1894,8 +1894,8 @@ Cannot call `inspector.connectToMainThread` because property `connectToMainThrea
                     ^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/node.js:3246:16
-   3246| declare module 'inspector' {
+   <BUILTINS>/node.js:3250:16
+   3250| declare module 'inspector' {
                         ^^^^^^^^^^^ [1]
 
 
@@ -1908,8 +1908,8 @@ Cannot call `inspector.disconnect` because property `disconnect` is missing in m
                     ^^^^^^^^^^
 
 References:
-   <BUILTINS>/node.js:3246:16
-   3246| declare module 'inspector' {
+   <BUILTINS>/node.js:3250:16
+   3250| declare module 'inspector' {
                         ^^^^^^^^^^^ [1]
 
 
@@ -1922,13 +1922,13 @@ Cannot call `session.post` because function [1] requires another argument. [inco
                  ^^^^
 
 References:
-   <BUILTINS>/node.js:3263:5
+   <BUILTINS>/node.js:3267:5
              v----
-   3263|     post(
-   3264|       method: string,
-   3265|       params?: Object,
-   3266|       callback?: Function
-   3267|     ): void;
+   3267|     post(
+   3268|       method: string,
+   3269|       params?: Object,
+   3270|       callback?: Function
+   3271|     ): void;
              ------^ [1]
 
 
@@ -1941,13 +1941,13 @@ Cannot call `session.post` because function [1] requires another argument. [inco
                   ^^^^
 
 References:
-   <BUILTINS>/node.js:3263:5
+   <BUILTINS>/node.js:3267:5
              v----
-   3263|     post(
-   3264|       method: string,
-   3265|       params?: Object,
-   3266|       callback?: Function
-   3267|     ): void;
+   3267|     post(
+   3268|       method: string,
+   3269|       params?: Object,
+   3270|       callback?: Function
+   3271|     ): void;
              ------^ [1]
 
 
@@ -1960,8 +1960,8 @@ Cannot cast `session.post()` to string because undefined [1] is incompatible wit
           ^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/node.js:3267:8
-   3267|     ): void;
+   <BUILTINS>/node.js:3271:8
+   3271|     ): void;
                 ^^^^ [1]
    inspector/inspector.js:90:19
      90| (session.post() : string); // error
@@ -2044,26 +2044,26 @@ References:
    process/emitWarning.js:10:1
      10| process.emitWarning(); // error
          ^^^^^^^^^^^^^^^^^^^^^ [1]
-   <BUILTINS>/node.js:3292:24
-   3292|   emitWarning(warning: string | Error): void;
+   <BUILTINS>/node.js:3296:24
+   3296|   emitWarning(warning: string | Error): void;
                                 ^^^^^^ [2]
-   <BUILTINS>/node.js:3292:33
-   3292|   emitWarning(warning: string | Error): void;
+   <BUILTINS>/node.js:3296:33
+   3296|   emitWarning(warning: string | Error): void;
                                          ^^^^^ [3]
-   <BUILTINS>/node.js:3293:3
-   3293|   emitWarning(warning: string, typeOrCtor: string | (...empty) => mixed): void;
+   <BUILTINS>/node.js:3297:3
+   3297|   emitWarning(warning: string, typeOrCtor: string | (...empty) => mixed): void;
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [4]
-   <BUILTINS>/node.js:3294:3
-   3294|   emitWarning(warning: string, type: string, codeOrCtor: string | (...empty) => mixed): void;
+   <BUILTINS>/node.js:3298:3
+   3298|   emitWarning(warning: string, type: string, codeOrCtor: string | (...empty) => mixed): void;
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [5]
-   <BUILTINS>/node.js:3295:3
+   <BUILTINS>/node.js:3299:3
            v-----------
-   3295|   emitWarning(
-   3296|     warning: string,
-   3297|     type: string,
-   3298|     code: string,
-   3299|     ctor?: (...empty) => mixed
-   3300|   ): void;
+   3299|   emitWarning(
+   3300|     warning: string,
+   3301|     type: string,
+   3302|     code: string,
+   3303|     ctor?: (...empty) => mixed
+   3304|   ): void;
            ------^ [6]
 
 
@@ -2082,14 +2082,14 @@ References:
    process/emitWarning.js:11:21
      11| process.emitWarning(42); // error
                              ^^ [1]
-   <BUILTINS>/node.js:3293:24
-   3293|   emitWarning(warning: string, typeOrCtor: string | (...empty) => mixed): void;
+   <BUILTINS>/node.js:3297:24
+   3297|   emitWarning(warning: string, typeOrCtor: string | (...empty) => mixed): void;
                                 ^^^^^^ [2]
-   <BUILTINS>/node.js:3294:24
-   3294|   emitWarning(warning: string, type: string, codeOrCtor: string | (...empty) => mixed): void;
+   <BUILTINS>/node.js:3298:24
+   3298|   emitWarning(warning: string, type: string, codeOrCtor: string | (...empty) => mixed): void;
                                 ^^^^^^ [3]
-   <BUILTINS>/node.js:3296:14
-   3296|     warning: string,
+   <BUILTINS>/node.js:3300:14
+   3300|     warning: string,
                       ^^^^^^ [4]
 
 
@@ -2107,11 +2107,11 @@ References:
    process/emitWarning.js:12:29
      12| process.emitWarning("blah", 42); // error
                                      ^^ [1]
-   <BUILTINS>/node.js:3294:38
-   3294|   emitWarning(warning: string, type: string, codeOrCtor: string | (...empty) => mixed): void;
+   <BUILTINS>/node.js:3298:38
+   3298|   emitWarning(warning: string, type: string, codeOrCtor: string | (...empty) => mixed): void;
                                               ^^^^^^ [2]
-   <BUILTINS>/node.js:3297:11
-   3297|     type: string,
+   <BUILTINS>/node.js:3301:11
+   3301|     type: string,
                    ^^^^^^ [3]
 
 
@@ -2129,11 +2129,11 @@ References:
    process/emitWarning.js:13:37
      13| process.emitWarning("blah", "blah", 42); // error
                                              ^^ [1]
-   <BUILTINS>/node.js:3298:11
-   3298|     code: string,
+   <BUILTINS>/node.js:3302:11
+   3302|     code: string,
                    ^^^^^^ [2]
-   <BUILTINS>/node.js:3294:58
-   3294|   emitWarning(warning: string, type: string, codeOrCtor: string | (...empty) => mixed): void;
+   <BUILTINS>/node.js:3298:58
+   3298|   emitWarning(warning: string, type: string, codeOrCtor: string | (...empty) => mixed): void;
                                                                   ^^^^^^ [3]
 
 
@@ -2147,8 +2147,8 @@ Cannot cast `process.emitWarning(...)` to string because undefined [1] is incomp
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/node.js:3292:41
-   3292|   emitWarning(warning: string | Error): void;
+   <BUILTINS>/node.js:3296:41
+   3296|   emitWarning(warning: string | Error): void;
                                                  ^^^^ [1]
    process/emitWarning.js:14:31
      14| (process.emitWarning("blah"): string); // error
@@ -2219,8 +2219,8 @@ type [2]. [incompatible-call]
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/node.js:3326:21
-   3326|   nextTick: <T>(cb: (...T) => mixed, ...T) => void;
+   <BUILTINS>/node.js:3330:21
+   3330|   nextTick: <T>(cb: (...T) => mixed, ...T) => void;
                              ^^^^^^^^^^^^^^^ [2]
 
 
@@ -2234,8 +2234,8 @@ Cannot cast `process.allowedNodeEnvironmentFlags` to string because `Set` [1] is
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/node.js:3281:32
-   3281|   allowedNodeEnvironmentFlags: Set<string>;
+   <BUILTINS>/node.js:3285:32
+   3285|   allowedNodeEnvironmentFlags: Set<string>;
                                         ^^^^^^^^^^^ [1]
    process/process.js:5:39
       5| (process.allowedNodeEnvironmentFlags: string); // error
@@ -2589,8 +2589,8 @@ Cannot get `values.invalid` because property `invalid` is missing in `util$Parse
                 ^^^^^^^
 
 References:
-   <BUILTINS>/node.js:2568:13
-   2568|     values: util$ParseArgsOptionsToValues<TOptions>,
+   <BUILTINS>/node.js:2572:13
+   2572|     values: util$ParseArgsOptionsToValues<TOptions>,
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 
@@ -2603,12 +2603,12 @@ Cannot get `parseArgs(...).tokens` because property `tokens` is missing in objec
                        ^^^^^^
 
 References:
-   <BUILTINS>/node.js:2567:8
+   <BUILTINS>/node.js:2571:8
                 v-
-   2567|   |}): {|
-   2568|     values: util$ParseArgsOptionsToValues<TOptions>,
-   2569|     positionals: Array<string>,
-   2570|   |};
+   2571|   |}): {|
+   2572|     values: util$ParseArgsOptionsToValues<TOptions>,
+   2573|     positionals: Array<string>,
+   2574|   |};
            -^ [1]
 
 
@@ -2621,12 +2621,12 @@ Cannot get `parseArgs(...).tokens` because property `tokens` is missing in objec
                                     ^^^^^^
 
 References:
-   <BUILTINS>/node.js:2567:8
+   <BUILTINS>/node.js:2571:8
                 v-
-   2567|   |}): {|
-   2568|     values: util$ParseArgsOptionsToValues<TOptions>,
-   2569|     positionals: Array<string>,
-   2570|   |};
+   2571|   |}): {|
+   2572|     values: util$ParseArgsOptionsToValues<TOptions>,
+   2573|     positionals: Array<string>,
+   2574|   |};
            -^ [1]
 
 


### PR DESCRIPTION
Hi,

add missing `canParse` static method.
DOM https://developer.mozilla.org/en-US/docs/Web/API/URL/canParse_static
Node https://nodejs.org/api/url.html#urlcanparseinput-base

Update and sync both definitions while at it.  
DOM https://developer.mozilla.org/en-US/docs/Web/API/URL
Node https://nodejs.org/api/url.html
Spec https://url.spec.whatwg.org/#url-class

Note: the `createFor` static method was removed.
See https://github.com/w3c/FileAPI/issues/57  



