### PR TITLE
Add package manager config to enforce Yarn version

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,5 +14,6 @@
   "scripts": {
     "prepublish": "yarn workspace flow-parser run prepublish"
   },
+  "packageManager": "yarn@1.22.19",
   "devDependencies": {}
 }


### PR DESCRIPTION
In #9084 I add to run and update the new tests.
`./tool record`  

Between other things, this requires installing and building the JS  packages and in consequence using Yarn. 
The current repo is using Yarn 1, which is the legacy version or Yarn.
Current Yarn version is Yarn berry 3, with 4 around the corner. 
Those are totally different beasts, and if a contributor tries to run `yarn` with a recent version, Yarn will try to upgrade to Yarn berry, and applies a lot of modifications. Also nothing works anymore after.

By using the `packageManager` key, we can enforce the desired Yarn version, which will be used automatically by `corepack`.
See https://nodejs.org/docs/latest-v18.x/api/corepack.html#corepack_configuring_a_package

I choose the `1.22.19` version which is the latest of the 1.x branch.  





