### PR TITLE
[DOCS] Fix typo in utilities.md

### DIFF
--- a/website/docs/types/utilities.md
+++ b/website/docs/types/utilities.md
@@ -346,7 +346,7 @@ type NumberRecord = Record<'foo' | 'bar', number>;
 type IndexedObject = {['foo' | 'bar']: number};
 
 // Record uses explicit fields, which means they are all required
-const rec: Record = {}; // error
+const rec: NumberRecord = {}; // error
 // Indexers do not have this same requirement
 const idx: IndexedObject = {}; // no error
 ```


### PR DESCRIPTION
Previous `rec: Record =` does not make sense. I believe `NumberRecord` is what it meant.

<!--
  If this is a change to library defintions, please include links to relevant documentation.
  If this is a documentation change, please prefix the title with [DOCS].

  If this is neither, ensure you opened a discussion issue and link it in the PR description.
-->
