### PR TITLE
Update ARM build image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,10 +34,10 @@ executors:
           <<: *opam_env
     working_directory: ~/flow
   linux-arm64:
-    machine:
-      image: default
-    environment:
-      <<: *opam_env
+    docker:
+      - image: flowtype/flow-ci:linux-arm64
+        environment:
+          <<: *opam_env
     resource_class: arm.medium
     working_directory: ~/flow
   linux-node:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ executors:
     working_directory: ~/flow
   linux-arm64:
     machine:
-      image: ubuntu-2004:202101-01
+      image: default
     environment:
       <<: *opam_env
     resource_class: arm.medium

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,8 +34,6 @@ executors:
           <<: *opam_env
     working_directory: ~/flow
   linux-arm64:
-    machine:
-      image: default
     environment:
       <<: *opam_env
     resource_class: arm.medium
@@ -206,41 +204,23 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/flow
-      - run:
-          name: Start Docker image
-          command: |
-            rm -rf /home/circleci/.opam && mkdir /home/circleci/.opam
-            container_id=$(\
-              docker run -it -d \
-                --mount type=bind,source=/home/circleci/.opam,target=/home/opam/.opam \
-                --mount type=bind,source=/home/circleci/flow,target=/home/opam/flow \
-                flowtype/flow-ci:linux-arm64 \
-                /bin/bash \
-            )
-            echo "export CONTAINER_ID=$container_id" >> $BASH_ENV
       - make-opam-cachebreaker
       - restore-opam-cache
       - run:
           name: Init opam
-          command: |
-            docker exec -it $CONTAINER_ID /bin/bash -c 'flow/.circleci/opam_init.sh'
+          command: .circleci/opam_init.sh
       - run:
           name: Install opam deps
-          command: |
-            docker exec -it $CONTAINER_ID /bin/bash -c 'cd flow && make deps'
+          command: make deps
       - save-opam-cache
       - run:
           name: Build flow
           command: |
-            docker exec -it $CONTAINER_ID /bin/bash -c 'cd flow && opam exec -- make bin/flow dist/flow.zip'
+            opam exec -- make bin/flow dist/flow.zip
             mkdir -p bin/linux-arm64 && cp bin/flow bin/linux-arm64/flow
       - run:
           name: Build libflowparser
-          command: |
-            docker exec -it $CONTAINER_ID /bin/bash -c 'cd flow && opam exec -- make -C src/parser dist/libflowparser.zip'
-      - run:
-          name: Stop Docker container
-          command: docker stop $CONTAINER_ID
+          command: opam exec -- make -C src/parser dist/libflowparser.zip
       - run:
           name: Create artifacts
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,7 @@ aliases:
 
 orbs:
   win: circleci/windows@2.4.0
+  jq: circleci/jq@3.0.0
 
   opam_windows:
     commands:
@@ -425,6 +426,8 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/flow
+      - jq/install:
+          version: jq-1.7
       - run:
           name: Run tests
           command: ./runtests.sh bin/linux-arm64/flow | cat

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,8 @@ executors:
           <<: *opam_env
     working_directory: ~/flow
   linux-arm64:
+    machine:
+      image: default
     environment:
       <<: *opam_env
     resource_class: arm.medium

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -218,10 +218,7 @@ jobs:
                 /bin/bash \
             )
             echo "export CONTAINER_ID=$container_id" >> $BASH_ENV
-      - run:
-          name: Create cache breaker
-          command: |
-            docker exec -it $CONTAINER_ID /bin/bash -c 'cd flow && .circleci/make_opam_cachebreaker.sh > .circleci/opamcachebreaker'
+      - make-opam-cachebreaker
       - restore-opam-cache
       - run:
           name: Init opam


### PR DESCRIPTION
CircleCI is deprecating these hardcoded linux versions. Following instructions in https://discuss.circleci.com/t/linux-image-deprecations-and-eol-for-2024/50177 to update. I also have to update the steps to not run in docker, but specify the docker in the executor instead, to deal with some weird permission errors.