### PR TITLE
[flow][test] Platform independent testing with symlinks in newtests

### DIFF
--- a/newtests/lsp/completion/node_modules_auto_imports/nested/bar/node_modules/workspace-pkg
+++ b/newtests/lsp/completion/node_modules_auto_imports/nested/bar/node_modules/workspace-pkg
@@ -1,1 +1,0 @@
-../../workspace/workspace-pkg

--- a/newtests/lsp/completion/node_modules_auto_imports/nested/node_modules
+++ b/newtests/lsp/completion/node_modules_auto_imports/nested/node_modules
@@ -1,1 +1,0 @@
-../third_party/node_modules/

--- a/newtests/lsp/completion/node_modules_auto_imports/test.js
+++ b/newtests/lsp/completion/node_modules_auto_imports/test.js
@@ -15,14 +15,13 @@ module.exports = (suite(
     lspInitializeParams,
     lspRequestAndWaitUntilResponse,
     addFiles,
+    addSymlinkDirs,
     addCode,
     lspIgnoreStatusAndCancellation,
   }) => [
     test('textDocument/completion with autoimports', [
       addFiles(
         'nested/bar/baz.js',
-        'nested/node_modules',
-        'nested/bar/node_modules/workspace-pkg',
         'nested/inner/node_modules/boo/package.json',
         'nested/inner/node_modules/boo/index.js',
         'nested/workspace/workspace-pkg/package.json',
@@ -31,6 +30,13 @@ module.exports = (suite(
         'node_modules/toplevel/Toplevel.js',
         'third_party/node_modules/foo/package.json',
         'third_party/node_modules/foo/index.js',
+      ),
+      addSymlinkDirs(
+        [
+          'nested/bar/node_modules/workspace-pkg',
+          '../../workspace/workspace-pkg',
+        ],
+        ['nested/node_modules', '../third_party/node_modules/'],
       ),
       lspStartAndConnect(),
       lspRequestAndWaitUntilResponse('textDocument/completion', {

--- a/packages/flow-dev-tools/src/test/TestStep.js
+++ b/packages/flow-dev-tools/src/test/TestStep.js
@@ -252,6 +252,14 @@ class TestStepFirstStage extends TestStepFirstOrSecondStage {
       env.triggerFlowCheck();
     });
 
+  addSymlinkDirs: (
+    ...destinationPathPairs: Array<[string, string]>
+  ) => TestStepFirstStage = (...sources) =>
+    this._cloneWithAction(async (builder, env) => {
+      await builder.addSymlinkDirs(sources);
+      env.triggerFlowCheck();
+    });
+
   addFixture: (source: string, dest?: string) => TestStepFirstStage = (
     source,
     dest,


### PR DESCRIPTION
Summary:
Symlink file format are not universal across OS, that's why the new tests with symlinks are failing on windows. In this diff, I replaced the checked in symlink files with symlinks created on the js side, which is platform independent.

Changelog: [internal]

Differential Revision: D60210755
