### PR TITLE
[core] Add a few missing ES additions

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -2101,6 +2101,11 @@ declare class $TypedArrayInternal<T: number | bigint> {
     length: number;
 
     /**
+     * Returns the item located at the specified index.
+     * @param index The zero-based index of the desired item. A negative index will count back from the last item.
+     */
+    at(index: number): T | void;
+    /**
      * Returns the this object after copying a section of the array identified by start and end
      * to the same array starting at position target
      * @param target If target is negative, it is treated as length+target where length is the

--- a/lib/core.js
+++ b/lib/core.js
@@ -175,6 +175,13 @@ declare class Object {
      */
     static getPrototypeOf: Object$GetPrototypeOf;
     /**
+     * Returns true if the specified object has the indicated property as its own property. 
+     * If the property is inherited, or does not exist, the method returns false. 
+     * @param obj The JavaScript object instance to test.
+     * @param prop The String name or Symbol of the property to test.
+     */
+    static hasOwn(obj: $NotNullOrVoid, prop: mixed): boolean;
+    /**
      * Returns true if the values are the same value, false otherwise.
      * @param a The first value.
      * @param b The second value.
@@ -771,6 +778,16 @@ declare class $ReadOnlyArray<+T> {
      */
     findLast<This>(callbackfn: (this : This, value: T, index: number, array: $ReadOnlyArray<T>) => mixed, thisArg: This): T | void;
     /**
+     * Returns the index of the last element in the array where predicate is true, and -1
+     * otherwise.
+     * @param callbackfn find calls predicate once for each element of the array, in reverse
+     * order, until it finds one where predicate returns true. If such an element is found,
+     * findLastIndex immediately returns that element index. Otherwise, findLastIndex returns -1.
+     * @param thisArg If provided, it will be used as the this value for each invocation of
+     * predicate. If it is not provided, undefined is used instead.
+     */
+    findLastIndex<This>(callbackfn: (this : This, value: T, index: number, array: $ReadOnlyArray<T>) => mixed, thisArg: This): number;
+    /**
      * Performs the specified action for each element in an array.
      * @param callbackfn  A function that accepts up to three arguments. forEach calls the callbackfn function one time for each element in the array.
      * @param thisArg  An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
@@ -1166,6 +1183,18 @@ declare class String {
      * @param name
      */
     anchor(name: string): string;
+    /**
+     * Returns a new String consisting of the single UTF-16 code unit located at 
+     * the specified offset. This method allows for positive and negative integers. 
+     * Negative integers count back from the last string character.
+     * @param index The index (position) of the string character to be returned. 
+     * Supports relative indexing from the end of the string when passed a negative index; 
+     * i.e. if a negative number is used, the character returned will be found by 
+     * counting back from the end of the string.
+     * @return A String consisting of the single UTF-16 code unit located at the specified position. 
+     * Returns undefined if the given index can not be found.
+     */
+    at(index: number): string | void;
     /**
      * Returns the character at the specified index.
      * @param pos The zero-based index of the desired character.

--- a/newtests/autocomplete/test.js
+++ b/newtests/autocomplete/test.js
@@ -91,6 +91,10 @@ module.exports = (suite(({addFile, flowCmd}) => [
                "type": "(name: string) => string"
              },
              {
+               "name": "at",
+               "type": "(index: number) => (string | void)"
+             },
+             {
                "name": "charAt",
                "type": "(pos: number) => string"
              },

--- a/tests/arith/arith.exp
+++ b/tests/arith/arith.exp
@@ -647,8 +647,8 @@ Cannot get `(x + y).length` because property `length` is missing in `Number` [1]
                     ^^^^^^
 
 References:
-   <BUILTINS>/core.js:376:15
-   376| declare class Number {
+   <BUILTINS>/core.js:383:15
+   383| declare class Number {
                       ^^^^^^ [1]
 
 
@@ -661,8 +661,8 @@ Cannot get `(1 + 2).length` because property `length` is missing in `Number` [1]
                     ^^^^^^
 
 References:
-   <BUILTINS>/core.js:376:15
-   376| declare class Number {
+   <BUILTINS>/core.js:383:15
+   383| declare class Number {
                       ^^^^^^ [1]
 
 

--- a/tests/arraylib/arraylib.exp
+++ b/tests/arraylib/arraylib.exp
@@ -107,8 +107,8 @@ References:
    array_lib.js:46:4
      46|   [""].reduce((acc, str) => acc * str.length); // error, string ~> number
             ^^ [1]
-   <BUILTINS>/core.js:1348:13
-   1348|     length: number;
+   <BUILTINS>/core.js:1377:13
+   1377|     length: number;
                      ^^^^^^ [2]
 
 
@@ -124,8 +124,8 @@ References:
    array_lib.js:47:4
      47|   [""].reduceRight((acc, str) => acc * str.length); // error, string ~> number
             ^^ [1]
-   <BUILTINS>/core.js:1348:13
-   1348|     length: number;
+   <BUILTINS>/core.js:1377:13
+   1377|     length: number;
                      ^^^^^^ [2]
 
 
@@ -139,8 +139,8 @@ Cannot cast `Array.from(...)` to array type because string [1] is incompatible w
             ^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:1133:37
-   1133|     static from(str: string): Array<string>;
+   <BUILTINS>/core.js:1150:37
+   1150|     static from(str: string): Array<string>;
                                              ^^^^^^ [1]
    array_lib.js:59:30
      59|   (Array.from("abcd"): Array<empty>); // ERROR
@@ -184,8 +184,8 @@ Cannot call `arr.at` because function [1] requires another argument. [incompatib
             ^^
 
 References:
-   <BUILTINS>/core.js:701:5
-   701|     at(index: number): T | void;
+   <BUILTINS>/core.js:708:5
+   708|     at(index: number): T | void;
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 
@@ -198,8 +198,8 @@ Cannot call `arr.at` with `"1"` bound to `index` because string [1] is incompati
                ^^^ [1]
 
 References:
-   <BUILTINS>/core.js:701:15
-   701|     at(index: number): T | void;
+   <BUILTINS>/core.js:708:15
+   708|     at(index: number): T | void;
                       ^^^^^^ [2]
 
 
@@ -212,8 +212,8 @@ Cannot call `roArr.at` because function [1] requires another argument. [incompat
               ^^
 
 References:
-   <BUILTINS>/core.js:701:5
-   701|     at(index: number): T | void;
+   <BUILTINS>/core.js:708:5
+   708|     at(index: number): T | void;
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 
@@ -227,8 +227,8 @@ Cannot call `roArr.at` with `"1"` bound to `index` because string [1] is incompa
                  ^^^ [1]
 
 References:
-   <BUILTINS>/core.js:701:15
-   701|     at(index: number): T | void;
+   <BUILTINS>/core.js:708:15
+   708|     at(index: number): T | void;
                       ^^^^^^ [2]
 
 
@@ -364,8 +364,8 @@ Cannot assign `arr3.flat(...)` to `result3_2` because mixed [1] is incompatible 
                                          ^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:843:32
-   843|     flat(depth: number): Array<mixed>;
+   <BUILTINS>/core.js:860:32
+   860|     flat(depth: number): Array<mixed>;
                                        ^^^^^ [1]
    flat.js:20:24
     20| const result3_2: Array<number> = arr3.flat(2); // Error - don't support this
@@ -382,8 +382,8 @@ Cannot assign `arr2.flat(...)` to `result2_6` because mixed [1] is incompatible 
                                          ^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:843:32
-   843|     flat(depth: number): Array<mixed>;
+   <BUILTINS>/core.js:860:32
+   860|     flat(depth: number): Array<mixed>;
                                        ^^^^^ [1]
    flat.js:25:24
     25| const result2_6: Array<number> = arr2.flat(x); // Error - don't support this

--- a/tests/arrows/arrows.exp
+++ b/tests/arrows/arrows.exp
@@ -42,8 +42,8 @@ return value. [incompatible-call]
                                             ^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:1081:38
-   1081|     sort(compareFn?: (a: T, b: T) => number): Array<T>;
+   <BUILTINS>/core.js:1098:38
+   1098|     sort(compareFn?: (a: T, b: T) => number): Array<T>;
                                               ^^^^^^ [2]
 
 

--- a/tests/async/async.exp
+++ b/tests/async/async.exp
@@ -10,8 +10,8 @@ References:
    async.js:9:30
       9| async function f1(): Promise<boolean> {
                                       ^^^^^^^ [2]
-   <BUILTINS>/core.js:1907:24
-   1907| declare class Promise<+R = mixed> {
+   <BUILTINS>/core.js:1936:24
+   1936| declare class Promise<+R = mixed> {
                                 ^ [3]
 
 
@@ -31,8 +31,8 @@ References:
    async.js:28:48
      28| async function f4(p: Promise<number>): Promise<boolean> {
                                                         ^^^^^^^ [2]
-   <BUILTINS>/core.js:1907:24
-   1907| declare class Promise<+R = mixed> {
+   <BUILTINS>/core.js:1936:24
+   1936| declare class Promise<+R = mixed> {
                                 ^ [3]
 
 
@@ -99,8 +99,8 @@ undefined in type argument `R` [2]. [incompatible-return]
                      ^^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:1907:24
-   1907| declare class Promise<+R = mixed> {
+   <BUILTINS>/core.js:1936:24
+   1936| declare class Promise<+R = mixed> {
                                 ^ [2]
 
 
@@ -142,8 +142,8 @@ References:
    async_return_void.js:1:32
       1| async function foo1(): Promise<string> {
                                         ^^^^^^ [2]
-   <BUILTINS>/core.js:1907:24
-   1907| declare class Promise<+R = mixed> {
+   <BUILTINS>/core.js:1936:24
+   1936| declare class Promise<+R = mixed> {
                                 ^ [3]
 
 
@@ -160,8 +160,8 @@ References:
    async_return_void.js:5:32
       5| async function foo2(): Promise<string> {
                                         ^^^^^^ [2]
-   <BUILTINS>/core.js:1907:24
-   1907| declare class Promise<+R = mixed> {
+   <BUILTINS>/core.js:1936:24
+   1936| declare class Promise<+R = mixed> {
                                 ^ [3]
 
 
@@ -181,8 +181,8 @@ References:
    async_return_void.js:9:32
       9| async function foo3(): Promise<string> {
                                         ^^^^^^ [2]
-   <BUILTINS>/core.js:1907:24
-   1907| declare class Promise<+R = mixed> {
+   <BUILTINS>/core.js:1936:24
+   1936| declare class Promise<+R = mixed> {
                                 ^ [3]
 
 

--- a/tests/async_iteration/async_iteration.exp
+++ b/tests/async_iteration/async_iteration.exp
@@ -113,8 +113,8 @@ Cannot cast `result.value` to string because undefined [1] is incompatible with 
               ^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:1718:14
-   1718|     +value?: Return,
+   <BUILTINS>/core.js:1747:14
+   1747|     +value?: Return,
                       ^^^^^^ [1]
    return.js:20:20
      20|     (result.value: string); // error: number | void ~> string

--- a/tests/autocomplete/autocomplete.exp
+++ b/tests/autocomplete/autocomplete.exp
@@ -16,6 +16,7 @@ Flags: --pretty
   "result":[
     {"name":"[Symbol.iterator]","type":"() => Iterator<string>"},
     {"name":"anchor","type":"(name: string) => string"},
+    {"name":"at","type":"(index: number) => (string | void)"},
     {"name":"charAt","type":"(pos: number) => string"},
     {"name":"charCodeAt","type":"(index: number) => number"},
     {"name":"codePointAt","type":"(index: number) => number"},
@@ -653,6 +654,7 @@ Flags: --pretty
   "result":[
     {"name":"[Symbol.iterator]","type":"() => Iterator<string>"},
     {"name":"anchor","type":"(name: string) => string"},
+    {"name":"at","type":"(index: number) => (string | void)"},
     {"name":"charAt","type":"(pos: number) => string"},
     {"name":"charCodeAt","type":"(index: number) => number"},
     {"name":"codePointAt","type":"(index: number) => number"},
@@ -978,6 +980,10 @@ Flags: --pretty
       "name":"?.findLast",
       "type":"void | (<This>(callbackfn: (value: T, index: number, array: $ReadOnlyArray<T>) => mixed, thisArg: This) => (T | void))"
     },
+    {
+      "name":"?.findLastIndex",
+      "type":"void | (<This>(callbackfn: (value: T, index: number, array: $ReadOnlyArray<T>) => mixed, thisArg: This) => number)"
+    },
     {"name":"?.flat","type":"void | ((depth: number) => Array<mixed>)"},
     {
       "name":"?.flatMap",
@@ -1082,6 +1088,10 @@ Flags: --pretty
     {
       "name":"findLast",
       "type":"<This>(callbackfn: (value: T, index: number, array: $ReadOnlyArray<T>) => mixed, thisArg: This) => (T | void)"
+    },
+    {
+      "name":"findLastIndex",
+      "type":"<This>(callbackfn: (value: T, index: number, array: $ReadOnlyArray<T>) => mixed, thisArg: This) => number"
     },
     {"name":"flat","type":"(depth: number) => Array<mixed>"},
     {

--- a/tests/automatic_require_default/automatic_require_default.exp
+++ b/tests/automatic_require_default/automatic_require_default.exp
@@ -7,8 +7,8 @@ Cannot get `Default.T` because property `T` is missing in `Number` [1]. [prop-mi
                      ^
 
 References:
-   <BUILTINS>/core.js:376:15
-   376| declare class Number {
+   <BUILTINS>/core.js:383:15
+   383| declare class Number {
                       ^^^^^^ [1]
 
 

--- a/tests/babel_loose_array_spread/babel_loose_array_spread.exp
+++ b/tests/babel_loose_array_spread/babel_loose_array_spread.exp
@@ -10,13 +10,13 @@ References:
    apply.js:3:11
       3| const it: Iterable<number> = [7,8,9];
                    ^^^^^^^^^^^^^^^^ [1]
-   <BUILTINS>/core.js:1141:22
+   <BUILTINS>/core.js:1158:22
                               v----------
-   1141| type $ArrayLike<T> = interface {
-   1142|   +[indexer: number]: T;
-   1143|   @@iterator(): Iterator<T>;
-   1144|   length: number;
-   1145| }
+   1158| type $ArrayLike<T> = interface {
+   1159|   +[indexer: number]: T;
+   1160|   @@iterator(): Iterator<T>;
+   1161|   length: number;
+   1162| }
          ^ [2]
 
 
@@ -43,8 +43,8 @@ References:
    compose.js:4:19
      4| declare var fns1: Iterable<(number) => number>;
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
-   <BUILTINS>/core.js:691:15
-   691| declare class $ReadOnlyArray<+T> {
+   <BUILTINS>/core.js:698:15
+   698| declare class $ReadOnlyArray<+T> {
                       ^^^^^^^^^^^^^^ [2]
 
 
@@ -60,8 +60,8 @@ References:
    iterables.js:1:11
      1| const it: Iterable<number> = [7,8,9];
                   ^^^^^^^^^^^^^^^^ [1]
-   <BUILTINS>/core.js:691:15
-   691| declare class $ReadOnlyArray<+T> {
+   <BUILTINS>/core.js:698:15
+   698| declare class $ReadOnlyArray<+T> {
                       ^^^^^^^^^^^^^^ [2]
 
 
@@ -77,8 +77,8 @@ References:
    iterables.js:1:11
      1| const it: Iterable<number> = [7,8,9];
                   ^^^^^^^^^^^^^^^^ [1]
-   <BUILTINS>/core.js:691:15
-   691| declare class $ReadOnlyArray<+T> {
+   <BUILTINS>/core.js:698:15
+   698| declare class $ReadOnlyArray<+T> {
                       ^^^^^^^^^^^^^^ [2]
 
 
@@ -94,8 +94,8 @@ References:
    iterables.js:1:11
      1| const it: Iterable<number> = [7,8,9];
                   ^^^^^^^^^^^^^^^^ [1]
-   <BUILTINS>/core.js:691:15
-   691| declare class $ReadOnlyArray<+T> {
+   <BUILTINS>/core.js:698:15
+   698| declare class $ReadOnlyArray<+T> {
                       ^^^^^^^^^^^^^^ [2]
 
 
@@ -111,8 +111,8 @@ References:
    opaque.js:6:30
      6| export const opaqueIterable: OpaqueIterable = [];
                                      ^^^^^^^^^^^^^^ [1]
-   <BUILTINS>/core.js:691:15
-   691| declare class $ReadOnlyArray<+T> {
+   <BUILTINS>/core.js:698:15
+   698| declare class $ReadOnlyArray<+T> {
                       ^^^^^^^^^^^^^^ [2]
 
 
@@ -128,8 +128,8 @@ References:
    opaque.js:6:30
      6| export const opaqueIterable: OpaqueIterable = [];
                                      ^^^^^^^^^^^^^^ [1]
-   <BUILTINS>/core.js:691:15
-   691| declare class $ReadOnlyArray<+T> {
+   <BUILTINS>/core.js:698:15
+   698| declare class $ReadOnlyArray<+T> {
                       ^^^^^^^^^^^^^^ [2]
 
 
@@ -145,8 +145,8 @@ References:
    opaque.js:6:30
      6| export const opaqueIterable: OpaqueIterable = [];
                                      ^^^^^^^^^^^^^^ [1]
-   <BUILTINS>/core.js:691:15
-   691| declare class $ReadOnlyArray<+T> {
+   <BUILTINS>/core.js:698:15
+   698| declare class $ReadOnlyArray<+T> {
                       ^^^^^^^^^^^^^^ [2]
 
 
@@ -162,8 +162,8 @@ References:
    maps.js:1:14
      1| const map1 = new Map<string, string>();
                      ^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
-   <BUILTINS>/core.js:691:15
-   691| declare class $ReadOnlyArray<+T> {
+   <BUILTINS>/core.js:698:15
+   698| declare class $ReadOnlyArray<+T> {
                       ^^^^^^^^^^^^^^ [2]
 
 
@@ -179,8 +179,8 @@ References:
    maps.js:2:14
      2| const map2 = new Map<string, string>();
                      ^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
-   <BUILTINS>/core.js:691:15
-   691| declare class $ReadOnlyArray<+T> {
+   <BUILTINS>/core.js:698:15
+   698| declare class $ReadOnlyArray<+T> {
                       ^^^^^^^^^^^^^^ [2]
 
 
@@ -196,8 +196,8 @@ References:
    maps.js:1:14
      1| const map1 = new Map<string, string>();
                      ^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
-   <BUILTINS>/core.js:691:15
-   691| declare class $ReadOnlyArray<+T> {
+   <BUILTINS>/core.js:698:15
+   698| declare class $ReadOnlyArray<+T> {
                       ^^^^^^^^^^^^^^ [2]
 
 
@@ -213,8 +213,8 @@ References:
    maps.js:2:14
      2| const map2 = new Map<string, string>();
                      ^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
-   <BUILTINS>/core.js:691:15
-   691| declare class $ReadOnlyArray<+T> {
+   <BUILTINS>/core.js:698:15
+   698| declare class $ReadOnlyArray<+T> {
                       ^^^^^^^^^^^^^^ [2]
 
 

--- a/tests/bigint/bigint.exp
+++ b/tests/bigint/bigint.exp
@@ -30,23 +30,23 @@ Cannot call `BigInt` with `null` bound to `value` because: [incompatible-call]
                 ^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:2703:18
-   2703|   static (value: boolean | string | number | bigint | interface {} | $ReadOnlyArray<mixed>): bigint;
+   <BUILTINS>/core.js:2737:18
+   2737|   static (value: boolean | string | number | bigint | interface {} | $ReadOnlyArray<mixed>): bigint;
                           ^^^^^^^ [2]
-   <BUILTINS>/core.js:2703:28
-   2703|   static (value: boolean | string | number | bigint | interface {} | $ReadOnlyArray<mixed>): bigint;
+   <BUILTINS>/core.js:2737:28
+   2737|   static (value: boolean | string | number | bigint | interface {} | $ReadOnlyArray<mixed>): bigint;
                                     ^^^^^^ [3]
-   <BUILTINS>/core.js:2703:37
-   2703|   static (value: boolean | string | number | bigint | interface {} | $ReadOnlyArray<mixed>): bigint;
+   <BUILTINS>/core.js:2737:37
+   2737|   static (value: boolean | string | number | bigint | interface {} | $ReadOnlyArray<mixed>): bigint;
                                              ^^^^^^ [4]
-   <BUILTINS>/core.js:2703:46
-   2703|   static (value: boolean | string | number | bigint | interface {} | $ReadOnlyArray<mixed>): bigint;
+   <BUILTINS>/core.js:2737:46
+   2737|   static (value: boolean | string | number | bigint | interface {} | $ReadOnlyArray<mixed>): bigint;
                                                       ^^^^^^ [5]
-   <BUILTINS>/core.js:2703:55
-   2703|   static (value: boolean | string | number | bigint | interface {} | $ReadOnlyArray<mixed>): bigint;
+   <BUILTINS>/core.js:2737:55
+   2737|   static (value: boolean | string | number | bigint | interface {} | $ReadOnlyArray<mixed>): bigint;
                                                                ^^^^^^^^^^^^ [6]
-   <BUILTINS>/core.js:2703:70
-   2703|   static (value: boolean | string | number | bigint | interface {} | $ReadOnlyArray<mixed>): bigint;
+   <BUILTINS>/core.js:2737:70
+   2737|   static (value: boolean | string | number | bigint | interface {} | $ReadOnlyArray<mixed>): bigint;
                                                                               ^^^^^^^^^^^^^^^^^^^^^ [7]
 
 

--- a/tests/compose/compose.exp
+++ b/tests/compose/compose.exp
@@ -7,8 +7,8 @@ Cannot cast `compose(...)(...)` to empty because string [1] is incompatible with
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:478:31
-   478|     toString(radix?: number): string;
+   <BUILTINS>/core.js:485:31
+   485|     toString(radix?: number): string;
                                       ^^^^^^ [1]
    basic.js:4:44
      4| (compose((n: number) => n.toString())(42): empty); // Error: string ~> empty
@@ -24,8 +24,8 @@ Cannot cast `composeReverse(...)(...)` to empty because string [1] is incompatib
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:478:31
-   478|     toString(radix?: number): string;
+   <BUILTINS>/core.js:485:31
+   485|     toString(radix?: number): string;
                                       ^^^^^^ [1]
    basic.js:6:51
      6| (composeReverse((n: number) => n.toString())(42): empty); // Error: string ~> empty
@@ -63,8 +63,8 @@ Cannot call `compose` with compose intermediate value bound to `n` because strin
           ^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:478:31
-   478|     toString(radix?: number): string;
+   <BUILTINS>/core.js:485:31
+   485|     toString(radix?: number): string;
                                       ^^^^^^ [1]
    basic.js:9:7
      9|   (n: number) => n * 5, // Error: string cannot be multiplied.
@@ -84,8 +84,8 @@ Cannot cast `composeReverse(...)(...)` to empty because string [1] is incompatib
         ----^
 
 References:
-   <BUILTINS>/core.js:478:31
-   478|     toString(radix?: number): string;
+   <BUILTINS>/core.js:485:31
+   485|     toString(radix?: number): string;
                                       ^^^^^^ [1]
    basic.js:16:8
     16| )(42): empty); // Error: string ~> empty
@@ -105,8 +105,8 @@ References:
    recompose.js:22:27
     22|   myEnhancer((props: {|p: string|}) => ({
                                   ^^^^^^ [1]
-   <BUILTINS>/core.js:648:14
-   648|     round(x: number): number,
+   <BUILTINS>/core.js:655:14
+   655|     round(x: number): number,
                      ^^^^^^ [2]
 
 

--- a/tests/computed_props/computed_props.exp
+++ b/tests/computed_props/computed_props.exp
@@ -198,8 +198,8 @@ Cannot assign `arr[0]()` to `y` because number [1] is incompatible with string [
                            ^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:1090:13
-   1090|     length: number;
+   <BUILTINS>/core.js:1107:13
+   1107|     length: number;
                      ^^^^^^ [1]
    test7.js:5:10
       5| const y: string = arr[0](); // error: number ~> string

--- a/tests/config_file_extensions/config_file_extensions.exp
+++ b/tests/config_file_extensions/config_file_extensions.exp
@@ -25,8 +25,8 @@ was defined. [method-unbinding]
                           ^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:240:5
-   240|     toString(): string;
+   <BUILTINS>/core.js:247:5
+   247|     toString(): string;
             ^^^^^^^^^^^^^^^^^^ [2]
 
 

--- a/tests/contextual_typing/contextual_typing.exp
+++ b/tests/contextual_typing/contextual_typing.exp
@@ -22,8 +22,8 @@ expression to your expected type. [underconstrained-implicit-instantiation]
                             ^^^
 
 References:
-   <BUILTINS>/core.js:1865:19
-   1865| declare class Set<T> extends $ReadOnlySet<T> {
+   <BUILTINS>/core.js:1894:19
+   1894| declare class Set<T> extends $ReadOnlySet<T> {
                            ^ [1]
    arr_rest.js:9:16
       9| const [...y] = new Set() // still error
@@ -298,8 +298,8 @@ Property `@@iterator` is missing in function [1] but exists in `$Iterable` [2]. 
                 ^^^^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:1733:11
-   1733| interface $Iterable<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:1762:11
+   1762| interface $Iterable<+Yield,+Return,-Next> {
                    ^^^^^^^^^ [2]
 
 
@@ -437,8 +437,8 @@ References:
    implicit_instantiation.js:150:11
     150|   (a: Set<empty>); // error Set<string> ~> Set<empty>
                    ^^^^^ [2]
-   <BUILTINS>/core.js:1865:19
-   1865| declare class Set<T> extends $ReadOnlySet<T> {
+   <BUILTINS>/core.js:1894:19
+   1894| declare class Set<T> extends $ReadOnlySet<T> {
                            ^ [3]
 
 
@@ -457,8 +457,8 @@ References:
    implicit_instantiation.js:151:11
     151|   (b: Set<empty>); // error Set<string> ~> Set<empty>
                    ^^^^^ [2]
-   <BUILTINS>/core.js:1865:19
-   1865| declare class Set<T> extends $ReadOnlySet<T> {
+   <BUILTINS>/core.js:1894:19
+   1894| declare class Set<T> extends $ReadOnlySet<T> {
                            ^ [3]
 
 
@@ -696,8 +696,8 @@ References:
    lits.js:43:26
      43|   (s2.values(): Iterator<string>); // error number ~> string
                                   ^^^^^^ [2]
-   <BUILTINS>/core.js:1731:16
-   1731| type Iterator<+T> = $Iterator<T,void,void>;
+   <BUILTINS>/core.js:1760:16
+   1760| type Iterator<+T> = $Iterator<T,void,void>;
                         ^ [3]
 
 
@@ -1006,8 +1006,8 @@ defined. [method-unbinding]
                                                          ^^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:970:5
-   970|     filter(callbackfn: typeof Boolean): Array<$NonMaybeType<T>>;
+   <BUILTINS>/core.js:987:5
+   987|     filter(callbackfn: typeof Boolean): Array<$NonMaybeType<T>>;
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [2]
 
 

--- a/tests/core_tests/core_tests.exp
+++ b/tests/core_tests/core_tests.exp
@@ -7,33 +7,33 @@ Cannot use `new` on object type [1]. Only classes can be constructed. [invalid-c
              ^^^^
 
 References:
-   <BUILTINS>/core.js:1687:19
+   <BUILTINS>/core.js:1716:19
                            v-
-   1687| declare var JSON: {|
-   1688|     /**
-   1689|      * Converts a JavaScript Object Notation (JSON) string into an object.
-   1690|      * @param text A valid JSON string.
-   1691|      * @param reviver A function that transforms the results. This function is called for each member of the object.
-   1692|      * If a member contains nested objects, the nested objects are transformed before the parent object is.
-   1693|      */
-   1694|     +parse: (text: string, reviver?: (key: any, value: any) => any) => any,
-   1695|     /**
-   1696|      * Converts a JavaScript value to a JavaScript Object Notation (JSON) string.
-   1697|      * @param value A JavaScript value, usually an object or array, to be converted.
-   1698|      * @param replacer A function that transforms the results or an array of strings and numbers that acts as a approved list for selecting the object properties that will be stringified.
-   1699|      * @param space Adds indentation, white space, and line break characters to the return-value JSON text to make it easier to read.
-   1700|      */
-   1701|     +stringify: ((
-   1702|         value: null | string | number | boolean | interface {} | $ReadOnlyArray<mixed>,
-   1703|         replacer?: ?((key: string, value: any) => any) | Array<any>,
-   1704|         space?: string | number
-   1705|       ) => string) &
-   1706|       (
-   1707|         value: mixed,
-   1708|         replacer?: ?((key: string, value: any) => any) | Array<any>,
-   1709|         space?: string | number
-   1710|       ) => string | void,
-   1711| |};
+   1716| declare var JSON: {|
+   1717|     /**
+   1718|      * Converts a JavaScript Object Notation (JSON) string into an object.
+   1719|      * @param text A valid JSON string.
+   1720|      * @param reviver A function that transforms the results. This function is called for each member of the object.
+   1721|      * If a member contains nested objects, the nested objects are transformed before the parent object is.
+   1722|      */
+   1723|     +parse: (text: string, reviver?: (key: any, value: any) => any) => any,
+   1724|     /**
+   1725|      * Converts a JavaScript value to a JavaScript Object Notation (JSON) string.
+   1726|      * @param value A JavaScript value, usually an object or array, to be converted.
+   1727|      * @param replacer A function that transforms the results or an array of strings and numbers that acts as a approved list for selecting the object properties that will be stringified.
+   1728|      * @param space Adds indentation, white space, and line break characters to the return-value JSON text to make it easier to read.
+   1729|      */
+   1730|     +stringify: ((
+   1731|         value: null | string | number | boolean | interface {} | $ReadOnlyArray<mixed>,
+   1732|         replacer?: ?((key: string, value: any) => any) | Array<any>,
+   1733|         space?: string | number
+   1734|       ) => string) &
+   1735|       (
+   1736|         value: mixed,
+   1737|         replacer?: ?((key: string, value: any) => any) | Array<any>,
+   1738|         space?: string | number
+   1739|       ) => string | void,
+   1740| |};
          -^ [1]
 
 
