### PR TITLE
Update Array.prototype.{shift,pop} to `T | void`

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -1042,7 +1042,7 @@ declare class Array<T> extends $ReadOnlyArray<T> {
     /**
      * Removes the last element from an array and returns it.
      */
-    pop(): T;
+    pop(): T | void;
     /**
      * Appends new elements to an array, and returns the new length of the array.
      * @param items New elements of the Array.
@@ -1087,7 +1087,7 @@ declare class Array<T> extends $ReadOnlyArray<T> {
     /**
      * Removes the first element from an array and returns it.
      */
-    shift(): T;
+    shift(): T | void;
     some<This>(callbackfn: (this : This, value: T, index: number, array: Array<T>) => mixed, thisArg: This): boolean;
     sort(compareFn?: (a: T, b: T) => number): Array<T>;
     splice(start: number, deleteCount?: number, ...items: Array<T>): Array<T>;

--- a/tests/autocomplete/autocomplete.exp
+++ b/tests/autocomplete/autocomplete.exp
@@ -671,7 +671,7 @@ Flags: --pretty
       "name":"?.map",
       "type":"void | (<U, This>(callbackfn: (value: T, index: number, array: Array<T>) => U, thisArg: This) => Array<U>)"
     },
-    {"name":"?.pop","type":"void | (() => T)"},
+    {"name":"?.pop","type":"void | (() => T | void)"},
     {"name":"?.push","type":"void | ((...items: Array<T>) => number)"},
     {
       "name":"?.reduce",
@@ -682,7 +682,7 @@ Flags: --pretty
       "type":"void | (<U>(callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: Array<T>) => U, initialValue: U) => U)"
     },
     {"name":"?.reverse","type":"void | (() => Array<T>)"},
-    {"name":"?.shift","type":"void | (() => T)"},
+    {"name":"?.shift","type":"void | (() => T | void)"},
     {"name":"?.slice","type":"void | ((start?: number, end?: number) => Array<T>)"},
     {
       "name":"?.some",
@@ -780,7 +780,7 @@ Flags: --pretty
       "name":"map",
       "type":"<U, This>(callbackfn: (value: T, index: number, array: Array<T>) => U, thisArg: This) => Array<U>"
     },
-    {"name":"pop","type":"() => T"},
+    {"name":"pop","type":"() => T | void"},
     {"name":"push","type":"(...items: Array<T>) => number"},
     {
       "name":"reduce",
@@ -791,7 +791,7 @@ Flags: --pretty
       "type":"<U>(callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: Array<T>) => U, initialValue: U) => U"
     },
     {"name":"reverse","type":"() => Array<T>"},
