### PR TITLE
[DOCS]

### DIFF
--- a/website/docs/tools/eslint.md
+++ b/website/docs/tools/eslint.md
@@ -16,7 +16,7 @@ yarn add --dev eslint hermes-eslint eslint-plugin-ft-flow
 npm install --save-dev eslint hermes-eslint eslint-plugin-ft-flow
 ```
 
-Then create a `.eslintrc.js` file in your project root with the following:
+Then create a `eslint.config.(js|mjs|cjs)` file in your project root with the following:
 
 ```js
 module.exports = {

--- a/website/docs/tools/eslint.md
+++ b/website/docs/tools/eslint.md
@@ -16,7 +16,7 @@ yarn add --dev eslint hermes-eslint eslint-plugin-ft-flow
 npm install --save-dev eslint hermes-eslint eslint-plugin-ft-flow
 ```
 
-Then create a `eslint.config.(js|mjs|cjs)` file in your project root with the following:
+Then create a `eslint.config.(js|mjs|cjs)` or `.eslintrc.js` file in your project root with the following:
 
 ```js
 module.exports = {


### PR DESCRIPTION
From ESLint v9.0.0, the default configuration file is now eslint.config.js.
Update ESLint config to eslint.config.js as per v9.0.0 migration guidelines. see https://eslint.org/docs/latest/use/configure/migration-guide

<!--
  If this is a change to library defintions, please include links to relevant documentation.
  If this is a documentation change, please prefix the title with [DOCS].

  If this is neither, ensure you opened a discussion issue and link it in the PR description.
-->
