### PR TITLE
Add missing types for IntersectionObserver

### DIFF
--- a/lib/bom.js
+++ b/lib/bom.js
@@ -707,6 +707,11 @@ declare type IntersectionObserverOptions = {
 };
 
 declare class IntersectionObserver {
+    root: HTMLElement | null;
+    rootMargin: string;
+    scrollMargin: string;
+    thresholds: number[];
+
     constructor(
       callback: IntersectionObserverCallback,
       options?: IntersectionObserverOptions

--- a/lib/bom.js
+++ b/lib/bom.js
@@ -707,17 +707,16 @@ declare type IntersectionObserverOptions = {
 };
 
 declare class IntersectionObserver {
-    root: HTMLElement | null;
-    rootMargin: string;
-    scrollMargin: string;
-    thresholds: number[];
-
     constructor(
       callback: IntersectionObserverCallback,
       options?: IntersectionObserverOptions
     ): void,
-    observe(target: HTMLElement): void,
-    unobserve(target: HTMLElement): void,
+    root: Element | null;
+    rootMargin: string;
+    scrollMargin: string;
+    thresholds: number[];
+    observe(target: Element): void,
+    unobserve(target: Element): void,
     takeRecords(): Array<IntersectionObserverEntry>,
     disconnect(): void,
 }


### PR DESCRIPTION
The interface for the IntersectionObserver is a little bit off from the MDN spec [here](https://w3c.github.io/IntersectionObserver/#intersection-observer-interface), which is causing issues internally.

This PR corrects the types. 