### PR TITLE
[ci] Properly test mac and linux in GitHub Actions CI

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -361,23 +361,23 @@ jobs:
       run: (cd packages/flow-dev-tools && yarn install | cat)
     - name: Run tool tests
       run: ./tool test --bin bin/macos/flow | cat
-  tool_test_win:
-    runs-on: windows-latest
-    needs:
-    - build_win
-    steps:
-    - uses: actions/checkout@v3.6.0
-    - uses: actions/download-artifact@v3.0.2
-      with:
-        name: build_win_bin
-        path: bin/win64
-    - name: Install tool deps from yarn
-      run: |-
-        cd packages/flow-dev-tools
-        yarn install --ignore-scripts --pure-lockfile
-    - name: Run tool tests
-      run: node packages/flow-dev-tools/bin/tool test --bin bin/win64/flow.exe --parallelism 1
-      shell: bash
+  # tool_test_win:
+  #  runs-on: windows-latest
+  #  needs:
+  #  - build_win
+  #  steps:
+  #  - uses: actions/checkout@v3.6.0
+  #  - uses: actions/download-artifact@v3.0.2
+  #    with:
+  #      name: build_win_bin
+  #      path: bin/win64
+  #  - name: Install tool deps from yarn
+  #    run: |-
+  #      cd packages/flow-dev-tools
+  #      yarn install --ignore-scripts --pure-lockfile
+  #  - name: Run tool tests
+  #    run: node packages/flow-dev-tools/bin/tool test --bin bin/win64/flow.exe --parallelism 1
+  #    shell: bash
   ounit_test_linux:
     runs-on: ubuntu-latest
     container:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -341,23 +341,19 @@ jobs:
       run: (cd packages/flow-dev-tools && yarn install | cat)
     - name: Run tool tests
       run: ./tool test --bin bin/macos/flow | cat
-  # tool_test_win:
-  #   runs-on: windows-latest
-  #   needs:
-  #   - build_win
-  #   steps:
-  #   - uses: actions/checkout@v3.6.0
-  #   - name: Install Node LTS
-  #     run: choco install nodejs-lts -y
-  #   - name: Enable Corepack
-  #     run: corepack enable
-  #   - name: Install tool deps from yarn
-  #     run: |-
-  #       cd packages/flow-dev-tools
-  #       yarn install --ignore-scripts --pure-lockfile
-  #   - name: Run tool tests
-  #     run: node packages/flow-dev-tools/bin/tool test --bin bin/win64/flow.exe --parallelism 1
-  #     shell: bash
+  tool_test_win:
+    runs-on: windows-latest
+    needs:
+    - build_win
+    steps:
+    - uses: actions/checkout@v3.6.0
+    - name: Install tool deps from yarn
+      run: |-
+        cd packages/flow-dev-tools
+        yarn install --ignore-scripts --pure-lockfile
+    - name: Run tool tests
+      run: node packages/flow-dev-tools/bin/tool test --bin bin/win64/flow.exe --parallelism 1
+      shell: bash
   ounit_test_linux:
     runs-on: ubuntu-latest
     container:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -303,6 +303,10 @@ jobs:
       FLOW_RUNTESTS_PARALLELISM: 8
     steps:
     - uses: actions/checkout@v3.6.0
+    - uses: actions/download-artifact@v3.0.2
+      with:
+        name: build_linux_bin
+        path: bin/linux
     - name: Run tests
       run: ./runtests.sh bin/linux/flow | cat
   runtests_macos:
@@ -314,6 +318,10 @@ jobs:
       with:
         xcode-version: '13.4'
     - uses: actions/checkout@v3.6.0
+    - uses: actions/download-artifact@v3.0.2
+      with:
+        name: build_macos_bin
+        path: bin/macos
     - name: Run tests
       run: ./runtests.sh bin/macos/flow | cat
   tool_test_linux:
@@ -324,6 +332,10 @@ jobs:
     - build_linux
     steps:
     - uses: actions/checkout@v3.6.0
+    - uses: actions/download-artifact@v3.0.2
+      with:
+        name: build_linux_bin
+        path: bin/linux
     - name: Install tool deps from yarn
       run: (cd packages/flow-dev-tools && yarn install | cat)
     - name: Run tool tests
@@ -337,6 +349,10 @@ jobs:
       with:
         xcode-version: '13.4'
     - uses: actions/checkout@v3.6.0
+    - uses: actions/download-artifact@v3.0.2
+      with:
+        name: build_macos_bin
+        path: bin/macos
     - name: Install tool deps from yarn
       run: (cd packages/flow-dev-tools && yarn install | cat)
     - name: Run tool tests
@@ -347,6 +363,10 @@ jobs:
     - build_win
     steps:
     - uses: actions/checkout@v3.6.0
+    - uses: actions/download-artifact@v3.0.2
+      with:
+        name: build_win_bin
+        path: bin/win64
     - name: Install tool deps from yarn
       run: |-
         cd packages/flow-dev-tools

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -307,6 +307,7 @@ jobs:
       with:
         name: build_linux_bin
         path: bin/linux
+    - run: chmod +x bin/linux/flow
     - name: Run tests
       run: ./runtests.sh bin/linux/flow | cat
   runtests_macos:
@@ -322,6 +323,7 @@ jobs:
       with:
         name: build_macos_bin
         path: bin/macos
+    - run: chmod +x bin/macos/flow
     - name: Run tests
       run: ./runtests.sh bin/macos/flow | cat
   tool_test_linux:
@@ -336,6 +338,7 @@ jobs:
       with:
         name: build_linux_bin
         path: bin/linux
+    - run: chmod +x bin/linux/flow
     - name: Install tool deps from yarn
       run: (cd packages/flow-dev-tools && yarn install | cat)
     - name: Run tool tests
@@ -353,6 +356,7 @@ jobs:
       with:
         name: build_macos_bin
         path: bin/macos
+    - run: chmod +x bin/macos/flow
     - name: Install tool deps from yarn
       run: (cd packages/flow-dev-tools && yarn install | cat)
     - name: Run tool tests


### PR DESCRIPTION
Currently, the mac and linux tests are passing, but if we look at the logs, they are failing for every single test. It turns out that we are not even downloading the artifacts from previous build jobs. We also need to set the executable bit to actually make the tests runnable (this is not needed in circle ci jobs and also not needed for windows builds, so it's unclear why, which needs further investigation)