### PR TITLE
Add flow-dev-tools binary declaration

### DIFF
--- a/packages/flow-dev-tools/package.json
+++ b/packages/flow-dev-tools/package.json
@@ -16,6 +16,9 @@
     "vscode-jsonrpc": "^6.0.0",
     "vscode-uri": "^2.1.2"
   },
+  "bin": {
+    "flow-dev-tools": "./bin/tool"
+  },
   "scripts": {
     "test": "node src/__tests__/all-tests.js"
   },


### PR DESCRIPTION
Greetings,

this will allows for using npm|yarn|pnpm link and gain an easier access to the tool.

The flow "tool", despite being unofficial, has gaining an important part in our workflow, Flow version migrations, or internal packages type changes.  

Currently the only way to access and use it I'm aware of is cloning the flow repository and calling the binary by its path.  
This often leads to a relative path mess such as:
```
$ ../../../../flow/packages/flow-dev-tools/bin/tool add-comments
```
Or  
```
$ ../../../../flow/tool add-comments
```

By just declaring the binary in its `package.json` we can now `npm link` it and access it globally.
```
$ flow-dev-tools add-comments
```


