### PR TITLE
[flow] Switch dune build to ocaml 5.2

### DIFF
--- a/.github/actions/install-opam-linux/action.yml
+++ b/.github/actions/install-opam-linux/action.yml
@@ -11,7 +11,7 @@ runs:
     run: |-
       if ! [ -x "$(command -v opam)" ]; then
         echo "Downloading opam..."
-        curl -sL -o "$RUNNER_TEMP/opam" "https://github.com/ocaml/opam/releases/download/2.1.3/opam-2.1.3-${{ inputs.arch }}-linux"
+        curl -sL -o "$RUNNER_TEMP/opam" "https://github.com/ocaml/opam/releases/download/2.2.0-beta3/opam-2.2.0-beta3-${{ inputs.arch }}-linux"
         echo "Installing opam..."
         sudo install -m 755 "$RUNNER_TEMP/opam" "/usr/local/bin/opam"
         echo "Removing opam temp file..."

--- a/.github/actions/install-opam-mac/action.yml
+++ b/.github/actions/install-opam-mac/action.yml
@@ -11,7 +11,7 @@ runs:
     run: |-
       if ! [ -x "$(command -v opam)" ]; then
         echo "Downloading opam..."
-        curl -sL -o "$RUNNER_TEMP/opam" "https://github.com/ocaml/opam/releases/download/2.1.3/opam-2.1.3-${{ inputs.arch }}-macos"
+        curl -sL -o "$RUNNER_TEMP/opam" "https://github.com/ocaml/opam/releases/download/2.2.0-beta3/opam-2.2.0-beta3-${{ inputs.arch }}-macos"
         echo "Installing opam..."
         install -m 755 "$RUNNER_TEMP/opam" "/usr/local/bin/opam"
         echo "Removing opam temp file..."

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -43,6 +43,8 @@ jobs:
       run: make deps-js
     - name: Build flow.js
       run: opam exec -- make js
+    - name: Test flow.js
+      run: opam exec -- make do-test-js
     - name: Build flow_parser.js
       run: opam exec -- make -C src/parser js
     - name: Create artifacts
@@ -278,9 +280,11 @@ jobs:
           perl
           mingw64-x86_64-gcc-core
           mingw64-x86_64-gcc-g++
-          mingw-w64-x86_64-gcc-libs
+          mingw64-x86_64-gcc-libs
           coreutils
           moreutils
+    - name: Install winget
+      uses: Cyberboss/install-winget@v1
     - name: Install opam
       run: .\scripts\windows\install_opam.ps1
       shell: pwsh
@@ -292,24 +296,31 @@ jobs:
           $Env:HOME/.opam
           _opam
     - name: Init opam
-      run: opam init default 'https://github.com/ocaml-opam/opam-repository-mingw.git#opam2' --bare --disable-sandboxing --no-setup
-      shell: C:\cygwin\bin\bash.exe -leo pipefail '{0}'
-    - name: Create opam switch
-      run: |-
-        make deps
+      run: opam init --bare --disable-sandboxing --no-setup --yes
       shell: C:\cygwin\bin\bash.exe '{0}'
       env:
-        PATH: /usr/local/bin:/usr/bin:/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/Wbem:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0
+        PATH: /usr/local/bin:/usr/bin:/cygdrive/bin:/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/Wbem:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0
+    - name: Git Safe Directory
+      run: git config --global --add safe.directory /cygdrive/d/a/flow/flow
+      shell: C:\cygwin\bin\bash.exe '{0}'
+      env:
+        PATH: /usr/local/bin:/usr/bin:/cygdrive/bin:/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/Wbem:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0
+    - name: Create opam switch
+      run: make deps
+      shell: C:\cygwin\bin\bash.exe '{0}'
+      env:
+        PATH: /usr/local/bin:/usr/bin:/cygdrive/bin:/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/Wbem:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0
     - name: Build flow.exe
       run: >-
         cd ${GITHUB_WORKSPACE} ;
+        echo $(opam env) ;
         eval $(opam env) ;
         make bin/flow.exe dist/flow.zip ;
         mkdir -p bin/win64 && cp bin/flow.exe bin/win64/flow.exe ;
         cp dist/flow.zip dist/flow-win64.zip
       shell: C:\cygwin\bin\bash.exe -leo pipefail '{0}'
       env:
-        PATH: /usr/local/bin:/usr/bin:/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/Wbem:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0
+        PATH: /usr/local/bin:/usr/bin:/cygdrive/bin:/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/Wbem:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0
     - name: Build parser test runner
       run: >-
         cd ${GITHUB_WORKSPACE} ;
@@ -318,7 +329,7 @@ jobs:
         cp _build/default/src/parser/test/run_tests.exe bin/win64/run_parser_tests.exe
       shell: C:\cygwin\bin\bash.exe -leo pipefail '{0}'
       env:
-        PATH: /usr/local/bin:/usr/bin:/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/Wbem:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0
+        PATH: /usr/local/bin:/usr/bin:/cygdrive/bin:/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/Wbem:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0
     - uses: actions/upload-artifact@v3.1.3
       with:
         name: build_win_bin

--- a/Makefile
+++ b/Makefile
@@ -9,14 +9,13 @@
 
 ifeq ($(OS), Windows_NT)
   EXE=.exe
-  SWITCH=ocaml-variants.4.14.0+mingw64c
 else
   EXE=
-  SWITCH=ocaml-base-compiler.4.14.0
 endif
 
