### PR TITLE
[docs] Fix React.PropsOf code sample

### DIFF
--- a/website/docs/react/types.md
+++ b/website/docs/react/types.md
@@ -214,7 +214,7 @@ component MyComponent(foo: number, bar: string = 'str') {
 }
 
 // Only foo is required
-({foo: 3}) as React.ElementConfig<typeof MyComponent>;
+({foo: 3}) as React.PropsOf<MyComponent>;
 ```
 
 ## `React.ElementConfig<typeof Component>` {#toc-react-elementconfig}


### PR DESCRIPTION
The code sample for `React.PropsOf` documentation is showcasing `React.ElementConfig`.   

https://flow.org/en/docs/react/types/#toc-react-propsof


