### PR TITLE
 Update ARM build image (#9123)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,10 +34,10 @@ executors:
           <<: *opam_env
     working_directory: ~/flow
   linux-arm64:
-    machine:
-      image: ubuntu-2004:202101-01
-    environment:
-      <<: *opam_env
+    docker:
+      - image: flowtype/flow-ci:linux-arm64
+        environment:
+          <<: *opam_env
     resource_class: arm.medium
     working_directory: ~/flow
   linux-node:
@@ -206,44 +206,23 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/flow
-      - run:
-          name: Start Docker image
-          command: |
-            rm -rf /home/circleci/.opam && mkdir /home/circleci/.opam
-            container_id=$(\
-              docker run -it -d \
-                --mount type=bind,source=/home/circleci/.opam,target=/home/opam/.opam \
-                --mount type=bind,source=/home/circleci/flow,target=/home/opam/flow \
-                flowtype/flow-ci:linux-arm64 \
-                /bin/bash \
-            )
-            echo "export CONTAINER_ID=$container_id" >> $BASH_ENV
-      - run:
-          name: Create cache breaker
-          command: |
-            docker exec -it $CONTAINER_ID /bin/bash -c 'cd flow && .circleci/make_opam_cachebreaker.sh > .circleci/opamcachebreaker'
+      - make-opam-cachebreaker
       - restore-opam-cache
       - run:
           name: Init opam
-          command: |
-            docker exec -it $CONTAINER_ID /bin/bash -c 'flow/.circleci/opam_init.sh'
+          command: .circleci/opam_init.sh
       - run:
           name: Install opam deps
-          command: |
-            docker exec -it $CONTAINER_ID /bin/bash -c 'cd flow && make deps'
+          command: make deps
       - save-opam-cache
       - run:
           name: Build flow
           command: |
-            docker exec -it $CONTAINER_ID /bin/bash -c 'cd flow && opam exec -- make bin/flow dist/flow.zip'
+            opam exec -- make bin/flow dist/flow.zip
             mkdir -p bin/linux-arm64 && cp bin/flow bin/linux-arm64/flow
       - run:
           name: Build libflowparser
-          command: |
-            docker exec -it $CONTAINER_ID /bin/bash -c 'cd flow && opam exec -- make -C src/parser dist/libflowparser.zip'
-      - run:
-          name: Stop Docker container
-          command: docker stop $CONTAINER_ID
+          command: opam exec -- make -C src/parser dist/libflowparser.zip
       - run:
           name: Create artifacts
           command: |

--- a/tests/ls/ls.exp
+++ b/tests/ls/ls.exp
@@ -58,42 +58,12 @@ ImplicitlyIncluded    implicitly_included.js
 ================================================================================
 JSON output without --explain should be an array
 ================================================================================
-[
-  "../other/explicitly_included.js",
-  "../other/implicitly_ignored.js",
-  ".flowconfig",
-  "explicit_lib.js",
-  "explicitly_ignored.js",
-  "flow-typed/implicit_lib.js",
-  "implicitly_included.js"
-]
+["../other/explicitly_included.js","../other/implicitly_ignored.js",".flowconfig","explicit_lib.js","explicitly_ignored.js","flow-typed/implicit_lib.js","implicitly_included.js"]
 
 ================================================================================
 JSON output with --explain should be JSON object
 ================================================================================
-{
-  "../other/explicitly_included.js": {
-    "explanation": "ExplicitlyIncluded"
-  },
-  "../other/implicitly_ignored.js": {
-    "explanation": "ImplicitlyIgnored"
-  },
-  ".flowconfig": {
-    "explanation": "ConfigFile"
-  },
-  "explicit_lib.js": {
-    "explanation": "ExplicitLib"
-  },
-  "explicitly_ignored.js": {
-    "explanation": "ExplicitlyIgnored"
-  },
-  "flow-typed/implicit_lib.js": {
-    "explanation": "ImplicitLib"
-  },
-  "implicitly_included.js": {
-    "explanation": "ImplicitlyIncluded"
-  }
-}
+{"../other/explicitly_included.js":{"explanation":"ExplicitlyIncluded"},"../other/implicitly_ignored.js":{"explanation":"ImplicitlyIgnored"},".flowconfig":{"explanation":"ConfigFile"},"explicit_lib.js":{"explanation":"ExplicitLib"},"explicitly_ignored.js":{"explanation":"ExplicitlyIgnored"},"flow-typed/implicit_lib.js":{"explanation":"ImplicitLib"},"implicitly_included.js":{"explanation":"ImplicitlyIncluded"}}
 
 ================================================================================
 Listing files over stdin

--- a/tests/ls/test.sh
+++ b/tests/ls/test.sh
@@ -52,13 +52,13 @@ echo ""
 echo "================================================================================"
 echo "JSON output without --explain should be an array"
 echo "================================================================================"
-assert_ok "$FLOW" ls --json --strip-root --root src --all $(cat files.txt) src/.flowconfig | jq
+assert_ok "$FLOW" ls --json --strip-root --root src --all $(cat files.txt) src/.flowconfig
 echo ""
 
 echo "================================================================================"
 echo "JSON output with --explain should be JSON object"
 echo "================================================================================"
-assert_ok "$FLOW" ls --json --strip-root --root src --all --explain $(cat files.txt) src/.flowconfig | jq
+assert_ok "$FLOW" ls --json --strip-root --root src --all --explain $(cat files.txt) src/.flowconfig
 echo ""
 
 echo "================================================================================"


### PR DESCRIPTION
Summary:
CircleCI is deprecating these hardcoded linux versions. Following instructions in https://discuss.circleci.com/t/linux-image-deprecations-and-eol-for-2024/50177 to update. I also have to update the steps to not run in docker, but specify the docker in the executor instead, to deal with some weird permission errors.


Reviewed By: alexmckenley

Differential Revision: D54510056

Pulled By: SamChou19815


