### PR TITLE
Define entry points for File System API

### DIFF
--- a/lib/bom.js
+++ b/lib/bom.js
@@ -288,6 +288,7 @@ declare class StorageManager {
   persist: () => Promise<boolean>;
   persisted: () => Promise<boolean>;
   estimate?: () => Promise<StorageEstimate>;
+  getDirectory: () => Promise<FileSystemDirectoryHandle>;
 }
 
 type StorageManagerRegisteredEndpoint = 'caches' | 'indexedDB' | 'localStorage' | 'serviceWorkerRegistrations' | 'sessionStorage';

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -4531,7 +4531,7 @@ declare function scrollBy(options: ScrollToOptions): void;
 
 /* Window file picker */
 
-type WindowFileSystemPickerFileType = {
+type WindowFileSystemPickerFileType = {|
   description?: string,
   /*
    * An Object with the keys set to the MIME type
@@ -4544,7 +4544,7 @@ type WindowFileSystemPickerFileType = {
   accept: {
     [string]: Array<string>,
   },
-};
+|};
 
 type WindowBaseFilePickerOptions = {|
   id?: number,

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -4546,7 +4546,7 @@ type WindowFileSystemPickerFileType = {
   },
 };
 
-type WindowBaseFilePickerOptions = {
+type WindowBaseFilePickerOptions = {|
   id?: number,
   startIn?:
     | FileSystemHandle
@@ -4556,24 +4556,24 @@ type WindowBaseFilePickerOptions = {
     | "music"
     | "pictures"
     | "videos",
-};
+|};
 
-type WindowFilePickerOptions = WindowBaseFilePickerOptions & {
+type WindowFilePickerOptions = WindowBaseFilePickerOptions & {|
   excludeAcceptAllOption?: boolean,
   types?: Array<WindowFileSystemPickerFileType>,
-};
+|};
 
-type WindowOpenFilePickerOptions = WindowFilePickerOptions & {
+type WindowOpenFilePickerOptions = WindowFilePickerOptions & {|
   multiple?: boolean,
-};
+|};
 
-type WindowSaveFilePickerOptions = WindowFilePickerOptions & {
+type WindowSaveFilePickerOptions = WindowFilePickerOptions & {|
   suggestedName?: string,
-};
+|};
 
-type WindowDirectoryFilePickerOptions = WindowBaseFilePickerOptions & {
+type WindowDirectoryFilePickerOptions = WindowBaseFilePickerOptions & {|
   mode?: "read" | "readwrite",
-};
+|};
 
 // https://wicg.github.io/file-system-access/#api-showopenfilepicker
 declare function showOpenFilePicker(

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -113,6 +113,7 @@ declare class DataTransferItemList {
   clear(): void;
 };
 
+// https://wicg.github.io/file-system-access/#drag-and-drop
 declare class DataTransferItem {
   kind: string; // readonly
   type: string; // readonly
@@ -124,6 +125,12 @@ declare class DataTransferItem {
    * https://developer.mozilla.org/en-US/docs/Web/API/DataTransferItem/webkitGetAsEntry
    */
   webkitGetAsEntry(): void | () => any;
+  /*
+   * Not supported in all browsers
+   * For up to date compatibility information, please visit
+   * https://developer.mozilla.org/en-US/docs/Web/API/DataTransferItem/getAsFileSystemHandle
+   */
+  getAsFileSystemHandle?: () => Promise<?FileSystemHandle>;
 };
 
 /* DOM */
@@ -4521,6 +4528,67 @@ declare function scrollTo(x: number, y: number): void;
 declare function scrollTo(options: ScrollToOptions): void;
 declare function scrollBy(x: number, y: number): void;
 declare function scrollBy(options: ScrollToOptions): void;
+
+/* Window file picker */
+
+type WindowFileSystemPickerFileType = {
+  description?: string,
+  /*
+   * An Object with the keys set to the MIME type
+   * and the values an Array of file extensions
+   * Example:
+   * accept: {
+   *   "image/*": [".png", ".gif", ".jpeg", ".jpg"],
+   * },
+   */
+  accept: {
+    [string]: Array<string>,
+  },
+};
+
+type WindowBaseFilePickerOptions = {
+  id?: number,
+  startIn?:
+    | FileSystemHandle
+    | "desktop"
+    | "documents"
+    | "downloads"
+    | "music"
+    | "pictures"
+    | "videos",
+};
+
+type WindowFilePickerOptions = WindowBaseFilePickerOptions & {
+  excludeAcceptAllOption?: boolean,
+  types?: Array<WindowFileSystemPickerFileType>,
+};
+
+type WindowOpenFilePickerOptions = WindowFilePickerOptions & {
+  multiple?: boolean,
+};
+
+type WindowSaveFilePickerOptions = WindowFilePickerOptions & {
+  suggestedName?: string,
+};
+
+type WindowDirectoryFilePickerOptions = WindowBaseFilePickerOptions & {
+  mode?: "read" | "readwrite",
+};
+
+// https://wicg.github.io/file-system-access/#api-showopenfilepicker
+declare function showOpenFilePicker(
+  options?: WindowOpenFilePickerOptions
+): Promise<Array<FileSystemFileHandle>>;
+
+// https://wicg.github.io/file-system-access/#api-showsavefilepicker
+declare function showSaveFilePicker(
+  options?: WindowSaveFilePickerOptions
+): Promise<FileSystemFileHandle>;
+
+// https://wicg.github.io/file-system-access/#api-showdirectorypicker
+declare function showDirectoryPicker(
+  options?: WindowDirectoryFilePickerOptions
+): Promise<FileSystemDirectoryHandle>;     
 
 /* Notification */
 type NotificationPermission = 'default' | 'denied' | 'granted';

--- a/tests/bom/bom.exp
+++ b/tests/bom/bom.exp
@@ -8,8 +8,8 @@ Cannot call `FormData` with empty string bound to `form` because string [1] is i
                      ^^ [1]
 
 References:
-   <BUILTINS>/bom.js:627:24
-   627|     constructor(form?: HTMLFormElement): void;
+   <BUILTINS>/bom.js:628:24
+   628|     constructor(form?: HTMLFormElement): void;
                                ^^^^^^^^^^^^^^^ [2]
 
 
@@ -23,11 +23,11 @@ with `HTMLFormElement` [2]. [incompatible-call]
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/dom.js:1167:70
-   1167|   createElement(tagName: 'input', options?: ElementCreationOptions): HTMLInputElement;
+   <BUILTINS>/dom.js:1174:70
+   1174|   createElement(tagName: 'input', options?: ElementCreationOptions): HTMLInputElement;
                                                                               ^^^^^^^^^^^^^^^^ [1]
-   <BUILTINS>/bom.js:627:24
-    627|     constructor(form?: HTMLFormElement): void;
+   <BUILTINS>/bom.js:628:24
+    628|     constructor(form?: HTMLFormElement): void;
                                 ^^^^^^^^^^^^^^^ [2]
 
 
@@ -40,8 +40,8 @@ Cannot assign `a.get(...)` to `d` because null or undefined [1] is incompatible 
                           ^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/bom.js:630:24
-   630|     get(name: string): ?FormDataEntryValue;
+   <BUILTINS>/bom.js:631:24
+   631|     get(name: string): ?FormDataEntryValue;
                                ^^^^^^^^^^^^^^^^^^^ [1]
    FormData.js:14:10
     14| const d: string = a.get('foo'); // incorrect
@@ -57,8 +57,8 @@ Cannot assign `a.get(...)` to `d` because `File` [1] is incompatible with string
                           ^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/bom.js:630:25
-   630|     get(name: string): ?FormDataEntryValue;
+   <BUILTINS>/bom.js:631:25
+   631|     get(name: string): ?FormDataEntryValue;
                                 ^^^^^^^^^^^^^^^^^^ [1]
    FormData.js:14:10
     14| const d: string = a.get('foo'); // incorrect
@@ -74,8 +74,8 @@ Cannot assign `a.get(...)` to `e` because null or undefined [1] is incompatible 
                         ^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/bom.js:630:24
-   630|     get(name: string): ?FormDataEntryValue;
+   <BUILTINS>/bom.js:631:24
+   631|     get(name: string): ?FormDataEntryValue;
                                ^^^^^^^^^^^^^^^^^^^ [1]
    FormData.js:15:10
     15| const e: Blob = a.get('foo'); // incorrect
@@ -91,8 +91,8 @@ Cannot assign `a.get(...)` to `e` because string [1] is incompatible with `Blob`
                         ^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/bom.js:630:25
-   630|     get(name: string): ?FormDataEntryValue;
+   <BUILTINS>/bom.js:631:25
+   631|     get(name: string): ?FormDataEntryValue;
                                 ^^^^^^^^^^^^^^^^^^ [1]
    FormData.js:15:10
     15| const e: Blob = a.get('foo'); // incorrect
@@ -108,8 +108,8 @@ Cannot call `a.get` with `2` bound to `name` because number [1] is incompatible 
               ^ [1]
 
 References:
-   <BUILTINS>/bom.js:630:15
-   630|     get(name: string): ?FormDataEntryValue;
+   <BUILTINS>/bom.js:631:15
+   631|     get(name: string): ?FormDataEntryValue;
                       ^^^^^^ [2]
 
 
@@ -130,11 +130,11 @@ References:
    FormData.js:21:33
     21| const a2: Array<string | File | number> = a.getAll('foo'); // incorrect
                                         ^^^^^^ [1]
-   <BUILTINS>/bom.js:624:27
-   624| type FormDataEntryValue = string | File
+   <BUILTINS>/bom.js:625:27
+   625| type FormDataEntryValue = string | File
                                   ^^^^^^ [2]
-   <BUILTINS>/bom.js:624:36
-   624| type FormDataEntryValue = string | File
+   <BUILTINS>/bom.js:625:36
+   625| type FormDataEntryValue = string | File
                                            ^^^^ [3]
 
 
@@ -155,11 +155,11 @@ References:
    FormData.js:22:26
     22| const a3: Array<string | Blob | File> = a.getAll('foo'); // incorrect
                                  ^^^^ [1]
-   <BUILTINS>/bom.js:624:36
-   624| type FormDataEntryValue = string | File
+   <BUILTINS>/bom.js:625:36
+   625| type FormDataEntryValue = string | File
                                            ^^^^ [2]
-   <BUILTINS>/bom.js:624:27
-   624| type FormDataEntryValue = string | File
+   <BUILTINS>/bom.js:625:27
+   625| type FormDataEntryValue = string | File
                                   ^^^^^^ [3]
 
 
@@ -172,8 +172,8 @@ Cannot call `a.getAll` with `23` bound to `name` because number [1] is incompati
                  ^^ [1]
 
 References:
-   <BUILTINS>/bom.js:631:18
-   631|     getAll(name: string): Array<FormDataEntryValue>;
+   <BUILTINS>/bom.js:632:18
+   632|     getAll(name: string): Array<FormDataEntryValue>;
                          ^^^^^^ [2]
 
 
@@ -191,11 +191,11 @@ References:
    FormData.js:27:14
     27| a.set('foo', {}); // incorrect
                      ^^ [1]
-   <BUILTINS>/bom.js:634:30
-   634|     set(name: string, value: Blob, filename?: string): void;
-                                     ^^^^ [2]
    <BUILTINS>/bom.js:635:30
-   635|     set(name: string, value: File, filename?: string): void;
+   635|     set(name: string, value: Blob, filename?: string): void;
+                                     ^^^^ [2]
+   <BUILTINS>/bom.js:636:30
+   636|     set(name: string, value: File, filename?: string): void;
                                      ^^^^ [3]
 
 
@@ -214,14 +214,14 @@ References:
    FormData.js:28:7
     28| a.set(2, 'bar'); // incorrect
               ^ [1]
-   <BUILTINS>/bom.js:633:15
-   633|     set(name: string, value: string): void;
-                      ^^^^^^ [2]
    <BUILTINS>/bom.js:634:15
-   634|     set(name: string, value: Blob, filename?: string): void;
-                      ^^^^^^ [3]
+   634|     set(name: string, value: string): void;
+                      ^^^^^^ [2]
    <BUILTINS>/bom.js:635:15
-   635|     set(name: string, value: File, filename?: string): void;
+   635|     set(name: string, value: Blob, filename?: string): void;
+                      ^^^^^^ [3]
+   <BUILTINS>/bom.js:636:15
+   636|     set(name: string, value: File, filename?: string): void;
                       ^^^^^^ [4]
 
 
@@ -239,11 +239,11 @@ References:
    FormData.js:29:14
     29| a.set('foo', 'bar', 'baz'); // incorrect
                      ^^^^^ [1]
-   <BUILTINS>/bom.js:634:30
-   634|     set(name: string, value: Blob, filename?: string): void;
-                                     ^^^^ [2]
    <BUILTINS>/bom.js:635:30
-   635|     set(name: string, value: File, filename?: string): void;
+   635|     set(name: string, value: Blob, filename?: string): void;
+                                     ^^^^ [2]
+   <BUILTINS>/bom.js:636:30
+   636|     set(name: string, value: File, filename?: string): void;
                                      ^^^^ [3]
 
 
@@ -261,11 +261,11 @@ References:
    FormData.js:32:33
     32| a.set('bar', new File([], 'q'), 2) // incorrect
                                         ^ [1]
-   <BUILTINS>/bom.js:634:47
-   634|     set(name: string, value: Blob, filename?: string): void;
-                                                      ^^^^^^ [2]
    <BUILTINS>/bom.js:635:47
-   635|     set(name: string, value: File, filename?: string): void;
+   635|     set(name: string, value: Blob, filename?: string): void;
+                                                      ^^^^^^ [2]
+   <BUILTINS>/bom.js:636:47
+   636|     set(name: string, value: File, filename?: string): void;
                                                       ^^^^^^ [3]
 
 
@@ -283,14 +283,14 @@ References:
    FormData.js:35:24
     35| a.set('bar', new Blob, 2) // incorrect
                                ^ [1]
-   <BUILTINS>/bom.js:634:47
-   634|     set(name: string, value: Blob, filename?: string): void;
+   <BUILTINS>/bom.js:635:47
+   635|     set(name: string, value: Blob, filename?: string): void;
                                                       ^^^^^^ [2]
    FormData.js:35:14
     35| a.set('bar', new Blob, 2) // incorrect
                      ^^^^^^^^ [3]
-   <BUILTINS>/bom.js:635:30
-   635|     set(name: string, value: File, filename?: string): void;
+   <BUILTINS>/bom.js:636:30
+   636|     set(name: string, value: File, filename?: string): void;
                                      ^^^^ [4]
 
 
@@ -308,11 +308,11 @@ References:
    FormData.js:39:17
     39| a.append('foo', {}); // incorrect
                         ^^ [1]
-   <BUILTINS>/bom.js:638:33
-   638|     append(name: string, value: Blob, filename?: string): void;
-                                        ^^^^ [2]
    <BUILTINS>/bom.js:639:33
-   639|     append(name: string, value: File, filename?: string): void;
+   639|     append(name: string, value: Blob, filename?: string): void;
+                                        ^^^^ [2]
+   <BUILTINS>/bom.js:640:33
+   640|     append(name: string, value: File, filename?: string): void;
                                         ^^^^ [3]
 
 
@@ -331,14 +331,14 @@ References:
    FormData.js:40:10
     40| a.append(2, 'bar'); // incorrect
                  ^ [1]
-   <BUILTINS>/bom.js:637:18
-   637|     append(name: string, value: string): void;
-                         ^^^^^^ [2]
    <BUILTINS>/bom.js:638:18
-   638|     append(name: string, value: Blob, filename?: string): void;
-                         ^^^^^^ [3]
+   638|     append(name: string, value: string): void;
+                         ^^^^^^ [2]
    <BUILTINS>/bom.js:639:18
-   639|     append(name: string, value: File, filename?: string): void;
+   639|     append(name: string, value: Blob, filename?: string): void;
+                         ^^^^^^ [3]
+   <BUILTINS>/bom.js:640:18
+   640|     append(name: string, value: File, filename?: string): void;
                          ^^^^^^ [4]
 
 
@@ -356,11 +356,11 @@ References:
    FormData.js:41:17
     41| a.append('foo', 'bar', 'baz'); // incorrect
                         ^^^^^ [1]
-   <BUILTINS>/bom.js:638:33
-   638|     append(name: string, value: Blob, filename?: string): void;
-                                        ^^^^ [2]
    <BUILTINS>/bom.js:639:33
-   639|     append(name: string, value: File, filename?: string): void;
+   639|     append(name: string, value: Blob, filename?: string): void;
+                                        ^^^^ [2]
+   <BUILTINS>/bom.js:640:33
+   640|     append(name: string, value: File, filename?: string): void;
                                         ^^^^ [3]
 
 
@@ -378,11 +378,11 @@ References:
    FormData.js:45:36
     45| a.append('bar', new File([], 'q'), 2) // incorrect
                                            ^ [1]
-   <BUILTINS>/bom.js:638:50
-   638|     append(name: string, value: Blob, filename?: string): void;
-                                                         ^^^^^^ [2]
    <BUILTINS>/bom.js:639:50
-   639|     append(name: string, value: File, filename?: string): void;
+   639|     append(name: string, value: Blob, filename?: string): void;
+                                                         ^^^^^^ [2]
+   <BUILTINS>/bom.js:640:50
+   640|     append(name: string, value: File, filename?: string): void;
                                                          ^^^^^^ [3]
 
 
@@ -400,14 +400,14 @@ References:
    FormData.js:48:27
     48| a.append('bar', new Blob, 2) // incorrect
                                   ^ [1]
-   <BUILTINS>/bom.js:638:50
-   638|     append(name: string, value: Blob, filename?: string): void;
+   <BUILTINS>/bom.js:639:50
+   639|     append(name: string, value: Blob, filename?: string): void;
                                                          ^^^^^^ [2]
    FormData.js:48:17
     48| a.append('bar', new Blob, 2) // incorrect
                         ^^^^^^^^ [3]
-   <BUILTINS>/bom.js:639:33
-   639|     append(name: string, value: File, filename?: string): void;
+   <BUILTINS>/bom.js:640:33
+   640|     append(name: string, value: File, filename?: string): void;
                                         ^^^^ [4]
 
 
@@ -420,8 +420,8 @@ Cannot call `a.delete` with `3` bound to `name` because number [1] is incompatib
                  ^ [1]
 
 References:
-   <BUILTINS>/bom.js:641:18
-   641|     delete(name: string): void;
+   <BUILTINS>/bom.js:642:18
+   642|     delete(name: string): void;
                          ^^^^^^ [2]
 
 
@@ -434,8 +434,8 @@ Cannot assign `x` to `x` because string [1] is incompatible with number [2]. [in
                               ^^^^^^^^
 
 References:
-   <BUILTINS>/bom.js:643:22
-   643|     keys(): Iterator<string>;
+   <BUILTINS>/bom.js:644:22
+   644|     keys(): Iterator<string>;
                              ^^^^^^ [1]
    FormData.js:56:13
     56| for (let x: number of a.keys()) {} // incorrect
@@ -456,11 +456,11 @@ References:
    FormData.js:64:43
     64| for (let [x, y]: [string, string | File | Blob] of a.entries()) {} // incorrect
                                                   ^^^^ [1]
-   <BUILTINS>/bom.js:624:36
-   624| type FormDataEntryValue = string | File
+   <BUILTINS>/bom.js:625:36
+   625| type FormDataEntryValue = string | File
                                            ^^^^ [2]
-   <BUILTINS>/bom.js:624:27
-   624| type FormDataEntryValue = string | File
+   <BUILTINS>/bom.js:625:27
+   625| type FormDataEntryValue = string | File
                                   ^^^^^^ [3]
 
 
@@ -474,8 +474,8 @@ Cannot assign for-of element to destructuring because string [1] is incompatible
                                              ^^^^^^^^^^^
 
 References:
-   <BUILTINS>/bom.js:645:26
-   645|     entries(): Iterator<[string, FormDataEntryValue]>;
+   <BUILTINS>/bom.js:646:26
+   646|     entries(): Iterator<[string, FormDataEntryValue]>;
                                  ^^^^^^ [1]
    FormData.js:65:19
     65| for (let [x, y]: [number, string] of a.entries()) {} // incorrect
@@ -492,8 +492,8 @@ Cannot assign for-of element to destructuring because `File` [1] is incompatible
                                              ^^^^^^^^^^^
 
 References:
-   <BUILTINS>/bom.js:645:34
-   645|     entries(): Iterator<[string, FormDataEntryValue]>;
+   <BUILTINS>/bom.js:646:34
+   646|     entries(): Iterator<[string, FormDataEntryValue]>;
                                          ^^^^^^^^^^^^^^^^^^ [1]
    FormData.js:65:27
     65| for (let [x, y]: [number, string] of a.entries()) {} // incorrect
@@ -510,8 +510,8 @@ Cannot assign for-of element to destructuring because `File` [1] is incompatible
                                              ^^^^^^^^^^^
 
 References:
-   <BUILTINS>/bom.js:645:34
-   645|     entries(): Iterator<[string, FormDataEntryValue]>;
+   <BUILTINS>/bom.js:646:34
+   646|     entries(): Iterator<[string, FormDataEntryValue]>;
                                          ^^^^^^^^^^^^^^^^^^ [1]
    FormData.js:66:27
     66| for (let [x, y]: [string, number] of a.entries()) {} // incorrect
@@ -528,8 +528,8 @@ Cannot assign for-of element to destructuring because string [1] is incompatible
                                              ^^^^^^^^^^^
 
 References:
-   <BUILTINS>/bom.js:645:34
-   645|     entries(): Iterator<[string, FormDataEntryValue]>;
+   <BUILTINS>/bom.js:646:34
+   646|     entries(): Iterator<[string, FormDataEntryValue]>;
                                          ^^^^^^^^^^^^^^^^^^ [1]
    FormData.js:66:27
     66| for (let [x, y]: [string, number] of a.entries()) {} // incorrect
@@ -550,11 +550,11 @@ References:
    FormData.js:66:27
     66| for (let [x, y]: [string, number] of a.entries()) {} // incorrect
                                   ^^^^^^ [1]
-   <BUILTINS>/bom.js:624:27
-   624| type FormDataEntryValue = string | File
+   <BUILTINS>/bom.js:625:27
+   625| type FormDataEntryValue = string | File
                                   ^^^^^^ [2]
-   <BUILTINS>/bom.js:624:36
-   624| type FormDataEntryValue = string | File
+   <BUILTINS>/bom.js:625:36
+   625| type FormDataEntryValue = string | File
                                            ^^^^ [3]
 
 
@@ -568,8 +568,8 @@ Cannot assign for-of element to destructuring because string [1] is incompatible
                                              ^^^^^^^^^^^
 
 References:
-   <BUILTINS>/bom.js:645:26
-   645|     entries(): Iterator<[string, FormDataEntryValue]>;
+   <BUILTINS>/bom.js:646:26
+   646|     entries(): Iterator<[string, FormDataEntryValue]>;
                                  ^^^^^^ [1]
    FormData.js:67:19
     67| for (let [x, y]: [number, number] of a.entries()) {} // incorrect
@@ -586,8 +586,8 @@ Cannot assign for-of element to destructuring because `File` [1] is incompatible
                                              ^^^^^^^^^^^
 
 References:
-   <BUILTINS>/bom.js:645:34
-   645|     entries(): Iterator<[string, FormDataEntryValue]>;
+   <BUILTINS>/bom.js:646:34
+   646|     entries(): Iterator<[string, FormDataEntryValue]>;
                                          ^^^^^^^^^^^^^^^^^^ [1]
    FormData.js:67:27
     67| for (let [x, y]: [number, number] of a.entries()) {} // incorrect
@@ -604,8 +604,8 @@ Cannot assign for-of element to destructuring because string [1] is incompatible
                                              ^^^^^^^^^^^
 
 References:
-   <BUILTINS>/bom.js:645:34
-   645|     entries(): Iterator<[string, FormDataEntryValue]>;
+   <BUILTINS>/bom.js:646:34
+   646|     entries(): Iterator<[string, FormDataEntryValue]>;
                                          ^^^^^^^^^^^^^^^^^^ [1]
    FormData.js:67:27
     67| for (let [x, y]: [number, number] of a.entries()) {} // incorrect
@@ -626,11 +626,11 @@ References:
    FormData.js:67:27
     67| for (let [x, y]: [number, number] of a.entries()) {} // incorrect
                                   ^^^^^^ [1]
-   <BUILTINS>/bom.js:624:27
-   624| type FormDataEntryValue = string | File
+   <BUILTINS>/bom.js:625:27
+   625| type FormDataEntryValue = string | File
                                   ^^^^^^ [2]
-   <BUILTINS>/bom.js:624:36
-   624| type FormDataEntryValue = string | File
+   <BUILTINS>/bom.js:625:36
+   625| type FormDataEntryValue = string | File
                                            ^^^^ [3]
 
 
@@ -643,8 +643,8 @@ Cannot assign `headers.get(...)` to `b` because null [1] is incompatible with st
                            ^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/bom.js:1575:24
-   1575|     get(name: string): null | string;
+   <BUILTINS>/bom.js:1576:24
+   1576|     get(name: string): null | string;
                                 ^^^^ [1]
    Headers.js:8:10
       8| const b: string = headers.get('foo'); // incorrect
@@ -661,8 +661,8 @@ Cannot call `navigator.mediaDevices.getUserMedia` because property `getUserMedia
                                ^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/bom.js:324:20
-   324|     mediaDevices?: MediaDevices;
+   <BUILTINS>/bom.js:325:20
+   325|     mediaDevices?: MediaDevices;
                            ^^^^^^^^^^^^ [1]
 
 
@@ -675,8 +675,8 @@ Cannot call `MutationObserver` because function [1] requires another argument. [
             ^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/bom.js:674:5
-   674|     constructor(callback: (arr: Array<MutationRecord>, observer: MutationObserver) => mixed): void;
+   <BUILTINS>/bom.js:675:5
+   675|     constructor(callback: (arr: Array<MutationRecord>, observer: MutationObserver) => mixed): void;
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 
@@ -690,8 +690,8 @@ Cannot call `MutationObserver` with `42` bound to `callback` because number [1] 
                              ^^ [1]
 
 References:
-   <BUILTINS>/bom.js:674:27
-   674|     constructor(callback: (arr: Array<MutationRecord>, observer: MutationObserver) => mixed): void;
+   <BUILTINS>/bom.js:675:27
+   675|     constructor(callback: (arr: Array<MutationRecord>, observer: MutationObserver) => mixed): void;
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [2]
 
 
@@ -705,8 +705,8 @@ in the first parameter. [incompatible-call]
                                  ^^^^^^ [1]
 
 References:
-   <BUILTINS>/bom.js:674:33
-   674|     constructor(callback: (arr: Array<MutationRecord>, observer: MutationObserver) => mixed): void;
+   <BUILTINS>/bom.js:675:33
+   675|     constructor(callback: (arr: Array<MutationRecord>, observer: MutationObserver) => mixed): void;
                                         ^^^^^^^^^^^^^^^^^^^^^ [2]
 
 
@@ -719,8 +719,8 @@ Cannot call `o.observe` because function [1] requires another argument. [incompa
           ^^^^^^^
 
 References:
-   <BUILTINS>/bom.js:675:5
-   675|     observe(target: Node, options: MutationObserverInit): void;
+   <BUILTINS>/bom.js:676:5
+   676|     observe(target: Node, options: MutationObserverInit): void;
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 
@@ -739,14 +739,14 @@ References:
    MutationObserver.js:18:1
     18| o.observe(); // incorrect
         ^^^^^^^^^^^ [1]
-   <BUILTINS>/bom.js:661:7
-   661|     | { childList: true, ... }
-              ^^^^^^^^^^^^^^^^^^^^^^^^ [2]
    <BUILTINS>/bom.js:662:7
-   662|     | { attributes: true, ... }
-              ^^^^^^^^^^^^^^^^^^^^^^^^^ [3]
+   662|     | { childList: true, ... }
+              ^^^^^^^^^^^^^^^^^^^^^^^^ [2]
    <BUILTINS>/bom.js:663:7
-   663|     | { characterData: true, ... }
+   663|     | { attributes: true, ... }
+              ^^^^^^^^^^^^^^^^^^^^^^^^^ [3]
+   <BUILTINS>/bom.js:664:7
+   664|     | { characterData: true, ... }
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [4]
 
 
@@ -759,8 +759,8 @@ Cannot call `o.observe` because function [1] requires another argument. [incompa
           ^^^^^^^
 
 References:
-   <BUILTINS>/bom.js:675:5
-   675|     observe(target: Node, options: MutationObserverInit): void;
+   <BUILTINS>/bom.js:676:5
+   676|     observe(target: Node, options: MutationObserverInit): void;
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 
@@ -779,14 +779,14 @@ References:
    MutationObserver.js:19:1
     19| o.observe('invalid'); // incorrect
         ^^^^^^^^^^^^^^^^^^^^ [1]
-   <BUILTINS>/bom.js:661:7
-   661|     | { childList: true, ... }
-              ^^^^^^^^^^^^^^^^^^^^^^^^ [2]
    <BUILTINS>/bom.js:662:7
-   662|     | { attributes: true, ... }
-              ^^^^^^^^^^^^^^^^^^^^^^^^^ [3]
+   662|     | { childList: true, ... }
+              ^^^^^^^^^^^^^^^^^^^^^^^^ [2]
    <BUILTINS>/bom.js:663:7
-   663|     | { characterData: true, ... }
+   663|     | { attributes: true, ... }
+              ^^^^^^^^^^^^^^^^^^^^^^^^^ [3]
+   <BUILTINS>/bom.js:664:7
+   664|     | { characterData: true, ... }
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [4]
 
 
@@ -800,8 +800,8 @@ Cannot call `o.observe` with `'invalid'` bound to `target` because string [1] is
                   ^^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/bom.js:675:21
-   675|     observe(target: Node, options: MutationObserverInit): void;
+   <BUILTINS>/bom.js:676:21
+   676|     observe(target: Node, options: MutationObserverInit): void;
                             ^^^^ [2]
 
 
@@ -814,8 +814,8 @@ Cannot call `o.observe` because function [1] requires another argument. [incompa
           ^^^^^^^
 
 References:
-   <BUILTINS>/bom.js:675:5
-   675|     observe(target: Node, options: MutationObserverInit): void;
+   <BUILTINS>/bom.js:676:5
+   676|     observe(target: Node, options: MutationObserverInit): void;
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 
@@ -834,14 +834,14 @@ References:
    MutationObserver.js:20:1
     20| o.observe(div); // incorrect
         ^^^^^^^^^^^^^^ [1]
-   <BUILTINS>/bom.js:661:7
-   661|     | { childList: true, ... }
-              ^^^^^^^^^^^^^^^^^^^^^^^^ [2]
    <BUILTINS>/bom.js:662:7
-   662|     | { attributes: true, ... }
-              ^^^^^^^^^^^^^^^^^^^^^^^^^ [3]
+   662|     | { childList: true, ... }
+              ^^^^^^^^^^^^^^^^^^^^^^^^ [2]
    <BUILTINS>/bom.js:663:7
-   663|     | { characterData: true, ... }
+   663|     | { attributes: true, ... }
+              ^^^^^^^^^^^^^^^^^^^^^^^^^ [3]
+   <BUILTINS>/bom.js:664:7
+   664|     | { characterData: true, ... }
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [4]
 
 
@@ -857,14 +857,14 @@ Cannot call `o.observe` with object literal bound to `options` because: [incompa
                        ^^ [1]
 
 References:
-   <BUILTINS>/bom.js:661:7
-   661|     | { childList: true, ... }
-              ^^^^^^^^^^^^^^^^^^^^^^^^ [2]
    <BUILTINS>/bom.js:662:7
-   662|     | { attributes: true, ... }
-              ^^^^^^^^^^^^^^^^^^^^^^^^^ [3]
+   662|     | { childList: true, ... }
+              ^^^^^^^^^^^^^^^^^^^^^^^^ [2]
    <BUILTINS>/bom.js:663:7
-   663|     | { characterData: true, ... }
+   663|     | { attributes: true, ... }
+              ^^^^^^^^^^^^^^^^^^^^^^^^^ [3]
+   <BUILTINS>/bom.js:664:7
+   664|     | { characterData: true, ... }
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [4]
 
 
@@ -880,14 +880,14 @@ Cannot call `o.observe` with object literal bound to `options` because: [incompa
                        ^^^^^^^^^^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/bom.js:661:7
-   661|     | { childList: true, ... }
-              ^^^^^^^^^^^^^^^^^^^^^^^^ [2]
    <BUILTINS>/bom.js:662:7
-   662|     | { attributes: true, ... }
-              ^^^^^^^^^^^^^^^^^^^^^^^^^ [3]
+   662|     | { childList: true, ... }
+              ^^^^^^^^^^^^^^^^^^^^^^^^ [2]
    <BUILTINS>/bom.js:663:7
-   663|     | { characterData: true, ... }
+   663|     | { attributes: true, ... }
+              ^^^^^^^^^^^^^^^^^^^^^^^^^ [3]
+   <BUILTINS>/bom.js:664:7
+   664|     | { characterData: true, ... }
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [4]
 
 
@@ -901,8 +901,8 @@ in property `attributeFilter`. [incompatible-call]
                                                             ^^^^ [1]
 
 References:
-   <BUILTINS>/bom.js:669:21
-   669|   attributeFilter?: Array<string>,
+   <BUILTINS>/bom.js:670:21
+   670|   attributeFilter?: Array<string>,
                             ^^^^^^^^^^^^^ [2]
 
 
@@ -944,8 +944,8 @@ Cannot assign `estimate.usageDetails` to `usageDetails` because undefined [1] is
                 ^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/bom.js:303:19
-   303|   +usageDetails?: StorageManagerUsageDetails;
+   <BUILTINS>/bom.js:304:19
+   304|   +usageDetails?: StorageManagerUsageDetails;
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
    StorageManager.js:11:27
     11|       const usageDetails: { [StorageManagerRegisteredEndpoint]: number } = // incorrect
@@ -961,8 +961,8 @@ Cannot assign `params.get(...)` to `b` because null [1] is incompatible with str
                            ^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/bom.js:1592:24
-   1592|     get(name: string): null | string;
+   <BUILTINS>/bom.js:1593:24
+   1593|     get(name: string): null | string;
                                 ^^^^ [1]
    URLSearchParams.js:8:10
       8| const b: string = params.get('foo'); // incorrect

--- a/tests/dom/dom.exp
+++ b/tests/dom/dom.exp
@@ -7,8 +7,8 @@ Cannot call `ctx.moveTo` with `'0'` bound to `x` because string [1] is incompati
                         ^^^ [1]
 
 References:
-   <BUILTINS>/dom.js:2490:13
-   2490|   moveTo(x: number, y: number): void;
+   <BUILTINS>/dom.js:2497:13
+   2497|   moveTo(x: number, y: number): void;
                      ^^^^^^ [2]
 
 
@@ -21,8 +21,8 @@ Cannot call `ctx.moveTo` with `'1'` bound to `y` because string [1] is incompati
                              ^^^ [1]
 
 References:
-   <BUILTINS>/dom.js:2490:24
-   2490|   moveTo(x: number, y: number): void;
+   <BUILTINS>/dom.js:2497:24
+   2497|   moveTo(x: number, y: number): void;
                                 ^^^^^^ [2]
 
 
@@ -36,8 +36,8 @@ Cannot call `ClipboardEvent` with `'invalid'` bound to `type` because string [1]
                                                     ^^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/dom.js:933:21
-   933|   constructor(type: ClipboardEventTypes, eventInit?: ClipboardEvent$Init): void;
+   <BUILTINS>/dom.js:940:21
+   940|   constructor(type: ClipboardEventTypes, eventInit?: ClipboardEvent$Init): void;
                             ^^^^^^^^^^^^^^^^^^^ [2]
 
 
@@ -51,8 +51,8 @@ object literal [1] but exists in `ClipboardEvent$Init` [2]. [prop-missing]
               ^^ [1]
 
 References:
-   <BUILTINS>/dom.js:933:54
-   933|   constructor(type: ClipboardEventTypes, eventInit?: ClipboardEvent$Init): void;
+   <BUILTINS>/dom.js:940:54
+   940|   constructor(type: ClipboardEventTypes, eventInit?: ClipboardEvent$Init): void;
                                                              ^^^^^^^^^^^^^^^^^^^ [2]
 
 
@@ -70,11 +70,11 @@ Cannot call `ClipboardEvent` with object literal bound to `eventInit` because in
               ---------------------------------------^ [1]
 
 References:
-   <BUILTINS>/dom.js:928:18
-   928|   clipboardData: DataTransfer | null,
+   <BUILTINS>/dom.js:935:18
+   935|   clipboardData: DataTransfer | null,
                          ^^^^^^^^^^^^ [2]
-   <BUILTINS>/dom.js:928:33
-   928|   clipboardData: DataTransfer | null,
+   <BUILTINS>/dom.js:935:33
+   935|   clipboardData: DataTransfer | null,
                                         ^^^^ [3]
 
 
@@ -87,8 +87,8 @@ Cannot call `e.clipboardData.getData` because property `getData` is missing in n
                               ^^^^^^^
 
 References:
-   <BUILTINS>/dom.js:934:19
-   934|   +clipboardData: ?DataTransfer; // readonly
+   <BUILTINS>/dom.js:941:19
+   941|   +clipboardData: ?DataTransfer; // readonly
                           ^^^^^^^^^^^^^ [1]
 
 
@@ -106,11 +106,11 @@ References:
    Element.js:14:40
      14|     element.scrollIntoView({ behavior: 'invalid' });
                                                 ^^^^^^^^^ [1]
-   <BUILTINS>/dom.js:1922:22
-   1922|          behavior?: ('auto' | 'instant' | 'smooth'),
+   <BUILTINS>/dom.js:1929:22
+   1929|          behavior?: ('auto' | 'instant' | 'smooth'),
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [2]
-   <BUILTINS>/dom.js:1921:25
-   1921|   scrollIntoView(arg?: (boolean | {
+   <BUILTINS>/dom.js:1928:25
+   1928|   scrollIntoView(arg?: (boolean | {
                                  ^^^^^^^ [4]
 
 
@@ -128,11 +128,11 @@ References:
    Element.js:15:37
      15|     element.scrollIntoView({ block: 'invalid' });
                                              ^^^^^^^^^ [1]
-   <BUILTINS>/dom.js:1923:19
-   1923|          block?: ('start' | 'center' | 'end' | 'nearest'),
+   <BUILTINS>/dom.js:1930:19
+   1930|          block?: ('start' | 'center' | 'end' | 'nearest'),
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [2]
-   <BUILTINS>/dom.js:1921:25
-   1921|   scrollIntoView(arg?: (boolean | {
+   <BUILTINS>/dom.js:1928:25
+   1928|   scrollIntoView(arg?: (boolean | {
                                  ^^^^^^^ [4]
 
 
@@ -147,17 +147,17 @@ Cannot call `element.scrollIntoView` with `1` bound to `arg` because: [incompati
                                     ^ [1]
 
 References:
-   <BUILTINS>/dom.js:1921:25
-   1921|   scrollIntoView(arg?: (boolean | {
+   <BUILTINS>/dom.js:1928:25
+   1928|   scrollIntoView(arg?: (boolean | {
                                  ^^^^^^^ [2]
-   <BUILTINS>/dom.js:1921:35
+   <BUILTINS>/dom.js:1928:35
                                            v
-   1921|   scrollIntoView(arg?: (boolean | {
-   1922|          behavior?: ('auto' | 'instant' | 'smooth'),
-   1923|          block?: ('start' | 'center' | 'end' | 'nearest'),
-   1924|          inline?: ('start' | 'center' | 'end' | 'nearest'),
-   1925|          ...
-   1926|   })): void;
+   1928|   scrollIntoView(arg?: (boolean | {
+   1929|          behavior?: ('auto' | 'instant' | 'smooth'),
+   1930|          block?: ('start' | 'center' | 'end' | 'nearest'),
+   1931|          inline?: ('start' | 'center' | 'end' | 'nearest'),
+   1932|          ...
+   1933|   })): void;
            ^ [3]
 
 
@@ -170,8 +170,8 @@ Cannot get `el.className` because property `className` is missing in null [1]. [
             ^^^^^^^^^
 
 References:
-   <BUILTINS>/dom.js:1075:56
-   1075|   item(nameOrIndex?: any, optionalIndex?: any): Elem | null;
+   <BUILTINS>/dom.js:1082:56
+   1082|   item(nameOrIndex?: any, optionalIndex?: any): Elem | null;
                                                                 ^^^^ [1]
 
 
@@ -184,8 +184,8 @@ Cannot get `el.className` because property `className` is missing in null [1]. [
             ^^^^^^^^^
 
 References:
-   <BUILTINS>/dom.js:1076:35
-   1076|   namedItem(name: string): Elem | null;
+   <BUILTINS>/dom.js:1083:35
+   1083|   namedItem(name: string): Elem | null;
                                            ^^^^ [1]
 
 
@@ -198,8 +198,8 @@ Cannot call `element.hasAttributes` because no arguments are expected by functio
                                    ^^^^^
 
 References:
-   <BUILTINS>/dom.js:1909:3
-   1909|   hasAttributes(): boolean;
+   <BUILTINS>/dom.js:1916:3
+   1916|   hasAttributes(): boolean;
            ^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 
@@ -217,11 +217,11 @@ References:
    HTMLElement.js:22:39
      22|     element.scrollIntoView({behavior: 'invalid'});
                                                ^^^^^^^^^ [1]
-   <BUILTINS>/dom.js:1922:22
-   1922|          behavior?: ('auto' | 'instant' | 'smooth'),
+   <BUILTINS>/dom.js:1929:22
+   1929|          behavior?: ('auto' | 'instant' | 'smooth'),
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [2]
-   <BUILTINS>/dom.js:1921:25
-   1921|   scrollIntoView(arg?: (boolean | {
+   <BUILTINS>/dom.js:1928:25
+   1928|   scrollIntoView(arg?: (boolean | {
                                  ^^^^^^^ [4]
 
 
@@ -239,11 +239,11 @@ References:
    HTMLElement.js:23:36
      23|     element.scrollIntoView({block: 'invalid'});
                                             ^^^^^^^^^ [1]
-   <BUILTINS>/dom.js:1923:19
-   1923|          block?: ('start' | 'center' | 'end' | 'nearest'),
+   <BUILTINS>/dom.js:1930:19
+   1930|          block?: ('start' | 'center' | 'end' | 'nearest'),
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [2]
-   <BUILTINS>/dom.js:1921:25
-   1921|   scrollIntoView(arg?: (boolean | {
+   <BUILTINS>/dom.js:1928:25
+   1928|   scrollIntoView(arg?: (boolean | {
                                  ^^^^^^^ [4]
 
 
@@ -258,17 +258,17 @@ Cannot call `element.scrollIntoView` with `1` bound to `arg` because: [incompati
                                     ^ [1]
 
 References:
-   <BUILTINS>/dom.js:1921:25
-   1921|   scrollIntoView(arg?: (boolean | {
+   <BUILTINS>/dom.js:1928:25
+   1928|   scrollIntoView(arg?: (boolean | {
                                  ^^^^^^^ [2]
-   <BUILTINS>/dom.js:1921:35
+   <BUILTINS>/dom.js:1928:35
                                            v
-   1921|   scrollIntoView(arg?: (boolean | {
-   1922|          behavior?: ('auto' | 'instant' | 'smooth'),
-   1923|          block?: ('start' | 'center' | 'end' | 'nearest'),
-   1924|          inline?: ('start' | 'center' | 'end' | 'nearest'),
-   1925|          ...
-   1926|   })): void;
+   1928|   scrollIntoView(arg?: (boolean | {
+   1929|          behavior?: ('auto' | 'instant' | 'smooth'),
+   1930|          block?: ('start' | 'center' | 'end' | 'nearest'),
+   1931|          inline?: ('start' | 'center' | 'end' | 'nearest'),
+   1932|          ...
+   1933|   })): void;
            ^ [3]
 
 
@@ -285,11 +285,11 @@ References:
    HTMLElement.js:46:57
      46|     element.getElementsByTagName(str) as HTMLCollection<HTMLAnchorElement>;
                                                                  ^^^^^^^^^^^^^^^^^ [1]
-   <BUILTINS>/dom.js:1852:54
-   1852|   getElementsByTagName(name: string): HTMLCollection<HTMLElement>;
+   <BUILTINS>/dom.js:1859:54
+   1859|   getElementsByTagName(name: string): HTMLCollection<HTMLElement>;
                                                               ^^^^^^^^^^^ [2]
-   <BUILTINS>/dom.js:1072:31
-   1072| declare class HTMLCollection<+Elem: HTMLElement> {
+   <BUILTINS>/dom.js:1079:31
+   1079| declare class HTMLCollection<+Elem: HTMLElement> {
                                        ^^^^ [3]
 
 
@@ -310,11 +310,11 @@ References:
    HTMLElement.js:50:25
      50|     ) as HTMLCollection<HTMLAnchorElement>;
                                  ^^^^^^^^^^^^^^^^^ [1]
-   <BUILTINS>/dom.js:1906:90
-   1906|   getElementsByTagNameNS(namespaceURI: string | null, localName: string): HTMLCollection<HTMLElement>;
+   <BUILTINS>/dom.js:1913:90
+   1913|   getElementsByTagNameNS(namespaceURI: string | null, localName: string): HTMLCollection<HTMLElement>;
                                                                                                   ^^^^^^^^^^^ [2]
-   <BUILTINS>/dom.js:1072:31
-   1072| declare class HTMLCollection<+Elem: HTMLElement> {
+   <BUILTINS>/dom.js:1079:31
+   1079| declare class HTMLCollection<+Elem: HTMLElement> {
                                        ^^^^ [3]
 
 
@@ -329,8 +329,8 @@ Cannot cast `element.querySelector(...)` to union type because: [incompatible-ca
              ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/dom.js:2012:36
-   2012|   querySelector(selector: string): HTMLElement | null;
+   <BUILTINS>/dom.js:2019:36
+   2019|   querySelector(selector: string): HTMLElement | null;
                                             ^^^^^^^^^^^ [1]
    HTMLElement.js:51:35
      51|     element.querySelector(str) as HTMLAnchorElement | null;
@@ -353,11 +353,11 @@ References:
    HTMLElement.js:52:47
      52|     element.querySelectorAll(str) as NodeList<HTMLAnchorElement>;
                                                        ^^^^^^^^^^^^^^^^^ [1]
-   <BUILTINS>/dom.js:2076:48
-   2076|   querySelectorAll(selector: string): NodeList<HTMLElement>;
+   <BUILTINS>/dom.js:2083:48
+   2083|   querySelectorAll(selector: string): NodeList<HTMLElement>;
                                                         ^^^^^^^^^^^ [2]
-   <BUILTINS>/dom.js:1036:24
-   1036| declare class NodeList<T> {
+   <BUILTINS>/dom.js:1043:24
+   1043| declare class NodeList<T> {
                                 ^ [3]
 
 
@@ -374,11 +374,11 @@ References:
    HTMLElement.js:55:59
      55|     element.getElementsByTagName('div') as HTMLCollection<HTMLAnchorElement>;
                                                                    ^^^^^^^^^^^^^^^^^ [1]
-   <BUILTINS>/dom.js:1811:53
-   1811|   getElementsByTagName(name: 'div'): HTMLCollection<HTMLDivElement>;
+   <BUILTINS>/dom.js:1818:53
+   1818|   getElementsByTagName(name: 'div'): HTMLCollection<HTMLDivElement>;
                                                              ^^^^^^^^^^^^^^ [2]
-   <BUILTINS>/dom.js:1072:31
-   1072| declare class HTMLCollection<+Elem: HTMLElement> {
+   <BUILTINS>/dom.js:1079:31
+   1079| declare class HTMLCollection<+Elem: HTMLElement> {
                                        ^^^^ [3]
 
 
@@ -399,11 +399,11 @@ References:
    HTMLElement.js:59:25
      59|     ) as HTMLCollection<HTMLAnchorElement>;
                                  ^^^^^^^^^^^^^^^^^ [1]
-   <BUILTINS>/dom.js:1865:89
-   1865|   getElementsByTagNameNS(namespaceURI: string | null, localName: 'div'): HTMLCollection<HTMLDivElement>;
+   <BUILTINS>/dom.js:1872:89
+   1872|   getElementsByTagNameNS(namespaceURI: string | null, localName: 'div'): HTMLCollection<HTMLDivElement>;
                                                                                                  ^^^^^^^^^^^^^^ [2]
-   <BUILTINS>/dom.js:1072:31
-   1072| declare class HTMLCollection<+Elem: HTMLElement> {
+   <BUILTINS>/dom.js:1079:31
+   1079| declare class HTMLCollection<+Elem: HTMLElement> {
                                        ^^^^ [3]
 
 
@@ -418,8 +418,8 @@ Cannot cast `element.querySelector(...)` to union type because: [incompatible-ca
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/dom.js:1965:35
-   1965|   querySelector(selector: 'div'): HTMLDivElement | null;
+   <BUILTINS>/dom.js:1972:35
+   1972|   querySelector(selector: 'div'): HTMLDivElement | null;
                                            ^^^^^^^^^^^^^^ [1]
    HTMLElement.js:60:37
      60|     element.querySelector('div') as HTMLAnchorElement | null;
@@ -442,11 +442,11 @@ References:
    HTMLElement.js:61:49
      61|     element.querySelectorAll('div') as NodeList<HTMLAnchorElement>;
                                                          ^^^^^^^^^^^^^^^^^ [1]
-   <BUILTINS>/dom.js:2029:47
-   2029|   querySelectorAll(selector: 'div'): NodeList<HTMLDivElement>;
+   <BUILTINS>/dom.js:2036:47
+   2036|   querySelectorAll(selector: 'div'): NodeList<HTMLDivElement>;
                                                        ^^^^^^^^^^^^^^ [2]
-   <BUILTINS>/dom.js:1036:24
-   1036| declare class NodeList<T> {
+   <BUILTINS>/dom.js:1043:24
+   1043| declare class NodeList<T> {
                                 ^ [3]
 
 
@@ -460,8 +460,8 @@ in property `preventScroll`. [incompatible-call]
                                            ^^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/dom.js:1733:39
-   1733| type FocusOptions = { preventScroll?: boolean, ... }
+   <BUILTINS>/dom.js:1740:39
+   1740| type FocusOptions = { preventScroll?: boolean, ... }
                                                ^^^^^^^ [2]
 
 
@@ -475,8 +475,8 @@ Cannot call `element.focus` with `1` bound to `options` because number [1] is in
                            ^ [1]
 
 References:
-   <BUILTINS>/dom.js:2088:19
-   2088|   focus(options?: FocusOptions): void;
+   <BUILTINS>/dom.js:2095:19
+   2095|   focus(options?: FocusOptions): void;
                            ^^^^^^^^^^^^ [2]
 
 
@@ -489,8 +489,8 @@ Cannot get `el.className` because property `className` is missing in null [1]. [
             ^^^^^^^^^
 
 References:
-   <BUILTINS>/dom.js:3422:43
-   3422|   [index: number | string]: HTMLElement | null;
+   <BUILTINS>/dom.js:3429:43
+   3429|   [index: number | string]: HTMLElement | null;
                                                    ^^^^ [1]
 
 
@@ -503,8 +503,8 @@ Cannot get `el.className` because property `className` is missing in null [1]. [
             ^^^^^^^^^
 
 References:
-   <BUILTINS>/dom.js:3422:43
-   3422|   [index: number | string]: HTMLElement | null;
+   <BUILTINS>/dom.js:3429:43
+   3429|   [index: number | string]: HTMLElement | null;
                                                    ^^^^ [1]
 
 
@@ -522,11 +522,11 @@ References:
    HTMLInputElement.js:7:28
       7|     el.setRangeText('foo', 123); // end is required
                                     ^^^ [1]
-   <BUILTINS>/dom.js:3815:45
-   3815|   setRangeText(replacement: string, start?: void, end?: void, selectMode?: void): void;
+   <BUILTINS>/dom.js:3822:45
+   3822|   setRangeText(replacement: string, start?: void, end?: void, selectMode?: void): void;
                                                      ^^^^ [2]
-   <BUILTINS>/dom.js:3816:3
-   3816|   setRangeText(replacement: string, start: number, end: number, selectMode?: SelectionMode): void;
+   <BUILTINS>/dom.js:3823:3
+   3823|   setRangeText(replacement: string, start: number, end: number, selectMode?: SelectionMode): void;
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [3]
    HTMLInputElement.js:7:5
       7|     el.setRangeText('foo', 123); // end is required
@@ -547,14 +547,14 @@ References:
    HTMLInputElement.js:10:38
      10|     el.setRangeText('foo', 123, 234, 'bogus'); // invalid value
                                               ^^^^^^^ [1]
-   <BUILTINS>/dom.js:3816:78
-   3816|   setRangeText(replacement: string, start: number, end: number, selectMode?: SelectionMode): void;
+   <BUILTINS>/dom.js:3823:78
+   3823|   setRangeText(replacement: string, start: number, end: number, selectMode?: SelectionMode): void;
                                                                                       ^^^^^^^^^^^^^ [2]
    HTMLInputElement.js:10:28
      10|     el.setRangeText('foo', 123, 234, 'bogus'); // invalid value
                                     ^^^ [3]
-   <BUILTINS>/dom.js:3815:45
-   3815|   setRangeText(replacement: string, start?: void, end?: void, selectMode?: void): void;
+   <BUILTINS>/dom.js:3822:45
+   3822|   setRangeText(replacement: string, start?: void, end?: void, selectMode?: void): void;
                                                      ^^^^ [4]
 
 
@@ -567,8 +567,8 @@ Cannot get `form.action` because property `action` is missing in null [1]. [inco
               ^^^^^^
 
 References:
-   <BUILTINS>/dom.js:3882:27
-   3882|   form: HTMLFormElement | null;
+   <BUILTINS>/dom.js:3889:27
+   3889|   form: HTMLFormElement | null;
                                    ^^^^ [1]
 
 
@@ -581,8 +581,8 @@ Cannot get `item.value` because property `value` is missing in null [1]. [incomp
               ^^^^^
 
 References:
-   <BUILTINS>/dom.js:3900:44
-   3900|   item(index: number): HTMLOptionElement | null;
+   <BUILTINS>/dom.js:3907:44
+   3907|   item(index: number): HTMLOptionElement | null;
                                                     ^^^^ [1]
 
 
@@ -595,8 +595,8 @@ Cannot get `item.value` because property `value` is missing in null [1]. [incomp
               ^^^^^
 
 References:
-   <BUILTINS>/dom.js:3901:48
-   3901|   namedItem(name: string): HTMLOptionElement | null;
+   <BUILTINS>/dom.js:3908:48
+   3908|   namedItem(name: string): HTMLOptionElement | null;
                                                         ^^^^ [1]
 
 
@@ -611,11 +611,11 @@ Cannot get `attributes[null]` because: [incompatible-type]
                         ^^^^ [1]
 
 References:
-   <BUILTINS>/dom.js:1053:11
-   1053|   [index: number | string]: Attr;
+   <BUILTINS>/dom.js:1060:11
+   1060|   [index: number | string]: Attr;
                    ^^^^^^ [2]
-   <BUILTINS>/dom.js:1053:20
-   1053|   [index: number | string]: Attr;
+   <BUILTINS>/dom.js:1060:20
+   1060|   [index: number | string]: Attr;
                             ^^^^^^ [3]
 
 
@@ -630,11 +630,11 @@ Cannot get `attributes[{...}]` because: [incompatible-type]
                         ^^ [1]
 
 References:
-   <BUILTINS>/dom.js:1053:11
-   1053|   [index: number | string]: Attr;
+   <BUILTINS>/dom.js:1060:11
+   1060|   [index: number | string]: Attr;
                    ^^^^^^ [2]
-   <BUILTINS>/dom.js:1053:20
-   1053|   [index: number | string]: Attr;
+   <BUILTINS>/dom.js:1060:20
+   1060|   [index: number | string]: Attr;
                             ^^^^^^ [3]
 
 
@@ -665,11 +665,11 @@ Cannot assign `true` to `root.innerHTML` because: [incompatible-type]
                              ^^^^ [1]
 
 References:
-   <BUILTINS>/dom.js:158:24
-   158|   set innerHTML(value: string | TrustedHTML): void;
+   <BUILTINS>/dom.js:165:24
+   165|   set innerHTML(value: string | TrustedHTML): void;
                                ^^^^^^ [2]
-   <BUILTINS>/dom.js:158:33
-   158|   set innerHTML(value: string | TrustedHTML): void;
+   <BUILTINS>/dom.js:165:33
+   165|   set innerHTML(value: string | TrustedHTML): void;
                                         ^^^^^^^^^^^ [3]
 
 
@@ -704,8 +704,8 @@ Cannot call `target.attachEvent` because undefined [1] is not a function. [not-a
                    ^^^^^^^^^^^
 
 References:
-   <BUILTINS>/dom.js:308:17
-   308|   attachEvent?: (type: string, listener: EventListener) => void;
+   <BUILTINS>/dom.js:315:17
+   315|   attachEvent?: (type: string, listener: EventListener) => void;
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 
@@ -718,8 +718,8 @@ Cannot call `target.detachEvent` because undefined [1] is not a function. [not-a
                    ^^^^^^^^^^^
 
 References:
-   <BUILTINS>/dom.js:327:17
-   327|   detachEvent?: (type: string, listener: EventListener) => void;
+   <BUILTINS>/dom.js:334:17
+   334|   detachEvent?: (type: string, listener: EventListener) => void;
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 
@@ -746,11 +746,11 @@ References:
    path2d.js:16:32
      16|     path.arcTo(0, 0, 0, 0, 10, '20', 5) as void; // invalid
                                         ^^^^ [1]
-   <BUILTINS>/dom.js:2347:83
-   2347|   arcTo(x1: number, y1: number, x2: number, y2: number, radiusX: number, radiusY: number, rotation: number): void;
+   <BUILTINS>/dom.js:2354:83
+   2354|   arcTo(x1: number, y1: number, x2: number, y2: number, radiusX: number, radiusY: number, rotation: number): void;
                                                                                            ^^^^^^ [2]
-   <BUILTINS>/dom.js:2346:76
-   2346|   arcTo(x1: number, y1: number, x2: number, y2: number, radius: number, _: void, _: void): void;
+   <BUILTINS>/dom.js:2353:76
+   2353|   arcTo(x1: number, y1: number, x2: number, y2: number, radius: number, _: void, _: void): void;
                                                                                     ^^^^ [3]
 
 
@@ -764,8 +764,8 @@ null [2] in the second parameter of property `prototype.attributeChangedCallback
                            ^^^^^^ [1]
 
 References:
-   <BUILTINS>/dom.js:1093:36
-   1093|                 oldAttributeValue: null,
+   <BUILTINS>/dom.js:1100:36
+   1100|                 oldAttributeValue: null,
                                             ^^^^ [2]
 
 
@@ -779,8 +779,8 @@ null [2] in the third parameter of property `prototype.attributeChangedCallback`
                            ^^^^^^ [1]
 
 References:
-   <BUILTINS>/dom.js:1108:36
-   1108|                 newAttributeValue: null,
+   <BUILTINS>/dom.js:1115:36
+   1115|                 newAttributeValue: null,
                                             ^^^^ [2]
 
 
@@ -798,11 +798,11 @@ References:
    traversal.js:29:33
      29|     document.createNodeIterator({}); // invalid
                                          ^^ [1]
-   <BUILTINS>/dom.js:1642:33
-   1642|   createNodeIterator<RootNodeT: Node>(root: RootNodeT, whatToShow?: number, filter?: NodeFilterInterface): NodeIterator<RootNodeT, Node>;
+   <BUILTINS>/dom.js:1649:33
+   1649|   createNodeIterator<RootNodeT: Node>(root: RootNodeT, whatToShow?: number, filter?: NodeFilterInterface): NodeIterator<RootNodeT, Node>;
                                          ^^^^ [2]
-   <BUILTINS>/dom.js:1631:3
-   1631|   createNodeIterator<RootNodeT: Node>(root: RootNodeT, whatToShow: 133, filter?: NodeFilterInterface): NodeIterator<RootNodeT, Text|Element|Comment>;
+   <BUILTINS>/dom.js:1638:3
+   1638|   createNodeIterator<RootNodeT: Node>(root: RootNodeT, whatToShow: 133, filter?: NodeFilterInterface): NodeIterator<RootNodeT, Text|Element|Comment>;
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [3]
    traversal.js:29:5
      29|     document.createNodeIterator({}); // invalid
@@ -823,11 +823,11 @@ References:
    traversal.js:33:31
      33|     document.createTreeWalker({}); // invalid
                                        ^^ [1]
-   <BUILTINS>/dom.js:1643:31
-   1643|   createTreeWalker<RootNodeT: Node>(root: RootNodeT, whatToShow?: number, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, Node>;
+   <BUILTINS>/dom.js:1650:31
+   1650|   createTreeWalker<RootNodeT: Node>(root: RootNodeT, whatToShow?: number, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, Node>;
                                        ^^^^ [2]
-   <BUILTINS>/dom.js:1638:3
-   1638|   createTreeWalker<RootNodeT: Node>(root: RootNodeT, whatToShow: 133, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, Text|Element|Comment>;
+   <BUILTINS>/dom.js:1645:3
+   1645|   createTreeWalker<RootNodeT: Node>(root: RootNodeT, whatToShow: 133, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, Text|Element|Comment>;
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [3]
    traversal.js:33:5
      33|     document.createTreeWalker({}); // invalid
@@ -886,125 +886,125 @@ References:
    traversal.js:186:48
     186|     document.createNodeIterator(document_body, -1, node => 'accept'); // invalid
                                                         ^^ [1]
-   <BUILTINS>/dom.js:1546:68
-   1546|   createNodeIterator<RootNodeT: Attr>(root: RootNodeT, whatToShow: 2, filter?: NodeFilterInterface): NodeIterator<RootNodeT, Attr>;
+   <BUILTINS>/dom.js:1553:68
+   1553|   createNodeIterator<RootNodeT: Attr>(root: RootNodeT, whatToShow: 2, filter?: NodeFilterInterface): NodeIterator<RootNodeT, Attr>;
                                                                             ^ [2]
-   <BUILTINS>/dom.js:1554:72
-   1554|   createNodeIterator<RootNodeT: Document>(root: RootNodeT, whatToShow: 256, filter?: NodeFilterInterface): NodeIterator<RootNodeT, Document>;
-                                                                                ^^^ [3]
-   <BUILTINS>/dom.js:1555:72
-   1555|   createNodeIterator<RootNodeT: Document>(root: RootNodeT, whatToShow: 257, filter?: NodeFilterInterface): NodeIterator<RootNodeT, Document|Element>;
-                                                                                ^^^ [4]
-   <BUILTINS>/dom.js:1556:72
-   1556|   createNodeIterator<RootNodeT: Document>(root: RootNodeT, whatToShow: 260, filter?: NodeFilterInterface): NodeIterator<RootNodeT, Document|Text>;
-                                                                                ^^^ [5]
-   <BUILTINS>/dom.js:1557:72
-   1557|   createNodeIterator<RootNodeT: Document>(root: RootNodeT, whatToShow: 261, filter?: NodeFilterInterface): NodeIterator<RootNodeT, Document|Element|Text>;
-                                                                                ^^^ [6]
-   <BUILTINS>/dom.js:1558:72
-   1558|   createNodeIterator<RootNodeT: Document>(root: RootNodeT, whatToShow: 384, filter?: NodeFilterInterface): NodeIterator<RootNodeT, Document|Comment>;
-                                                                                ^^^ [7]
-   <BUILTINS>/dom.js:1559:72
-   1559|   createNodeIterator<RootNodeT: Document>(root: RootNodeT, whatToShow: 385, filter?: NodeFilterInterface): NodeIterator<RootNodeT, Document|Element|Comment>;
-                                                                                ^^^ [8]
-   <BUILTINS>/dom.js:1560:72
-   1560|   createNodeIterator<RootNodeT: Document>(root: RootNodeT, whatToShow: 388, filter?: NodeFilterInterface): NodeIterator<RootNodeT, Document|Text|Comment>;
-                                                                                ^^^ [9]
    <BUILTINS>/dom.js:1561:72
-   1561|   createNodeIterator<RootNodeT: Document>(root: RootNodeT, whatToShow: 389, filter?: NodeFilterInterface): NodeIterator<RootNodeT, Document|Element|Text|Comment>;
-                                                                                ^^^ [10]
+   1561|   createNodeIterator<RootNodeT: Document>(root: RootNodeT, whatToShow: 256, filter?: NodeFilterInterface): NodeIterator<RootNodeT, Document>;
+                                                                                ^^^ [3]
    <BUILTINS>/dom.js:1562:72
-   1562|   createNodeIterator<RootNodeT: Document>(root: RootNodeT, whatToShow: 512, filter?: NodeFilterInterface): NodeIterator<RootNodeT, DocumentType>;
-                                                                                ^^^ [11]
+   1562|   createNodeIterator<RootNodeT: Document>(root: RootNodeT, whatToShow: 257, filter?: NodeFilterInterface): NodeIterator<RootNodeT, Document|Element>;
+                                                                                ^^^ [4]
    <BUILTINS>/dom.js:1563:72
-   1563|   createNodeIterator<RootNodeT: Document>(root: RootNodeT, whatToShow: 513, filter?: NodeFilterInterface): NodeIterator<RootNodeT, DocumentType|Element>;
-                                                                                ^^^ [12]
+   1563|   createNodeIterator<RootNodeT: Document>(root: RootNodeT, whatToShow: 260, filter?: NodeFilterInterface): NodeIterator<RootNodeT, Document|Text>;
+                                                                                ^^^ [5]
    <BUILTINS>/dom.js:1564:72
-   1564|   createNodeIterator<RootNodeT: Document>(root: RootNodeT, whatToShow: 516, filter?: NodeFilterInterface): NodeIterator<RootNodeT, DocumentType|Text>;
-                                                                                ^^^ [13]
+   1564|   createNodeIterator<RootNodeT: Document>(root: RootNodeT, whatToShow: 261, filter?: NodeFilterInterface): NodeIterator<RootNodeT, Document|Element|Text>;
+                                                                                ^^^ [6]
    <BUILTINS>/dom.js:1565:72
-   1565|   createNodeIterator<RootNodeT: Document>(root: RootNodeT, whatToShow: 517, filter?: NodeFilterInterface): NodeIterator<RootNodeT, DocumentType|Element|Text>;
-                                                                                ^^^ [14]
+   1565|   createNodeIterator<RootNodeT: Document>(root: RootNodeT, whatToShow: 384, filter?: NodeFilterInterface): NodeIterator<RootNodeT, Document|Comment>;
+                                                                                ^^^ [7]
    <BUILTINS>/dom.js:1566:72
-   1566|   createNodeIterator<RootNodeT: Document>(root: RootNodeT, whatToShow: 640, filter?: NodeFilterInterface): NodeIterator<RootNodeT, DocumentType|Comment>;
-                                                                                ^^^ [15]
+   1566|   createNodeIterator<RootNodeT: Document>(root: RootNodeT, whatToShow: 385, filter?: NodeFilterInterface): NodeIterator<RootNodeT, Document|Element|Comment>;
+                                                                                ^^^ [8]
    <BUILTINS>/dom.js:1567:72
-   1567|   createNodeIterator<RootNodeT: Document>(root: RootNodeT, whatToShow: 641, filter?: NodeFilterInterface): NodeIterator<RootNodeT, DocumentType|Element|Comment>;
-                                                                                ^^^ [16]
+   1567|   createNodeIterator<RootNodeT: Document>(root: RootNodeT, whatToShow: 388, filter?: NodeFilterInterface): NodeIterator<RootNodeT, Document|Text|Comment>;
+                                                                                ^^^ [9]
    <BUILTINS>/dom.js:1568:72
-   1568|   createNodeIterator<RootNodeT: Document>(root: RootNodeT, whatToShow: 644, filter?: NodeFilterInterface): NodeIterator<RootNodeT, DocumentType|Text|Comment>;
-                                                                                ^^^ [17]
+   1568|   createNodeIterator<RootNodeT: Document>(root: RootNodeT, whatToShow: 389, filter?: NodeFilterInterface): NodeIterator<RootNodeT, Document|Element|Text|Comment>;
+                                                                                ^^^ [10]
    <BUILTINS>/dom.js:1569:72
-   1569|   createNodeIterator<RootNodeT: Document>(root: RootNodeT, whatToShow: 645, filter?: NodeFilterInterface): NodeIterator<RootNodeT, DocumentType|Element|Text|Comment>;
-                                                                                ^^^ [18]
+   1569|   createNodeIterator<RootNodeT: Document>(root: RootNodeT, whatToShow: 512, filter?: NodeFilterInterface): NodeIterator<RootNodeT, DocumentType>;
+                                                                                ^^^ [11]
    <BUILTINS>/dom.js:1570:72
-   1570|   createNodeIterator<RootNodeT: Document>(root: RootNodeT, whatToShow: 768, filter?: NodeFilterInterface): NodeIterator<RootNodeT, DocumentType|Document>;
-                                                                                ^^^ [19]
+   1570|   createNodeIterator<RootNodeT: Document>(root: RootNodeT, whatToShow: 513, filter?: NodeFilterInterface): NodeIterator<RootNodeT, DocumentType|Element>;
+                                                                                ^^^ [12]
    <BUILTINS>/dom.js:1571:72
-   1571|   createNodeIterator<RootNodeT: Document>(root: RootNodeT, whatToShow: 769, filter?: NodeFilterInterface): NodeIterator<RootNodeT, DocumentType|Document|Element>;
-                                                                                ^^^ [20]
+   1571|   createNodeIterator<RootNodeT: Document>(root: RootNodeT, whatToShow: 516, filter?: NodeFilterInterface): NodeIterator<RootNodeT, DocumentType|Text>;
+                                                                                ^^^ [13]
    <BUILTINS>/dom.js:1572:72
-   1572|   createNodeIterator<RootNodeT: Document>(root: RootNodeT, whatToShow: 772, filter?: NodeFilterInterface): NodeIterator<RootNodeT, DocumentType|Document|Text>;
-                                                                                ^^^ [21]
+   1572|   createNodeIterator<RootNodeT: Document>(root: RootNodeT, whatToShow: 517, filter?: NodeFilterInterface): NodeIterator<RootNodeT, DocumentType|Element|Text>;
+                                                                                ^^^ [14]
    <BUILTINS>/dom.js:1573:72
-   1573|   createNodeIterator<RootNodeT: Document>(root: RootNodeT, whatToShow: 773, filter?: NodeFilterInterface): NodeIterator<RootNodeT, DocumentType|Document|Element|Text>;
-                                                                                ^^^ [22]
+   1573|   createNodeIterator<RootNodeT: Document>(root: RootNodeT, whatToShow: 640, filter?: NodeFilterInterface): NodeIterator<RootNodeT, DocumentType|Comment>;
+                                                                                ^^^ [15]
    <BUILTINS>/dom.js:1574:72
-   1574|   createNodeIterator<RootNodeT: Document>(root: RootNodeT, whatToShow: 896, filter?: NodeFilterInterface): NodeIterator<RootNodeT, DocumentType|Document|Comment>;
-                                                                                ^^^ [23]
+   1574|   createNodeIterator<RootNodeT: Document>(root: RootNodeT, whatToShow: 641, filter?: NodeFilterInterface): NodeIterator<RootNodeT, DocumentType|Element|Comment>;
+                                                                                ^^^ [16]
    <BUILTINS>/dom.js:1575:72
-   1575|   createNodeIterator<RootNodeT: Document>(root: RootNodeT, whatToShow: 897, filter?: NodeFilterInterface): NodeIterator<RootNodeT, DocumentType|Document|Element|Comment>;
-                                                                                ^^^ [24]
+   1575|   createNodeIterator<RootNodeT: Document>(root: RootNodeT, whatToShow: 644, filter?: NodeFilterInterface): NodeIterator<RootNodeT, DocumentType|Text|Comment>;
+                                                                                ^^^ [17]
    <BUILTINS>/dom.js:1576:72
-   1576|   createNodeIterator<RootNodeT: Document>(root: RootNodeT, whatToShow: 900, filter?: NodeFilterInterface): NodeIterator<RootNodeT, DocumentType|Document|Text|Comment>;
-                                                                                ^^^ [25]
+   1576|   createNodeIterator<RootNodeT: Document>(root: RootNodeT, whatToShow: 645, filter?: NodeFilterInterface): NodeIterator<RootNodeT, DocumentType|Element|Text|Comment>;
+                                                                                ^^^ [18]
    <BUILTINS>/dom.js:1577:72
-   1577|   createNodeIterator<RootNodeT: Document>(root: RootNodeT, whatToShow: 901, filter?: NodeFilterInterface): NodeIterator<RootNodeT, DocumentType|Document|Element|Text|Comment>;
+   1577|   createNodeIterator<RootNodeT: Document>(root: RootNodeT, whatToShow: 768, filter?: NodeFilterInterface): NodeIterator<RootNodeT, DocumentType|Document>;
+                                                                                ^^^ [19]
+   <BUILTINS>/dom.js:1578:72
+   1578|   createNodeIterator<RootNodeT: Document>(root: RootNodeT, whatToShow: 769, filter?: NodeFilterInterface): NodeIterator<RootNodeT, DocumentType|Document|Element>;
+                                                                                ^^^ [20]
+   <BUILTINS>/dom.js:1579:72
+   1579|   createNodeIterator<RootNodeT: Document>(root: RootNodeT, whatToShow: 772, filter?: NodeFilterInterface): NodeIterator<RootNodeT, DocumentType|Document|Text>;
+                                                                                ^^^ [21]
+   <BUILTINS>/dom.js:1580:72
+   1580|   createNodeIterator<RootNodeT: Document>(root: RootNodeT, whatToShow: 773, filter?: NodeFilterInterface): NodeIterator<RootNodeT, DocumentType|Document|Element|Text>;
+                                                                                ^^^ [22]
+   <BUILTINS>/dom.js:1581:72
+   1581|   createNodeIterator<RootNodeT: Document>(root: RootNodeT, whatToShow: 896, filter?: NodeFilterInterface): NodeIterator<RootNodeT, DocumentType|Document|Comment>;
+                                                                                ^^^ [23]
+   <BUILTINS>/dom.js:1582:72
+   1582|   createNodeIterator<RootNodeT: Document>(root: RootNodeT, whatToShow: 897, filter?: NodeFilterInterface): NodeIterator<RootNodeT, DocumentType|Document|Element|Comment>;
+                                                                                ^^^ [24]
+   <BUILTINS>/dom.js:1583:72
+   1583|   createNodeIterator<RootNodeT: Document>(root: RootNodeT, whatToShow: 900, filter?: NodeFilterInterface): NodeIterator<RootNodeT, DocumentType|Document|Text|Comment>;
+                                                                                ^^^ [25]
+   <BUILTINS>/dom.js:1584:72
+   1584|   createNodeIterator<RootNodeT: Document>(root: RootNodeT, whatToShow: 901, filter?: NodeFilterInterface): NodeIterator<RootNodeT, DocumentType|Document|Element|Text|Comment>;
                                                                                 ^^^ [26]
-   <BUILTINS>/dom.js:1605:80
-   1605|   createNodeIterator<RootNodeT: DocumentFragment>(root: RootNodeT, whatToShow: 1024, filter?: NodeFilterInterface): NodeIterator<RootNodeT, DocumentFragment>;
-                                                                                        ^^^^ [27]
-   <BUILTINS>/dom.js:1606:80
-   1606|   createNodeIterator<RootNodeT: DocumentFragment>(root: RootNodeT, whatToShow: 1025, filter?: NodeFilterInterface): NodeIterator<RootNodeT, DocumentFragment|Element>;
-                                                                                        ^^^^ [28]
-   <BUILTINS>/dom.js:1607:80
-   1607|   createNodeIterator<RootNodeT: DocumentFragment>(root: RootNodeT, whatToShow: 1028, filter?: NodeFilterInterface): NodeIterator<RootNodeT, DocumentFragment|Text>;
-                                                                                        ^^^^ [29]
-   <BUILTINS>/dom.js:1608:80
-   1608|   createNodeIterator<RootNodeT: DocumentFragment>(root: RootNodeT, whatToShow: 1029, filter?: NodeFilterInterface): NodeIterator<RootNodeT, DocumentFragment|Element|Text>;
-                                                                                        ^^^^ [30]
-   <BUILTINS>/dom.js:1609:80
-   1609|   createNodeIterator<RootNodeT: DocumentFragment>(root: RootNodeT, whatToShow: 1152, filter?: NodeFilterInterface): NodeIterator<RootNodeT, DocumentFragment|Comment>;
-                                                                                        ^^^^ [31]
-   <BUILTINS>/dom.js:1610:80
-   1610|   createNodeIterator<RootNodeT: DocumentFragment>(root: RootNodeT, whatToShow: 1153, filter?: NodeFilterInterface): NodeIterator<RootNodeT, DocumentFragment|Element|Comment>;
-                                                                                        ^^^^ [32]
-   <BUILTINS>/dom.js:1611:80
-   1611|   createNodeIterator<RootNodeT: DocumentFragment>(root: RootNodeT, whatToShow: 1156, filter?: NodeFilterInterface): NodeIterator<RootNodeT, DocumentFragment|Text|Comment>;
-                                                                                        ^^^^ [33]
    <BUILTINS>/dom.js:1612:80
-   1612|   createNodeIterator<RootNodeT: DocumentFragment>(root: RootNodeT, whatToShow: 1157, filter?: NodeFilterInterface): NodeIterator<RootNodeT, DocumentFragment|Element|Text|Comment>;
+   1612|   createNodeIterator<RootNodeT: DocumentFragment>(root: RootNodeT, whatToShow: 1024, filter?: NodeFilterInterface): NodeIterator<RootNodeT, DocumentFragment>;
+                                                                                        ^^^^ [27]
+   <BUILTINS>/dom.js:1613:80
+   1613|   createNodeIterator<RootNodeT: DocumentFragment>(root: RootNodeT, whatToShow: 1025, filter?: NodeFilterInterface): NodeIterator<RootNodeT, DocumentFragment|Element>;
+                                                                                        ^^^^ [28]
+   <BUILTINS>/dom.js:1614:80
+   1614|   createNodeIterator<RootNodeT: DocumentFragment>(root: RootNodeT, whatToShow: 1028, filter?: NodeFilterInterface): NodeIterator<RootNodeT, DocumentFragment|Text>;
+                                                                                        ^^^^ [29]
+   <BUILTINS>/dom.js:1615:80
+   1615|   createNodeIterator<RootNodeT: DocumentFragment>(root: RootNodeT, whatToShow: 1029, filter?: NodeFilterInterface): NodeIterator<RootNodeT, DocumentFragment|Element|Text>;
+                                                                                        ^^^^ [30]
+   <BUILTINS>/dom.js:1616:80
+   1616|   createNodeIterator<RootNodeT: DocumentFragment>(root: RootNodeT, whatToShow: 1152, filter?: NodeFilterInterface): NodeIterator<RootNodeT, DocumentFragment|Comment>;
+                                                                                        ^^^^ [31]
+   <BUILTINS>/dom.js:1617:80
+   1617|   createNodeIterator<RootNodeT: DocumentFragment>(root: RootNodeT, whatToShow: 1153, filter?: NodeFilterInterface): NodeIterator<RootNodeT, DocumentFragment|Element|Comment>;
+                                                                                        ^^^^ [32]
+   <BUILTINS>/dom.js:1618:80
+   1618|   createNodeIterator<RootNodeT: DocumentFragment>(root: RootNodeT, whatToShow: 1156, filter?: NodeFilterInterface): NodeIterator<RootNodeT, DocumentFragment|Text|Comment>;
+                                                                                        ^^^^ [33]
+   <BUILTINS>/dom.js:1619:80
+   1619|   createNodeIterator<RootNodeT: DocumentFragment>(root: RootNodeT, whatToShow: 1157, filter?: NodeFilterInterface): NodeIterator<RootNodeT, DocumentFragment|Element|Text|Comment>;
                                                                                         ^^^^ [34]
-   <BUILTINS>/dom.js:1625:68
-   1625|   createNodeIterator<RootNodeT: Node>(root: RootNodeT, whatToShow: 1, filter?: NodeFilterInterface): NodeIterator<RootNodeT, Element>;
+   <BUILTINS>/dom.js:1632:68
+   1632|   createNodeIterator<RootNodeT: Node>(root: RootNodeT, whatToShow: 1, filter?: NodeFilterInterface): NodeIterator<RootNodeT, Element>;
                                                                             ^ [35]
-   <BUILTINS>/dom.js:1626:68
-   1626|   createNodeIterator<RootNodeT: Node>(root: RootNodeT, whatToShow: 4, filter?: NodeFilterInterface): NodeIterator<RootNodeT, Text>;
+   <BUILTINS>/dom.js:1633:68
+   1633|   createNodeIterator<RootNodeT: Node>(root: RootNodeT, whatToShow: 4, filter?: NodeFilterInterface): NodeIterator<RootNodeT, Text>;
                                                                             ^ [36]
-   <BUILTINS>/dom.js:1627:68
-   1627|   createNodeIterator<RootNodeT: Node>(root: RootNodeT, whatToShow: 5, filter?: NodeFilterInterface): NodeIterator<RootNodeT, Element|Text>;
+   <BUILTINS>/dom.js:1634:68
+   1634|   createNodeIterator<RootNodeT: Node>(root: RootNodeT, whatToShow: 5, filter?: NodeFilterInterface): NodeIterator<RootNodeT, Element|Text>;
                                                                             ^ [37]
-   <BUILTINS>/dom.js:1628:68
-   1628|   createNodeIterator<RootNodeT: Node>(root: RootNodeT, whatToShow: 128, filter?: NodeFilterInterface): NodeIterator<RootNodeT, Comment>;
+   <BUILTINS>/dom.js:1635:68
+   1635|   createNodeIterator<RootNodeT: Node>(root: RootNodeT, whatToShow: 128, filter?: NodeFilterInterface): NodeIterator<RootNodeT, Comment>;
                                                                             ^^^ [38]
-   <BUILTINS>/dom.js:1629:68
-   1629|   createNodeIterator<RootNodeT: Node>(root: RootNodeT, whatToShow: 129, filter?: NodeFilterInterface): NodeIterator<RootNodeT, Element|Comment>;
+   <BUILTINS>/dom.js:1636:68
+   1636|   createNodeIterator<RootNodeT: Node>(root: RootNodeT, whatToShow: 129, filter?: NodeFilterInterface): NodeIterator<RootNodeT, Element|Comment>;
                                                                             ^^^ [39]
-   <BUILTINS>/dom.js:1630:68
-   1630|   createNodeIterator<RootNodeT: Node>(root: RootNodeT, whatToShow: 132, filter?: NodeFilterInterface): NodeIterator<RootNodeT, Text|Comment>;
+   <BUILTINS>/dom.js:1637:68
+   1637|   createNodeIterator<RootNodeT: Node>(root: RootNodeT, whatToShow: 132, filter?: NodeFilterInterface): NodeIterator<RootNodeT, Text|Comment>;
                                                                             ^^^ [40]
-   <BUILTINS>/dom.js:1631:68
-   1631|   createNodeIterator<RootNodeT: Node>(root: RootNodeT, whatToShow: 133, filter?: NodeFilterInterface): NodeIterator<RootNodeT, Text|Element|Comment>;
+   <BUILTINS>/dom.js:1638:68
+   1638|   createNodeIterator<RootNodeT: Node>(root: RootNodeT, whatToShow: 133, filter?: NodeFilterInterface): NodeIterator<RootNodeT, Text|Element|Comment>;
                                                                             ^^^ [41]
 
 
@@ -1022,17 +1022,17 @@ References:
    traversal.js:188:74
     188|     document.createNodeIterator(document_body, -1, { acceptNode: node => 'accept' }); // invalid
                                                                                   ^^^^^^^^ [1]
-   <BUILTINS>/dom.js:4425:1
+   <BUILTINS>/dom.js:4432:1
          v--------------------------------
-   4425| typeof NodeFilter.FILTER_ACCEPT |
-   4426| typeof NodeFilter.FILTER_REJECT |
-   4427| typeof NodeFilter.FILTER_SKIP;
+   4432| typeof NodeFilter.FILTER_ACCEPT |
+   4433| typeof NodeFilter.FILTER_REJECT |
+   4434| typeof NodeFilter.FILTER_SKIP;
          ----------------------------^ [2]
    traversal.js:188:48
     188|     document.createNodeIterator(document_body, -1, { acceptNode: node => 'accept' }); // invalid
                                                         ^^ [3]
-   <BUILTINS>/dom.js:1631:68
-   1631|   createNodeIterator<RootNodeT: Node>(root: RootNodeT, whatToShow: 133, filter?: NodeFilterInterface): NodeIterator<RootNodeT, Text|Element|Comment>;
+   <BUILTINS>/dom.js:1638:68
+   1638|   createNodeIterator<RootNodeT: Node>(root: RootNodeT, whatToShow: 133, filter?: NodeFilterInterface): NodeIterator<RootNodeT, Text|Element|Comment>;
                                                                             ^^^ [4]
 
 
@@ -1088,125 +1088,125 @@ References:
    traversal.js:189:48
     189|     document.createNodeIterator(document_body, -1, {}); // invalid
                                                         ^^ [1]
-   <BUILTINS>/dom.js:1546:68
-   1546|   createNodeIterator<RootNodeT: Attr>(root: RootNodeT, whatToShow: 2, filter?: NodeFilterInterface): NodeIterator<RootNodeT, Attr>;
+   <BUILTINS>/dom.js:1553:68
+   1553|   createNodeIterator<RootNodeT: Attr>(root: RootNodeT, whatToShow: 2, filter?: NodeFilterInterface): NodeIterator<RootNodeT, Attr>;
                                                                             ^ [2]
-   <BUILTINS>/dom.js:1554:72
-   1554|   createNodeIterator<RootNodeT: Document>(root: RootNodeT, whatToShow: 256, filter?: NodeFilterInterface): NodeIterator<RootNodeT, Document>;
-                                                                                ^^^ [3]
-   <BUILTINS>/dom.js:1555:72
-   1555|   createNodeIterator<RootNodeT: Document>(root: RootNodeT, whatToShow: 257, filter?: NodeFilterInterface): NodeIterator<RootNodeT, Document|Element>;
-                                                                                ^^^ [4]
-   <BUILTINS>/dom.js:1556:72
-   1556|   createNodeIterator<RootNodeT: Document>(root: RootNodeT, whatToShow: 260, filter?: NodeFilterInterface): NodeIterator<RootNodeT, Document|Text>;
-                                                                                ^^^ [5]
-   <BUILTINS>/dom.js:1557:72
-   1557|   createNodeIterator<RootNodeT: Document>(root: RootNodeT, whatToShow: 261, filter?: NodeFilterInterface): NodeIterator<RootNodeT, Document|Element|Text>;
-                                                                                ^^^ [6]
-   <BUILTINS>/dom.js:1558:72
-   1558|   createNodeIterator<RootNodeT: Document>(root: RootNodeT, whatToShow: 384, filter?: NodeFilterInterface): NodeIterator<RootNodeT, Document|Comment>;
-                                                                                ^^^ [7]
-   <BUILTINS>/dom.js:1559:72
-   1559|   createNodeIterator<RootNodeT: Document>(root: RootNodeT, whatToShow: 385, filter?: NodeFilterInterface): NodeIterator<RootNodeT, Document|Element|Comment>;
-                                                                                ^^^ [8]
-   <BUILTINS>/dom.js:1560:72
-   1560|   createNodeIterator<RootNodeT: Document>(root: RootNodeT, whatToShow: 388, filter?: NodeFilterInterface): NodeIterator<RootNodeT, Document|Text|Comment>;
-                                                                                ^^^ [9]
    <BUILTINS>/dom.js:1561:72
-   1561|   createNodeIterator<RootNodeT: Document>(root: RootNodeT, whatToShow: 389, filter?: NodeFilterInterface): NodeIterator<RootNodeT, Document|Element|Text|Comment>;
-                                                                                ^^^ [10]
+   1561|   createNodeIterator<RootNodeT: Document>(root: RootNodeT, whatToShow: 256, filter?: NodeFilterInterface): NodeIterator<RootNodeT, Document>;
+                                                                                ^^^ [3]
    <BUILTINS>/dom.js:1562:72
-   1562|   createNodeIterator<RootNodeT: Document>(root: RootNodeT, whatToShow: 512, filter?: NodeFilterInterface): NodeIterator<RootNodeT, DocumentType>;
-                                                                                ^^^ [11]
+   1562|   createNodeIterator<RootNodeT: Document>(root: RootNodeT, whatToShow: 257, filter?: NodeFilterInterface): NodeIterator<RootNodeT, Document|Element>;
+                                                                                ^^^ [4]
    <BUILTINS>/dom.js:1563:72
-   1563|   createNodeIterator<RootNodeT: Document>(root: RootNodeT, whatToShow: 513, filter?: NodeFilterInterface): NodeIterator<RootNodeT, DocumentType|Element>;
-                                                                                ^^^ [12]
+   1563|   createNodeIterator<RootNodeT: Document>(root: RootNodeT, whatToShow: 260, filter?: NodeFilterInterface): NodeIterator<RootNodeT, Document|Text>;
+                                                                                ^^^ [5]
    <BUILTINS>/dom.js:1564:72
-   1564|   createNodeIterator<RootNodeT: Document>(root: RootNodeT, whatToShow: 516, filter?: NodeFilterInterface): NodeIterator<RootNodeT, DocumentType|Text>;
-                                                                                ^^^ [13]
+   1564|   createNodeIterator<RootNodeT: Document>(root: RootNodeT, whatToShow: 261, filter?: NodeFilterInterface): NodeIterator<RootNodeT, Document|Element|Text>;
+                                                                                ^^^ [6]
    <BUILTINS>/dom.js:1565:72
-   1565|   createNodeIterator<RootNodeT: Document>(root: RootNodeT, whatToShow: 517, filter?: NodeFilterInterface): NodeIterator<RootNodeT, DocumentType|Element|Text>;
-                                                                                ^^^ [14]
+   1565|   createNodeIterator<RootNodeT: Document>(root: RootNodeT, whatToShow: 384, filter?: NodeFilterInterface): NodeIterator<RootNodeT, Document|Comment>;
+                                                                                ^^^ [7]
    <BUILTINS>/dom.js:1566:72
-   1566|   createNodeIterator<RootNodeT: Document>(root: RootNodeT, whatToShow: 640, filter?: NodeFilterInterface): NodeIterator<RootNodeT, DocumentType|Comment>;
-                                                                                ^^^ [15]
+   1566|   createNodeIterator<RootNodeT: Document>(root: RootNodeT, whatToShow: 385, filter?: NodeFilterInterface): NodeIterator<RootNodeT, Document|Element|Comment>;
+                                                                                ^^^ [8]
    <BUILTINS>/dom.js:1567:72
-   1567|   createNodeIterator<RootNodeT: Document>(root: RootNodeT, whatToShow: 641, filter?: NodeFilterInterface): NodeIterator<RootNodeT, DocumentType|Element|Comment>;
-                                                                                ^^^ [16]
+   1567|   createNodeIterator<RootNodeT: Document>(root: RootNodeT, whatToShow: 388, filter?: NodeFilterInterface): NodeIterator<RootNodeT, Document|Text|Comment>;
+                                                                                ^^^ [9]
    <BUILTINS>/dom.js:1568:72
-   1568|   createNodeIterator<RootNodeT: Document>(root: RootNodeT, whatToShow: 644, filter?: NodeFilterInterface): NodeIterator<RootNodeT, DocumentType|Text|Comment>;
-                                                                                ^^^ [17]
+   1568|   createNodeIterator<RootNodeT: Document>(root: RootNodeT, whatToShow: 389, filter?: NodeFilterInterface): NodeIterator<RootNodeT, Document|Element|Text|Comment>;
+                                                                                ^^^ [10]
    <BUILTINS>/dom.js:1569:72
-   1569|   createNodeIterator<RootNodeT: Document>(root: RootNodeT, whatToShow: 645, filter?: NodeFilterInterface): NodeIterator<RootNodeT, DocumentType|Element|Text|Comment>;
-                                                                                ^^^ [18]
+   1569|   createNodeIterator<RootNodeT: Document>(root: RootNodeT, whatToShow: 512, filter?: NodeFilterInterface): NodeIterator<RootNodeT, DocumentType>;
+                                                                                ^^^ [11]
    <BUILTINS>/dom.js:1570:72
-   1570|   createNodeIterator<RootNodeT: Document>(root: RootNodeT, whatToShow: 768, filter?: NodeFilterInterface): NodeIterator<RootNodeT, DocumentType|Document>;
-                                                                                ^^^ [19]
+   1570|   createNodeIterator<RootNodeT: Document>(root: RootNodeT, whatToShow: 513, filter?: NodeFilterInterface): NodeIterator<RootNodeT, DocumentType|Element>;
+                                                                                ^^^ [12]
    <BUILTINS>/dom.js:1571:72
-   1571|   createNodeIterator<RootNodeT: Document>(root: RootNodeT, whatToShow: 769, filter?: NodeFilterInterface): NodeIterator<RootNodeT, DocumentType|Document|Element>;
-                                                                                ^^^ [20]
+   1571|   createNodeIterator<RootNodeT: Document>(root: RootNodeT, whatToShow: 516, filter?: NodeFilterInterface): NodeIterator<RootNodeT, DocumentType|Text>;
+                                                                                ^^^ [13]
    <BUILTINS>/dom.js:1572:72
-   1572|   createNodeIterator<RootNodeT: Document>(root: RootNodeT, whatToShow: 772, filter?: NodeFilterInterface): NodeIterator<RootNodeT, DocumentType|Document|Text>;
-                                                                                ^^^ [21]
+   1572|   createNodeIterator<RootNodeT: Document>(root: RootNodeT, whatToShow: 517, filter?: NodeFilterInterface): NodeIterator<RootNodeT, DocumentType|Element|Text>;
+                                                                                ^^^ [14]
    <BUILTINS>/dom.js:1573:72
-   1573|   createNodeIterator<RootNodeT: Document>(root: RootNodeT, whatToShow: 773, filter?: NodeFilterInterface): NodeIterator<RootNodeT, DocumentType|Document|Element|Text>;
-                                                                                ^^^ [22]
+   1573|   createNodeIterator<RootNodeT: Document>(root: RootNodeT, whatToShow: 640, filter?: NodeFilterInterface): NodeIterator<RootNodeT, DocumentType|Comment>;
+                                                                                ^^^ [15]
    <BUILTINS>/dom.js:1574:72
-   1574|   createNodeIterator<RootNodeT: Document>(root: RootNodeT, whatToShow: 896, filter?: NodeFilterInterface): NodeIterator<RootNodeT, DocumentType|Document|Comment>;
-                                                                                ^^^ [23]
+   1574|   createNodeIterator<RootNodeT: Document>(root: RootNodeT, whatToShow: 641, filter?: NodeFilterInterface): NodeIterator<RootNodeT, DocumentType|Element|Comment>;
+                                                                                ^^^ [16]
    <BUILTINS>/dom.js:1575:72
-   1575|   createNodeIterator<RootNodeT: Document>(root: RootNodeT, whatToShow: 897, filter?: NodeFilterInterface): NodeIterator<RootNodeT, DocumentType|Document|Element|Comment>;
-                                                                                ^^^ [24]
+   1575|   createNodeIterator<RootNodeT: Document>(root: RootNodeT, whatToShow: 644, filter?: NodeFilterInterface): NodeIterator<RootNodeT, DocumentType|Text|Comment>;
+                                                                                ^^^ [17]
    <BUILTINS>/dom.js:1576:72
-   1576|   createNodeIterator<RootNodeT: Document>(root: RootNodeT, whatToShow: 900, filter?: NodeFilterInterface): NodeIterator<RootNodeT, DocumentType|Document|Text|Comment>;
-                                                                                ^^^ [25]
+   1576|   createNodeIterator<RootNodeT: Document>(root: RootNodeT, whatToShow: 645, filter?: NodeFilterInterface): NodeIterator<RootNodeT, DocumentType|Element|Text|Comment>;
+                                                                                ^^^ [18]
    <BUILTINS>/dom.js:1577:72
-   1577|   createNodeIterator<RootNodeT: Document>(root: RootNodeT, whatToShow: 901, filter?: NodeFilterInterface): NodeIterator<RootNodeT, DocumentType|Document|Element|Text|Comment>;
+   1577|   createNodeIterator<RootNodeT: Document>(root: RootNodeT, whatToShow: 768, filter?: NodeFilterInterface): NodeIterator<RootNodeT, DocumentType|Document>;
+                                                                                ^^^ [19]
+   <BUILTINS>/dom.js:1578:72
+   1578|   createNodeIterator<RootNodeT: Document>(root: RootNodeT, whatToShow: 769, filter?: NodeFilterInterface): NodeIterator<RootNodeT, DocumentType|Document|Element>;
+                                                                                ^^^ [20]
+   <BUILTINS>/dom.js:1579:72
+   1579|   createNodeIterator<RootNodeT: Document>(root: RootNodeT, whatToShow: 772, filter?: NodeFilterInterface): NodeIterator<RootNodeT, DocumentType|Document|Text>;
+                                                                                ^^^ [21]
+   <BUILTINS>/dom.js:1580:72
+   1580|   createNodeIterator<RootNodeT: Document>(root: RootNodeT, whatToShow: 773, filter?: NodeFilterInterface): NodeIterator<RootNodeT, DocumentType|Document|Element|Text>;
+                                                                                ^^^ [22]
+   <BUILTINS>/dom.js:1581:72
+   1581|   createNodeIterator<RootNodeT: Document>(root: RootNodeT, whatToShow: 896, filter?: NodeFilterInterface): NodeIterator<RootNodeT, DocumentType|Document|Comment>;
+                                                                                ^^^ [23]
+   <BUILTINS>/dom.js:1582:72
+   1582|   createNodeIterator<RootNodeT: Document>(root: RootNodeT, whatToShow: 897, filter?: NodeFilterInterface): NodeIterator<RootNodeT, DocumentType|Document|Element|Comment>;
+                                                                                ^^^ [24]
+   <BUILTINS>/dom.js:1583:72
+   1583|   createNodeIterator<RootNodeT: Document>(root: RootNodeT, whatToShow: 900, filter?: NodeFilterInterface): NodeIterator<RootNodeT, DocumentType|Document|Text|Comment>;
+                                                                                ^^^ [25]
+   <BUILTINS>/dom.js:1584:72
+   1584|   createNodeIterator<RootNodeT: Document>(root: RootNodeT, whatToShow: 901, filter?: NodeFilterInterface): NodeIterator<RootNodeT, DocumentType|Document|Element|Text|Comment>;
                                                                                 ^^^ [26]
-   <BUILTINS>/dom.js:1605:80
-   1605|   createNodeIterator<RootNodeT: DocumentFragment>(root: RootNodeT, whatToShow: 1024, filter?: NodeFilterInterface): NodeIterator<RootNodeT, DocumentFragment>;
-                                                                                        ^^^^ [27]
-   <BUILTINS>/dom.js:1606:80
-   1606|   createNodeIterator<RootNodeT: DocumentFragment>(root: RootNodeT, whatToShow: 1025, filter?: NodeFilterInterface): NodeIterator<RootNodeT, DocumentFragment|Element>;
-                                                                                        ^^^^ [28]
-   <BUILTINS>/dom.js:1607:80
-   1607|   createNodeIterator<RootNodeT: DocumentFragment>(root: RootNodeT, whatToShow: 1028, filter?: NodeFilterInterface): NodeIterator<RootNodeT, DocumentFragment|Text>;
-                                                                                        ^^^^ [29]
-   <BUILTINS>/dom.js:1608:80
-   1608|   createNodeIterator<RootNodeT: DocumentFragment>(root: RootNodeT, whatToShow: 1029, filter?: NodeFilterInterface): NodeIterator<RootNodeT, DocumentFragment|Element|Text>;
-                                                                                        ^^^^ [30]
-   <BUILTINS>/dom.js:1609:80
-   1609|   createNodeIterator<RootNodeT: DocumentFragment>(root: RootNodeT, whatToShow: 1152, filter?: NodeFilterInterface): NodeIterator<RootNodeT, DocumentFragment|Comment>;
-                                                                                        ^^^^ [31]
-   <BUILTINS>/dom.js:1610:80
-   1610|   createNodeIterator<RootNodeT: DocumentFragment>(root: RootNodeT, whatToShow: 1153, filter?: NodeFilterInterface): NodeIterator<RootNodeT, DocumentFragment|Element|Comment>;
-                                                                                        ^^^^ [32]
-   <BUILTINS>/dom.js:1611:80
-   1611|   createNodeIterator<RootNodeT: DocumentFragment>(root: RootNodeT, whatToShow: 1156, filter?: NodeFilterInterface): NodeIterator<RootNodeT, DocumentFragment|Text|Comment>;
-                                                                                        ^^^^ [33]
    <BUILTINS>/dom.js:1612:80
-   1612|   createNodeIterator<RootNodeT: DocumentFragment>(root: RootNodeT, whatToShow: 1157, filter?: NodeFilterInterface): NodeIterator<RootNodeT, DocumentFragment|Element|Text|Comment>;
+   1612|   createNodeIterator<RootNodeT: DocumentFragment>(root: RootNodeT, whatToShow: 1024, filter?: NodeFilterInterface): NodeIterator<RootNodeT, DocumentFragment>;
+                                                                                        ^^^^ [27]
+   <BUILTINS>/dom.js:1613:80
+   1613|   createNodeIterator<RootNodeT: DocumentFragment>(root: RootNodeT, whatToShow: 1025, filter?: NodeFilterInterface): NodeIterator<RootNodeT, DocumentFragment|Element>;
+                                                                                        ^^^^ [28]
+   <BUILTINS>/dom.js:1614:80
+   1614|   createNodeIterator<RootNodeT: DocumentFragment>(root: RootNodeT, whatToShow: 1028, filter?: NodeFilterInterface): NodeIterator<RootNodeT, DocumentFragment|Text>;
+                                                                                        ^^^^ [29]
+   <BUILTINS>/dom.js:1615:80
+   1615|   createNodeIterator<RootNodeT: DocumentFragment>(root: RootNodeT, whatToShow: 1029, filter?: NodeFilterInterface): NodeIterator<RootNodeT, DocumentFragment|Element|Text>;
+                                                                                        ^^^^ [30]
+   <BUILTINS>/dom.js:1616:80
+   1616|   createNodeIterator<RootNodeT: DocumentFragment>(root: RootNodeT, whatToShow: 1152, filter?: NodeFilterInterface): NodeIterator<RootNodeT, DocumentFragment|Comment>;
+                                                                                        ^^^^ [31]
+   <BUILTINS>/dom.js:1617:80
+   1617|   createNodeIterator<RootNodeT: DocumentFragment>(root: RootNodeT, whatToShow: 1153, filter?: NodeFilterInterface): NodeIterator<RootNodeT, DocumentFragment|Element|Comment>;
+                                                                                        ^^^^ [32]
+   <BUILTINS>/dom.js:1618:80
+   1618|   createNodeIterator<RootNodeT: DocumentFragment>(root: RootNodeT, whatToShow: 1156, filter?: NodeFilterInterface): NodeIterator<RootNodeT, DocumentFragment|Text|Comment>;
+                                                                                        ^^^^ [33]
+   <BUILTINS>/dom.js:1619:80
+   1619|   createNodeIterator<RootNodeT: DocumentFragment>(root: RootNodeT, whatToShow: 1157, filter?: NodeFilterInterface): NodeIterator<RootNodeT, DocumentFragment|Element|Text|Comment>;
                                                                                         ^^^^ [34]
-   <BUILTINS>/dom.js:1625:68
-   1625|   createNodeIterator<RootNodeT: Node>(root: RootNodeT, whatToShow: 1, filter?: NodeFilterInterface): NodeIterator<RootNodeT, Element>;
+   <BUILTINS>/dom.js:1632:68
+   1632|   createNodeIterator<RootNodeT: Node>(root: RootNodeT, whatToShow: 1, filter?: NodeFilterInterface): NodeIterator<RootNodeT, Element>;
                                                                             ^ [35]
-   <BUILTINS>/dom.js:1626:68
-   1626|   createNodeIterator<RootNodeT: Node>(root: RootNodeT, whatToShow: 4, filter?: NodeFilterInterface): NodeIterator<RootNodeT, Text>;
+   <BUILTINS>/dom.js:1633:68
+   1633|   createNodeIterator<RootNodeT: Node>(root: RootNodeT, whatToShow: 4, filter?: NodeFilterInterface): NodeIterator<RootNodeT, Text>;
                                                                             ^ [36]
-   <BUILTINS>/dom.js:1627:68
-   1627|   createNodeIterator<RootNodeT: Node>(root: RootNodeT, whatToShow: 5, filter?: NodeFilterInterface): NodeIterator<RootNodeT, Element|Text>;
+   <BUILTINS>/dom.js:1634:68
+   1634|   createNodeIterator<RootNodeT: Node>(root: RootNodeT, whatToShow: 5, filter?: NodeFilterInterface): NodeIterator<RootNodeT, Element|Text>;
                                                                             ^ [37]
-   <BUILTINS>/dom.js:1628:68
-   1628|   createNodeIterator<RootNodeT: Node>(root: RootNodeT, whatToShow: 128, filter?: NodeFilterInterface): NodeIterator<RootNodeT, Comment>;
+   <BUILTINS>/dom.js:1635:68
+   1635|   createNodeIterator<RootNodeT: Node>(root: RootNodeT, whatToShow: 128, filter?: NodeFilterInterface): NodeIterator<RootNodeT, Comment>;
                                                                             ^^^ [38]
-   <BUILTINS>/dom.js:1629:68
-   1629|   createNodeIterator<RootNodeT: Node>(root: RootNodeT, whatToShow: 129, filter?: NodeFilterInterface): NodeIterator<RootNodeT, Element|Comment>;
+   <BUILTINS>/dom.js:1636:68
+   1636|   createNodeIterator<RootNodeT: Node>(root: RootNodeT, whatToShow: 129, filter?: NodeFilterInterface): NodeIterator<RootNodeT, Element|Comment>;
                                                                             ^^^ [39]
-   <BUILTINS>/dom.js:1630:68
-   1630|   createNodeIterator<RootNodeT: Node>(root: RootNodeT, whatToShow: 132, filter?: NodeFilterInterface): NodeIterator<RootNodeT, Text|Comment>;
+   <BUILTINS>/dom.js:1637:68
+   1637|   createNodeIterator<RootNodeT: Node>(root: RootNodeT, whatToShow: 132, filter?: NodeFilterInterface): NodeIterator<RootNodeT, Text|Comment>;
                                                                             ^^^ [40]
-   <BUILTINS>/dom.js:1631:68
-   1631|   createNodeIterator<RootNodeT: Node>(root: RootNodeT, whatToShow: 133, filter?: NodeFilterInterface): NodeIterator<RootNodeT, Text|Element|Comment>;
+   <BUILTINS>/dom.js:1638:68
+   1638|   createNodeIterator<RootNodeT: Node>(root: RootNodeT, whatToShow: 133, filter?: NodeFilterInterface): NodeIterator<RootNodeT, Text|Element|Comment>;
                                                                             ^^^ [41]
 
 
@@ -1262,125 +1262,125 @@ References:
    traversal.js:193:46
     193|     document.createTreeWalker(document_body, -1, node => 'accept'); // invalid
                                                       ^^ [1]
-   <BUILTINS>/dom.js:1547:66
-   1547|   createTreeWalker<RootNodeT: Attr>(root: RootNodeT, whatToShow: 2, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, Attr>;
+   <BUILTINS>/dom.js:1554:66
+   1554|   createTreeWalker<RootNodeT: Attr>(root: RootNodeT, whatToShow: 2, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, Attr>;
                                                                           ^ [2]
-   <BUILTINS>/dom.js:1578:70
-   1578|   createTreeWalker<RootNodeT: Document>(root: RootNodeT, whatToShow: 256, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, Document>;
-                                                                              ^^^ [3]
-   <BUILTINS>/dom.js:1579:70
-   1579|   createTreeWalker<RootNodeT: Document>(root: RootNodeT, whatToShow: 257, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, Document|Element>;
-                                                                              ^^^ [4]
-   <BUILTINS>/dom.js:1580:70
-   1580|   createTreeWalker<RootNodeT: Document>(root: RootNodeT, whatToShow: 260, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, Document|Text>;
-                                                                              ^^^ [5]
-   <BUILTINS>/dom.js:1581:70
-   1581|   createTreeWalker<RootNodeT: Document>(root: RootNodeT, whatToShow: 261, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, Document|Element|Text>;
-                                                                              ^^^ [6]
-   <BUILTINS>/dom.js:1582:70
-   1582|   createTreeWalker<RootNodeT: Document>(root: RootNodeT, whatToShow: 384, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, Document|Comment>;
-                                                                              ^^^ [7]
-   <BUILTINS>/dom.js:1583:70
-   1583|   createTreeWalker<RootNodeT: Document>(root: RootNodeT, whatToShow: 385, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, Document|Element|Comment>;
-                                                                              ^^^ [8]
-   <BUILTINS>/dom.js:1584:70
-   1584|   createTreeWalker<RootNodeT: Document>(root: RootNodeT, whatToShow: 388, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, Document|Text|Comment>;
-                                                                              ^^^ [9]
    <BUILTINS>/dom.js:1585:70
-   1585|   createTreeWalker<RootNodeT: Document>(root: RootNodeT, whatToShow: 389, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, Document|Element|Text|Comment>;
-                                                                              ^^^ [10]
+   1585|   createTreeWalker<RootNodeT: Document>(root: RootNodeT, whatToShow: 256, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, Document>;
+                                                                              ^^^ [3]
    <BUILTINS>/dom.js:1586:70
-   1586|   createTreeWalker<RootNodeT: Document>(root: RootNodeT, whatToShow: 512, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, DocumentType>;
-                                                                              ^^^ [11]
+   1586|   createTreeWalker<RootNodeT: Document>(root: RootNodeT, whatToShow: 257, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, Document|Element>;
+                                                                              ^^^ [4]
    <BUILTINS>/dom.js:1587:70
-   1587|   createTreeWalker<RootNodeT: Document>(root: RootNodeT, whatToShow: 513, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, DocumentType|Element>;
-                                                                              ^^^ [12]
+   1587|   createTreeWalker<RootNodeT: Document>(root: RootNodeT, whatToShow: 260, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, Document|Text>;
+                                                                              ^^^ [5]
    <BUILTINS>/dom.js:1588:70
-   1588|   createTreeWalker<RootNodeT: Document>(root: RootNodeT, whatToShow: 516, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, DocumentType|Text>;
-                                                                              ^^^ [13]
+   1588|   createTreeWalker<RootNodeT: Document>(root: RootNodeT, whatToShow: 261, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, Document|Element|Text>;
+                                                                              ^^^ [6]
    <BUILTINS>/dom.js:1589:70
-   1589|   createTreeWalker<RootNodeT: Document>(root: RootNodeT, whatToShow: 517, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, DocumentType|Element|Text>;
-                                                                              ^^^ [14]
+   1589|   createTreeWalker<RootNodeT: Document>(root: RootNodeT, whatToShow: 384, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, Document|Comment>;
+                                                                              ^^^ [7]
    <BUILTINS>/dom.js:1590:70
-   1590|   createTreeWalker<RootNodeT: Document>(root: RootNodeT, whatToShow: 640, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, DocumentType|Comment>;
-                                                                              ^^^ [15]
+   1590|   createTreeWalker<RootNodeT: Document>(root: RootNodeT, whatToShow: 385, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, Document|Element|Comment>;
+                                                                              ^^^ [8]
    <BUILTINS>/dom.js:1591:70
-   1591|   createTreeWalker<RootNodeT: Document>(root: RootNodeT, whatToShow: 641, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, DocumentType|Element|Comment>;
-                                                                              ^^^ [16]
+   1591|   createTreeWalker<RootNodeT: Document>(root: RootNodeT, whatToShow: 388, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, Document|Text|Comment>;
+                                                                              ^^^ [9]
    <BUILTINS>/dom.js:1592:70
-   1592|   createTreeWalker<RootNodeT: Document>(root: RootNodeT, whatToShow: 644, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, DocumentType|Text|Comment>;
-                                                                              ^^^ [17]
+   1592|   createTreeWalker<RootNodeT: Document>(root: RootNodeT, whatToShow: 389, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, Document|Element|Text|Comment>;
+                                                                              ^^^ [10]
    <BUILTINS>/dom.js:1593:70
-   1593|   createTreeWalker<RootNodeT: Document>(root: RootNodeT, whatToShow: 645, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, DocumentType|Element|Text|Comment>;
-                                                                              ^^^ [18]
+   1593|   createTreeWalker<RootNodeT: Document>(root: RootNodeT, whatToShow: 512, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, DocumentType>;
+                                                                              ^^^ [11]
    <BUILTINS>/dom.js:1594:70
-   1594|   createTreeWalker<RootNodeT: Document>(root: RootNodeT, whatToShow: 768, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, DocumentType|Document>;
-                                                                              ^^^ [19]
+   1594|   createTreeWalker<RootNodeT: Document>(root: RootNodeT, whatToShow: 513, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, DocumentType|Element>;
+                                                                              ^^^ [12]
    <BUILTINS>/dom.js:1595:70
-   1595|   createTreeWalker<RootNodeT: Document>(root: RootNodeT, whatToShow: 769, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, DocumentType|Document|Element>;
-                                                                              ^^^ [20]
+   1595|   createTreeWalker<RootNodeT: Document>(root: RootNodeT, whatToShow: 516, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, DocumentType|Text>;
+                                                                              ^^^ [13]
    <BUILTINS>/dom.js:1596:70
-   1596|   createTreeWalker<RootNodeT: Document>(root: RootNodeT, whatToShow: 772, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, DocumentType|Document|Text>;
-                                                                              ^^^ [21]
+   1596|   createTreeWalker<RootNodeT: Document>(root: RootNodeT, whatToShow: 517, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, DocumentType|Element|Text>;
+                                                                              ^^^ [14]
    <BUILTINS>/dom.js:1597:70
-   1597|   createTreeWalker<RootNodeT: Document>(root: RootNodeT, whatToShow: 773, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, DocumentType|Document|Element|Text>;
-                                                                              ^^^ [22]
+   1597|   createTreeWalker<RootNodeT: Document>(root: RootNodeT, whatToShow: 640, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, DocumentType|Comment>;
+                                                                              ^^^ [15]
    <BUILTINS>/dom.js:1598:70
-   1598|   createTreeWalker<RootNodeT: Document>(root: RootNodeT, whatToShow: 896, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, DocumentType|Document|Comment>;
-                                                                              ^^^ [23]
+   1598|   createTreeWalker<RootNodeT: Document>(root: RootNodeT, whatToShow: 641, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, DocumentType|Element|Comment>;
+                                                                              ^^^ [16]
    <BUILTINS>/dom.js:1599:70
-   1599|   createTreeWalker<RootNodeT: Document>(root: RootNodeT, whatToShow: 897, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, DocumentType|Document|Element|Comment>;
-                                                                              ^^^ [24]
+   1599|   createTreeWalker<RootNodeT: Document>(root: RootNodeT, whatToShow: 644, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, DocumentType|Text|Comment>;
+                                                                              ^^^ [17]
    <BUILTINS>/dom.js:1600:70
-   1600|   createTreeWalker<RootNodeT: Document>(root: RootNodeT, whatToShow: 900, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, DocumentType|Document|Text|Comment>;
-                                                                              ^^^ [25]
+   1600|   createTreeWalker<RootNodeT: Document>(root: RootNodeT, whatToShow: 645, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, DocumentType|Element|Text|Comment>;
+                                                                              ^^^ [18]
    <BUILTINS>/dom.js:1601:70
-   1601|   createTreeWalker<RootNodeT: Document>(root: RootNodeT, whatToShow: 901, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, DocumentType|Document|Element|Text|Comment>;
+   1601|   createTreeWalker<RootNodeT: Document>(root: RootNodeT, whatToShow: 768, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, DocumentType|Document>;
+                                                                              ^^^ [19]
+   <BUILTINS>/dom.js:1602:70
+   1602|   createTreeWalker<RootNodeT: Document>(root: RootNodeT, whatToShow: 769, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, DocumentType|Document|Element>;
+                                                                              ^^^ [20]
+   <BUILTINS>/dom.js:1603:70
+   1603|   createTreeWalker<RootNodeT: Document>(root: RootNodeT, whatToShow: 772, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, DocumentType|Document|Text>;
+                                                                              ^^^ [21]
+   <BUILTINS>/dom.js:1604:70
+   1604|   createTreeWalker<RootNodeT: Document>(root: RootNodeT, whatToShow: 773, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, DocumentType|Document|Element|Text>;
+                                                                              ^^^ [22]
+   <BUILTINS>/dom.js:1605:70
+   1605|   createTreeWalker<RootNodeT: Document>(root: RootNodeT, whatToShow: 896, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, DocumentType|Document|Comment>;
+                                                                              ^^^ [23]
+   <BUILTINS>/dom.js:1606:70
+   1606|   createTreeWalker<RootNodeT: Document>(root: RootNodeT, whatToShow: 897, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, DocumentType|Document|Element|Comment>;
+                                                                              ^^^ [24]
+   <BUILTINS>/dom.js:1607:70
+   1607|   createTreeWalker<RootNodeT: Document>(root: RootNodeT, whatToShow: 900, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, DocumentType|Document|Text|Comment>;
+                                                                              ^^^ [25]
+   <BUILTINS>/dom.js:1608:70
+   1608|   createTreeWalker<RootNodeT: Document>(root: RootNodeT, whatToShow: 901, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, DocumentType|Document|Element|Text|Comment>;
                                                                               ^^^ [26]
-   <BUILTINS>/dom.js:1613:78
-   1613|   createTreeWalker<RootNodeT: DocumentFragment>(root: RootNodeT, whatToShow: 1024, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, DocumentFragment>;
-                                                                                      ^^^^ [27]
-   <BUILTINS>/dom.js:1614:78
-   1614|   createTreeWalker<RootNodeT: DocumentFragment>(root: RootNodeT, whatToShow: 1025, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, DocumentFragment|Element>;
-                                                                                      ^^^^ [28]
-   <BUILTINS>/dom.js:1615:78
-   1615|   createTreeWalker<RootNodeT: DocumentFragment>(root: RootNodeT, whatToShow: 1028, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, DocumentFragment|Text>;
-                                                                                      ^^^^ [29]
-   <BUILTINS>/dom.js:1616:78
-   1616|   createTreeWalker<RootNodeT: DocumentFragment>(root: RootNodeT, whatToShow: 1029, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, DocumentFragment|Element|Text>;
-                                                                                      ^^^^ [30]
-   <BUILTINS>/dom.js:1617:78
-   1617|   createTreeWalker<RootNodeT: DocumentFragment>(root: RootNodeT, whatToShow: 1152, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, DocumentFragment|Comment>;
-                                                                                      ^^^^ [31]
-   <BUILTINS>/dom.js:1618:78
-   1618|   createTreeWalker<RootNodeT: DocumentFragment>(root: RootNodeT, whatToShow: 1153, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, DocumentFragment|Element|Comment>;
-                                                                                      ^^^^ [32]
-   <BUILTINS>/dom.js:1619:78
-   1619|   createTreeWalker<RootNodeT: DocumentFragment>(root: RootNodeT, whatToShow: 1156, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, DocumentFragment|Text|Comment>;
-                                                                                      ^^^^ [33]
    <BUILTINS>/dom.js:1620:78
-   1620|   createTreeWalker<RootNodeT: DocumentFragment>(root: RootNodeT, whatToShow: 1157, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, DocumentFragment|Element|Text|Comment>;
+   1620|   createTreeWalker<RootNodeT: DocumentFragment>(root: RootNodeT, whatToShow: 1024, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, DocumentFragment>;
+                                                                                      ^^^^ [27]
+   <BUILTINS>/dom.js:1621:78
+   1621|   createTreeWalker<RootNodeT: DocumentFragment>(root: RootNodeT, whatToShow: 1025, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, DocumentFragment|Element>;
+                                                                                      ^^^^ [28]
+   <BUILTINS>/dom.js:1622:78
+   1622|   createTreeWalker<RootNodeT: DocumentFragment>(root: RootNodeT, whatToShow: 1028, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, DocumentFragment|Text>;
+                                                                                      ^^^^ [29]
+   <BUILTINS>/dom.js:1623:78
+   1623|   createTreeWalker<RootNodeT: DocumentFragment>(root: RootNodeT, whatToShow: 1029, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, DocumentFragment|Element|Text>;
+                                                                                      ^^^^ [30]
+   <BUILTINS>/dom.js:1624:78
+   1624|   createTreeWalker<RootNodeT: DocumentFragment>(root: RootNodeT, whatToShow: 1152, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, DocumentFragment|Comment>;
+                                                                                      ^^^^ [31]
+   <BUILTINS>/dom.js:1625:78
+   1625|   createTreeWalker<RootNodeT: DocumentFragment>(root: RootNodeT, whatToShow: 1153, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, DocumentFragment|Element|Comment>;
+                                                                                      ^^^^ [32]
+   <BUILTINS>/dom.js:1626:78
+   1626|   createTreeWalker<RootNodeT: DocumentFragment>(root: RootNodeT, whatToShow: 1156, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, DocumentFragment|Text|Comment>;
+                                                                                      ^^^^ [33]
+   <BUILTINS>/dom.js:1627:78
+   1627|   createTreeWalker<RootNodeT: DocumentFragment>(root: RootNodeT, whatToShow: 1157, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, DocumentFragment|Element|Text|Comment>;
                                                                                       ^^^^ [34]
-   <BUILTINS>/dom.js:1632:66
-   1632|   createTreeWalker<RootNodeT: Node>(root: RootNodeT, whatToShow: 1, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, Element>;
+   <BUILTINS>/dom.js:1639:66
+   1639|   createTreeWalker<RootNodeT: Node>(root: RootNodeT, whatToShow: 1, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, Element>;
                                                                           ^ [35]
-   <BUILTINS>/dom.js:1633:66
-   1633|   createTreeWalker<RootNodeT: Node>(root: RootNodeT, whatToShow: 4, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, Text>;
+   <BUILTINS>/dom.js:1640:66
+   1640|   createTreeWalker<RootNodeT: Node>(root: RootNodeT, whatToShow: 4, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, Text>;
                                                                           ^ [36]
-   <BUILTINS>/dom.js:1634:66
-   1634|   createTreeWalker<RootNodeT: Node>(root: RootNodeT, whatToShow: 5, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, Element|Text>;
+   <BUILTINS>/dom.js:1641:66
+   1641|   createTreeWalker<RootNodeT: Node>(root: RootNodeT, whatToShow: 5, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, Element|Text>;
                                                                           ^ [37]
-   <BUILTINS>/dom.js:1635:66
-   1635|   createTreeWalker<RootNodeT: Node>(root: RootNodeT, whatToShow: 128, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, Comment>;
+   <BUILTINS>/dom.js:1642:66
+   1642|   createTreeWalker<RootNodeT: Node>(root: RootNodeT, whatToShow: 128, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, Comment>;
                                                                           ^^^ [38]
-   <BUILTINS>/dom.js:1636:66
-   1636|   createTreeWalker<RootNodeT: Node>(root: RootNodeT, whatToShow: 129, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, Element|Comment>;
+   <BUILTINS>/dom.js:1643:66
+   1643|   createTreeWalker<RootNodeT: Node>(root: RootNodeT, whatToShow: 129, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, Element|Comment>;
                                                                           ^^^ [39]
-   <BUILTINS>/dom.js:1637:66
-   1637|   createTreeWalker<RootNodeT: Node>(root: RootNodeT, whatToShow: 132, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, Text|Comment>;
+   <BUILTINS>/dom.js:1644:66
+   1644|   createTreeWalker<RootNodeT: Node>(root: RootNodeT, whatToShow: 132, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, Text|Comment>;
                                                                           ^^^ [40]
-   <BUILTINS>/dom.js:1638:66
-   1638|   createTreeWalker<RootNodeT: Node>(root: RootNodeT, whatToShow: 133, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, Text|Element|Comment>;
+   <BUILTINS>/dom.js:1645:66
+   1645|   createTreeWalker<RootNodeT: Node>(root: RootNodeT, whatToShow: 133, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, Text|Element|Comment>;
                                                                           ^^^ [41]
 
 
@@ -1398,17 +1398,17 @@ References:
    traversal.js:195:72
     195|     document.createTreeWalker(document_body, -1, { acceptNode: node => 'accept' }); // invalid
                                                                                 ^^^^^^^^ [1]
-   <BUILTINS>/dom.js:4425:1
+   <BUILTINS>/dom.js:4432:1
          v--------------------------------
-   4425| typeof NodeFilter.FILTER_ACCEPT |
-   4426| typeof NodeFilter.FILTER_REJECT |
-   4427| typeof NodeFilter.FILTER_SKIP;
+   4432| typeof NodeFilter.FILTER_ACCEPT |
+   4433| typeof NodeFilter.FILTER_REJECT |
+   4434| typeof NodeFilter.FILTER_SKIP;
          ----------------------------^ [2]
    traversal.js:195:46
     195|     document.createTreeWalker(document_body, -1, { acceptNode: node => 'accept' }); // invalid
                                                       ^^ [3]
-   <BUILTINS>/dom.js:1638:66
-   1638|   createTreeWalker<RootNodeT: Node>(root: RootNodeT, whatToShow: 133, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, Text|Element|Comment>;
+   <BUILTINS>/dom.js:1645:66
+   1645|   createTreeWalker<RootNodeT: Node>(root: RootNodeT, whatToShow: 133, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, Text|Element|Comment>;
                                                                           ^^^ [4]
 
 
@@ -1464,125 +1464,125 @@ References:
    traversal.js:196:46
     196|     document.createTreeWalker(document_body, -1, {}); // invalid
                                                       ^^ [1]
-   <BUILTINS>/dom.js:1547:66
-   1547|   createTreeWalker<RootNodeT: Attr>(root: RootNodeT, whatToShow: 2, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, Attr>;
+   <BUILTINS>/dom.js:1554:66
+   1554|   createTreeWalker<RootNodeT: Attr>(root: RootNodeT, whatToShow: 2, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, Attr>;
                                                                           ^ [2]
-   <BUILTINS>/dom.js:1578:70
-   1578|   createTreeWalker<RootNodeT: Document>(root: RootNodeT, whatToShow: 256, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, Document>;
-                                                                              ^^^ [3]
-   <BUILTINS>/dom.js:1579:70
-   1579|   createTreeWalker<RootNodeT: Document>(root: RootNodeT, whatToShow: 257, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, Document|Element>;
-                                                                              ^^^ [4]
-   <BUILTINS>/dom.js:1580:70
-   1580|   createTreeWalker<RootNodeT: Document>(root: RootNodeT, whatToShow: 260, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, Document|Text>;
-                                                                              ^^^ [5]
-   <BUILTINS>/dom.js:1581:70
-   1581|   createTreeWalker<RootNodeT: Document>(root: RootNodeT, whatToShow: 261, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, Document|Element|Text>;
-                                                                              ^^^ [6]
-   <BUILTINS>/dom.js:1582:70
-   1582|   createTreeWalker<RootNodeT: Document>(root: RootNodeT, whatToShow: 384, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, Document|Comment>;
-                                                                              ^^^ [7]
-   <BUILTINS>/dom.js:1583:70
-   1583|   createTreeWalker<RootNodeT: Document>(root: RootNodeT, whatToShow: 385, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, Document|Element|Comment>;
-                                                                              ^^^ [8]
-   <BUILTINS>/dom.js:1584:70
-   1584|   createTreeWalker<RootNodeT: Document>(root: RootNodeT, whatToShow: 388, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, Document|Text|Comment>;
-                                                                              ^^^ [9]
    <BUILTINS>/dom.js:1585:70
-   1585|   createTreeWalker<RootNodeT: Document>(root: RootNodeT, whatToShow: 389, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, Document|Element|Text|Comment>;
-                                                                              ^^^ [10]
+   1585|   createTreeWalker<RootNodeT: Document>(root: RootNodeT, whatToShow: 256, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, Document>;
+                                                                              ^^^ [3]
    <BUILTINS>/dom.js:1586:70
-   1586|   createTreeWalker<RootNodeT: Document>(root: RootNodeT, whatToShow: 512, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, DocumentType>;
-                                                                              ^^^ [11]
+   1586|   createTreeWalker<RootNodeT: Document>(root: RootNodeT, whatToShow: 257, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, Document|Element>;
+                                                                              ^^^ [4]
    <BUILTINS>/dom.js:1587:70
-   1587|   createTreeWalker<RootNodeT: Document>(root: RootNodeT, whatToShow: 513, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, DocumentType|Element>;
-                                                                              ^^^ [12]
+   1587|   createTreeWalker<RootNodeT: Document>(root: RootNodeT, whatToShow: 260, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, Document|Text>;
+                                                                              ^^^ [5]
    <BUILTINS>/dom.js:1588:70
-   1588|   createTreeWalker<RootNodeT: Document>(root: RootNodeT, whatToShow: 516, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, DocumentType|Text>;
-                                                                              ^^^ [13]
+   1588|   createTreeWalker<RootNodeT: Document>(root: RootNodeT, whatToShow: 261, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, Document|Element|Text>;
+                                                                              ^^^ [6]
    <BUILTINS>/dom.js:1589:70
-   1589|   createTreeWalker<RootNodeT: Document>(root: RootNodeT, whatToShow: 517, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, DocumentType|Element|Text>;
-                                                                              ^^^ [14]
+   1589|   createTreeWalker<RootNodeT: Document>(root: RootNodeT, whatToShow: 384, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, Document|Comment>;
+                                                                              ^^^ [7]
    <BUILTINS>/dom.js:1590:70
-   1590|   createTreeWalker<RootNodeT: Document>(root: RootNodeT, whatToShow: 640, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, DocumentType|Comment>;
-                                                                              ^^^ [15]
+   1590|   createTreeWalker<RootNodeT: Document>(root: RootNodeT, whatToShow: 385, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, Document|Element|Comment>;
+                                                                              ^^^ [8]
    <BUILTINS>/dom.js:1591:70
-   1591|   createTreeWalker<RootNodeT: Document>(root: RootNodeT, whatToShow: 641, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, DocumentType|Element|Comment>;
-                                                                              ^^^ [16]
+   1591|   createTreeWalker<RootNodeT: Document>(root: RootNodeT, whatToShow: 388, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, Document|Text|Comment>;
+                                                                              ^^^ [9]
    <BUILTINS>/dom.js:1592:70
-   1592|   createTreeWalker<RootNodeT: Document>(root: RootNodeT, whatToShow: 644, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, DocumentType|Text|Comment>;
-                                                                              ^^^ [17]
+   1592|   createTreeWalker<RootNodeT: Document>(root: RootNodeT, whatToShow: 389, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, Document|Element|Text|Comment>;
+                                                                              ^^^ [10]
    <BUILTINS>/dom.js:1593:70
-   1593|   createTreeWalker<RootNodeT: Document>(root: RootNodeT, whatToShow: 645, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, DocumentType|Element|Text|Comment>;
-                                                                              ^^^ [18]
+   1593|   createTreeWalker<RootNodeT: Document>(root: RootNodeT, whatToShow: 512, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, DocumentType>;
+                                                                              ^^^ [11]
    <BUILTINS>/dom.js:1594:70
-   1594|   createTreeWalker<RootNodeT: Document>(root: RootNodeT, whatToShow: 768, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, DocumentType|Document>;
-                                                                              ^^^ [19]
+   1594|   createTreeWalker<RootNodeT: Document>(root: RootNodeT, whatToShow: 513, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, DocumentType|Element>;
+                                                                              ^^^ [12]
    <BUILTINS>/dom.js:1595:70
-   1595|   createTreeWalker<RootNodeT: Document>(root: RootNodeT, whatToShow: 769, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, DocumentType|Document|Element>;
-                                                                              ^^^ [20]
+   1595|   createTreeWalker<RootNodeT: Document>(root: RootNodeT, whatToShow: 516, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, DocumentType|Text>;
+                                                                              ^^^ [13]
    <BUILTINS>/dom.js:1596:70
-   1596|   createTreeWalker<RootNodeT: Document>(root: RootNodeT, whatToShow: 772, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, DocumentType|Document|Text>;
-                                                                              ^^^ [21]
+   1596|   createTreeWalker<RootNodeT: Document>(root: RootNodeT, whatToShow: 517, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, DocumentType|Element|Text>;
+                                                                              ^^^ [14]
    <BUILTINS>/dom.js:1597:70
-   1597|   createTreeWalker<RootNodeT: Document>(root: RootNodeT, whatToShow: 773, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, DocumentType|Document|Element|Text>;
-                                                                              ^^^ [22]
+   1597|   createTreeWalker<RootNodeT: Document>(root: RootNodeT, whatToShow: 640, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, DocumentType|Comment>;
+                                                                              ^^^ [15]
    <BUILTINS>/dom.js:1598:70
-   1598|   createTreeWalker<RootNodeT: Document>(root: RootNodeT, whatToShow: 896, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, DocumentType|Document|Comment>;
-                                                                              ^^^ [23]
+   1598|   createTreeWalker<RootNodeT: Document>(root: RootNodeT, whatToShow: 641, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, DocumentType|Element|Comment>;
+                                                                              ^^^ [16]
    <BUILTINS>/dom.js:1599:70
-   1599|   createTreeWalker<RootNodeT: Document>(root: RootNodeT, whatToShow: 897, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, DocumentType|Document|Element|Comment>;
-                                                                              ^^^ [24]
+   1599|   createTreeWalker<RootNodeT: Document>(root: RootNodeT, whatToShow: 644, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, DocumentType|Text|Comment>;
+                                                                              ^^^ [17]
    <BUILTINS>/dom.js:1600:70
-   1600|   createTreeWalker<RootNodeT: Document>(root: RootNodeT, whatToShow: 900, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, DocumentType|Document|Text|Comment>;
-                                                                              ^^^ [25]
+   1600|   createTreeWalker<RootNodeT: Document>(root: RootNodeT, whatToShow: 645, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, DocumentType|Element|Text|Comment>;
+                                                                              ^^^ [18]
    <BUILTINS>/dom.js:1601:70
-   1601|   createTreeWalker<RootNodeT: Document>(root: RootNodeT, whatToShow: 901, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, DocumentType|Document|Element|Text|Comment>;
+   1601|   createTreeWalker<RootNodeT: Document>(root: RootNodeT, whatToShow: 768, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, DocumentType|Document>;
+                                                                              ^^^ [19]
+   <BUILTINS>/dom.js:1602:70
+   1602|   createTreeWalker<RootNodeT: Document>(root: RootNodeT, whatToShow: 769, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, DocumentType|Document|Element>;
+                                                                              ^^^ [20]
+   <BUILTINS>/dom.js:1603:70
+   1603|   createTreeWalker<RootNodeT: Document>(root: RootNodeT, whatToShow: 772, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, DocumentType|Document|Text>;
+                                                                              ^^^ [21]
+   <BUILTINS>/dom.js:1604:70
+   1604|   createTreeWalker<RootNodeT: Document>(root: RootNodeT, whatToShow: 773, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, DocumentType|Document|Element|Text>;
+                                                                              ^^^ [22]
+   <BUILTINS>/dom.js:1605:70
+   1605|   createTreeWalker<RootNodeT: Document>(root: RootNodeT, whatToShow: 896, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, DocumentType|Document|Comment>;
+                                                                              ^^^ [23]
+   <BUILTINS>/dom.js:1606:70
+   1606|   createTreeWalker<RootNodeT: Document>(root: RootNodeT, whatToShow: 897, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, DocumentType|Document|Element|Comment>;
+                                                                              ^^^ [24]
+   <BUILTINS>/dom.js:1607:70
+   1607|   createTreeWalker<RootNodeT: Document>(root: RootNodeT, whatToShow: 900, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, DocumentType|Document|Text|Comment>;
+                                                                              ^^^ [25]
+   <BUILTINS>/dom.js:1608:70
+   1608|   createTreeWalker<RootNodeT: Document>(root: RootNodeT, whatToShow: 901, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, DocumentType|Document|Element|Text|Comment>;
                                                                               ^^^ [26]
-   <BUILTINS>/dom.js:1613:78
-   1613|   createTreeWalker<RootNodeT: DocumentFragment>(root: RootNodeT, whatToShow: 1024, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, DocumentFragment>;
-                                                                                      ^^^^ [27]
-   <BUILTINS>/dom.js:1614:78
-   1614|   createTreeWalker<RootNodeT: DocumentFragment>(root: RootNodeT, whatToShow: 1025, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, DocumentFragment|Element>;
-                                                                                      ^^^^ [28]
-   <BUILTINS>/dom.js:1615:78
-   1615|   createTreeWalker<RootNodeT: DocumentFragment>(root: RootNodeT, whatToShow: 1028, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, DocumentFragment|Text>;
-                                                                                      ^^^^ [29]
-   <BUILTINS>/dom.js:1616:78
-   1616|   createTreeWalker<RootNodeT: DocumentFragment>(root: RootNodeT, whatToShow: 1029, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, DocumentFragment|Element|Text>;
-                                                                                      ^^^^ [30]
-   <BUILTINS>/dom.js:1617:78
-   1617|   createTreeWalker<RootNodeT: DocumentFragment>(root: RootNodeT, whatToShow: 1152, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, DocumentFragment|Comment>;
-                                                                                      ^^^^ [31]
-   <BUILTINS>/dom.js:1618:78
-   1618|   createTreeWalker<RootNodeT: DocumentFragment>(root: RootNodeT, whatToShow: 1153, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, DocumentFragment|Element|Comment>;
-                                                                                      ^^^^ [32]
-   <BUILTINS>/dom.js:1619:78
-   1619|   createTreeWalker<RootNodeT: DocumentFragment>(root: RootNodeT, whatToShow: 1156, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, DocumentFragment|Text|Comment>;
-                                                                                      ^^^^ [33]
    <BUILTINS>/dom.js:1620:78
-   1620|   createTreeWalker<RootNodeT: DocumentFragment>(root: RootNodeT, whatToShow: 1157, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, DocumentFragment|Element|Text|Comment>;
+   1620|   createTreeWalker<RootNodeT: DocumentFragment>(root: RootNodeT, whatToShow: 1024, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, DocumentFragment>;
+                                                                                      ^^^^ [27]
+   <BUILTINS>/dom.js:1621:78
+   1621|   createTreeWalker<RootNodeT: DocumentFragment>(root: RootNodeT, whatToShow: 1025, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, DocumentFragment|Element>;
+                                                                                      ^^^^ [28]
+   <BUILTINS>/dom.js:1622:78
+   1622|   createTreeWalker<RootNodeT: DocumentFragment>(root: RootNodeT, whatToShow: 1028, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, DocumentFragment|Text>;
+                                                                                      ^^^^ [29]
+   <BUILTINS>/dom.js:1623:78
+   1623|   createTreeWalker<RootNodeT: DocumentFragment>(root: RootNodeT, whatToShow: 1029, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, DocumentFragment|Element|Text>;
+                                                                                      ^^^^ [30]
+   <BUILTINS>/dom.js:1624:78
+   1624|   createTreeWalker<RootNodeT: DocumentFragment>(root: RootNodeT, whatToShow: 1152, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, DocumentFragment|Comment>;
+                                                                                      ^^^^ [31]
+   <BUILTINS>/dom.js:1625:78
+   1625|   createTreeWalker<RootNodeT: DocumentFragment>(root: RootNodeT, whatToShow: 1153, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, DocumentFragment|Element|Comment>;
+                                                                                      ^^^^ [32]
+   <BUILTINS>/dom.js:1626:78
+   1626|   createTreeWalker<RootNodeT: DocumentFragment>(root: RootNodeT, whatToShow: 1156, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, DocumentFragment|Text|Comment>;
+                                                                                      ^^^^ [33]
+   <BUILTINS>/dom.js:1627:78
+   1627|   createTreeWalker<RootNodeT: DocumentFragment>(root: RootNodeT, whatToShow: 1157, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, DocumentFragment|Element|Text|Comment>;
                                                                                       ^^^^ [34]
-   <BUILTINS>/dom.js:1632:66
-   1632|   createTreeWalker<RootNodeT: Node>(root: RootNodeT, whatToShow: 1, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, Element>;
+   <BUILTINS>/dom.js:1639:66
+   1639|   createTreeWalker<RootNodeT: Node>(root: RootNodeT, whatToShow: 1, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, Element>;
                                                                           ^ [35]
-   <BUILTINS>/dom.js:1633:66
-   1633|   createTreeWalker<RootNodeT: Node>(root: RootNodeT, whatToShow: 4, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, Text>;
+   <BUILTINS>/dom.js:1640:66
+   1640|   createTreeWalker<RootNodeT: Node>(root: RootNodeT, whatToShow: 4, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, Text>;
                                                                           ^ [36]
-   <BUILTINS>/dom.js:1634:66
-   1634|   createTreeWalker<RootNodeT: Node>(root: RootNodeT, whatToShow: 5, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, Element|Text>;
+   <BUILTINS>/dom.js:1641:66
+   1641|   createTreeWalker<RootNodeT: Node>(root: RootNodeT, whatToShow: 5, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, Element|Text>;
                                                                           ^ [37]
-   <BUILTINS>/dom.js:1635:66
-   1635|   createTreeWalker<RootNodeT: Node>(root: RootNodeT, whatToShow: 128, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, Comment>;
+   <BUILTINS>/dom.js:1642:66
+   1642|   createTreeWalker<RootNodeT: Node>(root: RootNodeT, whatToShow: 128, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, Comment>;
                                                                           ^^^ [38]
-   <BUILTINS>/dom.js:1636:66
-   1636|   createTreeWalker<RootNodeT: Node>(root: RootNodeT, whatToShow: 129, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, Element|Comment>;
+   <BUILTINS>/dom.js:1643:66
+   1643|   createTreeWalker<RootNodeT: Node>(root: RootNodeT, whatToShow: 129, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, Element|Comment>;
                                                                           ^^^ [39]
-   <BUILTINS>/dom.js:1637:66
-   1637|   createTreeWalker<RootNodeT: Node>(root: RootNodeT, whatToShow: 132, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, Text|Comment>;
+   <BUILTINS>/dom.js:1644:66
+   1644|   createTreeWalker<RootNodeT: Node>(root: RootNodeT, whatToShow: 132, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, Text|Comment>;
                                                                           ^^^ [40]
-   <BUILTINS>/dom.js:1638:66
-   1638|   createTreeWalker<RootNodeT: Node>(root: RootNodeT, whatToShow: 133, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, Text|Element|Comment>;
+   <BUILTINS>/dom.js:1645:66
+   1645|   createTreeWalker<RootNodeT: Node>(root: RootNodeT, whatToShow: 133, filter?: NodeFilterInterface, entityReferenceExpansion?: boolean): TreeWalker<RootNodeT, Text|Element|Comment>;
                                                                           ^^^ [41]
 
 

--- a/tests/fetch/fetch.exp
+++ b/tests/fetch/fetch.exp
@@ -8,8 +8,8 @@ Cannot assign `fetch(...)` to `b` because `Response` [1] is incompatible with st
                                     ^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/bom.js:1709:76
-   1709| declare function fetch(input: RequestInfo, init?: RequestOptions): Promise<Response>;
+   <BUILTINS>/bom.js:1710:76
+   1710| declare function fetch(input: RequestInfo, init?: RequestOptions): Promise<Response>;
                                                                                     ^^^^^^^^ [1]
    fetch.js:12:18
      12| const b: Promise<string> = fetch(myRequest); // incorrect
@@ -32,8 +32,8 @@ References:
    fetch.js:25:18
      25| const d: Promise<Blob> = fetch('image.png'); // incorrect
                           ^^^^ [1]
-   <BUILTINS>/bom.js:1709:76
-   1709| declare function fetch(input: RequestInfo, init?: RequestOptions): Promise<Response>;
+   <BUILTINS>/bom.js:1710:76
+   1710| declare function fetch(input: RequestInfo, init?: RequestOptions): Promise<Response>;
                                                                                     ^^^^^^^^ [2]
    <BUILTINS>/core.js:1935:24
    1935| declare class Promise<+R = mixed> {
@@ -52,14 +52,14 @@ Cannot call `Headers` with `''Content-T...'` bound to `init` because: [incompati
                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/bom.js:1563:20
-   1563| type HeadersInit = Headers | Array<[string, string]> | { [key: string]: string, ... };
+   <BUILTINS>/bom.js:1564:20
+   1564| type HeadersInit = Headers | Array<[string, string]> | { [key: string]: string, ... };
                             ^^^^^^^ [2]
-   <BUILTINS>/bom.js:1563:30
-   1563| type HeadersInit = Headers | Array<[string, string]> | { [key: string]: string, ... };
+   <BUILTINS>/bom.js:1564:30
+   1564| type HeadersInit = Headers | Array<[string, string]> | { [key: string]: string, ... };
                                       ^^^^^^^^^^^^^^^^^^^^^^^ [3]
-   <BUILTINS>/bom.js:1563:56
-   1563| type HeadersInit = Headers | Array<[string, string]> | { [key: string]: string, ... };
+   <BUILTINS>/bom.js:1564:56
+   1564| type HeadersInit = Headers | Array<[string, string]> | { [key: string]: string, ... };
                                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [4]
 
 
@@ -77,11 +77,11 @@ References:
    headers.js:4:24
       4| const b = new Headers(['Content-Type', 'image/jpeg']); // not correct
                                 ^^^^^^^^^^^^^^ [1]
-   <BUILTINS>/bom.js:1563:36
-   1563| type HeadersInit = Headers | Array<[string, string]> | { [key: string]: string, ... };
+   <BUILTINS>/bom.js:1564:36
+   1564| type HeadersInit = Headers | Array<[string, string]> | { [key: string]: string, ... };
                                             ^^^^^^^^^^^^^^^^ [2]
-   <BUILTINS>/bom.js:1563:56
-   1563| type HeadersInit = Headers | Array<[string, string]> | { [key: string]: string, ... };
+   <BUILTINS>/bom.js:1564:56
+   1564| type HeadersInit = Headers | Array<[string, string]> | { [key: string]: string, ... };
                                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [4]
 
 
@@ -94,8 +94,8 @@ Cannot call `e.append` because function [1] requires another argument. [incompat
            ^^^^^^
 
 References:
-   <BUILTINS>/bom.js:1571:5
-   1571|     append(name: string, value: string): void;
+   <BUILTINS>/bom.js:1572:5
+   1572|     append(name: string, value: string): void;
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 
@@ -108,8 +108,8 @@ Cannot call `e.append` because function [1] requires another argument. [incompat
            ^^^^^^
 
 References:
-   <BUILTINS>/bom.js:1571:5
-   1571|     append(name: string, value: string): void;
+   <BUILTINS>/bom.js:1572:5
+   1572|     append(name: string, value: string): void;
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 
@@ -123,8 +123,8 @@ Cannot call `e.append` with object literal bound to `name` because object litera
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/bom.js:1571:18
-   1571|     append(name: string, value: string): void;
+   <BUILTINS>/bom.js:1572:18
+   1572|     append(name: string, value: string): void;
                           ^^^^^^ [2]
 
 
@@ -137,8 +137,8 @@ Cannot call `e.set` because function [1] requires another argument. [incompatibl
            ^^^
 
 References:
-   <BUILTINS>/bom.js:1578:5
-   1578|     set(name: string, value: string): void;
+   <BUILTINS>/bom.js:1579:5
+   1579|     set(name: string, value: string): void;
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 
@@ -151,8 +151,8 @@ Cannot call `e.set` because function [1] requires another argument. [incompatibl
            ^^^
 
 References:
-   <BUILTINS>/bom.js:1578:5
-   1578|     set(name: string, value: string): void;
+   <BUILTINS>/bom.js:1579:5
+   1579|     set(name: string, value: string): void;
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 
@@ -166,8 +166,8 @@ Cannot call `e.set` with object literal bound to `name` because object literal [
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/bom.js:1578:15
-   1578|     set(name: string, value: string): void;
+   <BUILTINS>/bom.js:1579:15
+   1579|     set(name: string, value: string): void;
                        ^^^^^^ [2]
 
 
@@ -180,8 +180,8 @@ Cannot assign `e.append(...)` to `f` because undefined [1] is incompatible with 
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/bom.js:1571:42
-   1571|     append(name: string, value: string): void;
+   <BUILTINS>/bom.js:1572:42
+   1572|     append(name: string, value: string): void;
                                                   ^^^^ [1]
    headers.js:15:10
      15| const f: Headers = e.append('Content-Type', 'image/jpeg'); // not correct
@@ -197,8 +197,8 @@ Cannot assign `e.get(...)` to `g` because null [1] is incompatible with string [
                            ^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/bom.js:1575:24
-   1575|     get(name: string): null | string;
+   <BUILTINS>/bom.js:1576:24
+   1576|     get(name: string): null | string;
                                 ^^^^ [1]
    headers.js:17:10
      17| const g: string = e.get('Content-Type'); // correct
@@ -214,8 +214,8 @@ Cannot assign `e.get(...)` to `h` because null [1] is incompatible with number [
                            ^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/bom.js:1575:24
-   1575|     get(name: string): null | string;
+   <BUILTINS>/bom.js:1576:24
+   1576|     get(name: string): null | string;
                                 ^^^^ [1]
    headers.js:18:10
      18| const h: number = e.get('Content-Type'); // not correct
@@ -231,8 +231,8 @@ Cannot assign `e.get(...)` to `h` because string [1] is incompatible with number
                            ^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/bom.js:1575:31
-   1575|     get(name: string): null | string;
+   <BUILTINS>/bom.js:1576:31
+   1576|     get(name: string): null | string;
                                        ^^^^^^ [1]
    headers.js:18:10
      18| const h: number = e.get('Content-Type'); // not correct
@@ -268,14 +268,14 @@ References:
    request.js:2:20
       2| const a: Request = new Request(); // incorrect
                             ^^^^^^^^^^^^^ [1]
-   <BUILTINS>/bom.js:1615:20
-   1615| type RequestInfo = Request | URL | string;
+   <BUILTINS>/bom.js:1616:20
+   1616| type RequestInfo = Request | URL | string;
                             ^^^^^^^ [2]
-   <BUILTINS>/bom.js:1615:30
-   1615| type RequestInfo = Request | URL | string;
+   <BUILTINS>/bom.js:1616:30
+   1616| type RequestInfo = Request | URL | string;
                                       ^^^ [3]
-   <BUILTINS>/bom.js:1615:36
-   1615| type RequestInfo = Request | URL | string;
+   <BUILTINS>/bom.js:1616:36
+   1616| type RequestInfo = Request | URL | string;
                                             ^^^^^^ [4]
 
 
@@ -293,8 +293,8 @@ References:
    request.js:4:10
       4| const c: Request = new Request(b); // correct
                   ^^^^^^^ [1]
-   <BUILTINS>/bom.js:1668:44
-   1668|     constructor(input: RequestInfo, init?: RequestOptions): void;
+   <BUILTINS>/bom.js:1669:44
+   1669|     constructor(input: RequestInfo, init?: RequestOptions): void;
                                                     ^^^^^^^^^^^^^^ [2]
 
 
@@ -311,8 +311,8 @@ References:
    request.js:4:10
       4| const c: Request = new Request(b); // correct
                   ^^^^^^^ [1]
-   <BUILTINS>/bom.js:1668:44
-   1668|     constructor(input: RequestInfo, init?: RequestOptions): void;
+   <BUILTINS>/bom.js:1669:44
+   1669|     constructor(input: RequestInfo, init?: RequestOptions): void;
                                                     ^^^^^^^^^^^^^^ [2]
 
 
@@ -327,11 +327,11 @@ https://flow.org/en/docs/faq/#why-cant-i-pass-a-string-to-a-function-that-takes-
                                            ^
 
 References:
-   <BUILTINS>/bom.js:1619:11
-   1619|   cache?: CacheType,
+   <BUILTINS>/bom.js:1620:11
+   1620|   cache?: CacheType,
                    ^^^^^^^^^ [1]
-   <BUILTINS>/bom.js:1673:12
-   1673|     cache: CacheType;
+   <BUILTINS>/bom.js:1674:12
+   1674|     cache: CacheType;
                     ^^^^^^^^^ [2]
 
 
@@ -346,11 +346,11 @@ https://flow.org/en/docs/faq/#why-cant-i-pass-a-string-to-a-function-that-takes-
                                            ^
 
 References:
-   <BUILTINS>/bom.js:1620:17
-   1620|   credentials?: CredentialsType,
+   <BUILTINS>/bom.js:1621:17
+   1621|   credentials?: CredentialsType,
                          ^^^^^^^^^^^^^^^ [1]
-   <BUILTINS>/bom.js:1674:18
-   1674|     credentials: CredentialsType;
+   <BUILTINS>/bom.js:1675:18
+   1675|     credentials: CredentialsType;
                           ^^^^^^^^^^^^^^^ [2]
 
 
@@ -365,11 +365,11 @@ https://flow.org/en/docs/faq/#why-cant-i-pass-a-string-to-a-function-that-takes-
                                            ^
 
 References:
-   <BUILTINS>/bom.js:1621:13
-   1621|   headers?: HeadersInit,
+   <BUILTINS>/bom.js:1622:13
+   1622|   headers?: HeadersInit,
                      ^^^^^^^^^^^ [1]
-   <BUILTINS>/bom.js:1675:14
-   1675|     headers: Headers;
+   <BUILTINS>/bom.js:1676:14
+   1676|     headers: Headers;
                       ^^^^^^^ [2]
 
 
@@ -384,11 +384,11 @@ https://flow.org/en/docs/faq/#why-cant-i-pass-a-string-to-a-function-that-takes-
                                            ^
 
 References:
-   <BUILTINS>/bom.js:1621:13
-   1621|   headers?: HeadersInit,
+   <BUILTINS>/bom.js:1622:13
+   1622|   headers?: HeadersInit,
                      ^^^^^^^^^^^ [1]
-   <BUILTINS>/bom.js:1675:14
-   1675|     headers: Headers;
+   <BUILTINS>/bom.js:1676:14
+   1676|     headers: Headers;
                       ^^^^^^^ [2]
 
 
@@ -403,11 +403,11 @@ https://flow.org/en/docs/faq/#why-cant-i-pass-a-string-to-a-function-that-takes-
                                            ^
 
 References:
-   <BUILTINS>/bom.js:1621:13
-   1621|   headers?: HeadersInit,
+   <BUILTINS>/bom.js:1622:13
+   1622|   headers?: HeadersInit,
                      ^^^^^^^^^^^ [1]
-   <BUILTINS>/bom.js:1675:14
-   1675|     headers: Headers;
+   <BUILTINS>/bom.js:1676:14
+   1676|     headers: Headers;
                       ^^^^^^^ [2]
 
 
@@ -422,11 +422,11 @@ https://flow.org/en/docs/faq/#why-cant-i-pass-a-string-to-a-function-that-takes-
                                            ^
 
 References:
-   <BUILTINS>/bom.js:1622:15
-   1622|   integrity?: string,
+   <BUILTINS>/bom.js:1623:15
+   1623|   integrity?: string,
                        ^^^^^^ [1]
-   <BUILTINS>/bom.js:1676:16
-   1676|     integrity: string;
+   <BUILTINS>/bom.js:1677:16
+   1677|     integrity: string;
                         ^^^^^^ [2]
 
 
@@ -441,11 +441,11 @@ https://flow.org/en/docs/faq/#why-cant-i-pass-a-string-to-a-function-that-takes-
                                            ^
 
 References:
-   <BUILTINS>/bom.js:1624:12
-   1624|   method?: string,
+   <BUILTINS>/bom.js:1625:12
+   1625|   method?: string,
                     ^^^^^^ [1]
-   <BUILTINS>/bom.js:1677:13
-   1677|     method: string;
+   <BUILTINS>/bom.js:1678:13
+   1678|     method: string;
                      ^^^^^^ [2]
 
 
@@ -460,11 +460,11 @@ https://flow.org/en/docs/faq/#why-cant-i-pass-a-string-to-a-function-that-takes-
                                            ^
 
 References:
-   <BUILTINS>/bom.js:1625:10
-   1625|   mode?: ModeType,
+   <BUILTINS>/bom.js:1626:10
+   1626|   mode?: ModeType,
                   ^^^^^^^^ [1]
-   <BUILTINS>/bom.js:1678:11
-   1678|     mode: ModeType;
+   <BUILTINS>/bom.js:1679:11
+   1679|     mode: ModeType;
                    ^^^^^^^^ [2]
 
 
@@ -479,11 +479,11 @@ https://flow.org/en/docs/faq/#why-cant-i-pass-a-string-to-a-function-that-takes-
                                            ^
 
 References:
-   <BUILTINS>/bom.js:1626:14
-   1626|   redirect?: RedirectType,
+   <BUILTINS>/bom.js:1627:14
+   1627|   redirect?: RedirectType,
                       ^^^^^^^^^^^^ [1]
-   <BUILTINS>/bom.js:1679:15
-   1679|     redirect: RedirectType;
+   <BUILTINS>/bom.js:1680:15
+   1680|     redirect: RedirectType;
                        ^^^^^^^^^^^^ [2]
 
 
@@ -498,11 +498,11 @@ https://flow.org/en/docs/faq/#why-cant-i-pass-a-string-to-a-function-that-takes-
                                            ^
 
 References:
-   <BUILTINS>/bom.js:1627:14
-   1627|   referrer?: string,
+   <BUILTINS>/bom.js:1628:14
+   1628|   referrer?: string,
                       ^^^^^^ [1]
-   <BUILTINS>/bom.js:1680:15
-   1680|     referrer: string;
+   <BUILTINS>/bom.js:1681:15
+   1681|     referrer: string;
                        ^^^^^^ [2]
 
 
@@ -517,11 +517,11 @@ https://flow.org/en/docs/faq/#why-cant-i-pass-a-string-to-a-function-that-takes-
                                            ^
 
 References:
-   <BUILTINS>/bom.js:1628:20
-   1628|   referrerPolicy?: ReferrerPolicyType,
+   <BUILTINS>/bom.js:1629:20
+   1629|   referrerPolicy?: ReferrerPolicyType,
                             ^^^^^^^^^^^^^^^^^^ [1]
-   <BUILTINS>/bom.js:1681:21
-   1681|     referrerPolicy: ReferrerPolicyType;
+   <BUILTINS>/bom.js:1682:21
+   1682|     referrerPolicy: ReferrerPolicyType;
                              ^^^^^^^^^^^^^^^^^^ [2]
 
 
@@ -536,11 +536,11 @@ Cannot call `Request` with object literal bound to `input` because: [incompatibl
                                         ^^ [1]
 
 References:
-   <BUILTINS>/bom.js:1615:20
-   1615| type RequestInfo = Request | URL | string;
+   <BUILTINS>/bom.js:1616:20
+   1616| type RequestInfo = Request | URL | string;
                             ^^^^^^^ [2]
-   <BUILTINS>/bom.js:1615:30
-   1615| type RequestInfo = Request | URL | string;
+   <BUILTINS>/bom.js:1616:30
+   1616| type RequestInfo = Request | URL | string;
                                       ^^^ [3]
 
 
@@ -558,8 +558,8 @@ References:
    request.js:24:19
      24| h.text().then((t: Buffer) => t); // incorrect
                            ^^^^^^ [1]
-   <BUILTINS>/bom.js:1691:21
-   1691|     text(): Promise<string>;
+   <BUILTINS>/bom.js:1692:21
+   1692|     text(): Promise<string>;
                              ^^^^^^ [2]
    request.js:24:15
      24| h.text().then((t: Buffer) => t); // incorrect
@@ -580,8 +580,8 @@ Cannot call `h.arrayBuffer().then` because: [incompatible-call]
                          ^^^^
 
 References:
-   <BUILTINS>/bom.js:1687:28
-   1687|     arrayBuffer(): Promise<ArrayBuffer>;
+   <BUILTINS>/bom.js:1688:28
+   1688|     arrayBuffer(): Promise<ArrayBuffer>;
                                     ^^^^^^^^^^^ [1]
    request.js:26:27
      26| h.arrayBuffer().then((ab: Buffer) => ab); // incorrect
@@ -606,14 +606,14 @@ Cannot call `Request` with object literal bound to `init` because in property `h
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/bom.js:1563:20
-   1563| type HeadersInit = Headers | Array<[string, string]> | { [key: string]: string, ... };
+   <BUILTINS>/bom.js:1564:20
+   1564| type HeadersInit = Headers | Array<[string, string]> | { [key: string]: string, ... };
                             ^^^^^^^ [2]
-   <BUILTINS>/bom.js:1563:30
-   1563| type HeadersInit = Headers | Array<[string, string]> | { [key: string]: string, ... };
+   <BUILTINS>/bom.js:1564:30
+   1564| type HeadersInit = Headers | Array<[string, string]> | { [key: string]: string, ... };
                                       ^^^^^^^^^^^^^^^^^^^^^^^ [3]
-   <BUILTINS>/bom.js:1563:56
-   1563| type HeadersInit = Headers | Array<[string, string]> | { [key: string]: string, ... };
+   <BUILTINS>/bom.js:1564:56
+   1564| type HeadersInit = Headers | Array<[string, string]> | { [key: string]: string, ... };
                                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [4]
 
 
@@ -627,8 +627,8 @@ Cannot call `Request` with object literal bound to `init` because null [1] is in
                                     ^^^^ [1]
 
 References:
-   <BUILTINS>/bom.js:1624:12
-   1624|   method?: string,
+   <BUILTINS>/bom.js:1625:12
+   1625|   method?: string,
                     ^^^^^^ [2]
 
 
@@ -642,8 +642,8 @@ property `status`. [incompatible-call]
                                     ^^^^^ [1]
 
 References:
-   <BUILTINS>/bom.js:1635:12
-   1635|   status?: number,
+   <BUILTINS>/bom.js:1636:12
+   1636|   status?: number,
                     ^^^^^^ [2]
 
 
@@ -657,8 +657,8 @@ Cannot call `Response` with object literal bound to `init` because null [1] is i
                                     ^^^^ [1]
 
 References:
-   <BUILTINS>/bom.js:1635:12
-   1635|   status?: number,
+   <BUILTINS>/bom.js:1636:12
+   1636|   status?: number,
                     ^^^^^^ [2]
 
 
@@ -674,14 +674,14 @@ Cannot call `Response` with object literal bound to `init` because in property `
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/bom.js:1563:20
-   1563| type HeadersInit = Headers | Array<[string, string]> | { [key: string]: string, ... };
+   <BUILTINS>/bom.js:1564:20
+   1564| type HeadersInit = Headers | Array<[string, string]> | { [key: string]: string, ... };
                             ^^^^^^^ [2]
-   <BUILTINS>/bom.js:1563:30
-   1563| type HeadersInit = Headers | Array<[string, string]> | { [key: string]: string, ... };
+   <BUILTINS>/bom.js:1564:30
+   1564| type HeadersInit = Headers | Array<[string, string]> | { [key: string]: string, ... };
                                       ^^^^^^^^^^^^^^^^^^^^^^^ [3]
-   <BUILTINS>/bom.js:1563:56
-   1563| type HeadersInit = Headers | Array<[string, string]> | { [key: string]: string, ... };
+   <BUILTINS>/bom.js:1564:56
+   1564| type HeadersInit = Headers | Array<[string, string]> | { [key: string]: string, ... };
                                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [4]
 
 
@@ -709,17 +709,17 @@ Cannot call `Response` with object literal bound to `input` because: [incompatib
          ^ [1]
 
 References:
-   <BUILTINS>/bom.js:1613:26
-   1613| type BodyInit = string | URLSearchParams | FormData | Blob | ArrayBuffer | $ArrayBufferView | ReadableStream;
+   <BUILTINS>/bom.js:1614:26
+   1614| type BodyInit = string | URLSearchParams | FormData | Blob | ArrayBuffer | $ArrayBufferView | ReadableStream;
                                   ^^^^^^^^^^^^^^^ [2]
-   <BUILTINS>/bom.js:1613:44
-   1613| type BodyInit = string | URLSearchParams | FormData | Blob | ArrayBuffer | $ArrayBufferView | ReadableStream;
+   <BUILTINS>/bom.js:1614:44
+   1614| type BodyInit = string | URLSearchParams | FormData | Blob | ArrayBuffer | $ArrayBufferView | ReadableStream;
                                                     ^^^^^^^^ [3]
-   <BUILTINS>/bom.js:1613:55
-   1613| type BodyInit = string | URLSearchParams | FormData | Blob | ArrayBuffer | $ArrayBufferView | ReadableStream;
+   <BUILTINS>/bom.js:1614:55
+   1614| type BodyInit = string | URLSearchParams | FormData | Blob | ArrayBuffer | $ArrayBufferView | ReadableStream;
                                                                ^^^^ [4]
-   <BUILTINS>/bom.js:1613:62
-   1613| type BodyInit = string | URLSearchParams | FormData | Blob | ArrayBuffer | $ArrayBufferView | ReadableStream;
+   <BUILTINS>/bom.js:1614:62
+   1614| type BodyInit = string | URLSearchParams | FormData | Blob | ArrayBuffer | $ArrayBufferView | ReadableStream;
                                                                       ^^^^^^^^^^^ [5]
    <BUILTINS>/core.js:2063:20
    2063| type $TypedArray = $TypedArrayNumber | BigInt64Array | BigUint64Array;
@@ -733,8 +733,8 @@ References:
    <BUILTINS>/core.js:2059:39
    2059| type $ArrayBufferView = $TypedArray | DataView;
                                                ^^^^^^^^ [9]
-   <BUILTINS>/bom.js:1613:95
-   1613| type BodyInit = string | URLSearchParams | FormData | Blob | ArrayBuffer | $ArrayBufferView | ReadableStream;
+   <BUILTINS>/bom.js:1614:95
+   1614| type BodyInit = string | URLSearchParams | FormData | Blob | ArrayBuffer | $ArrayBufferView | ReadableStream;
                                                                                                        ^^^^^^^^^^^^^^ [10]
 
 
@@ -752,8 +752,8 @@ References:
    response.js:42:19
      42| h.text().then((t: Buffer) => t); // incorrect
                            ^^^^^^ [1]
-   <BUILTINS>/bom.js:1664:21
-   1664|     text(): Promise<string>;
+   <BUILTINS>/bom.js:1665:21
+   1665|     text(): Promise<string>;
                              ^^^^^^ [2]
    response.js:42:15
      42| h.text().then((t: Buffer) => t); // incorrect
@@ -774,8 +774,8 @@ Cannot call `h.arrayBuffer().then` because: [incompatible-call]
                          ^^^^
 
 References:
-   <BUILTINS>/bom.js:1660:28
-   1660|     arrayBuffer(): Promise<ArrayBuffer>;
+   <BUILTINS>/bom.js:1661:28
+   1661|     arrayBuffer(): Promise<ArrayBuffer>;
                                     ^^^^^^^^^^^ [1]
    response.js:44:27
      44| h.arrayBuffer().then((ab: Buffer) => ab); // incorrect
@@ -802,11 +802,11 @@ References:
    urlsearchparams.js:4:32
       4| const b = new URLSearchParams(['key1', 'value1']); // not correct
                                         ^^^^^^ [1]
-   <BUILTINS>/bom.js:1587:57
-   1587|     constructor(init?: string | URLSearchParams | Array<[string, string]> | { [string]: string, ... } ): void;
+   <BUILTINS>/bom.js:1588:57
+   1588|     constructor(init?: string | URLSearchParams | Array<[string, string]> | { [string]: string, ... } ): void;
                                                                  ^^^^^^^^^^^^^^^^ [2]
-   <BUILTINS>/bom.js:1587:77
-   1587|     constructor(init?: string | URLSearchParams | Array<[string, string]> | { [string]: string, ... } ): void;
+   <BUILTINS>/bom.js:1588:77
+   1588|     constructor(init?: string | URLSearchParams | Array<[string, string]> | { [string]: string, ... } ): void;
                                                                                      ^^^^^^^^^^^^^^^^^^^^^^^^^ [4]
 
 
@@ -819,8 +819,8 @@ Cannot call `e.append` because function [1] requires another argument. [incompat
            ^^^^^^
 
 References:
-   <BUILTINS>/bom.js:1588:5
-   1588|     append(name: string, value: string): void;
+   <BUILTINS>/bom.js:1589:5
+   1589|     append(name: string, value: string): void;
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 
@@ -833,8 +833,8 @@ Cannot call `e.append` because function [1] requires another argument. [incompat
            ^^^^^^
 
 References:
-   <BUILTINS>/bom.js:1588:5
-   1588|     append(name: string, value: string): void;
+   <BUILTINS>/bom.js:1589:5
+   1589|     append(name: string, value: string): void;
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 
@@ -848,8 +848,8 @@ Cannot call `e.append` with object literal bound to `name` because object litera
                   ^^^^^^^^^^^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/bom.js:1588:18
-   1588|     append(name: string, value: string): void;
+   <BUILTINS>/bom.js:1589:18
+   1589|     append(name: string, value: string): void;
                           ^^^^^^ [2]
 
 
@@ -862,8 +862,8 @@ Cannot call `e.set` because function [1] requires another argument. [incompatibl
            ^^^
 
 References:
-   <BUILTINS>/bom.js:1596:5
-   1596|     set(name: string, value: string): void;
+   <BUILTINS>/bom.js:1597:5
+   1597|     set(name: string, value: string): void;
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 
@@ -876,8 +876,8 @@ Cannot call `e.set` because function [1] requires another argument. [incompatibl
            ^^^
 
 References:
-   <BUILTINS>/bom.js:1596:5
-   1596|     set(name: string, value: string): void;
+   <BUILTINS>/bom.js:1597:5
+   1597|     set(name: string, value: string): void;
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 
@@ -891,8 +891,8 @@ Cannot call `e.set` with object literal bound to `name` because object literal [
                ^^^^^^^^^^^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/bom.js:1596:15
-   1596|     set(name: string, value: string): void;
+   <BUILTINS>/bom.js:1597:15
+   1597|     set(name: string, value: string): void;
                        ^^^^^^ [2]
 
 
@@ -906,8 +906,8 @@ Cannot assign `e.append(...)` to `f` because undefined [1] is incompatible with 
                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/bom.js:1588:42
-   1588|     append(name: string, value: string): void;
+   <BUILTINS>/bom.js:1589:42
+   1589|     append(name: string, value: string): void;
                                                   ^^^^ [1]
    urlsearchparams.js:15:10
      15| const f: URLSearchParams = e.append('key1', 'value1'); // not correct
@@ -923,8 +923,8 @@ Cannot assign `e.get(...)` to `g` because null [1] is incompatible with string [
                            ^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/bom.js:1592:24
-   1592|     get(name: string): null | string;
+   <BUILTINS>/bom.js:1593:24
+   1593|     get(name: string): null | string;
                                 ^^^^ [1]
    urlsearchparams.js:17:10
      17| const g: string = e.get('key1'); // correct
@@ -940,8 +940,8 @@ Cannot assign `e.get(...)` to `h` because null [1] is incompatible with number [
                            ^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/bom.js:1592:24
-   1592|     get(name: string): null | string;
+   <BUILTINS>/bom.js:1593:24
+   1593|     get(name: string): null | string;
                                 ^^^^ [1]
    urlsearchparams.js:18:10
      18| const h: number = e.get('key1'); // not correct
@@ -957,8 +957,8 @@ Cannot assign `e.get(...)` to `h` because string [1] is incompatible with number
                            ^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/bom.js:1592:31
-   1592|     get(name: string): null | string;
+   <BUILTINS>/bom.js:1593:31
+   1593|     get(name: string): null | string;
                                        ^^^^^^ [1]
    urlsearchparams.js:18:10
      18| const h: number = e.get('key1'); // not correct


### PR DESCRIPTION
As a follow-up to #9127, this PR defines all currently available entry points for the [File System API](https://developer.mozilla.org/en-US/docs/Web/API/File_System_API):

- `window.showOpenFilePicker()`: [MDN](https://developer.mozilla.org/en-US/docs/Web/API/window/showOpenFilePicker), [WICG](https://wicg.github.io/file-system-access/#api-showopenfilepicker)
- `window.showSaveFilePicker()`: [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Window/showSaveFilePicker), [WICG](https://wicg.github.io/file-system-access/#api-showsavefilepicker)
- `window.showDirectoryPicker()`: [MDN](https://developer.mozilla.org/en-US/docs/Web/API/window/showDirectoryPicker), [WICG](https://wicg.github.io/file-system-access/#api-showdirectorypicker)
- `DataTransferItem.getAsFileSystemHandle()`: [MDN](https://developer.mozilla.org/en-US/docs/Web/API/DataTransferItem/getAsFileSystemHandle), [WICG](https://wicg.github.io/file-system-access/#dom-datatransferitem-getasfilesystemhandle)
- `StorageManager.getDirectory()`: [MDN](https://developer.mozilla.org/en-US/docs/Web/API/StorageManager/getDirectory), [WHATWG](https://fs.spec.whatwg.org/#dom-storagemanager-getdirectory)
