### PR TITLE
[flow][cleanup] Kill AssertImportIsValueT

### DIFF
--- a/src/typing/annotation_inference.ml
+++ b/src/typing/annotation_inference.ml
@@ -267,8 +267,6 @@ module rec ConsGen : S = struct
       ConsGen.cjs_extract_named_exports cx reason local_module t
   end
 
-  let assert_import_is_value _cx _reason _name _export_t = ()
-
   let with_concretized_type cx r f t = ConsGen.elab_t cx t (Annot_ConcretizeForImportsExports (r, f))
 
   module CJSRequireTKit = Flow_js_utils.CJSRequireTKit
@@ -637,7 +635,6 @@ module rec ConsGen : S = struct
       let (_name_loc_opt, t) =
         ImportDefaultTKit.on_ModuleT
           cx
-          ~assert_import_is_value
           ~with_concretized_type
           (reason, import_kind, local, is_strict)
           m
@@ -647,7 +644,6 @@ module rec ConsGen : S = struct
       let (_name_loc_opt, t) =
         ImportNamedTKit.on_ModuleT
           cx
-          ~assert_import_is_value
           ~with_concretized_type
           (reason, import_kind, export_name, module_name, is_strict)
           m

--- a/src/typing/debug_js.ml
+++ b/src/typing/debug_js.ml
@@ -681,7 +681,6 @@ and dump_use_t_ (depth, tvars) cx t =
     | AssertBinaryInLHST _ -> p t
     | AssertBinaryInRHST _ -> p t
     | AssertForInRHST _ -> p t
-    | AssertImportIsValueT _ -> p t
     | AssertInstanceofRHST _ -> p t
     | AssertNonComponentLikeT _ -> p t
     | AssertIterableT _ -> p t

--- a/src/typing/default_resolve.ml
+++ b/src/typing/default_resolve.ml
@@ -169,7 +169,6 @@ let rec default_resolve_touts ~flow ?resolve_callee cx loc u =
   | GetValuesT (_, t) -> resolve t
   | ElemT (_, _, _, action) -> resolve_elem_action action
   | MakeExactT (_, k) -> resolve_cont k
-  | AssertImportIsValueT _ -> ()
   | CJSExtractNamedExportsT (_, _, t)
   | CopyNamedExportsT (_, _, t)
   | CopyTypeExportsT (_, _, t) ->

--- a/src/typing/flow_js.ml
+++ b/src/typing/flow_js.ml
@@ -782,23 +782,6 @@ struct
           CopyTypeExportsTKit.on_AnyT cx target_module t
         | (_, CJSExtractNamedExportsT (reason, local_module, t_out)) ->
           CJSExtractNamedExportsTKit.on_concrete_type cx (reason, local_module) l t_out
-        (*****************)
-        (* Import checks *)
-        (*****************)
-        | (_, AssertImportIsValueT (reason, name)) ->
-          let test = function
-            | TypeT _
-            | ClassT (DefT (_, InstanceT { inst = { inst_kind = InterfaceKind _; _ }; _ })) ->
-              add_output cx (Error_message.EImportTypeAsValue (reason, name))
-            | _ -> ()
-          in
-          (* Imported polymorphic types will always have a concrete def_t, so
-           * unwrapping here without concretizing is safe. *)
-          (match l with
-          | DefT (_, PolyT { t_out = DefT (_, def_t); _ })
-          | DefT (_, def_t) ->
-            test def_t
-          | _ -> ())
         (******************************)
         (* optional chaining - part A *)
         (******************************)
@@ -7083,7 +7066,6 @@ struct
     | AssertBinaryInLHST _
     | AssertBinaryInRHST _
     | AssertForInRHST _
-    | AssertImportIsValueT _
     | AssertInstanceofRHST _
     | AssertNonComponentLikeT _
     | ComparatorT _

--- a/src/typing/flow_js_utils.ml
+++ b/src/typing/flow_js_utils.ml
@@ -1398,11 +1398,8 @@ end
 module ImportDefaultTKit = struct
   (* import [type] X from 'SomeModule'; *)
   let on_ModuleT
-      cx
-      ~assert_import_is_value
-      ~with_concretized_type
-      (reason, import_kind, (local_name, module_name), is_strict)
-      module_ =
+      cx ~with_concretized_type (reason, import_kind, (local_name, module_name), is_strict) module_
+      =
     let {
       module_reason;
       module_export_types = exports;
@@ -1458,19 +1455,13 @@ module ImportDefaultTKit = struct
           (ImportTypeofTKit.on_concrete_type cx reason "default")
           export_t
       )
-    | ImportValue ->
-      assert_import_is_value cx reason "default" export_t;
-      (loc_opt, export_t)
+    | ImportValue -> (loc_opt, export_t)
 end
 
 module ImportNamedTKit = struct
   (* import {X} from 'SomeModule'; *)
   let on_ModuleT
-      cx
-      ~assert_import_is_value
-      ~with_concretized_type
-      (reason, import_kind, export_name, module_name, is_strict)
-      module_ =
+      cx ~with_concretized_type (reason, import_kind, export_name, module_name, is_strict) module_ =
     let {
       module_reason = _;
       module_export_types = exports;
@@ -1539,12 +1530,9 @@ module ImportNamedTKit = struct
           (ImportTypeofTKit.on_concrete_type cx reason export_name)
           (AnyT.untyped reason)
       )
-    | (ImportValue, Some { preferred_def_locs = _; name_loc; type_ }) ->
-      assert_import_is_value cx reason export_name type_;
-      (name_loc, type_)
+    | (ImportValue, Some { preferred_def_locs = _; name_loc; type_ }) -> (name_loc, type_)
     | (ImportValue, None) when has_every_named_export ->
       let t = AnyT.untyped reason in