@@ -54,8 +54,8 @@ Cannot cast `JSON.stringify(...)` to string because undefined [1] is incompatibl
           ^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:1710:21
-   1710|       ) => string | void,
+   <BUILTINS>/core.js:1739:21
+   1739|       ) => string | void,
                              ^^^^ [1]
    json_stringify.js:7:24
       7| (JSON.stringify(bad1): string);
@@ -75,11 +75,11 @@ References:
    map.js:21:22
      21|     let x = new Map(['foo', 123]); // error
                               ^^^^^ [1]
-   <BUILTINS>/core.js:1793:38
-   1793|     constructor(iterable?: ?Iterable<[K, V]>): void;
+   <BUILTINS>/core.js:1822:38
+   1822|     constructor(iterable?: ?Iterable<[K, V]>): void;
                                               ^^^^^^ [2]
-   <BUILTINS>/core.js:1727:22
-   1727| interface $Iterator<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:1756:22
+   1756| interface $Iterator<+Yield,+Return,-Next> {
                               ^^^^^ [3]
 
 
@@ -96,11 +96,11 @@ References:
    map.js:21:29
      21|     let x = new Map(['foo', 123]); // error
                                      ^^^ [1]
-   <BUILTINS>/core.js:1793:38
-   1793|     constructor(iterable?: ?Iterable<[K, V]>): void;
+   <BUILTINS>/core.js:1822:38
+   1822|     constructor(iterable?: ?Iterable<[K, V]>): void;
                                               ^^^^^^ [2]
-   <BUILTINS>/core.js:1727:22
-   1727| interface $Iterator<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:1756:22
+   1756| interface $Iterator<+Yield,+Return,-Next> {
                               ^^^^^ [3]
 
 
@@ -120,8 +120,8 @@ References:
    map.js:22:16
      22|     let y: Map<number, string> = new Map([['foo', 123]]); // error
                         ^^^^^^ [2]
-   <BUILTINS>/core.js:1727:22
-   1727| interface $Iterator<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:1756:22
+   1756| interface $Iterator<+Yield,+Return,-Next> {
                               ^^^^^ [3]
 
 
@@ -141,8 +141,8 @@ References:
    map.js:22:24
      22|     let y: Map<number, string> = new Map([['foo', 123]]); // error
                                 ^^^^^^ [2]
-   <BUILTINS>/core.js:1727:22
-   1727| interface $Iterator<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:1756:22
+   1756| interface $Iterator<+Yield,+Return,-Next> {
                               ^^^^^ [3]
 
 
@@ -155,8 +155,8 @@ Cannot cast `x.get(...)` to boolean because undefined [1] is incompatible with b
               ^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:1801:22
-   1801|     get(key: K): V | void;
+   <BUILTINS>/core.js:1830:22
+   1830|     get(key: K): V | void;
                               ^^^^ [1]
    map.js:27:20
      27|     (x.get('foo'): boolean); // error, string | void
@@ -204,8 +204,8 @@ since `z` is not a member of the set. [invalid-charset-type-arg]
                            ^^^ [1]
 
 References:
-   <BUILTINS>/core.js:1147:21
-   1147| type RegExp$flags = $CharSet<"gimsuy">;
+   <BUILTINS>/core.js:1164:21
+   1164| type RegExp$flags = $CharSet<"gimsuy">;
                              ^^^^^^^^^^^^^^^^^^ [2]
 
 
@@ -219,8 +219,8 @@ since `z` is not a member of the set. [invalid-charset-type-arg]
                                ^^^ [1]
 
 References:
-   <BUILTINS>/core.js:1147:21
-   1147| type RegExp$flags = $CharSet<"gimsuy">;
+   <BUILTINS>/core.js:1164:21
+   1164| type RegExp$flags = $CharSet<"gimsuy">;
                              ^^^^^^^^^^^^^^^^^^ [2]
 
 
@@ -236,11 +236,11 @@ Cannot call `WeakRef` because in type argument `T`: [incompatible-call]
                                ^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:1824:26
-   1824| declare class WeakRef<T: interface {} | $ReadOnlyArray<mixed>> {
+   <BUILTINS>/core.js:1853:26
+   1853| declare class WeakRef<T: interface {} | $ReadOnlyArray<mixed>> {
                                   ^^^^^^^^^^^^ [2]
-   <BUILTINS>/core.js:1824:41
-   1824| declare class WeakRef<T: interface {} | $ReadOnlyArray<mixed>> {
+   <BUILTINS>/core.js:1853:41
+   1853| declare class WeakRef<T: interface {} | $ReadOnlyArray<mixed>> {
                                                  ^^^^^^^^^^^^^^^^^^^^^ [3]
 
 
@@ -256,11 +256,11 @@ Cannot call `WeakRef` because in type argument `T`: [incompatible-call]
                                ^^^ [1]
 
 References:
-   <BUILTINS>/core.js:1824:26
-   1824| declare class WeakRef<T: interface {} | $ReadOnlyArray<mixed>> {
+   <BUILTINS>/core.js:1853:26
+   1853| declare class WeakRef<T: interface {} | $ReadOnlyArray<mixed>> {
                                   ^^^^^^^^^^^^ [2]
-   <BUILTINS>/core.js:1824:41
-   1824| declare class WeakRef<T: interface {} | $ReadOnlyArray<mixed>> {
+   <BUILTINS>/core.js:1853:41
+   1853| declare class WeakRef<T: interface {} | $ReadOnlyArray<mixed>> {
                                                  ^^^^^^^^^^^^^^^^^^^^^ [3]
 
 
@@ -276,11 +276,11 @@ Cannot call `WeakRef` because in type argument `T`: [incompatible-call]
                                ^^^^^^^^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:1824:26
-   1824| declare class WeakRef<T: interface {} | $ReadOnlyArray<mixed>> {
+   <BUILTINS>/core.js:1853:26
+   1853| declare class WeakRef<T: interface {} | $ReadOnlyArray<mixed>> {
                                   ^^^^^^^^^^^^ [2]
-   <BUILTINS>/core.js:1824:41
-   1824| declare class WeakRef<T: interface {} | $ReadOnlyArray<mixed>> {
+   <BUILTINS>/core.js:1853:41
+   1853| declare class WeakRef<T: interface {} | $ReadOnlyArray<mixed>> {
                                                  ^^^^^^^^^^^^^^^^^^^^^ [3]
 
 
@@ -296,11 +296,11 @@ Cannot call `WeakSet` because in type argument `T`: [incompatible-call]
                                 ^ [1]
 
 References:
-   <BUILTINS>/core.js:1894:26
-   1894| declare class WeakSet<T: interface {} | $ReadOnlyArray<mixed>> extends $ReadOnlyWeakSet<T> {
+   <BUILTINS>/core.js:1923:26
+   1923| declare class WeakSet<T: interface {} | $ReadOnlyArray<mixed>> extends $ReadOnlyWeakSet<T> {
                                   ^^^^^^^^^^^^ [2]
-   <BUILTINS>/core.js:1894:41
-   1894| declare class WeakSet<T: interface {} | $ReadOnlyArray<mixed>> extends $ReadOnlyWeakSet<T> {
+   <BUILTINS>/core.js:1923:41
+   1923| declare class WeakSet<T: interface {} | $ReadOnlyArray<mixed>> extends $ReadOnlyWeakSet<T> {
                                                  ^^^^^^^^^^^^^^^^^^^^^ [3]
 
 
@@ -316,11 +316,11 @@ Cannot call `WeakSet` because in type argument `T`: [incompatible-call]
                                    ^ [1]
 
 References:
-   <BUILTINS>/core.js:1894:26
-   1894| declare class WeakSet<T: interface {} | $ReadOnlyArray<mixed>> extends $ReadOnlyWeakSet<T> {
+   <BUILTINS>/core.js:1923:26
+   1923| declare class WeakSet<T: interface {} | $ReadOnlyArray<mixed>> extends $ReadOnlyWeakSet<T> {
                                   ^^^^^^^^^^^^ [2]
-   <BUILTINS>/core.js:1894:41
-   1894| declare class WeakSet<T: interface {} | $ReadOnlyArray<mixed>> extends $ReadOnlyWeakSet<T> {
+   <BUILTINS>/core.js:1923:41
+   1923| declare class WeakSet<T: interface {} | $ReadOnlyArray<mixed>> extends $ReadOnlyWeakSet<T> {
                                                  ^^^^^^^^^^^^^^^^^^^^^ [3]
 
 
@@ -336,11 +336,11 @@ Cannot call `WeakSet` because in type argument `T`: [incompatible-call]
                                       ^ [1]
 
 References:
-   <BUILTINS>/core.js:1894:26
-   1894| declare class WeakSet<T: interface {} | $ReadOnlyArray<mixed>> extends $ReadOnlyWeakSet<T> {
+   <BUILTINS>/core.js:1923:26
+   1923| declare class WeakSet<T: interface {} | $ReadOnlyArray<mixed>> extends $ReadOnlyWeakSet<T> {
                                   ^^^^^^^^^^^^ [2]
-   <BUILTINS>/core.js:1894:41
-   1894| declare class WeakSet<T: interface {} | $ReadOnlyArray<mixed>> extends $ReadOnlyWeakSet<T> {
+   <BUILTINS>/core.js:1923:41
+   1923| declare class WeakSet<T: interface {} | $ReadOnlyArray<mixed>> extends $ReadOnlyWeakSet<T> {
                                                  ^^^^^^^^^^^^^^^^^^^^^ [3]
 
 
@@ -359,11 +359,11 @@ References:
    weakset.js:27:31
      27| function* numbers(): Iterable<number> {
                                        ^^^^^^ [1]
-   <BUILTINS>/core.js:1894:26
-   1894| declare class WeakSet<T: interface {} | $ReadOnlyArray<mixed>> extends $ReadOnlyWeakSet<T> {
+   <BUILTINS>/core.js:1923:26
+   1923| declare class WeakSet<T: interface {} | $ReadOnlyArray<mixed>> extends $ReadOnlyWeakSet<T> {
                                   ^^^^^^^^^^^^ [2]
-   <BUILTINS>/core.js:1894:41
-   1894| declare class WeakSet<T: interface {} | $ReadOnlyArray<mixed>> extends $ReadOnlyWeakSet<T> {
+   <BUILTINS>/core.js:1923:41
+   1923| declare class WeakSet<T: interface {} | $ReadOnlyArray<mixed>> extends $ReadOnlyWeakSet<T> {
                                                  ^^^^^^^^^^^^^^^^^^^^^ [3]
 
 

--- a/tests/date/date.exp
+++ b/tests/date/date.exp
@@ -7,8 +7,8 @@ Cannot assign `d.getTime()` to `x` because number [1] is incompatible with strin
                         ^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:1447:16
-   1447|     getTime(): number;
+   <BUILTINS>/core.js:1476:16
+   1476|     getTime(): number;
                         ^^^^^^ [1]
    date.js:2:7
       2| var x:string = d.getTime(); // expect error
@@ -46,11 +46,11 @@ References:
    date.js:18:10
      18| new Date({});
                   ^^ [1]
-   <BUILTINS>/core.js:1427:23
-   1427|     constructor(date: Date): void;
+   <BUILTINS>/core.js:1456:23
+   1456|     constructor(date: Date): void;
                                ^^^^ [2]
-   <BUILTINS>/core.js:1428:29
-   1428|     constructor(dateString: string): void;
+   <BUILTINS>/core.js:1457:29
+   1457|     constructor(dateString: string): void;
                                      ^^^^^^ [3]
 
 
@@ -68,11 +68,11 @@ References:
    date.js:19:16
      19| new Date(2015, '6');
                         ^^^ [1]
-   <BUILTINS>/core.js:1429:38
-   1429|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
+   <BUILTINS>/core.js:1458:38
+   1458|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
                                               ^^^^^^ [2]
-   <BUILTINS>/core.js:1428:5
-   1428|     constructor(dateString: string): void;
+   <BUILTINS>/core.js:1457:5
+   1457|     constructor(dateString: string): void;
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [3]
 
 
@@ -90,11 +90,11 @@ References:
    date.js:20:19
      20| new Date(2015, 6, '18');
                            ^^^^ [1]
-   <BUILTINS>/core.js:1429:52
-   1429|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
+   <BUILTINS>/core.js:1458:52
+   1458|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
                                                             ^^^^^^ [2]
-   <BUILTINS>/core.js:1428:5
-   1428|     constructor(dateString: string): void;
+   <BUILTINS>/core.js:1457:5
+   1457|     constructor(dateString: string): void;
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [3]
 
 
@@ -112,11 +112,11 @@ References:
    date.js:21:23
      21| new Date(2015, 6, 18, '11');
                                ^^^^ [1]
-   <BUILTINS>/core.js:1429:67
-   1429|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
+   <BUILTINS>/core.js:1458:67
+   1458|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
                                                                            ^^^^^^ [2]
-   <BUILTINS>/core.js:1428:5
-   1428|     constructor(dateString: string): void;
+   <BUILTINS>/core.js:1457:5
+   1457|     constructor(dateString: string): void;
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [3]
 
 
@@ -134,11 +134,11 @@ References:
    date.js:22:27
      22| new Date(2015, 6, 18, 11, '55');
                                    ^^^^ [1]
-   <BUILTINS>/core.js:1429:84
-   1429|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
+   <BUILTINS>/core.js:1458:84
+   1458|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
                                                                                             ^^^^^^ [2]
-   <BUILTINS>/core.js:1428:5
-   1428|     constructor(dateString: string): void;
+   <BUILTINS>/core.js:1457:5
+   1457|     constructor(dateString: string): void;
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [3]
 
 
@@ -156,11 +156,11 @@ References:
    date.js:23:31
      23| new Date(2015, 6, 18, 11, 55, '42');
                                        ^^^^ [1]
-   <BUILTINS>/core.js:1429:101
-   1429|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
+   <BUILTINS>/core.js:1458:101
+   1458|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
                                                                                                              ^^^^^^ [2]
-   <BUILTINS>/core.js:1428:5
-   1428|     constructor(dateString: string): void;
+   <BUILTINS>/core.js:1457:5
+   1457|     constructor(dateString: string): void;
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [3]
 
 
@@ -178,11 +178,11 @@ References:
    date.js:24:35
      24| new Date(2015, 6, 18, 11, 55, 42, '999');
                                            ^^^^^ [1]
-   <BUILTINS>/core.js:1429:123
-   1429|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
+   <BUILTINS>/core.js:1458:123
+   1458|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
                                                                                                                                    ^^^^^^ [2]
-   <BUILTINS>/core.js:1428:5
-   1428|     constructor(dateString: string): void;
+   <BUILTINS>/core.js:1457:5
+   1457|     constructor(dateString: string): void;
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [3]
 
 
@@ -200,20 +200,20 @@ Cannot call `Date` because: [incompatible-call]
              ^^^^
 
 References:
-   <BUILTINS>/core.js:1425:5
-   1425|     constructor(): void;
+   <BUILTINS>/core.js:1454:5
+   1454|     constructor(): void;
              ^^^^^^^^^^^^^^^^^^^ [1]
-   <BUILTINS>/core.js:1426:5
-   1426|     constructor(timestamp: number): void;
+   <BUILTINS>/core.js:1455:5
+   1455|     constructor(timestamp: number): void;
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [2]
-   <BUILTINS>/core.js:1427:5
-   1427|     constructor(date: Date): void;
+   <BUILTINS>/core.js:1456:5
+   1456|     constructor(date: Date): void;
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [3]
-   <BUILTINS>/core.js:1428:5
-   1428|     constructor(dateString: string): void;
+   <BUILTINS>/core.js:1457:5
+   1457|     constructor(dateString: string): void;
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [4]
-   <BUILTINS>/core.js:1429:5
-   1429|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
+   <BUILTINS>/core.js:1458:5
+   1458|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [5]
 
 
@@ -231,11 +231,11 @@ References:
    date.js:26:10
      26| new Date('2015', 6);
                   ^^^^^^ [1]
-   <BUILTINS>/core.js:1429:23
-   1429|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
+   <BUILTINS>/core.js:1458:23
+   1458|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
                                ^^^^^^ [2]
-   <BUILTINS>/core.js:1428:5
-   1428|     constructor(dateString: string): void;
+   <BUILTINS>/core.js:1457:5
+   1457|     constructor(dateString: string): void;
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [3]
 
 

--- a/tests/dictionary/dictionary.exp
+++ b/tests/dictionary/dictionary.exp
@@ -25,8 +25,8 @@ parameter of property `toString`. [method-unbinding]
                  ^
 
 References:
-   <BUILTINS>/core.js:240:5
-   240|     toString(): string;
+   <BUILTINS>/core.js:247:5
+   247|     toString(): string;
             ^^^^^^^^^^^^^^^^^^ [1]
 
 
@@ -84,8 +84,8 @@ Cannot cast `o.toString()` to boolean because string [1] is incompatible with bo
            ^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:240:17
-   240|     toString(): string;
+   <BUILTINS>/core.js:247:17
+   247|     toString(): string;
                         ^^^^^^ [1]
    dictionary.js:94:18
     94|   (o.toString(): boolean); // error: string ~> boolean
@@ -102,8 +102,8 @@ parameter of property `toString`. [method-unbinding]
                  ^
 
 References:
-   <BUILTINS>/core.js:240:5
-   240|     toString(): string;
+   <BUILTINS>/core.js:247:5
+   247|     toString(): string;
             ^^^^^^^^^^^^^^^^^^ [1]
 
 

--- a/tests/enums/enums.exp
+++ b/tests/enums/enums.exp
@@ -1252,8 +1252,8 @@ implicitly-returned undefined in type argument `Return` [2]. [incompatible-retur
                                             ^^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:1738:29
-   1738| interface Generator<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:1767:29
+   1767| interface Generator<+Yield,+Return,-Next> {
                                      ^^^^^^ [2]
 
 
@@ -1282,8 +1282,8 @@ undefined in type argument `R` [2]. [incompatible-return]
                                          ^^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:1907:24
-   1907| declare class Promise<+R = mixed> {
+   <BUILTINS>/core.js:1936:24
+   1936| declare class Promise<+R = mixed> {
                                 ^ [2]
 
 
@@ -1417,8 +1417,8 @@ References:
    exhaustive-check.js:3:6
       3| enum E {
               ^ [2]
-   <BUILTINS>/core.js:2588:3
-   2588|   isValid(this: TEnumObject, input: ?TRepresentation): boolean,
+   <BUILTINS>/core.js:2622:3
+   2622|   isValid(this: TEnumObject, input: ?TRepresentation): boolean,
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [3]
 
 
@@ -2079,15 +2079,15 @@ Cannot get `E.nonExistent` because property `nonExistent` is missing in `$EnumPr
            ^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:2585:56
+   <BUILTINS>/core.js:2619:56
                                                                 v-
-   2585| type $EnumProto<TEnumObject, TEnum, TRepresentation> = {|
-   2586|   cast(this: TEnumObject, input: ?TRepresentation): void | TEnum,
-   2587|   getName(this: TEnumObject, input: TEnum): string,
-   2588|   isValid(this: TEnumObject, input: ?TRepresentation): boolean,
-   2589|   members(this: TEnumObject): Iterator<TEnum>,
-   2590|   __proto__: null,
-   2591| |}
+   2619| type $EnumProto<TEnumObject, TEnum, TRepresentation> = {|
+   2620|   cast(this: TEnumObject, input: ?TRepresentation): void | TEnum,
+   2621|   getName(this: TEnumObject, input: TEnum): string,
+   2622|   isValid(this: TEnumObject, input: ?TRepresentation): boolean,
+   2623|   members(this: TEnumObject): Iterator<TEnum>,
+   2624|   __proto__: null,
+   2625| |}
          -^ [1]
 
 
@@ -2100,15 +2100,15 @@ Cannot call `E.nonExistent` because property `nonExistent` is missing in `$EnumP
            ^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:2585:56
+   <BUILTINS>/core.js:2619:56
                                                                 v-
-   2585| type $EnumProto<TEnumObject, TEnum, TRepresentation> = {|
-   2586|   cast(this: TEnumObject, input: ?TRepresentation): void | TEnum,
-   2587|   getName(this: TEnumObject, input: TEnum): string,
-   2588|   isValid(this: TEnumObject, input: ?TRepresentation): boolean,
-   2589|   members(this: TEnumObject): Iterator<TEnum>,
-   2590|   __proto__: null,
-   2591| |}
+   2619| type $EnumProto<TEnumObject, TEnum, TRepresentation> = {|
+   2620|   cast(this: TEnumObject, input: ?TRepresentation): void | TEnum,
+   2621|   getName(this: TEnumObject, input: TEnum): string,
+   2622|   isValid(this: TEnumObject, input: ?TRepresentation): boolean,
+   2623|   members(this: TEnumObject): Iterator<TEnum>,
+   2624|   __proto__: null,
+   2625| |}
          -^ [1]
 
 
@@ -2135,15 +2135,15 @@ Cannot call `E.A` because property `A` is missing in `$EnumProto` [1]. [prop-mis
            ^
 
 References:
-   <BUILTINS>/core.js:2585:56
+   <BUILTINS>/core.js:2619:56
                                                                 v-
-   2585| type $EnumProto<TEnumObject, TEnum, TRepresentation> = {|
-   2586|   cast(this: TEnumObject, input: ?TRepresentation): void | TEnum,
-   2587|   getName(this: TEnumObject, input: TEnum): string,
-   2588|   isValid(this: TEnumObject, input: ?TRepresentation): boolean,
-   2589|   members(this: TEnumObject): Iterator<TEnum>,
-   2590|   __proto__: null,
-   2591| |}
+   2619| type $EnumProto<TEnumObject, TEnum, TRepresentation> = {|
+   2620|   cast(this: TEnumObject, input: ?TRepresentation): void | TEnum,
+   2621|   getName(this: TEnumObject, input: TEnum): string,
+   2622|   isValid(this: TEnumObject, input: ?TRepresentation): boolean,
+   2623|   members(this: TEnumObject): Iterator<TEnum>,
+   2624|   __proto__: null,
+   2625| |}
          -^ [1]
 
 
@@ -2156,15 +2156,15 @@ Cannot call `E.toString` because property `toString` is missing in `$EnumProto` 
            ^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:2585:56
+   <BUILTINS>/core.js:2619:56
                                                                 v-
-   2585| type $EnumProto<TEnumObject, TEnum, TRepresentation> = {|
-   2586|   cast(this: TEnumObject, input: ?TRepresentation): void | TEnum,
-   2587|   getName(this: TEnumObject, input: TEnum): string,
-   2588|   isValid(this: TEnumObject, input: ?TRepresentation): boolean,
-   2589|   members(this: TEnumObject): Iterator<TEnum>,
-   2590|   __proto__: null,
-   2591| |}
+   2619| type $EnumProto<TEnumObject, TEnum, TRepresentation> = {|
+   2620|   cast(this: TEnumObject, input: ?TRepresentation): void | TEnum,
+   2621|   getName(this: TEnumObject, input: TEnum): string,
+   2622|   isValid(this: TEnumObject, input: ?TRepresentation): boolean,
+   2623|   members(this: TEnumObject): Iterator<TEnum>,
+   2624|   __proto__: null,
+   2625| |}
          -^ [1]
 
 
@@ -2177,8 +2177,8 @@ Cannot cast `E.getName(...)` to boolean because string [1] is incompatible with 
           ^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:2587:45
-   2587|   getName(this: TEnumObject, input: TEnum): string,
+   <BUILTINS>/core.js:2621:45
+   2621|   getName(this: TEnumObject, input: TEnum): string,
                                                      ^^^^^^ [1]
    methods.js:43:18
      43| (E.getName(E.B): boolean); // Error - wrong type

--- a/tests/fetch/fetch.exp
+++ b/tests/fetch/fetch.exp
@@ -14,8 +14,8 @@ References:
    fetch.js:12:18
      12| const b: Promise<string> = fetch(myRequest); // incorrect
                           ^^^^^^ [2]
-   <BUILTINS>/core.js:1907:24
-   1907| declare class Promise<+R = mixed> {
+   <BUILTINS>/core.js:1936:24
+   1936| declare class Promise<+R = mixed> {
                                 ^ [3]
 
 
@@ -35,8 +35,8 @@ References:
    <BUILTINS>/bom.js:1665:76
    1665| declare function fetch(input: RequestInfo, init?: RequestOptions): Promise<Response>;
                                                                                     ^^^^^^^^ [2]
-   <BUILTINS>/core.js:1907:24
-   1907| declare class Promise<+R = mixed> {
+   <BUILTINS>/core.js:1936:24
+   1936| declare class Promise<+R = mixed> {
                                 ^ [3]
 
 
@@ -564,8 +564,8 @@ References:
    request.js:24:15
      24| h.text().then((t: Buffer) => t); // incorrect
                        ^^^^^^^^^^^^^^^^ [3]
-   <BUILTINS>/core.js:1927:18
-   1927|       onFulfill: null | void,
+   <BUILTINS>/core.js:1956:18
+   1956|       onFulfill: null | void,
                           ^^^^^^^^^^^ [4]
 
 
@@ -589,8 +589,8 @@ References:
    request.js:26:22
      26| h.arrayBuffer().then((ab: Buffer) => ab); // incorrect
                               ^^^^^^^^^^^^^^^^^^ [3]
-   <BUILTINS>/core.js:1927:18
-   1927|       onFulfill: null | void,
+   <BUILTINS>/core.js:1956:18
+   1956|       onFulfill: null | void,
                           ^^^^^^^^^^^ [4]
 
 
@@ -721,17 +721,17 @@ References:
    <BUILTINS>/bom.js:1569:62
    1569| type BodyInit = string | URLSearchParams | FormData | Blob | ArrayBuffer | $ArrayBufferView | ReadableStream;
                                                                       ^^^^^^^^^^^ [5]
-   <BUILTINS>/core.js:2035:20
-   2035| type $TypedArray = $TypedArrayNumber | BigInt64Array | BigUint64Array;
+   <BUILTINS>/core.js:2064:20
+   2064| type $TypedArray = $TypedArrayNumber | BigInt64Array | BigUint64Array;
                             ^^^^^^^^^^^^^^^^^ [6]
-   <BUILTINS>/core.js:2035:40
-   2035| type $TypedArray = $TypedArrayNumber | BigInt64Array | BigUint64Array;
+   <BUILTINS>/core.js:2064:40
+   2064| type $TypedArray = $TypedArrayNumber | BigInt64Array | BigUint64Array;
                                                 ^^^^^^^^^^^^^ [7]
-   <BUILTINS>/core.js:2035:56
-   2035| type $TypedArray = $TypedArrayNumber | BigInt64Array | BigUint64Array;
+   <BUILTINS>/core.js:2064:56
+   2064| type $TypedArray = $TypedArrayNumber | BigInt64Array | BigUint64Array;
                                                                 ^^^^^^^^^^^^^^ [8]
-   <BUILTINS>/core.js:2031:39
-   2031| type $ArrayBufferView = $TypedArray | DataView;
+   <BUILTINS>/core.js:2060:39
+   2060| type $ArrayBufferView = $TypedArray | DataView;
                                                ^^^^^^^^ [9]
    <BUILTINS>/bom.js:1569:95
    1569| type BodyInit = string | URLSearchParams | FormData | Blob | ArrayBuffer | $ArrayBufferView | ReadableStream;
@@ -758,8 +758,8 @@ References:
    response.js:42:15
      42| h.text().then((t: Buffer) => t); // incorrect
                        ^^^^^^^^^^^^^^^^ [3]
-   <BUILTINS>/core.js:1927:18
-   1927|       onFulfill: null | void,
+   <BUILTINS>/core.js:1956:18
+   1956|       onFulfill: null | void,
                           ^^^^^^^^^^^ [4]
 
 
@@ -783,8 +783,8 @@ References:
    response.js:44:22
      44| h.arrayBuffer().then((ab: Buffer) => ab); // incorrect
                               ^^^^^^^^^^^^^^^^^^ [3]
-   <BUILTINS>/core.js:1927:18
-   1927|       onFulfill: null | void,
+   <BUILTINS>/core.js:1956:18
+   1956|       onFulfill: null | void,
                           ^^^^^^^^^^^ [4]
 
 

--- a/tests/forof/forof.exp
+++ b/tests/forof/forof.exp
@@ -45,8 +45,8 @@ References:
    forof.js:23:26
      23| function testString(str: string): void {
                                   ^^^^^^ [1]
-   <BUILTINS>/core.js:1733:11
-   1733| interface $Iterable<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:1762:11
+   1762| interface $Iterable<+Yield,+Return,-Next> {
                    ^^^^^^^^^ [2]
 
 
@@ -59,8 +59,8 @@ Cannot cast `elem` to number because tuple type [1] is incompatible with number 
               ^^^^
 
 References:
-   <BUILTINS>/core.js:1792:28
-   1792|     @@iterator(): Iterator<[K, V]>;
+   <BUILTINS>/core.js:1821:28
+   1821|     @@iterator(): Iterator<[K, V]>;
                                     ^^^^^^ [1]
    forof.js:32:12
      32|     (elem: number); // Error - tuple ~> number

--- a/tests/function/function.exp
+++ b/tests/function/function.exp
@@ -24,13 +24,13 @@ it into an object and attempt to use it as a subtype of an interface. [incompati
                         ^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:1141:22
+   <BUILTINS>/core.js:1158:22
                               v----------
-   1141| type $ArrayLike<T> = interface {
-   1142|   +[indexer: number]: T;
-   1143|   @@iterator(): Iterator<T>;
-   1144|   length: number;
-   1145| }
+   1158| type $ArrayLike<T> = interface {
+   1159|   +[indexer: number]: T;
+   1160|   @@iterator(): Iterator<T>;
+   1161|   length: number;
+   1162| }
          ^ [2]
 
 
@@ -93,16 +93,16 @@ Property `length` is missing in `Generator` [1] but exists in `$ArrayLike` [2]. 
                         ^^^^^
 
 References:
-   <BUILTINS>/core.js:1738:11
-   1738| interface Generator<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:1767:11
+   1767| interface Generator<+Yield,+Return,-Next> {
                    ^^^^^^^^^ [1]
-   <BUILTINS>/core.js:1141:22
+   <BUILTINS>/core.js:1158:22
                               v----------
-   1141| type $ArrayLike<T> = interface {
-   1142|   +[indexer: number]: T;
-   1143|   @@iterator(): Iterator<T>;
-   1144|   length: number;
-   1145| }
+   1158| type $ArrayLike<T> = interface {
+   1159|   +[indexer: number]: T;
+   1160|   @@iterator(): Iterator<T>;
+   1161|   length: number;
+   1162| }
          ^ [2]
 
 
@@ -118,13 +118,13 @@ References:
    apply-array-like.js:16:17
      16| function * gen() {
                          ^ [1]
-   <BUILTINS>/core.js:1141:22
+   <BUILTINS>/core.js:1158:22
                               v----------
-   1141| type $ArrayLike<T> = interface {
-   1142|   +[indexer: number]: T;
-   1143|   @@iterator(): Iterator<T>;
-   1144|   length: number;
-   1145| }
+   1158| type $ArrayLike<T> = interface {
+   1159|   +[indexer: number]: T;
+   1160|   @@iterator(): Iterator<T>;
+   1161|   length: number;
+   1162| }
          ^ [2]
 
 
@@ -151,8 +151,8 @@ Cannot call `test.apply` because no more than 2 arguments are expected by functi
         ^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:353:18
-   353|     proto apply: Function$Prototype$Apply; // (thisArg: any, argArray?: any) => any
+   <BUILTINS>/core.js:360:18
+   360|     proto apply: Function$Prototype$Apply; // (thisArg: any, argArray?: any) => any
                          ^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 
@@ -210,13 +210,13 @@ it into an object and attempt to use it as a subtype of an interface. [incompati
                         ^^^^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:1141:22
+   <BUILTINS>/core.js:1158:22
                               v----------
-   1141| type $ArrayLike<T> = interface {
-   1142|   +[indexer: number]: T;
-   1143|   @@iterator(): Iterator<T>;
-   1144|   length: number;
-   1145| }
+   1158| type $ArrayLike<T> = interface {
+   1159|   +[indexer: number]: T;
+   1160|   @@iterator(): Iterator<T>;
+   1161|   length: number;
+   1162| }
          ^ [2]
 
 
@@ -605,8 +605,8 @@ Cannot cast `x.length` to undefined because number [1] is incompatible with unde
              ^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:360:14
-   360|     +length: number;
+   <BUILTINS>/core.js:367:14
+   367|     +length: number;
                      ^^^^^^ [1]
    function.js:37:16
     37|     (x.length: void); // error, it's a number
@@ -622,8 +622,8 @@ Cannot cast `y.length` to undefined because number [1] is incompatible with unde
              ^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:360:14
-   360|     +length: number;
+   <BUILTINS>/core.js:367:14
+   367|     +length: number;
                      ^^^^^^ [1]
    function.js:38:16
     38|     (y.length: void); // error, it's a number
@@ -639,8 +639,8 @@ Cannot cast `x.name` to undefined because string [1] is incompatible with undefi
              ^^^^^^
 
 References:
-   <BUILTINS>/core.js:364:12
-   364|     +name: string;
+   <BUILTINS>/core.js:371:12
+   371|     +name: string;
                    ^^^^^^ [1]
    function.js:40:14
     40|     (x.name: void); // error, it's a string
@@ -656,8 +656,8 @@ Cannot cast `y.name` to undefined because string [1] is incompatible with undefi
              ^^^^^^
 
 References:
-   <BUILTINS>/core.js:364:12
-   364|     +name: string;
+   <BUILTINS>/core.js:371:12
+   371|     +name: string;
                    ^^^^^^ [1]
    function.js:41:14
     41|     (y.name: void); // error, it's a string

--- a/tests/generators/generators.exp
+++ b/tests/generators/generators.exp
@@ -42,8 +42,8 @@ References:
    class.js:23:39
      23|   *stmt_return_err(): Generator<void, number, void> {
                                                ^^^^^^ [2]
-   <BUILTINS>/core.js:1738:29
-   1738| interface Generator<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:1767:29
+   1767| interface Generator<+Yield,+Return,-Next> {
                                      ^^^^^^ [3]
 
 
@@ -125,14 +125,14 @@ of property `@@iterator`. [incompatible-type-arg]
                     ^^
 
 References:
-   <BUILTINS>/core.js:1731:38
-   1731| type Iterator<+T> = $Iterator<T,void,void>;
+   <BUILTINS>/core.js:1760:38
+   1760| type Iterator<+T> = $Iterator<T,void,void>;
                                               ^^^^ [1]
    class.js:71:71
      71|   *delegate_next_iterable(xs: Array<number>): Generator<number, void, string> {
                                                                                ^^^^^^ [2]
-   <BUILTINS>/core.js:1727:37
-   1727| interface $Iterator<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:1756:37
+   1756| interface $Iterator<+Yield,+Return,-Next> {
                                              ^^^^ [3]
 
 
@@ -374,8 +374,8 @@ References:
    generators.js:22:46
      22| function *stmt_return_err(): Generator<void, number, void> {
                                                       ^^^^^^ [2]
-   <BUILTINS>/core.js:1738:29
-   1738| interface Generator<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:1767:29
+   1767| interface Generator<+Yield,+Return,-Next> {
                                      ^^^^^^ [3]
 
 
@@ -679,8 +679,8 @@ Cannot cast `refuse_return_result.value` to string because undefined [1] is inco
             ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:1718:14
-   1718|     +value?: Return,
+   <BUILTINS>/core.js:1747:14
+   1747|     +value?: Return,
                       ^^^^^^ [1]
    return.js:20:32
      20|   (refuse_return_result.value: string); // error: number | void ~> string

--- a/tests/generic_escape/generic_escape.exp
+++ b/tests/generic_escape/generic_escape.exp
@@ -431,8 +431,8 @@ the expression to your expected type. [underconstrained-implicit-instantiation]
                     ^^^^^
 
 References:
-   <BUILTINS>/core.js:931:21
-   931| declare class Array<T> extends $ReadOnlyArray<T> {
+   <BUILTINS>/core.js:948:21
+   948| declare class Array<T> extends $ReadOnlyArray<T> {
                             ^ [1]
    misc.js:3:9
      3| var e = new Array(10);

--- a/tests/generic_zeroed/generic_zeroed.exp
+++ b/tests/generic_zeroed/generic_zeroed.exp
@@ -77,11 +77,11 @@ References:
    reduce.js:7:22
       7|   return nums.reduce<T>(
                               ^ [2]
-   <BUILTINS>/core.js:1044:5
+   <BUILTINS>/core.js:1061:5
              v------
-   1044|     reduce(
-   1045|       callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: Array<T>) => T,
-   1046|     ): T;
+   1061|     reduce(
+   1062|       callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: Array<T>) => T,
+   1063|     ): T;
              ---^ [3]
 
 

--- a/tests/get_def_enums/get_def_enums.exp
+++ b/tests/get_def_enums/get_def_enums.exp
@@ -28,9 +28,9 @@ library.js:4:3,4:5
 
 main.js:27:13
 Flags:
-[LIB] core.js:2586:3,2586:6
+[LIB] core.js:2620:3,2620:6
 
 main.js:30:13
 Flags:
-[LIB] core.js:2588:3,2588:9
+[LIB] core.js:2622:3,2622:9
 

--- a/tests/interface/interface.exp
+++ b/tests/interface/interface.exp
@@ -782,8 +782,8 @@ References:
    string.js:1:18
       1| declare const s: string;
                           ^^^^^^ [1]
-   <BUILTINS>/core.js:1733:11
-   1733| interface $Iterable<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:1762:11
+   1762| interface $Iterable<+Yield,+Return,-Next> {
                    ^^^^^^^^^ [2]
 
 

--- a/tests/iterable/iterable.exp
+++ b/tests/iterable/iterable.exp
@@ -14,8 +14,8 @@ References:
    array.js:7:19
       7| (["hi"]: Iterable<number>); // Error string ~> number
                            ^^^^^^ [2]
-   <BUILTINS>/core.js:1727:22
-   1727| interface $Iterator<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:1756:22
+   1756| interface $Iterator<+Yield,+Return,-Next> {
                               ^^^^^ [3]
 
 
@@ -35,8 +35,8 @@ References:
    array.js:8:22
       8| (["hi", 1]: Iterable<string>); // Error number ~> string
                               ^^^^^^ [2]
-   <BUILTINS>/core.js:1727:22
-   1727| interface $Iterator<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:1756:22
+   1756| interface $Iterator<+Yield,+Return,-Next> {
                               ^^^^^ [3]
 
 
@@ -56,8 +56,8 @@ References:
    caching_bug.js:21:62
      21| function miss_the_cache(x: Array<string | number>): Iterable<string> { return x; }
                                                                       ^^^^^^ [2]
-   <BUILTINS>/core.js:1727:22
-   1727| interface $Iterator<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:1756:22
+   1756| interface $Iterator<+Yield,+Return,-Next> {
                               ^^^^^ [3]
 
 
@@ -86,13 +86,13 @@ Cannot return object literal because property `value` is missing in object liter
                         ^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:1721:5
+   <BUILTINS>/core.js:1750:5
              v
-   1721|   | {
-   1722|     done: false,
-   1723|     +value: Yield,
-   1724|     ...
-   1725| };
+   1750|   | {
+   1751|     done: false,
+   1752|     +value: Yield,
+   1753|     ...
+   1754| };
          ^ [2]
 
 
@@ -106,14 +106,14 @@ value of property `@@iterator`. [incompatible-return]
                   ^^^
 
 References:
-   <BUILTINS>/core.js:1792:28
-   1792|     @@iterator(): Iterator<[K, V]>;
+   <BUILTINS>/core.js:1821:28
+   1821|     @@iterator(): Iterator<[K, V]>;
                                     ^^^^^^ [1]
    map.js:13:55
      13| function mapTest4(map: Map<number, string>): Iterable<string> {
                                                                ^^^^^^ [2]
-   <BUILTINS>/core.js:1727:22
-   1727| interface $Iterator<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:1756:22
+   1756| interface $Iterator<+Yield,+Return,-Next> {
                               ^^^^^ [3]
 
 
@@ -133,8 +133,8 @@ References:
    set.js:13:47
      13| function setTest4(set: Set<string>): Iterable<number> {
                                                        ^^^^^^ [2]
-   <BUILTINS>/core.js:1727:22
-   1727| interface $Iterator<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:1756:22
+   1756| interface $Iterator<+Yield,+Return,-Next> {
                               ^^^^^ [3]
 
 
@@ -148,14 +148,14 @@ Cannot cast `new String(...)` to `Iterable` because string [1] is incompatible w
           ^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:1163:28
-   1163|     @@iterator(): Iterator<string>;
+   <BUILTINS>/core.js:1180:28
+   1180|     @@iterator(): Iterator<string>;
                                     ^^^^^^ [1]
    string.js:3:29
       3| (new String("hi"): Iterable<number>); // Error - string is a Iterable<string>
                                      ^^^^^^ [2]
-   <BUILTINS>/core.js:1727:22
-   1727| interface $Iterator<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:1756:22
+   1756| interface $Iterator<+Yield,+Return,-Next> {
                               ^^^^^ [3]
 
 

--- a/tests/lib/lib.exp
+++ b/tests/lib/lib.exp
@@ -24,8 +24,8 @@ Cannot assign `Number.MAX_VALUE` to `y` because number [1] is incompatible with 
                        ^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:390:23
-   390|     static MAX_VALUE: number;
+   <BUILTINS>/core.js:397:23
+   397|     static MAX_VALUE: number;
                               ^^^^^^ [1]
    libtest.js:2:7
      2| var y:string = Number.MAX_VALUE;
@@ -41,8 +41,8 @@ Cannot assign `(new TypeError()).name` to `z` because string [1] is incompatible
                         ^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:1633:11
-   1633|     name: string;
+   <BUILTINS>/core.js:1662:11
+   1662|     name: string;
                    ^^^^^^ [1]
    libtest.js:3:7
       3| var z:number = new TypeError().name;

--- a/tests/local_inference_annotations/local_inference_annotations.exp
+++ b/tests/local_inference_annotations/local_inference_annotations.exp
@@ -63,8 +63,8 @@ Property `@@iterator` is missing in function [1] but exists in `$Iterable` [2]. 
                 ^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:1733:11
-   1733| interface $Iterable<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:1762:11
+   1762| interface $Iterable<+Yield,+Return,-Next> {
                    ^^^^^^^^^ [2]
 
 
@@ -497,8 +497,8 @@ Property `@@iterator` is missing in function [1] but exists in `$Iterable` [2]. 
                           ^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:1733:11
-   1733| interface $Iterable<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:1762:11
+   1762| interface $Iterable<+Yield,+Return,-Next> {
                    ^^^^^^^^^ [2]
 
 

--- a/tests/lti_friendly_errors/lti_friendly_errors.exp
+++ b/tests/lti_friendly_errors/lti_friendly_errors.exp
@@ -8,14 +8,14 @@ in type argument `R` [3]. [incompatible-cast]
           ^
 
 References:
-   <BUILTINS>/core.js:1907:28
-   1907| declare class Promise<+R = mixed> {
+   <BUILTINS>/core.js:1936:28
+   1936| declare class Promise<+R = mixed> {
                                     ^^^^^ [1]
    reason_of_inferred_targs.js:2:13
       2| (p: Promise<string>); // error
                      ^^^^^^ [2]
-   <BUILTINS>/core.js:1907:24
-   1907| declare class Promise<+R = mixed> {
+   <BUILTINS>/core.js:1936:24
+   1936| declare class Promise<+R = mixed> {
                                 ^ [3]
 
 

--- a/tests/lti_implicit_instantiation/lti_implicit_instantiation.exp
+++ b/tests/lti_implicit_instantiation/lti_implicit_instantiation.exp
@@ -8,8 +8,8 @@ expression to your expected type. [underconstrained-implicit-instantiation]
                   ^^^^^^^^^^^ [2]
 
 References:
-   <BUILTINS>/core.js:2016:25
-   2016| declare function $await<T>(p: Promise<T> | T): T;
+   <BUILTINS>/core.js:2045:25
+   2045| declare function $await<T>(p: Promise<T> | T): T;
                                  ^ [1]
 
 
@@ -169,8 +169,8 @@ the expression to your expected type. [underconstrained-implicit-instantiation]
             ^^^^^
 
 References:
-   <BUILTINS>/core.js:931:21
-   931| declare class Array<T> extends $ReadOnlyArray<T> {
+   <BUILTINS>/core.js:948:21
+   948| declare class Array<T> extends $ReadOnlyArray<T> {
                             ^ [1]
    underconstrained_class_constructor.js:18:1
     18| new Array(1); // Error
@@ -688,8 +688,8 @@ Cannot get `r1.bad` because property `bad` is missing in `Array` [1]. [prop-miss
              ^^^
 
 References:
-   <BUILTINS>/core.js:931:15
-   931| declare class Array<T> extends $ReadOnlyArray<T> {
+   <BUILTINS>/core.js:948:15
+   948| declare class Array<T> extends $ReadOnlyArray<T> {
                       ^^^^^ [1]
 
 
@@ -736,8 +736,8 @@ Cannot get `r2.bad` because property `bad` is missing in `Array` [1]. [prop-miss
              ^^^
 
 References:
-   <BUILTINS>/core.js:931:15
-   931| declare class Array<T> extends $ReadOnlyArray<T> {
+   <BUILTINS>/core.js:948:15
+   948| declare class Array<T> extends $ReadOnlyArray<T> {
                       ^^^^^ [1]
 
 

--- a/tests/mapped_type_utilities/mapped_type_utilities.exp
+++ b/tests/mapped_type_utilities/mapped_type_utilities.exp
@@ -85,8 +85,8 @@ Cannot cast `pickedO1.bar` to string because undefined [1] is incompatible with 
           ^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:2759:62
-   2759| type Pick<O: interface {}, Keys: $Keys<O>> = {[key in Keys]: O[key]};
+   <BUILTINS>/core.js:2793:62
+   2793| type Pick<O: interface {}, Keys: $Keys<O>> = {[key in Keys]: O[key]};
                                                                       ^^^^^^ [1]
    pick.js:9:16
       9| (pickedO1.bar: string); // ERROR bar is optional

--- a/tests/meta_property/meta_property.exp
+++ b/tests/meta_property/meta_property.exp
@@ -8,13 +8,13 @@ Cannot cast `import.meta` to number literal `1` because `Import$Meta` [1] is inc
           ^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:2696:20
+   <BUILTINS>/core.js:2730:20
                             v
-   2696| type Import$Meta = {
-   2697|   [string]: mixed,
-   2698|   url?: string,
-   2699|   ...
-   2700| };
+   2730| type Import$Meta = {
+   2731|   [string]: mixed,
+   2732|   url?: string,
+   2733|   ...
+   2734| };
          ^ [1]
    import_meta.js:5:15
       5| (import.meta: 1); // Error
@@ -31,8 +31,8 @@ Cannot cast `import.meta.XXX` to number literal `1` because mixed [1] is incompa
           ^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:2697:13
-   2697|   [string]: mixed,
+   <BUILTINS>/core.js:2731:13
+   2731|   [string]: mixed,
                      ^^^^^ [1]
    import_meta.js:6:19
       6| (import.meta.XXX: 1); // Error

--- a/tests/new_env/new_env.exp
+++ b/tests/new_env/new_env.exp
@@ -197,12 +197,12 @@ Cannot call `Promise` because function [1] requires another argument. [incompati
                      ^^^^^^^
 
 References:
-   <BUILTINS>/core.js:1908:5
+   <BUILTINS>/core.js:1937:5
              v----------------------
-   1908|     constructor(callback: (
-   1909|       resolve: (result: Promise<R> | R) => void,
-   1910|       reject: (error: any) => void
-   1911|     ) => mixed): void;
+   1937|     constructor(callback: (
+   1938|       resolve: (result: Promise<R> | R) => void,
+   1939|       reject: (error: any) => void
+   1940|     ) => mixed): void;
              ----------------^ [1]
 
 

--- a/tests/new_merge/new_merge.exp
+++ b/tests/new_merge/new_merge.exp
@@ -273,8 +273,8 @@ Cannot cast `f15()` to empty because `Promise` [1] is incompatible with empty [2
           ^^^^^
 
 References:
-   <BUILTINS>/core.js:1907:15
-   1907| declare class Promise<+R = mixed> {
+   <BUILTINS>/core.js:1936:15
+   1936| declare class Promise<+R = mixed> {
                        ^^^^^^^ [1]
    main.js:58:9
      58| (f15(): empty);

--- a/tests/no_source_error/no_source_error.exp
+++ b/tests/no_source_error/no_source_error.exp
@@ -18,8 +18,8 @@ References:
    no_source.js:13:8
     13|   +z : (x: FooPlus) => boolean = (x) => { return true; }
                ^^^^^^^^^^^^^^^^^^^^^^^ [3]
-   <BUILTINS>/core.js:367:15
-   367| declare class Boolean {
+   <BUILTINS>/core.js:374:15
+   374| declare class Boolean {
                       ^^^^^^^ [4]
 
 

--- a/tests/number_constants/number_constants.exp
+++ b/tests/number_constants/number_constants.exp
@@ -7,8 +7,8 @@ Cannot assign `Number.MAX_SAFE_INTEGER` to `b` because number [1] is incompatibl
                         ^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:388:30
-   388|     static MAX_SAFE_INTEGER: number;
+   <BUILTINS>/core.js:395:30
+   395|     static MAX_SAFE_INTEGER: number;
                                      ^^^^^^ [1]
    number_constants.js:2:8
      2| var b: string = Number.MAX_SAFE_INTEGER;
@@ -24,8 +24,8 @@ Cannot assign `Number.MIN_SAFE_INTEGER` to `d` because number [1] is incompatibl
                         ^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:396:30
-   396|     static MIN_SAFE_INTEGER: number;
+   <BUILTINS>/core.js:403:30
+   403|     static MIN_SAFE_INTEGER: number;
                                      ^^^^^^ [1]
    number_constants.js:4:8
      4| var d: string = Number.MIN_SAFE_INTEGER;
@@ -41,8 +41,8 @@ Cannot assign `Number.MAX_VALUE` to `f` because number [1] is incompatible with 
                         ^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:390:23
-   390|     static MAX_VALUE: number;
+   <BUILTINS>/core.js:397:23
+   397|     static MAX_VALUE: number;
                               ^^^^^^ [1]
    number_constants.js:6:8
      6| var f: string = Number.MAX_VALUE;
@@ -58,8 +58,8 @@ Cannot assign `Number.MIN_VALUE` to `h` because number [1] is incompatible with 
                         ^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:398:23
-   398|     static MIN_VALUE: number;
+   <BUILTINS>/core.js:405:23
+   405|     static MIN_VALUE: number;
                               ^^^^^^ [1]
    number_constants.js:8:8
      8| var h: string = Number.MIN_VALUE;
@@ -75,8 +75,8 @@ Cannot assign `Number.NaN` to `j` because number [1] is incompatible with string
                         ^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:403:17
-   403|     static NaN: number;
+   <BUILTINS>/core.js:410:17
+   410|     static NaN: number;
                         ^^^^^^ [1]
    number_constants.js:10:8
     10| var j: string = Number.NaN;
@@ -92,8 +92,8 @@ Cannot assign `Number.EPSILON` to `l` because number [1] is incompatible with st
                         ^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:382:21
-   382|     static EPSILON: number;
+   <BUILTINS>/core.js:389:21
+   389|     static EPSILON: number;
                             ^^^^^^ [1]
    number_constants.js:12:8
     12| var l: string = Number.EPSILON;

--- a/tests/object_api/object_api.exp
+++ b/tests/object_api/object_api.exp
@@ -523,8 +523,8 @@ defined in the `this` parameter. [method-unbinding]
                                        ^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:240:5
-   240|     toString(): string;
+   <BUILTINS>/core.js:247:5
+   247|     toString(): string;
             ^^^^^^^^^^^^^^^^^^ [1]
 
 
@@ -551,8 +551,8 @@ Cannot assign `x.toString` to `xToString` because function type [1] is incompati
                                  ^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:240:5
-   240|     toString(): string;
+   <BUILTINS>/core.js:247:5
+   247|     toString(): string;
             ^^^^^^^^^^^^^^^^^^ [1]
    object_prototype.js:38:17
     38| var xToString : number = x.toString; // error
@@ -569,8 +569,8 @@ Cannot get `x.toString` because property `toString` [1] cannot be unbound from t
                                    ^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:240:5
-   240|     toString(): string;
+   <BUILTINS>/core.js:247:5
+   247|     toString(): string;
             ^^^^^^^^^^^^^^^^^^ [2]
 
 
@@ -584,8 +584,8 @@ Cannot assign `x.toString` to `xToString2` because string [1] is incompatible wi
                                         ^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:240:17
-   240|     toString(): string;
+   <BUILTINS>/core.js:247:17
+   247|     toString(): string;
                         ^^^^^^ [1]
    object_prototype.js:39:24
     39| var xToString2 : () => number = x.toString; // error
@@ -602,8 +602,8 @@ Cannot get `x.toString` because property `toString` [1] cannot be unbound from t
                                           ^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:240:5
-   240|     toString(): string;
+   <BUILTINS>/core.js:247:5
+   247|     toString(): string;
             ^^^^^^^^^^^^^^^^^^ [2]
 
 
@@ -616,8 +616,8 @@ Cannot assign `y.toString` to `yToString` because function type [1] is incompati
                                  ^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:240:5
-   240|     toString(): string;
+   <BUILTINS>/core.js:247:5
+   247|     toString(): string;
             ^^^^^^^^^^^^^^^^^^ [1]
    object_prototype.js:43:17
     43| var yToString : number = y.toString; // error
@@ -634,8 +634,8 @@ Cannot get `y.toString` because property `toString` [1] cannot be unbound from t
                                    ^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:240:5
-   240|     toString(): string;
+   <BUILTINS>/core.js:247:5
+   247|     toString(): string;
             ^^^^^^^^^^^^^^^^^^ [2]
 
 
@@ -649,8 +649,8 @@ Cannot get `123.toString` because property `toString` [1] cannot be unbound from
               ^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:478:5
-   478|     toString(radix?: number): string;
+   <BUILTINS>/core.js:485:5
+   485|     toString(radix?: number): string;
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [2]
 
 
@@ -678,8 +678,8 @@ Cannot call `123.toString` with `'foo'` bound to `radix` because string [1] is i
                        ^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:478:22
-   478|     toString(radix?: number): string;
+   <BUILTINS>/core.js:485:22
+   485|     toString(radix?: number): string;
                              ^^^^^^ [2]
 
 
@@ -693,8 +693,8 @@ Cannot call `123.toString` with `null` bound to `radix` because null [1] is inco
                        ^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:478:22
-   478|     toString(radix?: number): string;
+   <BUILTINS>/core.js:485:22
+   485|     toString(radix?: number): string;
                              ^^^^^^ [2]
 
 
@@ -708,8 +708,8 @@ where it was defined in the `this` parameter. [method-unbinding]
                                                           ^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:226:5
-   226|     hasOwnProperty(prop: mixed): boolean;
+   <BUILTINS>/core.js:233:5
+   233|     hasOwnProperty(prop: mixed): boolean;
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 
@@ -738,8 +738,8 @@ Cannot assign `x.hasOwnProperty` to `xHasOwnProperty` because function type [1] 
                                        ^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:226:5
-   226|     hasOwnProperty(prop: mixed): boolean;
+   <BUILTINS>/core.js:233:5
+   233|     hasOwnProperty(prop: mixed): boolean;
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
    object_prototype.js:71:23
     71| var xHasOwnProperty : number = x.hasOwnProperty; // error
@@ -756,8 +756,8 @@ defined. [method-unbinding]
                                          ^^^^^^^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:226:5
-   226|     hasOwnProperty(prop: mixed): boolean;
+   <BUILTINS>/core.js:233:5
+   233|     hasOwnProperty(prop: mixed): boolean;
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [2]
 
 
@@ -771,8 +771,8 @@ value. [incompatible-type]
                                                           ^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:226:34
-   226|     hasOwnProperty(prop: mixed): boolean;
+   <BUILTINS>/core.js:233:34
+   233|     hasOwnProperty(prop: mixed): boolean;
                                          ^^^^^^^ [1]
    object_prototype.js:72:42
     72| var xHasOwnProperty2 : (prop: string) => number = x.hasOwnProperty; // error
@@ -789,8 +789,8 @@ defined. [method-unbinding]
                                                             ^^^^^^^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:226:5
-   226|     hasOwnProperty(prop: mixed): boolean;
+   <BUILTINS>/core.js:233:5
+   233|     hasOwnProperty(prop: mixed): boolean;
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [2]
 
 
@@ -804,8 +804,8 @@ Cannot assign `y.hasOwnProperty` to `yHasOwnProperty` because function type [1] 
                                        ^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:226:5
-   226|     hasOwnProperty(prop: mixed): boolean;
+   <BUILTINS>/core.js:233:5
+   233|     hasOwnProperty(prop: mixed): boolean;
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
    object_prototype.js:76:23
     76| var yHasOwnProperty : number = y.hasOwnProperty; // error
@@ -822,8 +822,8 @@ defined. [method-unbinding]
                                          ^^^^^^^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:226:5
-   226|     hasOwnProperty(prop: mixed): boolean;
+   <BUILTINS>/core.js:233:5
+   233|     hasOwnProperty(prop: mixed): boolean;
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [2]
 
 
@@ -837,8 +837,8 @@ context [1] where it was defined in the `this` parameter. [method-unbinding]
                                                                 ^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:236:5
-   236|     propertyIsEnumerable(prop: mixed): boolean;
+   <BUILTINS>/core.js:243:5
+   243|     propertyIsEnumerable(prop: mixed): boolean;
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 
@@ -867,8 +867,8 @@ number [2]. [incompatible-type]
                                              ^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:236:5
-   236|     propertyIsEnumerable(prop: mixed): boolean;
+   <BUILTINS>/core.js:243:5
+   243|     propertyIsEnumerable(prop: mixed): boolean;
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
    object_prototype.js:96:29
     96| var xPropertyIsEnumerable : number = x.propertyIsEnumerable; // error
@@ -885,8 +885,8 @@ where it was defined. [method-unbinding]
                                                ^^^^^^^^^^^^^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:236:5
-   236|     propertyIsEnumerable(prop: mixed): boolean;
+   <BUILTINS>/core.js:243:5
+   243|     propertyIsEnumerable(prop: mixed): boolean;
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [2]
 
 
@@ -900,8 +900,8 @@ in the return value. [incompatible-type]
           ^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:236:40
-   236|     propertyIsEnumerable(prop: mixed): boolean;
+   <BUILTINS>/core.js:243:40
+   243|     propertyIsEnumerable(prop: mixed): boolean;
                                                ^^^^^^^ [1]
    object_prototype.js:97:48
     97| var xPropertyIsEnumerable2 : (prop: string) => number =
@@ -918,8 +918,8 @@ where it was defined. [method-unbinding]
             ^^^^^^^^^^^^^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:236:5
-   236|     propertyIsEnumerable(prop: mixed): boolean;
+   <BUILTINS>/core.js:243:5
+   243|     propertyIsEnumerable(prop: mixed): boolean;
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [2]
 
 
@@ -933,8 +933,8 @@ number [2]. [incompatible-type]
                                              ^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:236:5
-   236|     propertyIsEnumerable(prop: mixed): boolean;
+   <BUILTINS>/core.js:243:5
+   243|     propertyIsEnumerable(prop: mixed): boolean;
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
    object_prototype.js:102:29
    102| var yPropertyIsEnumerable : number = y.propertyIsEnumerable; // error
@@ -951,8 +951,8 @@ where it was defined. [method-unbinding]
                                                ^^^^^^^^^^^^^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:236:5
-   236|     propertyIsEnumerable(prop: mixed): boolean;
+   <BUILTINS>/core.js:243:5
+   243|     propertyIsEnumerable(prop: mixed): boolean;
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [2]
 
 
@@ -979,8 +979,8 @@ Cannot assign `x.valueOf` to `xValueOf` because function type [1] is incompatibl
                                  ^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:1588:5
-   1588|     valueOf(): number;
+   <BUILTINS>/core.js:1617:5
+   1617|     valueOf(): number;
              ^^^^^^^^^^^^^^^^^ [1]
    object_prototype.js:122:16
     122| var xValueOf : number = x.valueOf; // error
@@ -997,8 +997,8 @@ Cannot get `x.valueOf` because property `valueOf` [1] cannot be unbound from the
                                    ^^^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:1588:5
-   1588|     valueOf(): number;
+   <BUILTINS>/core.js:1617:5
+   1617|     valueOf(): number;
              ^^^^^^^^^^^^^^^^^ [2]
 
 
@@ -1011,8 +1011,8 @@ Cannot assign `y.valueOf` to `yValueOf` because function type [1] is incompatibl
                                 ^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:242:5
-   242|     valueOf(): mixed;
+   <BUILTINS>/core.js:249:5
+   249|     valueOf(): mixed;
             ^^^^^^^^^^^^^^^^ [1]
    object_prototype.js:126:16
    126| var yValueOf : number = y.valueOf; // error
@@ -1029,8 +1029,8 @@ Cannot get `y.valueOf` because property `valueOf` [1] cannot be unbound from the
                                   ^^^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:242:5
-   242|     valueOf(): mixed;
+   <BUILTINS>/core.js:249:5
+   249|     valueOf(): mixed;
             ^^^^^^^^^^^^^^^^ [2]
 
 
@@ -1044,8 +1044,8 @@ where it was defined in the `this` parameter. [method-unbinding]
                                              ^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:238:5
-   238|     toLocaleString(): string;
+   <BUILTINS>/core.js:245:5
+   245|     toLocaleString(): string;
             ^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 
@@ -1074,8 +1074,8 @@ Cannot assign `x.toLocaleString` to `xToLocaleString` because function type [1] 
                                         ^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:1576:5
-   1576|     toLocaleString(locales?: string | Array<string>, options?: Intl$DateTimeFormatOptions): string;
+   <BUILTINS>/core.js:1605:5
+   1605|     toLocaleString(locales?: string | Array<string>, options?: Intl$DateTimeFormatOptions): string;
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
    object_prototype.js:150:23
     150| var xToLocaleString : number = x.toLocaleString; // error
@@ -1092,8 +1092,8 @@ defined. [method-unbinding]
                                           ^^^^^^^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:1576:5
-   1576|     toLocaleString(locales?: string | Array<string>, options?: Intl$DateTimeFormatOptions): string;
+   <BUILTINS>/core.js:1605:5
+   1605|     toLocaleString(locales?: string | Array<string>, options?: Intl$DateTimeFormatOptions): string;
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [2]
 
 
@@ -1107,8 +1107,8 @@ value. [incompatible-type]
                                                ^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:1576:93
-   1576|     toLocaleString(locales?: string | Array<string>, options?: Intl$DateTimeFormatOptions): string;
+   <BUILTINS>/core.js:1605:93
+   1605|     toLocaleString(locales?: string | Array<string>, options?: Intl$DateTimeFormatOptions): string;
                                                                                                      ^^^^^^ [1]
    object_prototype.js:151:30
     151| var xToLocaleString2 : () => number = x.toLocaleString; // error
@@ -1125,8 +1125,8 @@ defined. [method-unbinding]
                                                  ^^^^^^^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:1576:5
-   1576|     toLocaleString(locales?: string | Array<string>, options?: Intl$DateTimeFormatOptions): string;
+   <BUILTINS>/core.js:1605:5
+   1605|     toLocaleString(locales?: string | Array<string>, options?: Intl$DateTimeFormatOptions): string;
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [2]
 
 
@@ -1140,8 +1140,8 @@ Cannot assign `y.toLocaleString` to `yToLocaleString` because function type [1] 
                                        ^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:238:5
-   238|     toLocaleString(): string;
+   <BUILTINS>/core.js:245:5
+   245|     toLocaleString(): string;
             ^^^^^^^^^^^^^^^^^^^^^^^^ [1]
    object_prototype.js:155:23
    155| var yToLocaleString : number = y.toLocaleString; // error
@@ -1158,8 +1158,8 @@ defined. [method-unbinding]
                                          ^^^^^^^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:238:5
-   238|     toLocaleString(): string;
+   <BUILTINS>/core.js:245:5
+   245|     toLocaleString(): string;
             ^^^^^^^^^^^^^^^^^^^^^^^^ [2]
 
 
@@ -1371,8 +1371,8 @@ Cannot cast `o1_proto.toString` to empty because function type [1] is incompatib
          ^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:240:5
-   240|     toString(): string;
+   <BUILTINS>/core.js:247:5
+   247|     toString(): string;
             ^^^^^^^^^^^^^^^^^^ [1]
    proto.js:3:21
      3| (o1_proto.toString: empty); // error: function ~> empty
@@ -1389,8 +1389,8 @@ defined. [method-unbinding]
                   ^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:240:5
-   240|     toString(): string;
+   <BUILTINS>/core.js:247:5
+   247|     toString(): string;
             ^^^^^^^^^^^^^^^^^^ [2]
 
 

--- a/tests/object_assign/object_assign.exp
+++ b/tests/object_assign/object_assign.exp
@@ -150,8 +150,8 @@ Cannot call `Object.assign.apply` because no more than 2 arguments are expected 
          ^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:353:18
-   353|     proto apply: Function$Prototype$Apply; // (thisArg: any, argArray?: any) => any
+   <BUILTINS>/core.js:360:18
+   360|     proto apply: Function$Prototype$Apply; // (thisArg: any, argArray?: any) => any
                          ^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 
@@ -193,8 +193,8 @@ Cannot cast `Object.assign.length` to string because number [1] is incompatible 
          ^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:360:14
-   360|     +length: number;
+   <BUILTINS>/core.js:367:14
+   367|     +length: number;
                      ^^^^^^ [1]
    apply.js:10:25
     10| (Object.assign.length : string); // error
@@ -210,8 +210,8 @@ Cannot cast `Object.assign.name` to number because string [1] is incompatible wi
          ^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:364:12
-   364|     +name: string;
+   <BUILTINS>/core.js:371:12
+   371|     +name: string;
                    ^^^^^^ [1]
    apply.js:12:23
     12| (Object.assign.name : number); // error

--- a/tests/object_is/object_is.exp
+++ b/tests/object_is/object_is.exp
@@ -7,8 +7,8 @@ Cannot assign `Object.is(...)` to `b` because boolean [1] is incompatible with s
                         ^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:182:31
-   182|     static is<T>(a: T, b: T): boolean;
+   <BUILTINS>/core.js:189:31
+   189|     static is<T>(a: T, b: T): boolean;
                                       ^^^^^^^ [1]
    object_is.js:20:8
     20| var b: string = Object.is('a', 'a');
@@ -24,8 +24,8 @@ Cannot call method `is` because no more than 2 arguments are expected by functio
                                              ^^^
 
 References:
-   <BUILTINS>/core.js:182:5
-   182|     static is<T>(a: T, b: T): boolean;
+   <BUILTINS>/core.js:189:5
+   189|     static is<T>(a: T, b: T): boolean;
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 

--- a/tests/objects/objects.exp
+++ b/tests/objects/objects.exp
@@ -325,8 +325,8 @@ Cannot cast `y['hasOwnProperty']` to string because function type [1] is incompa
          ^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:226:5
-   226|     hasOwnProperty(prop: mixed): boolean;
+   <BUILTINS>/core.js:233:5
+   233|     hasOwnProperty(prop: mixed): boolean;
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
    objects.js:18:23
     18| (y['hasOwnProperty']: string); // error, prototype method is not a string

--- a/tests/overload/overload.exp
+++ b/tests/overload/overload.exp
@@ -29,8 +29,8 @@ Cannot assign `"".match(...)[0]` to `x1` because string [1] is incompatible with
                           ^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:1148:33
-   1148| type RegExp$matchResult = Array<string> & {
+   <BUILTINS>/core.js:1165:33
+   1165| type RegExp$matchResult = Array<string> & {
                                          ^^^^^^ [1]
    overload.js:7:9
       7| var x1: number = "".match(0)[0];
@@ -46,8 +46,8 @@ Cannot get `"".match(...)[0]` because null [1] does not have properties. [incomp
                                       ^
 
 References:
-   <BUILTINS>/core.js:1232:58
-   1232|     match(regexp: string | RegExp): RegExp$matchResult | null;
+   <BUILTINS>/core.js:1261:58
+   1261|     match(regexp: string | RegExp): RegExp$matchResult | null;
                                                                   ^^^^ [1]
 
 
@@ -62,11 +62,11 @@ Cannot call `"".match` with `0` bound to `regexp` because: [incompatible-call]
                                    ^ [1]
 
 References:
-   <BUILTINS>/core.js:1232:19
-   1232|     match(regexp: string | RegExp): RegExp$matchResult | null;
+   <BUILTINS>/core.js:1261:19
+   1261|     match(regexp: string | RegExp): RegExp$matchResult | null;
                            ^^^^^^ [2]
-   <BUILTINS>/core.js:1232:28
-   1232|     match(regexp: string | RegExp): RegExp$matchResult | null;
+   <BUILTINS>/core.js:1261:28
+   1261|     match(regexp: string | RegExp): RegExp$matchResult | null;
                                     ^^^^^^ [3]
 
 
@@ -79,8 +79,8 @@ Cannot assign `"".match(...)[0]` to `x2` because string [1] is incompatible with
                           ^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:1148:33
-   1148| type RegExp$matchResult = Array<string> & {
+   <BUILTINS>/core.js:1165:33
+   1165| type RegExp$matchResult = Array<string> & {
                                          ^^^^^^ [1]
    overload.js:8:9
       8| var x2: number = "".match(/pattern/)[0];
@@ -96,8 +96,8 @@ Cannot get `"".match(...)[0]` because null [1] does not have properties. [incomp
                                               ^
 
 References:
-   <BUILTINS>/core.js:1232:58
-   1232|     match(regexp: string | RegExp): RegExp$matchResult | null;
+   <BUILTINS>/core.js:1261:58
+   1261|     match(regexp: string | RegExp): RegExp$matchResult | null;
                                                                   ^^^^ [1]
 
 
@@ -110,8 +110,8 @@ Cannot assign `"".split(...)[0]` to `x4` because string [1] is incompatible with
                           ^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:1305:63
-   1305|     split(separator?: string | RegExp, limit?: number): Array<string>;
+   <BUILTINS>/core.js:1334:63
+   1334|     split(separator?: string | RegExp, limit?: number): Array<string>;
                                                                        ^^^^^^ [1]
    overload.js:10:9
      10| var x4: number = "".split(/pattern/)[0];

--- a/tests/predicates_declared/predicates_declared.exp
+++ b/tests/predicates_declared/predicates_declared.exp
@@ -95,8 +95,8 @@ Cannot return `Array.isArray(...)` because boolean [1] is incompatible with stri
                                                        ^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:1092:33
-   1092|     static isArray(obj: mixed): boolean;
+   <BUILTINS>/core.js:1109:33
+   1109|     static isArray(obj: mixed): boolean;
                                          ^^^^^^^ [1]
    sanity-return-type.js:1:32
       1| declare function f2(x: mixed): string %checks(Array.isArray(x));

--- a/tests/promises/promises.exp
+++ b/tests/promises/promises.exp
@@ -109,8 +109,8 @@ Cannot call `Promise.all` because function [1] requires another argument. [incom
                  ^^^
 
 References:
-   <BUILTINS>/core.js:1982:5
-   1982|     static all<T: Iterable<mixed>>(promises: T): Promise<$TupleMap<T, typeof $await>>;
+   <BUILTINS>/core.js:2011:5
+   2011|     static all<T: Iterable<mixed>>(promises: T): Promise<$TupleMap<T, typeof $await>>;
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 
@@ -138,8 +138,8 @@ Cannot call `Promise.allSettled` because function [1] requires another argument.
                  ^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:1989:5
-   1989|     static allSettled<T: Iterable<mixed>>(promises: T): Promise<$TupleMap<T, <T>(p: Promise<T> | T) => $SettledPromiseResult<T>>>;
+   <BUILTINS>/core.js:2018:5
+   2018|     static allSettled<T: Iterable<mixed>>(promises: T): Promise<$TupleMap<T, <T>(p: Promise<T> | T) => $SettledPromiseResult<T>>>;
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 
@@ -168,8 +168,8 @@ Cannot cast `first.status` to empty because string literal `rejected` [1] is inc
                 ^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:2011:12
-   2011|   +status: 'rejected',
+   <BUILTINS>/core.js:2040:12
+   2040|   +status: 'rejected',
                     ^^^^^^^^^^ [1]
    allSettled.js:34:22
      34|       (first.status: empty) // Error: 'rejected' case was not covered
@@ -200,8 +200,8 @@ expected type. [underconstrained-implicit-instantiation]
                                     ^^^^^
 
 References:
-   <BUILTINS>/core.js:2016:25
-   2016| declare function $await<T>(p: Promise<T> | T): T;
+   <BUILTINS>/core.js:2045:25
+   2045| declare function $await<T>(p: Promise<T> | T): T;
                                  ^ [1]
    allSettled.js:44:5
      44|     return (second.status: empty); // Spurious underconstrained-implicit-instantiation error in LTI due to lack of empty propagation
@@ -217,8 +217,8 @@ Cannot use function type [1] with fewer than 2 type arguments. [missing-type-arg
          ^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:2004:15
-   2004|     static any<T, Elem: Promise<T> | T>(promises: Iterable<Elem>): Promise<T>;
+   <BUILTINS>/core.js:2033:15
+   2033|     static any<T, Elem: Promise<T> | T>(promises: Iterable<Elem>): Promise<T>;
                        ^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 
@@ -231,8 +231,8 @@ Cannot call `Promise.any` because function [1] requires another argument. [incom
                  ^^^
 
 References:
-   <BUILTINS>/core.js:2004:5
-   2004|     static any<T, Elem: Promise<T> | T>(promises: Iterable<Elem>): Promise<T>;
+   <BUILTINS>/core.js:2033:5
+   2033|     static any<T, Elem: Promise<T> | T>(promises: Iterable<Elem>): Promise<T>;
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 
@@ -245,8 +245,8 @@ Cannot use function type [1] with fewer than 2 type arguments. [missing-type-arg
          ^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:2004:15
-   2004|     static any<T, Elem: Promise<T> | T>(promises: Iterable<Elem>): Promise<T>;
+   <BUILTINS>/core.js:2033:15
+   2033|     static any<T, Elem: Promise<T> | T>(promises: Iterable<Elem>): Promise<T>;
                        ^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 
@@ -261,8 +261,8 @@ an interface. [incompatible-type]
                                    ^ [1]
 
 References:
-   <BUILTINS>/core.js:2004:51
-   2004|     static any<T, Elem: Promise<T> | T>(promises: Iterable<Elem>): Promise<T>;
+   <BUILTINS>/core.js:2033:51
+   2033|     static any<T, Elem: Promise<T> | T>(promises: Iterable<Elem>): Promise<T>;
                                                            ^^^^^^^^^^^^^^ [2]
 
 
@@ -647,8 +647,8 @@ References:
    resolve_void.js:1:29
       1| (Promise.resolve(): Promise<number>); // error
                                      ^^^^^^ [2]
-   <BUILTINS>/core.js:1907:24
-   1907| declare class Promise<+R = mixed> {
+   <BUILTINS>/core.js:1936:24
+   1936| declare class Promise<+R = mixed> {
                                 ^ [3]
 
 
@@ -665,8 +665,8 @@ References:
    resolve_void.js:3:38
       3| (Promise.resolve(undefined): Promise<number>); // error
                                               ^^^^^^ [2]
-   <BUILTINS>/core.js:1907:24
-   1907| declare class Promise<+R = mixed> {
+   <BUILTINS>/core.js:1936:24
+   1936| declare class Promise<+R = mixed> {
                                 ^ [3]
 
 

--- a/tests/react_16_6/react_16_6.exp
+++ b/tests/react_16_6/react_16_6.exp
@@ -76,8 +76,8 @@ References:
    <BUILTINS>/react.js:308:30
     308|     component: () => Promise<{ default: React$AbstractComponent<Config, Instance, React$Node>, ... }>,
                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [2]
-   <BUILTINS>/core.js:1907:24
-   1907| declare class Promise<+R = mixed> {
+   <BUILTINS>/core.js:1936:24
+   1936| declare class Promise<+R = mixed> {
                                 ^ [3]
 
 
@@ -97,8 +97,8 @@ References:
    <BUILTINS>/react.js:308:30
     308|     component: () => Promise<{ default: React$AbstractComponent<Config, Instance, React$Node>, ... }>,
                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [2]
-   <BUILTINS>/core.js:1907:24
-   1907| declare class Promise<+R = mixed> {
+   <BUILTINS>/core.js:1936:24
+   1936| declare class Promise<+R = mixed> {
                                 ^ [3]
 
 

--- a/tests/react_abstract_component/react_abstract_component.exp
+++ b/tests/react_abstract_component/react_abstract_component.exp
@@ -114,8 +114,8 @@ Cannot return `x` because `$Iterable` [1] does not render number [2]. [incompati
                   ^
 
 References:
-   <BUILTINS>/core.js:1736:21
-   1736| type Iterable<+T> = $Iterable<T,void,void>;
+   <BUILTINS>/core.js:1765:21
+   1765| type Iterable<+T> = $Iterable<T,void,void>;
                              ^^^^^^^^^^^^^^^^^^^^^^ [1]
    arity.js:20:107
      20| function defaultsErrorMessages(x: React$AbstractComponent<empty>): React$AbstractComponent<empty, number, number> {

--- a/tests/rec/rec.exp
+++ b/tests/rec/rec.exp
@@ -332,8 +332,8 @@ defined. [method-unbinding]
                                   ^^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:707:5
-   707|     concat<S, Item: $ReadOnlyArray<S> | S>(...items: Array<Item>): Array<T | S>;
+   <BUILTINS>/core.js:714:5
+   714|     concat<S, Item: $ReadOnlyArray<S> | S>(...items: Array<Item>): Array<T | S>;
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [2]
 
 

--- a/tests/refinements/refinements.exp
+++ b/tests/refinements/refinements.exp
@@ -3040,8 +3040,8 @@ expected type. [underconstrained-implicit-instantiation]
                       ^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:2016:25
-   2016| declare function $await<T>(p: Promise<T> | T): T;
+   <BUILTINS>/core.js:2045:25
+   2045| declare function $await<T>(p: Promise<T> | T): T;
                                  ^ [1]
    issue-7104.js:20:7
      20|       return (box: empty).value; // underconstrained-implicit-instantiation error in LTI due to lack of empty propagation
@@ -4964,8 +4964,8 @@ References:
    tagged_union.js:107:34
    107|     x: Array<string>, y: string, z: number, q: boolean,
                                          ^ [2]
-   <BUILTINS>/core.js:478:5
-   478|     toString(radix?: number): string;
+   <BUILTINS>/core.js:485:5
+   485|     toString(radix?: number): string;
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [3]
 
 
@@ -5013,8 +5013,8 @@ References:
    tagged_union.js:107:45
    107|     x: Array<string>, y: string, z: number, q: boolean,
                                                     ^ [2]
-   <BUILTINS>/core.js:371:5
-   371|     valueOf(): boolean;
+   <BUILTINS>/core.js:378:5
+   378|     valueOf(): boolean;
             ^^^^^^^^^^^^^^^^^^ [3]
 
 
@@ -5062,8 +5062,8 @@ References:
    tagged_union.js:108:29
    108|     r: Object, s: Function, t: () => void
                                     ^ [2]
-   <BUILTINS>/core.js:355:17
-   355|     proto call: Function$Prototype$Call; // (thisArg: any, ...argArray: Array<any>) => any
+   <BUILTINS>/core.js:362:17
+   362|     proto call: Function$Prototype$Call; // (thisArg: any, ...argArray: Array<any>) => any
                         ^^^^^^^^^^^^^^^^^^^^^^^ [3]
 
 
@@ -6046,8 +6046,8 @@ Cannot get `x[0]` because an index signature declaring the expected key / value 
             ^^^^
 
 References:
-   <BUILTINS>/core.js:367:15
-   367| declare class Boolean {
+   <BUILTINS>/core.js:374:15
+   374| declare class Boolean {
                       ^^^^^^^ [1]
 
 

--- a/tests/regexp/regexp.exp
+++ b/tests/regexp/regexp.exp
@@ -7,8 +7,8 @@ Cannot assign `patt.test(...)` to `match` because boolean [1] is incompatible wi
                             ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:1418:27
-   1418|     test(string: string): boolean;
+   <BUILTINS>/core.js:1447:27
+   1447|     test(string: string): boolean;
                                    ^^^^^^^ [1]
    regexp.js:2:11
       2| var match:number = patt.test("Hello world!");

--- a/tests/resolved_env/resolved_env.exp
+++ b/tests/resolved_env/resolved_env.exp
@@ -36,8 +36,8 @@ expression to your expected type. [underconstrained-implicit-instantiation]
                      ^^^^^^^^^^^^^^^^^ [2]
 
 References:
-   <BUILTINS>/core.js:2016:25
-   2016| declare function $await<T>(p: Promise<T> | T): T;
+   <BUILTINS>/core.js:2045:25
+   2045| declare function $await<T>(p: Promise<T> | T): T;
                                  ^ [1]
 
 
@@ -51,8 +51,8 @@ in `new Number(...))` to turn it into an object and attempt to use it as a subty
                                    ^^ [1]
 
 References:
-   <BUILTINS>/core.js:1755:11
-   1755| interface $AsyncIterable<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:1784:11
+   1784| interface $AsyncIterable<+Yield,+Return,-Next> {
                    ^^^^^^^^^^^^^^ [2]
 
 

--- a/tests/return/return.exp
+++ b/tests/return/return.exp
@@ -40,8 +40,8 @@ undefined in type argument `R` [2]. [incompatible-return]
                                       ^^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:1907:24
-   1907| declare class Promise<+R = mixed> {
+   <BUILTINS>/core.js:1936:24
+   1936| declare class Promise<+R = mixed> {
                                 ^ [2]
 
 

--- a/tests/symbol/symbol.exp
+++ b/tests/symbol/symbol.exp
@@ -25,8 +25,8 @@ Cannot call `Symbol` because no more than 1 argument is expected by function typ
                         ^^^^^
 
 References:
-   <BUILTINS>/core.js:264:10
-   264|   static (value?: mixed): symbol;
+   <BUILTINS>/core.js:271:10
+   271|   static (value?: mixed): symbol;
                  ^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 
@@ -74,8 +74,8 @@ Cannot assign `Symbol.toPrimitive` to `y` because `$SymbolToPrimitive` [1] is in
                                   ^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:336:24
-   336|   static +toPrimitive: $SymbolToPrimitive;
+   <BUILTINS>/core.js:343:24
+   343|   static +toPrimitive: $SymbolToPrimitive;
                                ^^^^^^^^^^^^^^^^^^ [1]
    symbol.js:45:12
     45|   const y: $SymbolMatch = Symbol.toPrimitive; // Error

--- a/tests/template/template.exp
+++ b/tests/template/template.exp
@@ -49,8 +49,8 @@ Cannot cast `quasis.raw` to empty because read-only array type [1] is incompatib
               ^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:1156:9
-   1156|   +raw: $ReadOnlyArray<string>;
+   <BUILTINS>/core.js:1173:9
+   1173|   +raw: $ReadOnlyArray<string>;
                  ^^^^^^^^^^^^^^^^^^^^^^ [1]
    tagged_template.js:25:18
      25|     (quasis.raw: empty); // ERROR
@@ -66,8 +66,8 @@ Cannot cast `x` to empty because string [1] is incompatible with empty [2]. [inc
             ^
 
 References:
-   <BUILTINS>/core.js:1365:110
-   1365|     static raw(callSite: interface {+raw: $ReadOnlyArray<string>}, ...substitutions: $ReadOnlyArray<mixed>): string;
+   <BUILTINS>/core.js:1394:110
+   1394|     static raw(callSite: interface {+raw: $ReadOnlyArray<string>}, ...substitutions: $ReadOnlyArray<mixed>): string;
                                                                                                                       ^^^^^^ [1]
    tagged_template.js:34:7
      34|   (x: empty); // ERROR
@@ -85,8 +85,8 @@ subtype of an interface. [incompatible-type]
                       ^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:1365:26
-   1365|     static raw(callSite: interface {+raw: $ReadOnlyArray<string>}, ...substitutions: $ReadOnlyArray<mixed>): string;
+   <BUILTINS>/core.js:1394:26
+   1394|     static raw(callSite: interface {+raw: $ReadOnlyArray<string>}, ...substitutions: $ReadOnlyArray<mixed>): string;
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [2]
 
 
@@ -99,8 +99,8 @@ Cannot cast `x` to empty because string [1] is incompatible with empty [2]. [inc
             ^
 
 References:
-   <BUILTINS>/core.js:1365:110
-   1365|     static raw(callSite: interface {+raw: $ReadOnlyArray<string>}, ...substitutions: $ReadOnlyArray<mixed>): string;
+   <BUILTINS>/core.js:1394:110
+   1394|     static raw(callSite: interface {+raw: $ReadOnlyArray<string>}, ...substitutions: $ReadOnlyArray<mixed>): string;
                                                                                                                       ^^^^^^ [1]
    tagged_template.js:45:7
      45|   (x: empty); // ERROR

--- a/tests/tuples/tuples.exp
+++ b/tests/tuples/tuples.exp
@@ -904,8 +904,8 @@ Cannot call `readOnlyRef.push` because property `push` is missing in `$ReadOnlyA
                         ^^^^
 
 References:
-   <BUILTINS>/core.js:778:77
-   778|     forEach<This>(callbackfn: (this : This, value: T, index: number, array: $ReadOnlyArray<T>) => mixed, thisArg: This): void;
+   <BUILTINS>/core.js:795:77
+   795|     forEach<This>(callbackfn: (this : This, value: T, index: number, array: $ReadOnlyArray<T>) => mixed, thisArg: This): void;
                                                                                     ^^^^^^^^^^^^^^^^^ [1]
 
 

--- a/tests/type_guards/type_guards.exp
+++ b/tests/type_guards/type_guards.exp
@@ -801,8 +801,8 @@ Error --------------------------------------------------------------------------
                                         ^^^^^^^^^^^ [2]
 
 References:
-   <BUILTINS>/core.js:1738:11
-   1738| interface Generator<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:1767:11
+   1767| interface Generator<+Yield,+Return,-Next> {
                    ^^^^^^^^^ [1]
 
 
@@ -816,8 +816,8 @@ it into an object and attempt to use it as a subtype of an interface. [incompati
                                         ^^^^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:1733:11
-   1733| interface $Iterable<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:1762:11
+   1762| interface $Iterable<+Yield,+Return,-Next> {
                    ^^^^^^^^^ [2]
 
 
@@ -830,8 +830,8 @@ Cannot return `(typeof x) == "number"` because `Generator` [1] is incompatible w
                   ^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:1738:11
-   1738| interface Generator<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:1767:11
+   1767| interface Generator<+Yield,+Return,-Next> {
                    ^^^^^^^^^ [1]
    invalid.js:19:32
      19| function *generator(x: mixed): x is number { // error
@@ -872,8 +872,8 @@ Cannot return `(typeof x) == "number"` because `Promise` [1] is incompatible wit
                   ^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:1907:15
-   1907| declare class Promise<+R = mixed> {
+   <BUILTINS>/core.js:1936:15
+   1936| declare class Promise<+R = mixed> {
                        ^^^^^^^ [1]
    invalid.js:28:33
      28| async function async(x: mixed): x is number { // error
@@ -1179,8 +1179,8 @@ References:
    refinement.js:47:42
     47|   const arr2: Array<string> = arr.filter((x: mixed): x is number => { return typeof x === "number"; }); // error
                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [3]
-   <BUILTINS>/core.js:367:15
-   367| declare class Boolean {
+   <BUILTINS>/core.js:374:15
+   374| declare class Boolean {
                       ^^^^^^^ [4]
 
 
@@ -1198,8 +1198,8 @@ References:
    refinement.js:48:42
     48|   const arr3: Array<string> = arr.filter((x: mixed) => { return typeof x === "number"; }); // error no refinement
                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
-   <BUILTINS>/core.js:367:15
-   367| declare class Boolean {
+   <BUILTINS>/core.js:374:15
+   374| declare class Boolean {
                       ^^^^^^^ [2]
    refinement.js:40:35
     40|     filter<This, S: T>(predicate: (this: This, value: T, index: number, array: $ReadOnlyArray<T>) => value is S, thisArg?: This): Array<S>;

--- a/tests/union/union.exp
+++ b/tests/union/union.exp
@@ -7,8 +7,8 @@ Cannot call `str.toFixed` because property `toFixed` is missing in `String` [1].
                            ^^^^^^^
 
 References:
-   <BUILTINS>/core.js:462:39
-   462|     toFixed(fractionDigits?: number): string;
+   <BUILTINS>/core.js:469:39
+   469|     toFixed(fractionDigits?: number): string;
                                               ^^^^^^ [1]
 
 

--- a/tests/union_new/union_new.exp
+++ b/tests/union_new/union_new.exp
@@ -202,8 +202,8 @@ References:
    test20.js:14:2
      14| [""].reduce((acc,str) => acc * str.length);
           ^^ [1]
-   <BUILTINS>/core.js:1348:13
-   1348|     length: number;
+   <BUILTINS>/core.js:1377:13
+   1377|     length: number;
                      ^^^^^^ [2]
 
 


### PR DESCRIPTION
Namely,

`Array.prototype.findLastIndex()` [ES2023]    
MDN https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/findLastIndex
Spec https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.findlastindex

`String.prototype.at()` [ES2022]    
MDN https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/at
Spec https://tc39.es/ecma262/multipage/text-processing.html#sec-string.prototype.at

`TypedArray.prototype.at()` [ES2022]    
MDN https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/at
Spec https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.at 

`Object.hasOwn()` [ES2022]    
MDN https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwn  
Spec https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-object.hasown  
