### PR TITLE
[flow][ci] Fix github_upload.sh

### DIFF
--- a/.circleci/github_upload.sh
+++ b/.circleci/github_upload.sh
@@ -12,8 +12,8 @@ echo "Fetching from https://api.github.com/repos/$REPO/releases/tags/$GITHUB_REF
 auth="Authorization: token $FLOW_BOT_TOKEN"
 response=$(curl -sH "$auth" "https://api.github.com/repos/$REPO/releases/tags/$GITHUB_REF_NAME")
 echo "API Response:"
-echo "$response"
-id=$(echo "$response" | jq .id)
+printf "%s" "$response"
+id=$(printf "%s" "$response" | jq .id)
 
 echo "Uploading release to https://uploads.github.com/repos/$REPO/releases/$id/assets?name=$DST"
 curl -H "$auth" \


### PR DESCRIPTION
In the release changelog, we will have multiline messages, which will show up in the json like [this](https://api.github.com/repos/facebook/flow/releases/tags/v0.238.2). Echo will turn the escape sequence `\n` into actual new lines, and produce an illegal json, which the jq cannot deal with.

To fix, we use printf instead. We can see the difference with the following tests

```
$ printf "%s\n" "\n"
\n                                                                           
$ echo "\n"