-      assert_import_is_value cx reason export_name t;
       (None, t)
     | (ImportValue, None) when NameUtils.Map.mem (OrdinaryName export_name) type_exports_tmap ->
       add_output cx (Error_message.EImportTypeAsValue (reason, export_name));

--- a/src/typing/implicit_instantiation.ml
+++ b/src/typing/implicit_instantiation.ml
@@ -339,9 +339,8 @@ module Make (Observer : OBSERVER) (Flow : Flow_common.S) : S = struct
     | GetKeysT _
     | GetValuesT _
     | GetDictValuesT _
-    (* Import-export related upper bounds won't appear during implicit instantiation. *)
-    | AssertImportIsValueT _
     | AssertNonComponentLikeT _
+    (* Import-export related upper bounds won't appear during implicit instantiation. *)
     | CJSExtractNamedExportsT _
     | CopyNamedExportsT _
     | CopyTypeExportsT _

--- a/src/typing/statement.ml
+++ b/src/typing/statement.ml
@@ -2515,7 +2515,6 @@ module Make
                   name_loc
               )
             in
-            Flow.flow cx (t, AssertImportIsValueT (reason, name));
             Base.Option.iter default ~f:(fun d ->
                 let default_t = Flow.mk_default cx reason d in
                 Flow.flow cx (default_t, UseT (use_op, t))

--- a/src/typing/ty_normalizer.ml
+++ b/src/typing/ty_normalizer.ml
@@ -473,9 +473,7 @@ module Make (I : INPUT) : S = struct
           uses_t_aux (t :: acc) rest
         | T.ReposLowerT (_, _, u) :: rest -> uses_t_aux acc (u :: rest)
         (* skip these *)
-        | T.AssertImportIsValueT _ :: rest
-        | T.CJSExtractNamedExportsT _ :: rest ->
-          uses_t_aux acc rest
+        | T.CJSExtractNamedExportsT _ :: rest -> uses_t_aux acc rest
         | u :: _ -> return (Ty.SomeUnknownUpper (T.string_of_use_ctor u))
       in
       (fun uses -> uses_t_aux [] uses)

--- a/src/typing/type.ml
+++ b/src/typing/type.ml
@@ -800,7 +800,6 @@ module rec TypeTerm : sig
     | ElemT of use_op * reason * t * elem_action
     (* exact ops *)
     | MakeExactT of reason * cont
-    | AssertImportIsValueT of reason * string
     (* Module export handling *)
     | CJSExtractNamedExportsT of
         reason
@@ -4148,7 +4147,6 @@ let string_of_use_ctor = function
   | AssertInstanceofRHST _ -> "AssertInstanceofRHST"
   | AssertNonComponentLikeT _ -> "AssertNonComponentLikeT"
   | AssertIterableT _ -> "AssertIterableT"
-  | AssertImportIsValueT _ -> "AssertImportIsValueT"
   | BindT _ -> "BindT"
   | CallElemT _ -> "CallElemT"
   | CallLatentPredT _ -> "CallLatentPredT"

--- a/src/typing/typeUtil.ml
+++ b/src/typing/typeUtil.ml
@@ -59,7 +59,6 @@ and reason_of_use_t = function
   | AssertInstanceofRHST reason -> reason
   | AssertNonComponentLikeT (_, reason) -> reason
   | AssertIterableT { reason; _ } -> reason
-  | AssertImportIsValueT (reason, _) -> reason
   | BindT (_, reason, _) -> reason
   | CallElemT (_, reason, _, _, _) -> reason
   | CallLatentPredT { reason; _ } -> reason
@@ -327,7 +326,6 @@ let rec util_use_op_of_use_t :
   | ObjTestProtoT (_, _)
   | ObjTestT (_, _, _)
   | GetValuesT (_, _)
-  | AssertImportIsValueT (_, _)
   | CJSExtractNamedExportsT (_, _, _)
   | CopyNamedExportsT (_, _, _)
   | CopyTypeExportsT (_, _, _)

--- a/src/typing/type_operation_utils.ml
+++ b/src/typing/type_operation_utils.ml
@@ -97,12 +97,6 @@ module Import_export = struct
     let is_strict = Context.is_strict cx in
     let name_def_loc_ref = ref None in
     let t =
-      let assert_import_is_value cx reason name export_t =
-        Flow.FlowJs.flow_opt
-          cx
-          ~trace:DepthTrace.dummy_trace
-          (export_t, AssertImportIsValueT (reason, name))
-      in
       let with_concretized_type cx r f t =
         f (singleton_concretize_type_for_imports_exports cx r t)
       in
@@ -112,14 +106,12 @@ module Import_export = struct
           if remote_name = "default" then
             Flow_js_utils.ImportDefaultTKit.on_ModuleT
               cx
-              ~assert_import_is_value
               ~with_concretized_type
               (import_reason, import_kind, (local_name, module_name), is_strict)
               m
           else
             Flow_js_utils.ImportNamedTKit.on_ModuleT
               cx
-              ~assert_import_is_value
               ~with_concretized_type
               (import_reason, import_kind, remote_name, module_name, is_strict)
               m


### PR DESCRIPTION
Summary:
The check here is unnecessary, since we already ensured that the import is value [here](https://github.com/facebook/flow/blob/5422a344243a92e8795e728b3eac7b839f82731a/src/typing/flow_js_utils.ml#L1419) and [here](https://github.com/facebook/flow/blob/5422a344243a92e8795e728b3eac7b839f82731a/src/typing/flow_js_utils.ml#L1502).

Changelog: [internal]

Differential Revision: D59248925


