### PR TITLE
Integrate with dotslash

### DIFF
--- a/.github/dotslash-config.json
+++ b/.github/dotslash-config.json
@@ -1,0 +1,34 @@
+{
+    "exclude-github-release-provider": true,
+    "outputs": {
+      "flow": {
+        "platforms": {
+          "macos-aarch64": {
+            "regex": "^flow-osx-arm64-v.*.zip$",
+            "format": "zip",
+            "path": "flow/flow"
+          },
+          "linux-aarch64": {
+            "regex": "^flow-linux-arm64-v.*.zip$",
+            "format": "zip",
+            "path": "flow/flow"
+          },
+          "macos-x86_64": {
+            "regex": "^flow-osx-v.*.zip$",
+            "format": "zip",
+            "path": "flow/flow"
+          },
+          "windows-x86_64": {
+            "regex": "^flow-win64-v.*.zip$",
+            "format": "zip",
+            "path": "flow/flow.exe"
+          },
+          "linux-x86_64": {
+            "regex": "^flow-linux64-v.*.zip$",
+            "format": "zip",
+            "path": "flow/flow"
+          }
+        }
+      }
+    }
+  }

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -670,6 +670,12 @@ jobs:
         path: dist
     - name: Upload Windows binary
       run: .circleci/github_upload.sh dist/flow-win64.zip "flow-win64-${{ github.ref_name }}.zip"
+    - uses: facebook/dotslash-publish-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        config: .github/dotslash-config.json
+        tag: ${{ github.ref_name }}
   flow_bin_deploy:
     if: contains(github.event_name, 'push') && startsWith( github.ref, 'refs/tags/v' )
     runs-on: ubuntu-22.04


### PR DESCRIPTION
This was modeled on https://github.com/facebook/buck2/pull/565

Test plan:

```
$cd $folder_containing_flow_github_repo
$git clone https://github.com/facebook/dotslash-publish-release
$cd dotslash-publish-release
$ pip3 install blake3
$ ./process_config.py --config ../flow/.github/dotslash-config.json --tag v0.239.1 --repo facebook/flow --local-config
...
2024-07-09 09:57:24,369 [INFO] wrote manifest to /var/folders/q1/_xmg0gk95mjbfbbly6_1ch8w0000gn/T/facebook_flow_dotslashw7rb3gl4/flow
```

Running this file works as expected:
```
$  /var/folders/q1/_xmg0gk95mjbfbbly6_1ch8w0000gn/T/facebook_flow_dotslashw7rb3gl4/flow
Could not find a .flowconfig in . or any of its parent directories.
See "flow init --help" for more info

```

<!--
  If this is a change to library defintions, please include links to relevant documentation.
  If this is a documentation change, please prefix the title with [DOCS].

  If this is neither, ensure you opened a discussion issue and link it in the PR description.
-->
