### PR TITLE
promise resolve generic

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -1925,7 +1925,7 @@ declare class WeakSet<T: interface {} | $ReadOnlyArray<mixed>> extends $ReadOnly
  */
 declare class Promise<+R = mixed> {
     constructor(callback: (
-      resolve: (result: Promise<R> | R) => void,
+      resolve: <PR: Promise<R> | R>(result: PR) => void,
       reject: (error: any) => void
     ) => mixed): void;
 


### PR DESCRIPTION
Due to contravariant typing for function parameters, unions need to be generics otherwise the inputs need to satisfy all union variants. Change to resolve function to support only Promise or non promise values