### PR TITLE
[type-definition] Add missing type for Canvas rects

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -2382,6 +2382,7 @@ declare class CanvasRenderingContext2D {
   // rects
   clearRect(x: number, y: number, w: number, h: number): void;
   fillRect(x: number, y: number, w: number, h: number): void;
+  roundRect(x: number, y: number, w: number, h: number, r: number | DOMPoint | DOMPointReadOnly | [number] | [number, number] | [number, number, number] | [number, number, number, number]): void;
   strokeRect(x: number, y: number, w: number, h: number): void;
 
   // path API


### PR DESCRIPTION
Add missing type for in `CanvasRenderingContext2D:` https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/roundRect