### PR TITLE
[flow] cleanup hover type refs

### DIFF
--- a/src/common/ty/dune
+++ b/src/common/ty/dune
@@ -2,7 +2,6 @@
  (name flow_typing_ty)
  (wrapped false)
  (libraries
-  file_url
   flow_common
   flow_parser_utils_aloc
   flow_parser_utils_output

--- a/src/common/ty/ty_printer.mli
+++ b/src/common/ty/ty_printer.mli
@@ -28,8 +28,7 @@ val string_of_type_at_pos_result :
   ?prefer_single_quotes:bool ->
   ?with_comments:bool ->
   ?exact_by_default:bool ->
-  client:[ `LSP | `CLI ] option ->
   Ty.type_at_pos_result ->
-  string * string list option
+  string * (string * Loc.t) list option
 
 val utf8_escape : quote:string -> string -> string

--- a/src/common/utils/utils_js.ml
+++ b/src/common/utils/utils_js.ml
@@ -63,6 +63,12 @@ let assert_false s =
     );
   failwith s
 
+let ite cond a b =
+  if cond then
+    a
+  else
+    b
+
 let map_pair f g (a, b) = (f a, g b)
 
 let map_fst f (a, b) = (f a, b)

--- a/src/flow_dot_js.ml
+++ b/src/flow_dot_js.ml
@@ -501,9 +501,7 @@ let infer_type filename content line col js_config_object : Loc.t * (string, str
         | FailureNoMatch -> (Loc.none, Error "No match")
         | FailureUnparseable (loc, _, _) -> (loc, Error "Unparseable")
         | Success (loc, result) ->
-          let (result, _) =
-            Ty_printer.string_of_type_at_pos_result ~exact_by_default:true ~client:None result
-          in
+          let (result, _) = Ty_printer.string_of_type_at_pos_result ~exact_by_default:true result in
           (loc, Ok result)
       end
 

--- a/src/server/protocol/serverProt.ml
+++ b/src/server/protocol/serverProt.ml
@@ -19,7 +19,6 @@ module Infer_type_options = struct
     strip_root: File_path.t option;
     expanded: bool;
     no_typed_ast_for_imports: bool;
-    client: [ `LSP | `CLI ] option;
   }
 end
 
@@ -248,7 +247,7 @@ module Response = struct
   type get_def_response = (Loc.t list, string) result
 
   type infer_type_response_payload =
-    | Infer_type_string of (string * string list option) option
+    | Infer_type_string of (string * (string * Loc.t) list option (* refs *)) option
     | Infer_type_JSON of Hh_json.json
 
   type infer_type_response_ok =


### PR DESCRIPTION
Summary:
This is a much better design. The server shouldn't need to know about the client specifics to adapt the location formatting. This should happen in the client like with most other commands.

This diff fixes achieves this by storing `(string * Loc.t)`s in the hover response in ServerProt, instead of raw strings.

Changelog: [internal]

Differential Revision: D59309580


