### PR TITLE
Fix [].toSpliced() type

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -923,7 +923,7 @@ declare class $ReadOnlyArray<+T> {
      * @param deleteCount An integer indicating the number of elements in the array to remove from start.
      * @param items The elements to add to the array, beginning from start.
      */
-    toSpliced<S, Item: $ReadOnlyArray<S> | S>(start: number, deleteCount?: number, ...items: Array<Item>): Array<T | S>;
+    toSpliced<S>(start: number, deleteCount?: number, ...items: Array<S>): Array<T | S>;
     /**
      * Returns an iterable of values in the array
      */

--- a/tests/autocomplete/autocomplete.exp
+++ b/tests/autocomplete/autocomplete.exp
@@ -719,7 +719,7 @@ Flags: --pretty
     },
     {
       "name":"?.toSpliced",
-      "type":"void | (<S, Item: $ReadOnlyArray<S> | S>(start: number, deleteCount?: number, ...items: Array<Item>) => Array<T | S>)"
+      "type":"void | (<S>(start: number, deleteCount?: number, ...items: Array<S>) => Array<T | S>)"
     },
     {"name":"?.unshift","type":"void | ((...items: Array<T>) => number)"},
     {"name":"?.values","type":"void | (() => Iterator<T>)"},
@@ -822,7 +822,7 @@ Flags: --pretty
     {"name":"toSorted","type":"(compareFn?: (a: T, b: T) => number) => Array<T>"},
     {
       "name":"toSpliced",
-      "type":"<S, Item: $ReadOnlyArray<S> | S>(start: number, deleteCount?: number, ...items: Array<Item>) => Array<T | S>"
+      "type":"<S>(start: number, deleteCount?: number, ...items: Array<S>) => Array<T | S>"
     },
     {"name":"unshift","type":"(...items: Array<T>) => number"},
     {"name":"values","type":"() => Iterator<T>"},


### PR DESCRIPTION
This PR fixes the library type for `[].toSpliced()` ([MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/toSpliced)).

It looks like we took the items type from [[].concat()](https://github.com/facebook/flow/blob/main/lib/core.js#L716), which has [special treatment for Array arguments](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/concat#parameters), rather than [[].splice()](https://github.com/facebook/flow/blob/main/lib/core.js#L1093), which does not. The type was added in https://github.com/facebook/flow/pull/9075

We can quickly confirm that [].toSpliced() matches [].splice() behavior:
```
[].toSpliced(0,0,[1]) -> [[1]]
```

The existing type also causes some weird errors: Try Flow
