### PR TITLE
Bring back ppx_expect for tests

### DIFF
--- a/flowtype.opam
+++ b/flowtype.opam
@@ -21,6 +21,7 @@ depends: [
   "lwt_log" {>= "1.1.1"}
   "lwt_ppx"
   "ppxlib" {= "0.28.0"}
+  "ppx_expect" {>= "0.17.0"}
   "ppx_let" {>= "0.14.0"}
   "ppx_deriving" {build}
   "ppx_gen_rec" {build}


### PR DESCRIPTION
This dependency is brought in implicitly through core, now that core is removed, this dependency is accidentally done. Bring it back so that tests like name_def_tests can continue to be run.

<!--
  If this is a change to library defintions, please include links to relevant documentation.
  If this is a documentation change, please prefix the title with [DOCS].

  If this is neither, ensure you opened a discussion issue and link it in the PR description.
-->