-    {"name":"shift","type":"() => T"},
+    {"name":"shift","type":"() => T | void"},
     {"name":"slice","type":"(start?: number, end?: number) => Array<T>"},
     {
       "name":"some",

--- a/tests/interface/array.js
+++ b/tests/interface/array.js
@@ -1,4 +1,4 @@
 declare var a: Array<number>;
 
-(a: interface {pop(): number}); // OK
-(a: interface {pop(): boolean}); // ERROR
+(a: interface {pop(): number | void}); // OK
+(a: interface {pop(): boolean | void}); // ERROR

--- a/tests/interface/interface.exp
+++ b/tests/interface/interface.exp
@@ -1,10 +1,11 @@
 Error ----------------------------------------------------------------------------------------------------- array.js:4:2
 
-Cannot cast `a` to interface type because number [1] is incompatible with boolean [2] in the return value of property
-`pop`. [incompatible-cast]
+Cannot cast `a` to interface type because in the return value of property `pop`: [incompatible-cast]
+ - Either number [1] is incompatible with boolean [2].
+ - Or number [1] is incompatible with undefined [3].
 
    array.js:4:2
-   4| (a: interface {pop(): boolean}); // ERROR
+   4| (a: interface {pop(): boolean | void}); // ERROR
        ^
 
 References:
@@ -12,8 +13,11 @@ References:
    1| declare var a: Array<number>;
                            ^^^^^^ [1]
    array.js:4:23
-   4| (a: interface {pop(): boolean}); // ERROR
+   4| (a: interface {pop(): boolean | void}); // ERROR
                             ^^^^^^^ [2]
+   array.js:4:33
+   4| (a: interface {pop(): boolean | void}); // ERROR
+                                      ^^^^ [3]
 
 
 Error ------------------------------------------------------------------------------------------------------ fun.js:5:19

--- a/tests/node_tests/events/events.js
+++ b/tests/node_tests/events/events.js
@@ -16,7 +16,9 @@ emitter.emit({});                         // err: `event` must be a string
 emitter.eventNames().pop();               // ok: returns string[]
 emitter.eventNames('foo')                 // err: does not process args
 
-emitter.listeners('foo').pop()();         // ok: returns Function[]
+emitter.listeners('foo').pop();           // ok: returns Function[]
+emitter.listeners('foo').pop()();         // err: Function | void
+emitter.listeners('foo').pop()?.();       // ok: optional chaining of Function | void
 emitter.listeners();                      // err: requires `event`
 
 emitter.listenerCount('foo').toFixed();   // ok: returns a number
@@ -61,7 +63,9 @@ emitter.setMaxListeners('foo');           // err: numeric arg is required
 emitter.getMaxListeners().toFixed();      // ok
 emitter.getMaxListeners('foo');           // err: does not process args
 
-emitter.rawListeners('foo').pop()();      // ok: returns Function[]
+emitter.rawListeners('foo').pop();        // ok: returns Function[]
+emitter.rawListeners('foo').pop()();      // err: Function | void
+emitter.rawListeners('foo').pop()?.();    // ok: optional chaining of Function | void
 emitter.rawListeners();                   // err: requires `event`
 
 EventEmitter.defaultMaxListeners.toFixed() // ok

--- a/tests/node_tests/node_tests.exp
+++ b/tests/node_tests/node_tests.exp
@@ -415,12 +415,26 @@ References:
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 
-Error -------------------------------------------------------------------------------------------- events/events.js:20:9
+Error -------------------------------------------------------------------------------------------- events/events.js:20:1
+
+Cannot call `emitter.listeners(...).pop()` because undefined [1] is not a function. [not-a-function]
+
+   events/events.js:20:1
+     20| emitter.listeners('foo').pop()();         // err: Function | void
+         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+References:
+   <BUILTINS>/core.js:1045:16
+   1045|     pop(): T | void;
+                        ^^^^ [1]
+
+
+Error -------------------------------------------------------------------------------------------- events/events.js:22:9
 
 Cannot call `emitter.listeners` because function [1] requires another argument. [incompatible-call]
 
-   events/events.js:20:9
-    20| emitter.listeners();                      // err: requires `event`
+   events/events.js:22:9
+    22| emitter.listeners();                      // err: requires `event`
                 ^^^^^^^^^
 
 References:
@@ -429,12 +443,12 @@ References:
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 
-Error -------------------------------------------------------------------------------------------- events/events.js:23:9
+Error -------------------------------------------------------------------------------------------- events/events.js:25:9
 
 Cannot call `emitter.listenerCount` because function [1] requires another argument. [incompatible-call]
 
-   events/events.js:23:9
-    23| emitter.listenerCount();                  // err: requires `event`
+   events/events.js:25:9
+    25| emitter.listenerCount();                  // err: requires `event`
                 ^^^^^^^^^^^^^
 
 References:
@@ -443,13 +457,13 @@ References:
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 
-Error ------------------------------------------------------------------------------------------- events/events.js:27:12
+Error ------------------------------------------------------------------------------------------- events/events.js:29:12
 
 Cannot call `emitter.on` with `123` bound to `event` because number [1] is incompatible with string [2].
 [incompatible-call]
 
-   events/events.js:27:12
-    27| emitter.on(123, []);                      // err: `event` and `handler `type mismatch
+   events/events.js:29:12
+    29| emitter.on(123, []);                      // err: `event` and `handler `type mismatch
                    ^^^ [1]
 
 References:
@@ -458,13 +472,13 @@ References:
                     ^^^^^^ [2]
 
 
-Error ------------------------------------------------------------------------------------------- events/events.js:31:14
+Error ------------------------------------------------------------------------------------------- events/events.js:33:14
 
 Cannot call `emitter.once` with `123` bound to `event` because number [1] is incompatible with string [2].
 [incompatible-call]
 
-   events/events.js:31:14
-    31| emitter.once(123, []);                    // err: `event` and `handler `type mismatch
+   events/events.js:33:14
+    33| emitter.once(123, []);                    // err: `event` and `handler `type mismatch
                      ^^^ [1]
 
 References:
@@ -473,12 +487,12 @@ References:
                       ^^^^^^ [2]
 
 
-Error -------------------------------------------------------------------------------------------- events/events.js:35:9
+Error -------------------------------------------------------------------------------------------- events/events.js:37:9
 
 Cannot call `emitter.prependListener` because function [1] requires another argument. [incompatible-call]
 
-   events/events.js:35:9
-    35| emitter.prependListener();                // err: both args are required
+   events/events.js:37:9
+    37| emitter.prependListener();                // err: both args are required
                 ^^^^^^^^^^^^^^^
 
 References:
@@ -487,13 +501,13 @@ References:
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 
-Error ------------------------------------------------------------------------------------------- events/events.js:36:25
+Error ------------------------------------------------------------------------------------------- events/events.js:38:25
 
 Cannot call `emitter.prependListener` with `123` bound to `event` because number [1] is incompatible with string [2].
 [incompatible-call]
 
-   events/events.js:36:25
-    36| emitter.prependListener(123, {});         // err: `event` and `handler `type mismatch
+   events/events.js:38:25
+    38| emitter.prependListener(123, {});         // err: `event` and `handler `type mismatch
                                 ^^^ [1]
 
 References:
@@ -502,12 +516,12 @@ References:
                                  ^^^^^^ [2]
 
 
-Error -------------------------------------------------------------------------------------------- events/events.js:40:9
+Error -------------------------------------------------------------------------------------------- events/events.js:42:9
 
 Cannot call `emitter.prependOnceListener` because function [1] requires another argument. [incompatible-call]
 
-   events/events.js:40:9
-    40| emitter.prependOnceListener();            // err: both args are required
+   events/events.js:42:9
+    42| emitter.prependOnceListener();            // err: both args are required
                 ^^^^^^^^^^^^^^^^^^^
 
 References:
@@ -516,13 +530,13 @@ References:
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 
-Error ------------------------------------------------------------------------------------------- events/events.js:41:29
+Error ------------------------------------------------------------------------------------------- events/events.js:43:29
 
 Cannot call `emitter.prependOnceListener` with `123` bound to `event` because number [1] is incompatible with
 string [2]. [incompatible-call]
 
-   events/events.js:41:29
-    41| emitter.prependOnceListener(123, {});     // err: `event` and `handler `type mismatch
+   events/events.js:43:29
+    43| emitter.prependOnceListener(123, {});     // err: `event` and `handler `type mismatch
                                     ^^^ [1]
 
 References:
@@ -531,13 +545,13 @@ References:
                                      ^^^^^^ [2]
 
 
-Error ------------------------------------------------------------------------------------------- events/events.js:46:28
+Error ------------------------------------------------------------------------------------------- events/events.js:48:28
 
 Cannot call `emitter.removeAllListeners` with `123` bound to `event` because number [1] is incompatible with string [2].
 [incompatible-call]
 
-   events/events.js:46:28
-    46| emitter.removeAllListeners(123);          // err: `event` must be a string
+   events/events.js:48:28
+    48| emitter.removeAllListeners(123);          // err: `event` must be a string
                                    ^^^ [1]
 
 References:
@@ -546,12 +560,12 @@ References:
                                      ^^^^^^ [2]
 
 
-Error -------------------------------------------------------------------------------------------- events/events.js:50:9
+Error -------------------------------------------------------------------------------------------- events/events.js:52:9
 
 Cannot call `emitter.removeListener` because function [1] requires another argument. [incompatible-call]
 
-   events/events.js:50:9
-    50| emitter.removeListener();                 // err: both args are required
+   events/events.js:52:9
+    52| emitter.removeListener();                 // err: both args are required
                 ^^^^^^^^^^^^^^
 
 References:
@@ -560,13 +574,13 @@ References:
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 
-Error ------------------------------------------------------------------------------------------- events/events.js:51:24
+Error ------------------------------------------------------------------------------------------- events/events.js:53:24
 
 Cannot call `emitter.removeListener` with `123` bound to `event` because number [1] is incompatible with string [2].
 [incompatible-call]
 
-   events/events.js:51:24
-    51| emitter.removeListener(123, {});          // `event` and `handler `type mismatch
+   events/events.js:53:24
+    53| emitter.removeListener(123, {});          // `event` and `handler `type mismatch
                                ^^^ [1]
 
 References:
@@ -575,12 +589,12 @@ References:
                                 ^^^^^^ [2]
 
 
-Error -------------------------------------------------------------------------------------------- events/events.js:55:9
+Error -------------------------------------------------------------------------------------------- events/events.js:57:9
 
 Cannot call `emitter.off` because function [1] requires another argument. [incompatible-call]
 
-   events/events.js:55:9
-    55| emitter.off();                            // err: both args are required
+   events/events.js:57:9
+    57| emitter.off();                            // err: both args are required
                 ^^^
 
 References:
@@ -589,13 +603,13 @@ References:
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 
-Error ------------------------------------------------------------------------------------------- events/events.js:56:13
+Error ------------------------------------------------------------------------------------------- events/events.js:58:13
 
 Cannot call `emitter.off` with `123` bound to `event` because number [1] is incompatible with string [2].
 [incompatible-call]
 
-   events/events.js:56:13
-    56| emitter.off(123, {});                     // `event` and `handler `type mismatch
+   events/events.js:58:13
+    58| emitter.off(123, {});                     // `event` and `handler `type mismatch
                     ^^^ [1]
 
 References:
@@ -604,13 +618,13 @@ References:
                      ^^^^^^ [2]
 
 
-Error ------------------------------------------------------------------------------------------- events/events.js:59:25
+Error ------------------------------------------------------------------------------------------- events/events.js:61:25
 
 Cannot call `emitter.setMaxListeners` with `'foo'` bound to `n` because string [1] is incompatible with number [2].
 [incompatible-call]
 
-   events/events.js:59:25
-    59| emitter.setMaxListeners('foo');           // err: numeric arg is required
+   events/events.js:61:25
+    61| emitter.setMaxListeners('foo');           // err: numeric arg is required
                                 ^^^^^ [1]
 
 References:
@@ -619,12 +633,12 @@ References:
                              ^^^^^^ [2]
 
 
-Error ------------------------------------------------------------------------------------------- events/events.js:62:25
+Error ------------------------------------------------------------------------------------------- events/events.js:64:25
 
 Cannot call `emitter.getMaxListeners` because no arguments are expected by function type [1]. [extra-arg]
 
-   events/events.js:62:25
-    62| emitter.getMaxListeners('foo');           // err: does not process args
+   events/events.js:64:25
+    64| emitter.getMaxListeners('foo');           // err: does not process args
                                 ^^^^^
 
 References:
@@ -633,12 +647,26 @@ References:
           ^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 
-Error -------------------------------------------------------------------------------------------- events/events.js:65:9
+Error -------------------------------------------------------------------------------------------- events/events.js:67:1
+
+Cannot call `emitter.rawListeners(...).pop()` because undefined [1] is not a function. [not-a-function]
+
+   events/events.js:67:1
+     67| emitter.rawListeners('foo').pop()();      // err: Function | void
+         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+References:
+   <BUILTINS>/core.js:1045:16
+   1045|     pop(): T | void;
+                        ^^^^ [1]
+
+
+Error -------------------------------------------------------------------------------------------- events/events.js:69:9
 
 Cannot call `emitter.rawListeners` because function [1] requires another argument. [incompatible-call]
 
-   events/events.js:65:9
-    65| emitter.rawListeners();                   // err: requires `event`
+   events/events.js:69:9
+    69| emitter.rawListeners();                   // err: requires `event`
                 ^^^^^^^^^^^^
 
 References:
@@ -2631,7 +2659,7 @@ References:
 
 
 
-Found 129 errors
+Found 131 errors
 
 Only showing the most relevant union/intersection branches.
 To see all branches, re-run Flow with --show-all-branches

--- a/tests/predicates_inferred/predicates_inferred.exp
+++ b/tests/predicates_inferred/predicates_inferred.exp
@@ -47,12 +47,12 @@ References:
                        ^^^^^^ [1]
 
 
-Error ----------------------------------------------------------------------------------------- sanity-ordering.js:13:17
+Error ----------------------------------------------------------------------------------------- sanity-ordering.js:16:17
 
 Cannot access object with computed property using string [1]. [invalid-computed-prop]
 
-   sanity-ordering.js:13:17
-     13|     head = head[key] || create && (head[key] = {}); // error: no indexed type
+   sanity-ordering.js:16:17
+     16|     head = head[key] || create && (head[key] = {}); // error: no indexed type
                          ^^^
 
 References:
@@ -61,13 +61,13 @@ References:
                                                                        ^^^^^^ [1]
 
 
-Error ----------------------------------------------------------------------------------------- sanity-ordering.js:13:41
+Error ----------------------------------------------------------------------------------------- sanity-ordering.js:16:41
 
 Cannot assign object literal to `head[key]` because an index signature declaring the expected key / value type is
 missing in object type [1]. [prop-missing]
 
-   sanity-ordering.js:13:41
-   13|     head = head[key] || create && (head[key] = {}); // error: no indexed type
+   sanity-ordering.js:16:41
+   16|     head = head[key] || create && (head[key] = {}); // error: no indexed type
                                                ^^^
 
 References:

--- a/tests/predicates_inferred/sanity-ordering.js
+++ b/tests/predicates_inferred/sanity-ordering.js
@@ -10,6 +10,9 @@ function dotAccess(head: { page: ?Object; }, create?: mixed) {
   const stack = path.split('.');
   do {
     const key = stack.shift();
+    if (!key) {
+      break;
+    }
     head = head[key] || create && (head[key] = {}); // error: no indexed type
   } while (stack.length && head);
   return head;


### PR DESCRIPTION
These currently return type `T`, which is incorrect by spec and inconsistent with `Array.prototype.at`. This also aligns with TypeScript, which consistently types these methods as `T | undefined`.

This does not modify regular indexed access. That remains `T` (which is consistent with default TypeScript behavior).