### PR TITLE
Fixes flow_parser opam constraints

### DIFF
--- a/flow_parser.opam
+++ b/flow_parser.opam
@@ -10,7 +10,9 @@ license: "MIT"
 build: ["dune" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml" {>= "4.14.0"}
-  "dune" {>= "3.0"}
+  "dune" {>= "3.2"}
+  "base" {>= "v0.14.1"}
+  "ppxlib" {>= "0.26.0"}
   "ppx_deriving" {build}
   "ppx_gen_rec" {build}
   "wtf8"


### PR DESCRIPTION
Changes needed in https://github.com/ocaml/opam-repository/pull/25339:

- Bump `dune` to `>= 3.2` as the repository uses `(lang dune 3.2)` in [dune-workspace](https://github.com/facebook/flow/blob/main/dune-workspace).
- Add missing `base` dependency.
- Set `ppxlib` to `0.26.0` since `flow_parser` does not compile with versions below.

In https://github.com/ocaml/opam-repository/pull/25339 I also had to constrain OCaml to `< 5.2` as it wasn't compiling, but I don't think it is necessary here. Let me know if you want me to add it.