-JS_OF_OCAML_VERSION=5.5.2
-OUNIT_VERSION=2.2.2.4
+SWITCH=ocaml-variants.5.2.0+options
+JS_OF_OCAML_VERSION=5.7.2
+OUNIT_VERSION=2.2.2.6
 
 # set FLOW_RELEASE=[1|true] or CI=true for an optimized build; otherwise,
 # defaults to dev mode that builds faster but is less efficient at runtime.

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Flow-typed JavaScript can use this to generate Flow's syntax tree with annotated
 
 ## Building Flow from source
 
-Flow is written in OCaml (OCaml 4.14.0 is required).
+Flow is written in OCaml (OCaml 5.2.0 is required).
 
 1. Install system dependencies:
 
@@ -107,7 +107,7 @@ Flow is written in OCaml (OCaml 4.14.0 is required).
 6. Build `flow.js` (optional):
 
     ```sh
-    opam install -y js_of_ocaml.5.5.2
+    opam install -y js_of_ocaml.5.7.2
     make js
     ```
 

--- a/dune
+++ b/dune
@@ -3,4 +3,4 @@
   (flags
    (:standard -w @a-4-29-35-41-42-44-45-48-50-58-70))
   (js_of_ocaml
-    (flags --disable genprim --Werror))))
+    (flags --disable genprim))))

--- a/flow_parser.opam
+++ b/flow_parser.opam
@@ -9,10 +9,10 @@ license: "MIT"
 
 build: ["dune" "build" "-p" name "-j" jobs]
 depends: [
-  "ocaml" {>= "4.14.0"}
+  "ocaml" {>= "5.2.0"}
   "dune" {>= "3.2"}
-  "base" {>= "v0.14.1"}
-  "ppxlib" {>= "0.26.0"}
+  "base" {>= "v0.16.3"}
+  "ppxlib" {>= "0.32.1"}
   "ppx_deriving" {build}
   "ppx_gen_rec" {build}
   "wtf8"

--- a/flowtype.opam
+++ b/flowtype.opam
@@ -8,19 +8,21 @@ homepage: "https://flow.org"
 doc: "https://flow.org/en/docs/getting-started/"
 bug-reports: "https://github.com/facebook/flow/issues"
 depends: [
-  "ocaml" {>= "4.14.0"}
-  "base" {>= "v0.14.1"}
+  "ocaml" {>= "5.2.0"}
+  "base" {>= "v0.16.3"}
   "base-unix"
   "base-bytes"
+  "camlp-streams" {>= "5.0.1"}
   "dtoa" {>= "0.3.2"}
-  "fileutils" {>= "0.6.3"}
+  "fileutils" {>= "0.6.4"}
   "flow_parser" {= "0.238.1"}
   "inotify" {os = "linux" & >= "2.4.1"}
   "ounit2" {with-test}
-  "lwt" {>= "5.4.0"}
+  "lwt" {>= "5.7.0"}
   "lwt_log" {>= "1.1.1"}
-  "lwt_ppx"
-  "ppxlib" {= "0.28.0"}
+  "lwt_ppx" {>= "2.1.0"}
+  "ppxlib" {>= "0.32.1"}
+  "ppx_expect" {>= "0.17.0"}
   "ppx_expect" {>= "0.17.0"}
   "ppx_let" {>= "0.14.0"}
   "ppx_deriving" {build}

--- a/scripts/windows/install_opam.ps1
+++ b/scripts/windows/install_opam.ps1
@@ -13,13 +13,4 @@ if (!$cygwin_root) {
     echo "Found cygwin in $cygwin_root"
 }
 
-$install_dir = "$Env:TEMP\flow\opam_installer"
-New-Item -ErrorAction Ignore -ItemType Directory $install_dir
-echo "Downloading opam64.tar.xz to $install_dir\opam64.tar.xz"
-(New-Object System.Net.WebClient).DownloadFile("https://github.com/fdopen/opam-repository-mingw/releases/download/0.0.0.2/opam64.tar.xz", "$install_dir\opam64.tar.xz")
-$out_dir = "$install_dir".Replace("\", "/")
-echo "Extracting opam64.tar.xz"
-& $cygwin_root\bin\bash.exe -l -c "tar -x --force-local -f '$install_dir\opam64.tar.xz' -C '$out_dir'"
-echo "Installing opam"
-& $cygwin_root\bin\bash.exe -l "$install_dir\opam64\install.sh"
-echo "Done"
+winget install opam --disable-interactivity --accept-source-agreements --location $cygwin_root

--- a/src/third-party/fuzzy-path/Makefile
+++ b/src/third-party/fuzzy-path/Makefile
@@ -1,5 +1,7 @@
 
 ifeq ($(OS), Windows_NT)
+  CC:=x86_64-w64-mingw32-gcc.exe
+  CPP:=x86_64-w64-mingw32-cpp.exe
   CXX:=x86_64-w64-mingw32-g++
   AR:=x86_64-w64-mingw32-gcc-ar
 endif

--- a/src/third-party/ocaml-vlq/src/dune
+++ b/src/third-party/ocaml-vlq/src/dune
@@ -1,3 +1,4 @@
 (library
  (name flow_third_party_vlq)
- (wrapped false))
+ (wrapped false)
+ (libraries camlp-streams))


### PR DESCRIPTION
Summary:
- The new OCaml 5 setup requires opam 2.2.0-beta3, so I updated the action.yml to install that instead. On the windows side, I used `winget` to install it.
- I bumped the package versions for OCaml 5. The versions are chosen based on the internal buck build's versions.
- In the Makefile of fuzzy-path: we need to explicitly set the `CC` and `CPP` env var that's previously implicitly set by the windows opam fork.

Differential Revision: D58630448
