### PR TITLE
[flow-remove-types] fix `hermes-parser` config

### DIFF
--- a/packages/flow-remove-types/index.js
+++ b/packages/flow-remove-types/index.js
@@ -57,7 +57,7 @@ module.exports = function flowRemoveTypes(source, options) {
   }
 
   // This parse configuration is intended to be as permissive as possible.
-  var ast = parse(source, {types: true, tokens: true});
+  var ast = parse(source, {flow: all ? 'all' : 'detect', tokens: true});
 
   var removedNodes = [];
 


### PR DESCRIPTION
This PR fixes a case where `flow-remove-types` fails when `all` option is specified and there is no `@flow` pragma in the file.

HermesParser defaults to looking for `@flow` pragma via it's parser options ([reference](https://github.com/facebook/hermes/blob/b112ed91e5873810b9ab93c4c7e1f60dad0d7c24/tools/hermes-parser/js/hermes-parser/src/index.js#L26)) therefore we need to pass the `all` option to the parser to behave as expected.

I've also removed `types` option passed to `parse` method since it's not present in HermesParser options ([reference](https://github.com/facebook/hermes/blob/main/tools/hermes-parser/js/hermes-parser/src/ParserOptions.js))
