### PR TITLE
Add new set operation methods to `Set`

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -1950,6 +1950,18 @@ declare class Set<T> extends $ReadOnlySet<T> {
     values(): Iterator<T>;
     +[key: $SymbolToStringTag]: (...any) => any;
     static +[key: $SymbolSpecies]: (...any) => any; // This would the Set constructor, can't think of a way to correctly type this
+    /** Takes a `Set` and returns a new `Set` containing elements in this `Set` but not in the given `Set`. */
+    difference(other: Set<T>): Set<T>;
+    /** Takes a `Set` and returns a new `Set` containing elements in both this `Set` and the given `Set`. */
+    intersection(other: Set<T>): Set<T>;
+    /** Takes a `Set` and returns a `boolean` indicating if this `Set` has no elements in common with the given `Set`. */
+    isDisjointFrom(other: Set<T>): boolean;
+    /** Takes a `Set` and returns a `boolean` indicating if all elements of this `Set` are in the given `Set`. */
+    isSubsetOf(other: Set<T>): boolean;
+    /** Takes a `Set` and returns a `boolean` indicating if all elements of the given `Set` are in this `Set`. */
+    isSupersetOf(other: Set<T>): boolean;
+    /** Returns a new `Set` containing elements which are in either this `Set` or the given `Set`, but not in both. */
+    symmetricDifference(other: Set<T>): Set<T>;
 }
 
 declare class $ReadOnlyWeakSet<T: WeaklyReferenceable> {


### PR DESCRIPTION
<!--
  If this is a change to library defintions, please include links to relevant documentation.
  If this is a documentation change, please prefix the title with [DOCS].

  If this is neither, ensure you opened a discussion issue and link it in the PR description.
-->

Docs: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/difference