### PR TITLE
Add type for util.stripVTControlCharacters

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -2606,6 +2606,7 @@ declare module "util" {
   declare function deprecate(f: Function, string: string): Function;
   declare function promisify(f: Function): Function;
   declare function callbackify(f: Function): Function;
+  declare function stripVTControlCharacters(str: string): string;
 
   declare function parseArgs<
     TOptions: {[string]: util$ParseArgsOption} = {||},


### PR DESCRIPTION
https://nodejs.org/api/util.html#utilstripvtcontrolcharactersstr Available in the util module since Node 16.11

<!--
  If this is a change to library defintions, please include links to relevant documentation.
  If this is a documentation change, please prefix the title with [DOCS].

  If this is neither, ensure you opened a discussion issue and link it in the PR description.
-->
