### PR TITLE
Type iterator helpers

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -1847,8 +1847,13 @@ declare class Iterator<+Yield,+Return=void,-Next=void> implements $IteratorProto
      * Iterates this iterator. Will hang if it's infinite and has no matches.
      * @param callbackfn  A function that accepts up to two arguments: the yielded value and its index.
      */
-     find<Refined: Yield>(predicate: (value: Yield, index: number) => implies value is Refined): Refined | void;
-     find(callbackfn: (value: Yield, index: number) => mixed): Yield | void;
+    find<Refined: Yield>(predicate: (value: Yield, index: number) => implies value is Refined): Refined | void;
+    find(callbackfn: (value: Yield, index: number) => mixed): Yield | void;
+    /**
+     * This method allows wrapping objects that implement the iterator protocol in an Iterator to get the built-in helpers.
+     * @returns The argument object if it's already an Iterator subclass, or a wrapping Iterator if the argument objects implements the iterable or iterator protocols.
+     */
+    static from<+Yield,+Return,-Next>(source: $IteratorProtocol<Yield,Return,Next> | $Iterable<Yield,Return,Next>): Iterator<Yield,Return,Next>;
 }
 
 type $Iterator<+Yield,+Return,-Next> = Iterator<Yield,Return,Next>;

--- a/lib/core.js
+++ b/lib/core.js
@@ -1750,6 +1750,21 @@ interface $Iterator<+Yield,+Return,-Next> extends $Iterable<Yield,Return,Next> {
      * @param callbackfn A function that accepts up to two arguments: the yielded value, and it's index. The map method calls the callbackfn function once per iteration.
      */
     map<U>(callbackfn: (value: Yield, index: number) => U): $Iterator<U, void, mixed>;
+    /**
+     * Returns a new iterator that yields only those elements of the iterator for which the provided predicate returns a truthy value.
+     * @param callbackfn A function that accepts up to two arguments: the yielded value and it's index. The filter method calls the predicate function once per iteration.
+     */
+    filter(callbackfn: typeof Boolean): $Iterator<$NonMaybeType<Yield>, void, mixed>;
+    /**
+     * Returns a new iterator that yields only those elements of the iterator for which the provided predicate returns a truthy value.
+     * @param callbackfn A function that accepts up to two arguments: the yielded value and it's index. The filter method calls the predicate function once per iteration.
+     */
+    filter<Refined: Yield>(callbackfn: (value: Yield, index: number) => implies value is Refined): $Iterator<Refined, void, mixed>;
+    /**
+     * Returns a new iterator that yields only those elements of the iterator for which the provided predicate returns a truthy value.
+     * @param callbackfn A function that accepts up to two arguments: the yielded value and it's index. The filter method calls the predicate function once per iteration.
+     */
+    filter(callbackfn: (value: Yield, index: number) => mixed): $Iterator<Yield, void, mixed>;
 }
 type Iterator<+T> = $Iterator<T,void,void>;
 

--- a/lib/core.js
+++ b/lib/core.js
@@ -1770,6 +1770,11 @@ interface $Iterator<+Yield,+Return,-Next> extends $Iterable<Yield,Return,Next> {
      * @param limit The maximum number of values to yield.
      */
     take(limit: number): $Iterator<Yield, void, mixed>;
+    /**
+     * Returns a new iterator that yields values from this iterator after skipping the provided count. If the this iterator has fewer than limit elements, the new iterator will be completed the first time next() is called.
+     * @param count The number of values to drop.
+     */
+    drop(count: number): $Iterator<Yield, void, mixed>;
 }
 type Iterator<+T> = $Iterator<T,void,void>;
 

--- a/lib/core.js
+++ b/lib/core.js
@@ -1742,44 +1742,58 @@ type IteratorResult<+Yield,+Return> =
     ...
 };
 
-interface $Iterator<+Yield,+Return,-Next> extends $Iterable<Yield,Return,Next> {
-    @@iterator(): $Iterator<Yield,Return,Next>;
+/**
+ * The iterator protocol expected by built-ins like Iterator.from().
+ * You can implement this yourself.
+ */
+interface $IteratorProtocol<+Yield,+Return=void,-Next=void> {
+    next(value?: Next): IteratorResult<Yield,Return>;
+}
+
+/**
+ * The built-in Iterator abstract base class. Iterators for Arrays, Strings, and Generators all inherit from this class.
+ * Extend this class to implement custom iterators that support all iterator helper methods.
+ * Note that you can use `Iterator.from()` to get an iterator helper wrapping any object that implements
+ * the iterator protocol.
+ */
+declare class Iterator<+Yield,+Return=void,-Next=void> implements $IteratorProtocol<Yield,Return,Next>, $Iterable<Yield,Return,Next> {
+    @@iterator(): Iterator<Yield,Return,Next>;
     next(value?: Next): IteratorResult<Yield,Return>;
     /**
      * Returns a new iterator that yields that values returned by calling the argument callback on each value yielded by this iterator.
      * @param callbackfn A function that accepts up to two arguments: the yielded value and its index. The map method calls the callbackfn function once per iteration.
      */
-    map<U>(callbackfn: (value: Yield, index: number) => U): $Iterator<U, void, mixed>;
+    map<U>(callbackfn: (value: Yield, index: number) => U): Iterator<U, void, mixed>;
     /**
      * Returns a new iterator that yields only those elements of the iterator for which the provided predicate returns a truthy value.
      * @param callbackfn A function that accepts up to two arguments: the yielded value and its index. The filter method calls the predicate function once per iteration.
      */
-    filter(callbackfn: typeof Boolean): $Iterator<$NonMaybeType<Yield>, void, mixed>;
+    filter(callbackfn: typeof Boolean): Iterator<$NonMaybeType<Yield>, void, mixed>;
     /**
      * Returns a new iterator that yields only those elements of the iterator for which the provided predicate returns a truthy value.
      * @param callbackfn A function that accepts up to two arguments: the yielded value and its index. The filter method calls the predicate function once per iteration.
      */
-    filter<Refined: Yield>(callbackfn: (value: Yield, index: number) => implies value is Refined): $Iterator<Refined, void, mixed>;
+    filter<Refined: Yield>(callbackfn: (value: Yield, index: number) => implies value is Refined): Iterator<Refined, void, mixed>;
     /**
      * Returns a new iterator that yields only those elements of the iterator for which the provided predicate returns a truthy value.
      * @param callbackfn A function that accepts up to two arguments: the yielded value and its index. The filter method calls the predicate function once per iteration.
      */
-    filter(callbackfn: (value: Yield, index: number) => mixed): $Iterator<Yield, void, mixed>;
+    filter(callbackfn: (value: Yield, index: number) => mixed): Iterator<Yield, void, mixed>;
     /**
      * Returns a new iterator that yields up to the given number of elements in this iterator and then terminates.
      * @param limit The maximum number of values to yield.
      */
-    take(limit: number): $Iterator<Yield, void, mixed>;
+    take(limit: number): Iterator<Yield, void, mixed>;
     /**
      * Returns a new iterator that yields values from this iterator after skipping the provided count. If the this iterator has fewer than limit elements, the new iterator will be completed the first time next() is called.
      * @param count The number of values to drop.
      */
-    drop(count: number): $Iterator<Yield, void, mixed>;
+    drop(count: number): Iterator<Yield, void, mixed>;
     /**
      * Returns a new iterator that takes each value yielded by this iterator, runs it through the argument mapping function to get another iterable, and yields each value returned by these mapped iterables.
      * @param callbackfn A function that accepts up to two arguments: the yielded value and its index. The map method calls the callbackfn function once per iteration. The callback must return an iterable.
      */
-    flatMap<U>(callbackfn: (value: Yield, index: number) => $Iterable<U, mixed, void>): $Iterator<U, void, mixed>;
+    flatMap<U>(callbackfn: (value: Yield, index: number) => $IteratorProtocol<U, mixed, void> | $Iterable<U, mixed, void>): Iterator<U, void, mixed>;
     /**
      * Calls the argument "reducer" callback function on each value produced by this iterator, passing in the return value from the calculation on the preceding iteration. The final result of running the reducer across all elements is a single value.
      * Exhausts this iterator. Will hang if it's infinite.
@@ -1836,19 +1850,28 @@ interface $Iterator<+Yield,+Return,-Next> extends $Iterable<Yield,Return,Next> {
      find<Refined: Yield>(predicate: (value: Yield, index: number) => implies value is Refined): Refined | void;
      find(callbackfn: (value: Yield, index: number) => mixed): Yield | void;
 }
-type Iterator<+T> = $Iterator<T,void,void>;
 
+type $Iterator<+Yield,+Return,-Next> = Iterator<Yield,Return,Next>;
+
+/**
+ * The iterable protocol expected by built-ins like Array.from().
+ * You can implement this yourself.
+ */
 interface $Iterable<+Yield,+Return,-Next> {
-    @@iterator(): $Iterator<Yield,Return,Next>;
+    @@iterator(): $IteratorProtocol<Yield,Return,Next>;
 }
 type Iterable<+T> = $Iterable<T,void,void>;
 
-interface Generator<+Yield,+Return,-Next> {
-    @@iterator(): $Iterator<Yield,Return,Next>;
-    next(value?: Next): IteratorResult<Yield,Return>;
+// The generator class is not exposed in the global namespace.
+declare class $Generator<+Yield,+Return,-Next> extends Iterator<Yield,Return,Next> {
     return<R>(value: R): IteratorResult<Yield,R|Return>;
     throw(error?: any): IteratorResult<Yield,Return>;
 }
+
+/**
+ * Built-in Generator objects returned by generator functions.
+ */
+type Generator<+Yield,+Return,-Next> = $Generator<Yield,Return,Next>;
 
 declare function $iterate<T>(p: Iterable<T>): T;
 

--- a/lib/core.js
+++ b/lib/core.js
@@ -1765,6 +1765,11 @@ interface $Iterator<+Yield,+Return,-Next> extends $Iterable<Yield,Return,Next> {
      * @param callbackfn A function that accepts up to two arguments: the yielded value and it's index. The filter method calls the predicate function once per iteration.
      */
     filter(callbackfn: (value: Yield, index: number) => mixed): $Iterator<Yield, void, mixed>;
+    /**
+     * Returns a new iterator that yields up to the given number of elements in this iterator and then terminates.
+     * @param limit The maximum number of values to yield.
+     */
+    take(limit: number): $Iterator<Yield, void, mixed>;
 }
 type Iterator<+T> = $Iterator<T,void,void>;
 

--- a/lib/core.js
+++ b/lib/core.js
@@ -1775,6 +1775,11 @@ interface $Iterator<+Yield,+Return,-Next> extends $Iterable<Yield,Return,Next> {
      * @param count The number of values to drop.
      */
     drop(count: number): $Iterator<Yield, void, mixed>;
+    /**
+     * Returns a new iterator that takes each value yielded by this iterator, runs it through the argument mapping function to get another iterable, and yields each value returned by these mapped iterables.
+     * @param callbackfn A function that accepts up to two arguments: the yielded value, and it's index. The map method calls the callbackfn function once per iteration. The callback must return an iterable.
+     */
+    flatMap<U>(callbackfn: (value: Yield, index: number) => $Iterable<U, mixed, void>): $Iterator<U, void, mixed>;
 }
 type Iterator<+T> = $Iterator<T,void,void>;
 

--- a/lib/core.js
+++ b/lib/core.js
@@ -1804,6 +1804,11 @@ interface $Iterator<+Yield,+Return,-Next> extends $Iterable<Yield,Return,Next> {
      * Calling this on an infinite iterator will cause the process to hang.
      */
     toArray(): Array<Yield>;
+    /**
+     * Calls the argument function for each value yielded by the iterator. Any returned values are ignored.
+     * @param callbackfn  A function that accepts up to two arguments: the yielded value and it's index.
+     */
+    forEach(callbackfn: (value: Yield, index: number) => mixed): void;
 }
 type Iterator<+T> = $Iterator<T,void,void>;
 

--- a/lib/core.js
+++ b/lib/core.js
@@ -1826,6 +1826,15 @@ interface $Iterator<+Yield,+Return,-Next> extends $Iterable<Yield,Return,Next> {
      * @param callbackfn  A function that accepts up to two arguments: the yielded value and its index.
      */
     every(callbackfn: (value: Yield, index: number) => mixed): boolean;
+    /**
+     * Calls the argument function for values yielded by the iterator until one returns a truthy value.
+     * Returns the first value that produced a truthy predicate.
+     * Returns undefined if the iterator completes without a match.
+     * Iterates this iterator. Will hang if it's infinite and has no matches.
+     * @param callbackfn  A function that accepts up to two arguments: the yielded value and its index.
+     */
+     find<Refined: Yield>(predicate: (value: Yield, index: number) => implies value is Refined): Refined | void;
+     find(callbackfn: (value: Yield, index: number) => mixed): Yield | void;
 }
 type Iterator<+T> = $Iterator<T,void,void>;
 

--- a/lib/core.js
+++ b/lib/core.js
@@ -1780,6 +1780,25 @@ interface $Iterator<+Yield,+Return,-Next> extends $Iterable<Yield,Return,Next> {
      * @param callbackfn A function that accepts up to two arguments: the yielded value, and it's index. The map method calls the callbackfn function once per iteration. The callback must return an iterable.
      */
     flatMap<U>(callbackfn: (value: Yield, index: number) => $Iterable<U, mixed, void>): $Iterator<U, void, mixed>;
+    /**
+     * Calls the argument "reducer" callback function on each value produced by this iterator, passing in the return value from the calculation on the preceding iteration. The final result of running the reducer across all elements is a single value.
+     * @param callbackfn A function that accepts up to three arguments: the accumulated value, the current value, and the current index.
+     * @param initialValue If initialValue is specified, it is used as the initial value to start
+     * the accumulation. If omitted, the first call of the callback gets the first two iterated values.
+     */
+    reduce<U>(
+      callbackfn: (previousValue: Yield | U, currentValue: Yield, index: number) => U,
+    ): Yield | U;
+    /**
+     * Calls the argument "reducer" callback function on each value produced by this iterator, passing in the return value from the calculation on the preceding iteration. The final result of running the reducer across all elements is a single value.
+     * @param callbackfn A function that accepts up to three arguments: the accumulated value, the current value, and the current index.
+     * @param initialValue If initialValue is specified, it is used as the initial value to start
+     * the accumulation. If omitted, the first call of the callback gets the first two iterated values.
+     */
+    reduce<U>(
+      callbackfn: (previousValue: U, currentValue: Yield, index: number) => U,
+      initialValue: U
+    ): U;
 }
 type Iterator<+T> = $Iterator<T,void,void>;
 

--- a/lib/core.js
+++ b/lib/core.js
@@ -699,7 +699,7 @@ declare var Math: {
  */
 declare class $ReadOnlyArray<+T> {
     @@iterator(): Iterator<T>;
-        /**
+    /**
      * Returns a string representation of an array. The elements are converted to string using their toLocalString methods.
      */
     toLocaleString(): string;
@@ -1745,6 +1745,11 @@ type IteratorResult<+Yield,+Return> =
 interface $Iterator<+Yield,+Return,-Next> extends $Iterable<Yield,Return,Next> {
     @@iterator(): $Iterator<Yield,Return,Next>;
     next(value?: Next): IteratorResult<Yield,Return>;
+    /**
+     * Calls a defined callback function on each element returned from this iterator.
+     * @param callbackfn A function that accepts up to two arguments: the yielded value, and it's index. The map method calls the callbackfn function once per iteration.
+     */
+    map<U>(callbackfn: (value: Yield, index: number) => U): $Iterator<U, void, mixed>;
 }
 type Iterator<+T> = $Iterator<T,void,void>;
 

--- a/lib/core.js
+++ b/lib/core.js
@@ -1746,23 +1746,23 @@ interface $Iterator<+Yield,+Return,-Next> extends $Iterable<Yield,Return,Next> {
     @@iterator(): $Iterator<Yield,Return,Next>;
     next(value?: Next): IteratorResult<Yield,Return>;
     /**
-     * Calls a defined callback function on each element returned from this iterator.
-     * @param callbackfn A function that accepts up to two arguments: the yielded value, and it's index. The map method calls the callbackfn function once per iteration.
+     * Returns a new iterator that yields that values returned by calling the argument callback on each value yielded by this iterator.
+     * @param callbackfn A function that accepts up to two arguments: the yielded value and its index. The map method calls the callbackfn function once per iteration.
      */
     map<U>(callbackfn: (value: Yield, index: number) => U): $Iterator<U, void, mixed>;
     /**
      * Returns a new iterator that yields only those elements of the iterator for which the provided predicate returns a truthy value.
-     * @param callbackfn A function that accepts up to two arguments: the yielded value and it's index. The filter method calls the predicate function once per iteration.
+     * @param callbackfn A function that accepts up to two arguments: the yielded value and its index. The filter method calls the predicate function once per iteration.
      */
     filter(callbackfn: typeof Boolean): $Iterator<$NonMaybeType<Yield>, void, mixed>;
     /**
      * Returns a new iterator that yields only those elements of the iterator for which the provided predicate returns a truthy value.
-     * @param callbackfn A function that accepts up to two arguments: the yielded value and it's index. The filter method calls the predicate function once per iteration.
+     * @param callbackfn A function that accepts up to two arguments: the yielded value and its index. The filter method calls the predicate function once per iteration.
      */
     filter<Refined: Yield>(callbackfn: (value: Yield, index: number) => implies value is Refined): $Iterator<Refined, void, mixed>;
     /**
      * Returns a new iterator that yields only those elements of the iterator for which the provided predicate returns a truthy value.
-     * @param callbackfn A function that accepts up to two arguments: the yielded value and it's index. The filter method calls the predicate function once per iteration.
+     * @param callbackfn A function that accepts up to two arguments: the yielded value and its index. The filter method calls the predicate function once per iteration.
      */
     filter(callbackfn: (value: Yield, index: number) => mixed): $Iterator<Yield, void, mixed>;
     /**
@@ -1777,11 +1777,12 @@ interface $Iterator<+Yield,+Return,-Next> extends $Iterable<Yield,Return,Next> {
     drop(count: number): $Iterator<Yield, void, mixed>;
     /**
      * Returns a new iterator that takes each value yielded by this iterator, runs it through the argument mapping function to get another iterable, and yields each value returned by these mapped iterables.
-     * @param callbackfn A function that accepts up to two arguments: the yielded value, and it's index. The map method calls the callbackfn function once per iteration. The callback must return an iterable.
+     * @param callbackfn A function that accepts up to two arguments: the yielded value and its index. The map method calls the callbackfn function once per iteration. The callback must return an iterable.
      */
     flatMap<U>(callbackfn: (value: Yield, index: number) => $Iterable<U, mixed, void>): $Iterator<U, void, mixed>;
     /**
      * Calls the argument "reducer" callback function on each value produced by this iterator, passing in the return value from the calculation on the preceding iteration. The final result of running the reducer across all elements is a single value.
+     * Exhausts this iterator. Will hang if it's infinite.
      * @param callbackfn A function that accepts up to three arguments: the accumulated value, the current value, and the current index.
      * @param initialValue If initialValue is specified, it is used as the initial value to start
      * the accumulation. If omitted, the first call of the callback gets the first two iterated values.
@@ -1791,6 +1792,7 @@ interface $Iterator<+Yield,+Return,-Next> extends $Iterable<Yield,Return,Next> {
     ): Yield | U;
     /**
      * Calls the argument "reducer" callback function on each value produced by this iterator, passing in the return value from the calculation on the preceding iteration. The final result of running the reducer across all elements is a single value.
+     * Exhausts this iterator. Will hang if it's infinite.
      * @param callbackfn A function that accepts up to three arguments: the accumulated value, the current value, and the current index.
      * @param initialValue If initialValue is specified, it is used as the initial value to start
      * the accumulation. If omitted, the first call of the callback gets the first two iterated values.
@@ -1801,14 +1803,22 @@ interface $Iterator<+Yield,+Return,-Next> extends $Iterable<Yield,Return,Next> {
     ): U;
     /**
      * Creates a new array from the values yielded by this iterator.
-     * Calling this on an infinite iterator will cause the process to hang.
+     * Exhausts this iterator. Will hang if it's infinite.
      */
     toArray(): Array<Yield>;
     /**
      * Calls the argument function for each value yielded by the iterator. Any returned values are ignored.
-     * @param callbackfn  A function that accepts up to two arguments: the yielded value and it's index.
+     * Exhausts this iterator. Will hang if it's infinite.
+     * @param callbackfn  A function that accepts up to two arguments: the yielded value and its index.
      */
     forEach(callbackfn: (value: Yield, index: number) => mixed): void;
+    /**
+     * Calls the argument function for each value yielded by the iterator.
+     * Returns true if the predicate function ever returns a truthy values.
+     * Exhausts this iterator. Will hang if it's infinite.
+     * @param callbackfn  A function that accepts up to two arguments: the yielded value and its index.
+     */
+    some(callbackfn: (value: Yield, index: number) => mixed): boolean;
 }
 type Iterator<+T> = $Iterator<T,void,void>;
 

--- a/lib/core.js
+++ b/lib/core.js
@@ -1799,6 +1799,11 @@ interface $Iterator<+Yield,+Return,-Next> extends $Iterable<Yield,Return,Next> {
       callbackfn: (previousValue: U, currentValue: Yield, index: number) => U,
       initialValue: U
     ): U;
+    /**
+     * Creates a new array from the values yielded by this iterator.
+     * Calling this on an infinite iterator will cause the process to hang.
+     */
+    toArray(): Array<Yield>;
 }
 type Iterator<+T> = $Iterator<T,void,void>;
 

--- a/lib/core.js
+++ b/lib/core.js
@@ -1814,11 +1814,18 @@ interface $Iterator<+Yield,+Return,-Next> extends $Iterable<Yield,Return,Next> {
     forEach(callbackfn: (value: Yield, index: number) => mixed): void;
     /**
      * Calls the argument function for each value yielded by the iterator.
-     * Returns true if the predicate function ever returns a truthy values.
+     * Returns true if the predicate function ever returns a truthy value.
      * Exhausts this iterator. Will hang if it's infinite.
      * @param callbackfn  A function that accepts up to two arguments: the yielded value and its index.
      */
     some(callbackfn: (value: Yield, index: number) => mixed): boolean;
+    /**
+     * Calls the argument function for each value yielded by the iterator.
+     * Returns true if the predicate function returns a truthy value for all iterated values.
+     * Exhausts this iterator. Will hang if it's infinite.
+     * @param callbackfn  A function that accepts up to two arguments: the yielded value and its index.
+     */
+    every(callbackfn: (value: Yield, index: number) => mixed): boolean;
 }
 type Iterator<+T> = $Iterator<T,void,void>;
 

--- a/tests/async/async.exp
+++ b/tests/async/async.exp
@@ -10,8 +10,8 @@ References:
    async.js:9:30
       9| async function f1(): Promise<boolean> {
                                       ^^^^^^^ [2]
-   <BUILTINS>/core.js:1984:24
-   1984| declare class Promise<+R = mixed> {
+   <BUILTINS>/core.js:2102:24
+   2102| declare class Promise<+R = mixed> {
                                 ^ [3]
 
 
@@ -31,8 +31,8 @@ References:
    async.js:28:48
      28| async function f4(p: Promise<number>): Promise<boolean> {
                                                         ^^^^^^^ [2]
-   <BUILTINS>/core.js:1984:24
-   1984| declare class Promise<+R = mixed> {
+   <BUILTINS>/core.js:2102:24
+   2102| declare class Promise<+R = mixed> {
                                 ^ [3]
 
 
@@ -99,8 +99,8 @@ undefined in type argument `R` [2]. [incompatible-return]
                      ^^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:1984:24
-   1984| declare class Promise<+R = mixed> {
+   <BUILTINS>/core.js:2102:24
+   2102| declare class Promise<+R = mixed> {
                                 ^ [2]
 
 
@@ -142,8 +142,8 @@ References:
    async_return_void.js:1:32
       1| async function foo1(): Promise<string> {
                                         ^^^^^^ [2]
-   <BUILTINS>/core.js:1984:24
-   1984| declare class Promise<+R = mixed> {
+   <BUILTINS>/core.js:2102:24
+   2102| declare class Promise<+R = mixed> {
                                 ^ [3]
 
 
@@ -160,8 +160,8 @@ References:
    async_return_void.js:5:32
       5| async function foo2(): Promise<string> {
                                         ^^^^^^ [2]
-   <BUILTINS>/core.js:1984:24
-   1984| declare class Promise<+R = mixed> {
+   <BUILTINS>/core.js:2102:24
+   2102| declare class Promise<+R = mixed> {
                                 ^ [3]
 
 
@@ -181,8 +181,8 @@ References:
    async_return_void.js:9:32
       9| async function foo3(): Promise<string> {
                                         ^^^^^^ [2]
-   <BUILTINS>/core.js:1984:24
-   1984| declare class Promise<+R = mixed> {
+   <BUILTINS>/core.js:2102:24
+   2102| declare class Promise<+R = mixed> {
                                 ^ [3]
 
 
@@ -220,11 +220,11 @@ string [2] in type argument `Yield` [3]. [incompatible-return]
                                                      ^^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:2047:58
-   2047|       T extends $ReadOnlyArray<mixed> ? {[K in keyof T]: Awaited<T[K]>} :
+   <BUILTINS>/core.js:2165:58
+   2165|       T extends $ReadOnlyArray<mixed> ? {[K in keyof T]: Awaited<T[K]>} :
                                                                   ^^^^^^^^^^^^^ [2]
-   <BUILTINS>/core.js:1778:27
-   1778| interface AsyncGenerator<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:1896:27
+   1896| interface AsyncGenerator<+Yield,+Return,-Next> {
                                    ^^^^^ [3]
 
 
@@ -237,14 +237,14 @@ string [1] is incompatible with number [2] in type argument `Yield` [3]. [incomp
                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:2047:58
-   2047|       T extends $ReadOnlyArray<mixed> ? {[K in keyof T]: Awaited<T[K]>} :
+   <BUILTINS>/core.js:2165:58
+   2165|       T extends $ReadOnlyArray<mixed> ? {[K in keyof T]: Awaited<T[K]>} :
                                                                   ^^^^^^^^^^^^^ [1]
    generator.js:21:45
      21| async function *genError1(): AsyncGenerator<number, void, void> {
                                                      ^^^^^^ [2]
-   <BUILTINS>/core.js:1778:27
-   1778| interface AsyncGenerator<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:1896:27
+   1896| interface AsyncGenerator<+Yield,+Return,-Next> {
                                    ^^^^^ [3]
 
 
@@ -258,8 +258,8 @@ Cannot yield `1` because number [1], a primitive, cannot be used as a subtype of
                     ^ [1]
 
 References:
-   <BUILTINS>/core.js:1789:7
-   1789|     : $Iterable<Yield, Return, Next>;
+   <BUILTINS>/core.js:1907:7
+   1907|     : $Iterable<Yield, Return, Next>;
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [2]
 
 

--- a/tests/autocomplete/autocomplete.exp
+++ b/tests/autocomplete/autocomplete.exp
@@ -1311,6 +1311,7 @@ Flags: --pretty
     {"name":"Intl$PluralRules","type":"typeof Intl$PluralRules"},
     {"name":"isFinite","type":"(number: mixed) => boolean"},
     {"name":"isNaN","type":"(number: mixed) => boolean"},
+    {"name":"Iterator","type":"typeof Iterator"},
     {
       "name":"JSON",
       "type":"{|+parse: (text: string, reviver?: (key: any, value: any) => any) => any, +stringify: ((value: null | string | number | boolean | interface {} | $ReadOnlyArray<mixed>, replacer?: ?((key: string, value: any) => any) | Array<any>, space?: string | number) => string) & ((value: mixed, replacer?: ?((key: string, value: any) => any) | Array<any>, space?: string | number) => string | void)|}"

--- a/tests/babel_loose_array_spread/babel_loose_array_spread.exp
+++ b/tests/babel_loose_array_spread/babel_loose_array_spread.exp
@@ -16,6 +16,24 @@ References:
                                     ^^^^^^^^^^^^^^^^^ [2]
 
 
+Error --------------------------------------------------------------------------------------------------- apply.js:11:15
+
+Cannot call `f.apply` because `$IteratorProtocol` [1] is incompatible with `Iterator` [2] in the return value of
+property `@@iterator` of type argument `A`. [incompatible-call]
+
+   apply.js:11:15
+     11| f.apply(null, it); // Error
+                       ^^
+
+References:
+   <BUILTINS>/core.js:1866:19
+   1866|     @@iterator(): $IteratorProtocol<Yield,Return,Next>;
+                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
+   <BUILTINS>/core.js:1149:17
+   1149|   @@iterator(): Iterator<T>;
+                         ^^^^^^^^^^^ [2]
+
+
 Error ------------------------------------------------------------------------------------------------- iterables.js:2:5
 
 `$Iterable` [1] is incompatible with `$ReadOnlyArray` [2]. [incompatible-type]
@@ -187,4 +205,4 @@ References:
 
 
 
-Found 11 errors
+Found 12 errors

--- a/tests/badly_positioned_func_proto/badly_positioned_func_proto.exp
+++ b/tests/badly_positioned_func_proto/badly_positioned_func_proto.exp
@@ -8,8 +8,8 @@ it into an object and attempt to use it as a subtype of an interface. [incompati
                       ^ [1]
 
 References:
-   <BUILTINS>/core.js:1751:11
-   1751| interface $Iterable<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:1865:11
+   1865| interface $Iterable<+Yield,+Return,-Next> {
                    ^^^^^^^^^ [2]
 
 
@@ -23,8 +23,8 @@ it into an object and attempt to use it as a subtype of an interface. [incompati
                         ^ [1]
 
 References:
-   <BUILTINS>/core.js:1751:11
-   1751| interface $Iterable<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:1865:11
+   1865| interface $Iterable<+Yield,+Return,-Next> {
                    ^^^^^^^^^ [2]
 
 

--- a/tests/bigint/bigint.exp
+++ b/tests/bigint/bigint.exp
@@ -30,23 +30,23 @@ Cannot call `BigInt` with `null` bound to `value` because: [incompatible-call]
                 ^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:2774:18
-   2774|   static (value: boolean | string | number | bigint | interface {} | $ReadOnlyArray<mixed>): bigint;
+   <BUILTINS>/core.js:2892:18
+   2892|   static (value: boolean | string | number | bigint | interface {} | $ReadOnlyArray<mixed>): bigint;
                           ^^^^^^^ [2]
-   <BUILTINS>/core.js:2774:28
-   2774|   static (value: boolean | string | number | bigint | interface {} | $ReadOnlyArray<mixed>): bigint;
+   <BUILTINS>/core.js:2892:28
+   2892|   static (value: boolean | string | number | bigint | interface {} | $ReadOnlyArray<mixed>): bigint;
                                     ^^^^^^ [3]
-   <BUILTINS>/core.js:2774:37
-   2774|   static (value: boolean | string | number | bigint | interface {} | $ReadOnlyArray<mixed>): bigint;
+   <BUILTINS>/core.js:2892:37
+   2892|   static (value: boolean | string | number | bigint | interface {} | $ReadOnlyArray<mixed>): bigint;
                                              ^^^^^^ [4]
-   <BUILTINS>/core.js:2774:46
-   2774|   static (value: boolean | string | number | bigint | interface {} | $ReadOnlyArray<mixed>): bigint;
+   <BUILTINS>/core.js:2892:46
+   2892|   static (value: boolean | string | number | bigint | interface {} | $ReadOnlyArray<mixed>): bigint;
                                                       ^^^^^^ [5]
-   <BUILTINS>/core.js:2774:55
-   2774|   static (value: boolean | string | number | bigint | interface {} | $ReadOnlyArray<mixed>): bigint;
+   <BUILTINS>/core.js:2892:55
+   2892|   static (value: boolean | string | number | bigint | interface {} | $ReadOnlyArray<mixed>): bigint;
                                                                ^^^^^^^^^^^^ [6]
-   <BUILTINS>/core.js:2774:70
-   2774|   static (value: boolean | string | number | bigint | interface {} | $ReadOnlyArray<mixed>): bigint;
+   <BUILTINS>/core.js:2892:70
+   2892|   static (value: boolean | string | number | bigint | interface {} | $ReadOnlyArray<mixed>): bigint;
                                                                               ^^^^^^^^^^^^^^^^^^^^^ [7]
 
 

--- a/tests/component_type/component_type.exp
+++ b/tests/component_type/component_type.exp
@@ -573,8 +573,8 @@ References:
    everything_implicit_instantiation.js:6:46
       6| declare component B(ref: React.RefSetter<Set<string>>, foo: string, bar: number) renders? A;
                                                       ^^^^^^ [2]
-   <BUILTINS>/core.js:1942:19
-   1942| declare class Set<T> extends $ReadOnlySet<T> {
+   <BUILTINS>/core.js:2060:19
+   2060| declare class Set<T> extends $ReadOnlySet<T> {
                            ^ [3]
    <BUILTINS>/react.js:235:19
     235|   type RefSetter<-T> = React$RefSetter<T>;
@@ -929,8 +929,8 @@ References:
    props_implicit_instantiation.js:7:46
       7| declare component A(ref: React.RefSetter<Set<string>>, foo: string, bar: number);
                                                       ^^^^^^ [2]
-   <BUILTINS>/core.js:1942:19
-   1942| declare class Set<T> extends $ReadOnlySet<T> {
+   <BUILTINS>/core.js:2060:19
+   2060| declare class Set<T> extends $ReadOnlySet<T> {
                            ^ [3]
    <BUILTINS>/react.js:235:19
     235|   type RefSetter<-T> = React$RefSetter<T>;

--- a/tests/contextual_typing/contextual_typing.exp
+++ b/tests/contextual_typing/contextual_typing.exp
@@ -22,8 +22,8 @@ expression to your expected type. [underconstrained-implicit-instantiation]
                             ^^^
 
 References:
-   <BUILTINS>/core.js:1942:19
-   1942| declare class Set<T> extends $ReadOnlySet<T> {
+   <BUILTINS>/core.js:2060:19
+   2060| declare class Set<T> extends $ReadOnlySet<T> {
                            ^ [1]
    arr_rest.js:9:16
       9| const [...y] = new Set() // still error
@@ -322,8 +322,8 @@ Property `@@iterator` is missing in function [1] but exists in `$Iterable` [2]. 
                 ^^^^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:1751:11
-   1751| interface $Iterable<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:1865:11
+   1865| interface $Iterable<+Yield,+Return,-Next> {
                    ^^^^^^^^^ [2]
 
 
@@ -461,8 +461,8 @@ References:
    implicit_instantiation.js:147:11
     147|   (a: Set<empty>); // error Set<string> ~> Set<empty>
                    ^^^^^ [2]
-   <BUILTINS>/core.js:1942:19
-   1942| declare class Set<T> extends $ReadOnlySet<T> {
+   <BUILTINS>/core.js:2060:19
+   2060| declare class Set<T> extends $ReadOnlySet<T> {
                            ^ [3]
 
 
@@ -481,8 +481,8 @@ References:
    implicit_instantiation.js:148:11
     148|   (b: Set<empty>); // error Set<string> ~> Set<empty>
                    ^^^^^ [2]
-   <BUILTINS>/core.js:1942:19
-   1942| declare class Set<T> extends $ReadOnlySet<T> {
+   <BUILTINS>/core.js:2060:19
+   2060| declare class Set<T> extends $ReadOnlySet<T> {
                            ^ [3]
 
 
@@ -723,7 +723,7 @@ Cannot determine type of empty array literal. Please provide an annotation. [mis
 
 Error ----------------------------------------------------------------------------------------------------- lits.js:52:3
 
-Cannot cast `s2.values()` to `Iterator` because number [1] is incompatible with string [2] in type argument `T` [3].
+Cannot cast `s2.values()` to `Iterator` because number [1] is incompatible with string [2] in type argument `Yield` [3].
 [incompatible-cast]
 
    lits.js:52:3
@@ -737,9 +737,9 @@ References:
    lits.js:52:27
      52|   s2.values() as Iterator<string>; // error number ~> string
                                    ^^^^^^ [2]
-   <BUILTINS>/core.js:1749:16
-   1749| type Iterator<+T> = $Iterator<T,void,void>;
-                        ^ [3]
+   <BUILTINS>/core.js:1759:25
+   1759| declare class Iterator<+Yield,+Return=void,-Next=void> implements $IteratorProtocol<Yield,Return,Next>, $Iterable<Yield,Return,Next> {
+                                 ^^^^^ [3]
 
 
 Error ------------------------------------------------------------------------------------------ misplaced_error.js:9:31

--- a/tests/core_tests/core_tests.exp
+++ b/tests/core_tests/core_tests.exp
@@ -75,12 +75,12 @@ References:
    map.js:21:22
      21|     let x = new Map(['foo', 123]); // error
                               ^^^^^ [1]
-   <BUILTINS>/core.js:1815:38
-   1815|     constructor(iterable?: ?Iterable<[K, V]>): void;
+   <BUILTINS>/core.js:1933:38
+   1933|     constructor(iterable?: ?Iterable<[K, V]>): void;
                                               ^^^^^^ [2]
-   <BUILTINS>/core.js:1745:22
-   1745| interface $Iterator<+Yield,+Return,-Next> extends $Iterable<Yield,Return,Next> {
-                              ^^^^^ [3]
+   <BUILTINS>/core.js:1749:30
+   1749| interface $IteratorProtocol<+Yield,+Return=void,-Next=void> {
+                                      ^^^^^ [3]
 
 
 Error ----------------------------------------------------------------------------------------------------- map.js:21:21
@@ -96,12 +96,12 @@ References:
    map.js:21:29
      21|     let x = new Map(['foo', 123]); // error
                                      ^^^ [1]
-   <BUILTINS>/core.js:1815:38
-   1815|     constructor(iterable?: ?Iterable<[K, V]>): void;
+   <BUILTINS>/core.js:1933:38
+   1933|     constructor(iterable?: ?Iterable<[K, V]>): void;
                                               ^^^^^^ [2]
-   <BUILTINS>/core.js:1745:22
-   1745| interface $Iterator<+Yield,+Return,-Next> extends $Iterable<Yield,Return,Next> {
-                              ^^^^^ [3]
+   <BUILTINS>/core.js:1749:30
+   1749| interface $IteratorProtocol<+Yield,+Return=void,-Next=void> {
+                                      ^^^^^ [3]
 
 
 Error ----------------------------------------------------------------------------------------------------- map.js:22:42
@@ -120,9 +120,9 @@ References:
    map.js:22:16
      22|     let y: Map<number, string> = new Map([['foo', 123]]); // error
                         ^^^^^^ [2]
-   <BUILTINS>/core.js:1745:22
-   1745| interface $Iterator<+Yield,+Return,-Next> extends $Iterable<Yield,Return,Next> {
-                              ^^^^^ [3]
+   <BUILTINS>/core.js:1749:30
+   1749| interface $IteratorProtocol<+Yield,+Return=void,-Next=void> {
+                                      ^^^^^ [3]
 
 
 Error ----------------------------------------------------------------------------------------------------- map.js:22:42
@@ -141,9 +141,9 @@ References:
    map.js:22:24
      22|     let y: Map<number, string> = new Map([['foo', 123]]); // error
                                 ^^^^^^ [2]
-   <BUILTINS>/core.js:1745:22
-   1745| interface $Iterator<+Yield,+Return,-Next> extends $Iterable<Yield,Return,Next> {
-                              ^^^^^ [3]
+   <BUILTINS>/core.js:1749:30
+   1749| interface $IteratorProtocol<+Yield,+Return=void,-Next=void> {
+                                      ^^^^^ [3]
 
 
 Error ------------------------------------------------------------------------------------------------------ map.js:27:6
@@ -155,8 +155,8 @@ Cannot cast `x.get(...)` to boolean because undefined [1] is incompatible with b
               ^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:1823:22
-   1823|     get(key: K): V | void;
+   <BUILTINS>/core.js:1941:22
+   1941|     get(key: K): V | void;
                               ^^^^ [1]
    map.js:27:20
      27|     (x.get('foo'): boolean); // error, string | void
@@ -206,11 +206,11 @@ Cannot call `WeakRef` because in type argument `T`: [incompatible-call]
                                ^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:1840:28
-   1840| type WeaklyReferenceable = interface {} | $ReadOnlyArray<mixed>;
+   <BUILTINS>/core.js:1958:28
+   1958| type WeaklyReferenceable = interface {} | $ReadOnlyArray<mixed>;
                                     ^^^^^^^^^^^^ [2]
-   <BUILTINS>/core.js:1840:43
-   1840| type WeaklyReferenceable = interface {} | $ReadOnlyArray<mixed>;
+   <BUILTINS>/core.js:1958:43
+   1958| type WeaklyReferenceable = interface {} | $ReadOnlyArray<mixed>;
                                                    ^^^^^^^^^^^^^^^^^^^^^ [3]
 
 
@@ -226,11 +226,11 @@ Cannot call `WeakRef` because in type argument `T`: [incompatible-call]
                                ^^^ [1]
 
 References:
-   <BUILTINS>/core.js:1840:28
-   1840| type WeaklyReferenceable = interface {} | $ReadOnlyArray<mixed>;
+   <BUILTINS>/core.js:1958:28
+   1958| type WeaklyReferenceable = interface {} | $ReadOnlyArray<mixed>;
                                     ^^^^^^^^^^^^ [2]
-   <BUILTINS>/core.js:1840:43
-   1840| type WeaklyReferenceable = interface {} | $ReadOnlyArray<mixed>;
+   <BUILTINS>/core.js:1958:43
+   1958| type WeaklyReferenceable = interface {} | $ReadOnlyArray<mixed>;
                                                    ^^^^^^^^^^^^^^^^^^^^^ [3]
 
 
@@ -246,11 +246,11 @@ Cannot call `WeakRef` because in type argument `T`: [incompatible-call]
                                ^^^^^^^^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:1840:28
-   1840| type WeaklyReferenceable = interface {} | $ReadOnlyArray<mixed>;
+   <BUILTINS>/core.js:1958:28
+   1958| type WeaklyReferenceable = interface {} | $ReadOnlyArray<mixed>;
                                     ^^^^^^^^^^^^ [2]
-   <BUILTINS>/core.js:1840:43
-   1840| type WeaklyReferenceable = interface {} | $ReadOnlyArray<mixed>;
+   <BUILTINS>/core.js:1958:43
+   1958| type WeaklyReferenceable = interface {} | $ReadOnlyArray<mixed>;
                                                    ^^^^^^^^^^^^^^^^^^^^^ [3]
 
 
@@ -266,11 +266,11 @@ Cannot call `WeakSet` because in type argument `T`: [incompatible-call]
                                 ^ [1]
 
 References:
-   <BUILTINS>/core.js:1840:28
-   1840| type WeaklyReferenceable = interface {} | $ReadOnlyArray<mixed>;
+   <BUILTINS>/core.js:1958:28
+   1958| type WeaklyReferenceable = interface {} | $ReadOnlyArray<mixed>;
                                     ^^^^^^^^^^^^ [2]
-   <BUILTINS>/core.js:1840:43
-   1840| type WeaklyReferenceable = interface {} | $ReadOnlyArray<mixed>;
+   <BUILTINS>/core.js:1958:43
+   1958| type WeaklyReferenceable = interface {} | $ReadOnlyArray<mixed>;
                                                    ^^^^^^^^^^^^^^^^^^^^^ [3]
 
 
@@ -286,11 +286,11 @@ Cannot call `WeakSet` because in type argument `T`: [incompatible-call]
                                    ^ [1]
 
 References:
-   <BUILTINS>/core.js:1840:28
-   1840| type WeaklyReferenceable = interface {} | $ReadOnlyArray<mixed>;
+   <BUILTINS>/core.js:1958:28
+   1958| type WeaklyReferenceable = interface {} | $ReadOnlyArray<mixed>;
                                     ^^^^^^^^^^^^ [2]
-   <BUILTINS>/core.js:1840:43
-   1840| type WeaklyReferenceable = interface {} | $ReadOnlyArray<mixed>;
+   <BUILTINS>/core.js:1958:43
+   1958| type WeaklyReferenceable = interface {} | $ReadOnlyArray<mixed>;
                                                    ^^^^^^^^^^^^^^^^^^^^^ [3]
 
 
@@ -306,11 +306,11 @@ Cannot call `WeakSet` because in type argument `T`: [incompatible-call]
                                       ^ [1]
 
 References:
-   <BUILTINS>/core.js:1840:28
-   1840| type WeaklyReferenceable = interface {} | $ReadOnlyArray<mixed>;
+   <BUILTINS>/core.js:1958:28
+   1958| type WeaklyReferenceable = interface {} | $ReadOnlyArray<mixed>;
                                     ^^^^^^^^^^^^ [2]
-   <BUILTINS>/core.js:1840:43
-   1840| type WeaklyReferenceable = interface {} | $ReadOnlyArray<mixed>;
+   <BUILTINS>/core.js:1958:43
+   1958| type WeaklyReferenceable = interface {} | $ReadOnlyArray<mixed>;
                                                    ^^^^^^^^^^^^^^^^^^^^^ [3]
 
 
@@ -329,11 +329,11 @@ References:
    weakset.js:27:31
      27| function* numbers(): Iterable<number> {
                                        ^^^^^^ [1]
-   <BUILTINS>/core.js:1840:28
-   1840| type WeaklyReferenceable = interface {} | $ReadOnlyArray<mixed>;
+   <BUILTINS>/core.js:1958:28
+   1958| type WeaklyReferenceable = interface {} | $ReadOnlyArray<mixed>;
                                     ^^^^^^^^^^^^ [2]
-   <BUILTINS>/core.js:1840:43
-   1840| type WeaklyReferenceable = interface {} | $ReadOnlyArray<mixed>;
+   <BUILTINS>/core.js:1958:43
+   1958| type WeaklyReferenceable = interface {} | $ReadOnlyArray<mixed>;
                                                    ^^^^^^^^^^^^^^^^^^^^^ [3]
 
 

--- a/tests/enums/enums.exp
+++ b/tests/enums/enums.exp
@@ -48,20 +48,20 @@ Cannot instantiate `EnumValue` because in type argument `TRepresentationType`: [
                           ^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:2858:32
-   2858| type EnumRepresentationTypes = string | number | symbol | boolean | bigint;
+   <BUILTINS>/core.js:2976:32
+   2976| type EnumRepresentationTypes = string | number | symbol | boolean | bigint;
                                         ^^^^^^ [2]
-   <BUILTINS>/core.js:2858:41
-   2858| type EnumRepresentationTypes = string | number | symbol | boolean | bigint;
+   <BUILTINS>/core.js:2976:41
+   2976| type EnumRepresentationTypes = string | number | symbol | boolean | bigint;
                                                  ^^^^^^ [3]
-   <BUILTINS>/core.js:2858:50
-   2858| type EnumRepresentationTypes = string | number | symbol | boolean | bigint;
+   <BUILTINS>/core.js:2976:50
+   2976| type EnumRepresentationTypes = string | number | symbol | boolean | bigint;
                                                           ^^^^^^ [4]
-   <BUILTINS>/core.js:2858:59
-   2858| type EnumRepresentationTypes = string | number | symbol | boolean | bigint;
+   <BUILTINS>/core.js:2976:59
+   2976| type EnumRepresentationTypes = string | number | symbol | boolean | bigint;
                                                                    ^^^^^^^ [5]
-   <BUILTINS>/core.js:2858:69
-   2858| type EnumRepresentationTypes = string | number | symbol | boolean | bigint;
+   <BUILTINS>/core.js:2976:69
+   2976| type EnumRepresentationTypes = string | number | symbol | boolean | bigint;
                                                                              ^^^^^^ [6]
 
 
@@ -143,8 +143,8 @@ Cannot cast `x` to `EnumValue` because number [1] is incompatible with boolean [
            ^
 
 References:
-   <BUILTINS>/core.js:2872:16
-   2872| > = $EnumValue<TRepresentationType>;
+   <BUILTINS>/core.js:2990:16
+   2990| > = $EnumValue<TRepresentationType>;
                         ^^^^^^^^^^^^^^^^^^^ [1]
    abstract-enum-value.js:35:18
      35|   x as EnumValue<boolean>; // ERROR
@@ -161,8 +161,8 @@ Cannot cast `x` to `EnumValue` because string [1] is incompatible with boolean [
            ^
 
 References:
-   <BUILTINS>/core.js:2872:16
-   2872| > = $EnumValue<TRepresentationType>;
+   <BUILTINS>/core.js:2990:16
+   2990| > = $EnumValue<TRepresentationType>;
                         ^^^^^^^^^^^^^^^^^^^ [1]
    abstract-enum-value.js:35:18
      35|   x as EnumValue<boolean>; // ERROR
@@ -232,8 +232,8 @@ Cannot instantiate `Enum` because boolean [1] is incompatible with `EnumValue` [
                        ^^^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:2889:24
-   2889| type Enum<+TEnumValue: EnumValue<> = EnumValue<>> = $Enum<TEnumValue>;
+   <BUILTINS>/core.js:3007:24
+   3007| type Enum<+TEnumValue: EnumValue<> = EnumValue<>> = $Enum<TEnumValue>;
                                 ^^^^^^^^^^^ [2]
 
 
@@ -270,11 +270,11 @@ References:
    abstract-enum.js:19:23
      19|   x as Enum<EnumValue<boolean>>; // ERROR
                                ^^^^^^^ [2]
-   <BUILTINS>/core.js:2871:4
-   2871|   +TRepresentationType: EnumRepresentationTypes = EnumRepresentationTypes
+   <BUILTINS>/core.js:2989:4
+   2989|   +TRepresentationType: EnumRepresentationTypes = EnumRepresentationTypes
             ^^^^^^^^^^^^^^^^^^^ [3]
-   <BUILTINS>/core.js:2889:12
-   2889| type Enum<+TEnumValue: EnumValue<> = EnumValue<>> = $Enum<TEnumValue>;
+   <BUILTINS>/core.js:3007:12
+   3007| type Enum<+TEnumValue: EnumValue<> = EnumValue<>> = $Enum<TEnumValue>;
                     ^^^^^^^^^^ [4]
 
 
@@ -294,8 +294,8 @@ References:
    abstract-enum.js:20:13
      20|   x as Enum<E>; // ERROR
                      ^ [2]
-   <BUILTINS>/core.js:2889:12
-   2889| type Enum<+TEnumValue: EnumValue<> = EnumValue<>> = $Enum<TEnumValue>;
+   <BUILTINS>/core.js:3007:12
+   3007| type Enum<+TEnumValue: EnumValue<> = EnumValue<>> = $Enum<TEnumValue>;
                     ^^^^^^^^^^ [3]
 
 
@@ -338,8 +338,8 @@ Cannot call `f` because boolean [1] is incompatible with `EnumValue` [2] in type
            ^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:2889:24
-   2889| type Enum<+TEnumValue: EnumValue<> = EnumValue<>> = $Enum<TEnumValue>;
+   <BUILTINS>/core.js:3007:24
+   3007| type Enum<+TEnumValue: EnumValue<> = EnumValue<>> = $Enum<TEnumValue>;
                                 ^^^^^^^^^^^ [2]
 
 
@@ -1629,9 +1629,9 @@ implicitly-returned undefined in type argument `Return` [2]. [incompatible-retur
                                             ^^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:1756:29
-   1756| interface Generator<+Yield,+Return,-Next> {
-                                     ^^^^^^ [2]
+   <BUILTINS>/core.js:1879:24
+   1879| type Generator<+Yield,+Return,-Next> = $Generator<Yield,Return,Next>;
+                                ^^^^^^ [2]
 
 
 Error ----------------------------------------------------------------------- exhaustive-check-implicit-return.js:202:11
@@ -1659,8 +1659,8 @@ undefined in type argument `R` [2]. [incompatible-return]
                                          ^^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:1984:24
-   1984| declare class Promise<+R = mixed> {
+   <BUILTINS>/core.js:2102:24
+   2102| declare class Promise<+R = mixed> {
                                 ^ [2]
 
 
@@ -1794,8 +1794,8 @@ References:
    exhaustive-check.js:3:6
       3| enum E {
               ^ [2]
-   <BUILTINS>/core.js:2659:3
-   2659|   isValid(this: TEnum, input: ?TRepresentationType | TEnumValue): boolean,
+   <BUILTINS>/core.js:2777:3
+   2777|   isValid(this: TEnum, input: ?TRepresentationType | TEnumValue): boolean,
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [3]
 
 
@@ -2513,15 +2513,15 @@ Cannot get `E.nonExistent` because property `nonExistent` is missing in `$EnumPr
            ^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:2656:59
+   <BUILTINS>/core.js:2774:59
                                                                    v-
-   2656| type $EnumProto<TEnum, TEnumValue, TRepresentationType> = {|
-   2657|   cast(this: TEnum, input: ?TRepresentationType): void | TEnumValue,
-   2658|   getName(this: TEnum, input: TEnumValue): string,
-   2659|   isValid(this: TEnum, input: ?TRepresentationType | TEnumValue): boolean,
-   2660|   members(this: TEnum): Iterator<TEnumValue>,
-   2661|   __proto__: null,
-   2662| |}
+   2774| type $EnumProto<TEnum, TEnumValue, TRepresentationType> = {|
+   2775|   cast(this: TEnum, input: ?TRepresentationType): void | TEnumValue,
+   2776|   getName(this: TEnum, input: TEnumValue): string,
+   2777|   isValid(this: TEnum, input: ?TRepresentationType | TEnumValue): boolean,
+   2778|   members(this: TEnum): Iterator<TEnumValue>,
+   2779|   __proto__: null,
+   2780| |}
          -^ [1]
 
 
@@ -2534,15 +2534,15 @@ Cannot call `E.nonExistent` because property `nonExistent` is missing in `$EnumP
            ^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:2656:59
+   <BUILTINS>/core.js:2774:59
                                                                    v-
-   2656| type $EnumProto<TEnum, TEnumValue, TRepresentationType> = {|
-   2657|   cast(this: TEnum, input: ?TRepresentationType): void | TEnumValue,
-   2658|   getName(this: TEnum, input: TEnumValue): string,
-   2659|   isValid(this: TEnum, input: ?TRepresentationType | TEnumValue): boolean,
-   2660|   members(this: TEnum): Iterator<TEnumValue>,
-   2661|   __proto__: null,
-   2662| |}
+   2774| type $EnumProto<TEnum, TEnumValue, TRepresentationType> = {|
+   2775|   cast(this: TEnum, input: ?TRepresentationType): void | TEnumValue,
+   2776|   getName(this: TEnum, input: TEnumValue): string,
+   2777|   isValid(this: TEnum, input: ?TRepresentationType | TEnumValue): boolean,
+   2778|   members(this: TEnum): Iterator<TEnumValue>,
+   2779|   __proto__: null,
+   2780| |}
          -^ [1]
 
 
@@ -2569,15 +2569,15 @@ Cannot call `E.A` because property `A` is missing in `$EnumProto` [1]. [prop-mis
            ^
 
 References:
-   <BUILTINS>/core.js:2656:59
+   <BUILTINS>/core.js:2774:59
                                                                    v-
-   2656| type $EnumProto<TEnum, TEnumValue, TRepresentationType> = {|
-   2657|   cast(this: TEnum, input: ?TRepresentationType): void | TEnumValue,
-   2658|   getName(this: TEnum, input: TEnumValue): string,
-   2659|   isValid(this: TEnum, input: ?TRepresentationType | TEnumValue): boolean,
-   2660|   members(this: TEnum): Iterator<TEnumValue>,
-   2661|   __proto__: null,
-   2662| |}
+   2774| type $EnumProto<TEnum, TEnumValue, TRepresentationType> = {|
+   2775|   cast(this: TEnum, input: ?TRepresentationType): void | TEnumValue,
+   2776|   getName(this: TEnum, input: TEnumValue): string,
+   2777|   isValid(this: TEnum, input: ?TRepresentationType | TEnumValue): boolean,
+   2778|   members(this: TEnum): Iterator<TEnumValue>,
+   2779|   __proto__: null,
+   2780| |}
          -^ [1]
 
 
@@ -2590,15 +2590,15 @@ Cannot call `E.toString` because property `toString` is missing in `$EnumProto` 
            ^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:2656:59
+   <BUILTINS>/core.js:2774:59
                                                                    v-
-   2656| type $EnumProto<TEnum, TEnumValue, TRepresentationType> = {|
-   2657|   cast(this: TEnum, input: ?TRepresentationType): void | TEnumValue,
-   2658|   getName(this: TEnum, input: TEnumValue): string,
-   2659|   isValid(this: TEnum, input: ?TRepresentationType | TEnumValue): boolean,
-   2660|   members(this: TEnum): Iterator<TEnumValue>,
-   2661|   __proto__: null,
-   2662| |}
+   2774| type $EnumProto<TEnum, TEnumValue, TRepresentationType> = {|
+   2775|   cast(this: TEnum, input: ?TRepresentationType): void | TEnumValue,
+   2776|   getName(this: TEnum, input: TEnumValue): string,
+   2777|   isValid(this: TEnum, input: ?TRepresentationType | TEnumValue): boolean,
+   2778|   members(this: TEnum): Iterator<TEnumValue>,
+   2779|   __proto__: null,
+   2780| |}
          -^ [1]
 
 
@@ -2611,8 +2611,8 @@ Cannot cast `E.getName(...)` to boolean because string [1] is incompatible with 
          ^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:2658:44
-   2658|   getName(this: TEnum, input: TEnumValue): string,
+   <BUILTINS>/core.js:2776:44
+   2776|   getName(this: TEnum, input: TEnumValue): string,
                                                     ^^^^^^ [1]
    methods.js:44:19
      44| E.getName(E.B) as boolean; // Error - wrong type

--- a/tests/fetch/fetch.exp
+++ b/tests/fetch/fetch.exp
@@ -14,8 +14,8 @@ References:
    fetch.js:12:18
      12| const b: Promise<string> = fetch(myRequest); // incorrect
                           ^^^^^^ [2]
-   <BUILTINS>/core.js:1984:24
-   1984| declare class Promise<+R = mixed> {
+   <BUILTINS>/core.js:2102:24
+   2102| declare class Promise<+R = mixed> {
                                 ^ [3]
 
 
@@ -35,8 +35,8 @@ References:
    <BUILTINS>/bom.js:1733:76
    1733| declare function fetch(input: RequestInfo, init?: RequestOptions): Promise<Response>;
                                                                                     ^^^^^^^^ [2]
-   <BUILTINS>/core.js:1984:24
-   1984| declare class Promise<+R = mixed> {
+   <BUILTINS>/core.js:2102:24
+   2102| declare class Promise<+R = mixed> {
                                 ^ [3]
 
 
@@ -564,8 +564,8 @@ References:
    request.js:24:15
      24| h.text().then((t: Buffer) => t); // incorrect
                        ^^^^^^^^^^^^^^^^ [3]
-   <BUILTINS>/core.js:1997:18
-   1997|       onFulfill: null | void,
+   <BUILTINS>/core.js:2115:18
+   2115|       onFulfill: null | void,
                           ^^^^^^^^^^^ [4]
 
 
@@ -589,8 +589,8 @@ References:
    request.js:26:22
      26| h.arrayBuffer().then((ab: Buffer) => ab); // incorrect
                               ^^^^^^^^^^^^^^^^^^ [3]
-   <BUILTINS>/core.js:1997:18
-   1997|       onFulfill: null | void,
+   <BUILTINS>/core.js:2115:18
+   2115|       onFulfill: null | void,
                           ^^^^^^^^^^^ [4]
 
 
@@ -721,17 +721,17 @@ References:
    <BUILTINS>/bom.js:1637:62
    1637| type BodyInit = string | URLSearchParams | FormData | Blob | ArrayBuffer | $ArrayBufferView | ReadableStream;
                                                                       ^^^^^^^^^^^ [5]
-   <BUILTINS>/core.js:2102:20
-   2102| type $TypedArray = $TypedArrayNumber | BigInt64Array | BigUint64Array;
+   <BUILTINS>/core.js:2220:20
+   2220| type $TypedArray = $TypedArrayNumber | BigInt64Array | BigUint64Array;
                             ^^^^^^^^^^^^^^^^^ [6]
-   <BUILTINS>/core.js:2102:40
-   2102| type $TypedArray = $TypedArrayNumber | BigInt64Array | BigUint64Array;
+   <BUILTINS>/core.js:2220:40
+   2220| type $TypedArray = $TypedArrayNumber | BigInt64Array | BigUint64Array;
                                                 ^^^^^^^^^^^^^ [7]
-   <BUILTINS>/core.js:2102:56
-   2102| type $TypedArray = $TypedArrayNumber | BigInt64Array | BigUint64Array;
+   <BUILTINS>/core.js:2220:56
+   2220| type $TypedArray = $TypedArrayNumber | BigInt64Array | BigUint64Array;
                                                                 ^^^^^^^^^^^^^^ [8]
-   <BUILTINS>/core.js:2098:39
-   2098| type $ArrayBufferView = $TypedArray | DataView;
+   <BUILTINS>/core.js:2216:39
+   2216| type $ArrayBufferView = $TypedArray | DataView;
                                                ^^^^^^^^ [9]
    <BUILTINS>/bom.js:1637:95
    1637| type BodyInit = string | URLSearchParams | FormData | Blob | ArrayBuffer | $ArrayBufferView | ReadableStream;
@@ -758,8 +758,8 @@ References:
    response.js:42:15
      42| h.text().then((t: Buffer) => t); // incorrect
                        ^^^^^^^^^^^^^^^^ [3]
-   <BUILTINS>/core.js:1997:18
-   1997|       onFulfill: null | void,
+   <BUILTINS>/core.js:2115:18
+   2115|       onFulfill: null | void,
                           ^^^^^^^^^^^ [4]
 
 
@@ -783,8 +783,8 @@ References:
    response.js:44:22
      44| h.arrayBuffer().then((ab: Buffer) => ab); // incorrect
                               ^^^^^^^^^^^^^^^^^^ [3]
-   <BUILTINS>/core.js:1997:18
-   1997|       onFulfill: null | void,
+   <BUILTINS>/core.js:2115:18
+   2115|       onFulfill: null | void,
                           ^^^^^^^^^^^ [4]
 
 

--- a/tests/forof/forof.exp
+++ b/tests/forof/forof.exp
@@ -45,8 +45,8 @@ References:
    forof.js:23:26
      23| function testString(str: string): void {
                                   ^^^^^^ [1]
-   <BUILTINS>/core.js:1751:11
-   1751| interface $Iterable<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:1865:11
+   1865| interface $Iterable<+Yield,+Return,-Next> {
                    ^^^^^^^^^ [2]
 
 
@@ -59,8 +59,8 @@ Cannot cast `elem` to number because tuple type [1] is incompatible with number 
              ^^^^
 
 References:
-   <BUILTINS>/core.js:1814:28
-   1814|     @@iterator(): Iterator<[K, V]>;
+   <BUILTINS>/core.js:1932:28
+   1932|     @@iterator(): Iterator<[K, V]>;
                                     ^^^^^^ [1]
    forof.js:32:13
      32|     elem as number; // Error - tuple ~> number

--- a/tests/function/function.exp
+++ b/tests/function/function.exp
@@ -43,8 +43,8 @@ it into an object and attempt to use it as a subtype of an interface. [incompati
                         ^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:1751:11
-   1751| interface $Iterable<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:1865:11
+   1865| interface $Iterable<+Yield,+Return,-Next> {
                    ^^^^^^^^^ [2]
 
 
@@ -103,7 +103,7 @@ References:
 
 Error ---------------------------------------------------------------------------------------- apply-array-like.js:21:16
 
-Cannot call `test.apply` because property `length` is missing in `Generator` [1] but exists in `$ArrayLike` [2] in type
+Cannot call `test.apply` because property `length` is missing in `$Generator` [1] but exists in `$ArrayLike` [2] in type
 argument `A`. [prop-missing]
 
    apply-array-like.js:21:16
@@ -111,9 +111,9 @@ argument `A`. [prop-missing]
                         ^^^^^
 
 References:
-   <BUILTINS>/core.js:1756:11
-   1756| interface Generator<+Yield,+Return,-Next> {
-                   ^^^^^^^^^ [1]
+   <BUILTINS>/core.js:1879:40
+   1879| type Generator<+Yield,+Return,-Next> = $Generator<Yield,Return,Next>;
+                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
    <BUILTINS>/core.js:362:29
     362|     proto apply: (<T, R, A: $ArrayLike<mixed> = []>(this: (this: T, ...args: A) => R, thisArg: T, args?: A) => R);
                                      ^^^^^^^^^^^^^^^^^ [2]
@@ -121,7 +121,7 @@ References:
 
 Error ---------------------------------------------------------------------------------------- apply-array-like.js:21:16
 
-Cannot call `test.apply` because property `length` is missing in `Generator` [1] but exists in `$ArrayLike` [2] in type
+Cannot call `test.apply` because property `length` is missing in `$Generator` [1] but exists in `$ArrayLike` [2] in type
 argument `A`. [prop-missing]
 
    apply-array-like.js:21:16
@@ -242,8 +242,8 @@ it into an object and attempt to use it as a subtype of an interface. [incompati
                         ^^^^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:1751:11
-   1751| interface $Iterable<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:1865:11
+   1865| interface $Iterable<+Yield,+Return,-Next> {
                    ^^^^^^^^^ [2]
 
 

--- a/tests/generators/generators.exp
+++ b/tests/generators/generators.exp
@@ -42,9 +42,9 @@ References:
    class.js:23:39
      23|   *stmt_return_err(): Generator<void, number, void> {
                                                ^^^^^^ [2]
-   <BUILTINS>/core.js:1756:29
-   1756| interface Generator<+Yield,+Return,-Next> {
-                                     ^^^^^^ [3]
+   <BUILTINS>/core.js:1879:24
+   1879| type Generator<+Yield,+Return,-Next> = $Generator<Yield,Return,Next>;
+                                ^^^^^^ [3]
 
 
 Error --------------------------------------------------------------------------------------------------- class.js:28:22
@@ -125,15 +125,15 @@ of property `@@iterator`. [incompatible-type-arg]
                     ^^
 
 References:
-   <BUILTINS>/core.js:1749:38
-   1749| type Iterator<+T> = $Iterator<T,void,void>;
-                                              ^^^^ [1]
+   <BUILTINS>/core.js:1759:50
+   1759| declare class Iterator<+Yield,+Return=void,-Next=void> implements $IteratorProtocol<Yield,Return,Next>, $Iterable<Yield,Return,Next> {
+                                                          ^^^^ [1]
    class.js:71:71
      71|   *delegate_next_iterable(xs: Array<number>): Generator<number, void, string> {
                                                                                ^^^^^^ [2]
-   <BUILTINS>/core.js:1745:37
-   1745| interface $Iterator<+Yield,+Return,-Next> extends $Iterable<Yield,Return,Next> {
-                                             ^^^^ [3]
+   <BUILTINS>/core.js:1749:50
+   1749| interface $IteratorProtocol<+Yield,+Return=void,-Next=void> {
+                                                          ^^^^ [3]
 
 
 Error --------------------------------------------------------------------------------------------------- class.js:98:41
@@ -374,9 +374,9 @@ References:
    generators.js:22:46
      22| function *stmt_return_err(): Generator<void, number, void> {
                                                       ^^^^^^ [2]
-   <BUILTINS>/core.js:1756:29
-   1756| interface Generator<+Yield,+Return,-Next> {
-                                     ^^^^^^ [3]
+   <BUILTINS>/core.js:1879:24
+   1879| type Generator<+Yield,+Return,-Next> = $Generator<Yield,Return,Next>;
+                                ^^^^^^ [3]
 
 
 Error ---------------------------------------------------------------------------------------------- generators.js:27:20

--- a/tests/get_def_enums/get_def_enums.exp
+++ b/tests/get_def_enums/get_def_enums.exp
@@ -28,9 +28,9 @@ library.js:4:3,4:5
 
 main.js:27:13
 Flags:
-[LIB] core.js:2657:3,2657:6
+[LIB] core.js:2775:3,2775:6
 
 main.js:30:13
 Flags:
-[LIB] core.js:2659:3,2659:9
+[LIB] core.js:2777:3,2777:9
 

--- a/tests/interface/interface.exp
+++ b/tests/interface/interface.exp
@@ -859,8 +859,8 @@ References:
    string.js:1:18
       1| declare const s: string;
                           ^^^^^^ [1]
-   <BUILTINS>/core.js:1751:11
-   1751| interface $Iterable<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:1865:11
+   1865| interface $Iterable<+Yield,+Return,-Next> {
                    ^^^^^^^^^ [2]
 
 

--- a/tests/iterable/iterable.exp
+++ b/tests/iterable/iterable.exp
@@ -14,9 +14,9 @@ References:
    array.js:7:20
       7| ['hi'] as Iterable<number>; // Error string ~> number
                             ^^^^^^ [2]
-   <BUILTINS>/core.js:1745:22
-   1745| interface $Iterator<+Yield,+Return,-Next> extends $Iterable<Yield,Return,Next> {
-                              ^^^^^ [3]
+   <BUILTINS>/core.js:1749:30
+   1749| interface $IteratorProtocol<+Yield,+Return=void,-Next=void> {
+                                      ^^^^^ [3]
 
 
 Error ----------------------------------------------------------------------------------------------------- array.js:8:1
@@ -35,9 +35,9 @@ References:
    array.js:8:23
       8| ['hi', 1] as Iterable<string>; // Error number ~> string
                                ^^^^^^ [2]
-   <BUILTINS>/core.js:1745:22
-   1745| interface $Iterator<+Yield,+Return,-Next> extends $Iterable<Yield,Return,Next> {
-                              ^^^^^ [3]
+   <BUILTINS>/core.js:1749:30
+   1749| interface $IteratorProtocol<+Yield,+Return=void,-Next=void> {
+                                      ^^^^^ [3]
 
 
 Error --------------------------------------------------------------------------------------------- caching_bug.js:21:79
@@ -56,9 +56,9 @@ References:
    caching_bug.js:21:62
      21| function miss_the_cache(x: Array<string | number>): Iterable<string> { return x; }
                                                                       ^^^^^^ [2]
-   <BUILTINS>/core.js:1745:22
-   1745| interface $Iterator<+Yield,+Return,-Next> extends $Iterable<Yield,Return,Next> {
-                              ^^^^^ [3]
+   <BUILTINS>/core.js:1749:30
+   1749| interface $IteratorProtocol<+Yield,+Return=void,-Next=void> {
+                                      ^^^^^ [3]
 
 
 Error ----------------------------------------------------------------------------------------- iterator_result.js:23:31
@@ -106,15 +106,15 @@ value of property `@@iterator`. [incompatible-return]
                   ^^^
 
 References:
-   <BUILTINS>/core.js:1814:28
-   1814|     @@iterator(): Iterator<[K, V]>;
+   <BUILTINS>/core.js:1926:28
+   1926|     @@iterator(): Iterator<[K, V]>;
                                     ^^^^^^ [1]
    map.js:13:55
      13| function mapTest4(map: Map<number, string>): Iterable<string> {
                                                                ^^^^^^ [2]
-   <BUILTINS>/core.js:1745:22
-   1745| interface $Iterator<+Yield,+Return,-Next> extends $Iterable<Yield,Return,Next> {
-                              ^^^^^ [3]
+   <BUILTINS>/core.js:1749:30
+   1749| interface $IteratorProtocol<+Yield,+Return=void,-Next=void> {
+                                      ^^^^^ [3]
 
 
 Error ----------------------------------------------------------------------------------------------------- set.js:14:10
@@ -133,9 +133,9 @@ References:
    set.js:13:47
      13| function setTest4(set: Set<string>): Iterable<number> {
                                                        ^^^^^^ [2]
-   <BUILTINS>/core.js:1745:22
-   1745| interface $Iterator<+Yield,+Return,-Next> extends $Iterable<Yield,Return,Next> {
-                              ^^^^^ [3]
+   <BUILTINS>/core.js:1749:30
+   1749| interface $IteratorProtocol<+Yield,+Return=void,-Next=void> {
+                                      ^^^^^ [3]
 
 
 Error ---------------------------------------------------------------------------------------------------- string.js:3:2
@@ -154,9 +154,9 @@ References:
    string.js:3:29
       3| (new String("hi"): Iterable<number>); // Error - string is a Iterable<string>
                                      ^^^^^^ [2]
-   <BUILTINS>/core.js:1745:22
-   1745| interface $Iterator<+Yield,+Return,-Next> extends $Iterable<Yield,Return,Next> {
-                              ^^^^^ [3]
+   <BUILTINS>/core.js:1749:30
+   1749| interface $IteratorProtocol<+Yield,+Return=void,-Next=void> {
+                                      ^^^^^ [3]
 
 
 

--- a/tests/iterable/iterable.exp
+++ b/tests/iterable/iterable.exp
@@ -106,8 +106,8 @@ value of property `@@iterator`. [incompatible-return]
                   ^^^
 
 References:
-   <BUILTINS>/core.js:1926:28
-   1926|     @@iterator(): Iterator<[K, V]>;
+   <BUILTINS>/core.js:1932:28
+   1932|     @@iterator(): Iterator<[K, V]>;
                                     ^^^^^^ [1]
    map.js:13:55
      13| function mapTest4(map: Map<number, string>): Iterable<string> {

--- a/tests/iterable/iterator_result.js
+++ b/tests/iterable/iterator_result.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-function makeIterator1(coin_flip: () => boolean ): Iterator<string> {
+function makeIterator1(coin_flip: () => boolean ): $IteratorProtocol<string> {
   return {
     "@@iterator"() { return makeIterator1(coin_flip); },
     next(): IteratorResult<string, void> {
@@ -14,7 +14,7 @@ function makeIterator1(coin_flip: () => boolean ): Iterator<string> {
   }
 }
 
-function makeIterator2(coin_flip: () => boolean ): Iterator<string> {
+function makeIterator2(coin_flip: () => boolean ): $IteratorProtocol<string> {
   return {
     "@@iterator"() { return makeIterator2(coin_flip); },
     next(): IteratorResult<string, void> {

--- a/tests/iterator_helpers/.flowconfig
+++ b/tests/iterator_helpers/.flowconfig
@@ -1,0 +1,3 @@
+[options]
+no_flowlib=false
+all=true

--- a/tests/iterator_helpers/drop.js
+++ b/tests/iterator_helpers/drop.js
@@ -1,0 +1,10 @@
+/* @flow */
+declare const iterator: Iterator<number>;
+
+// Basic usage
+(iterator.drop(2): Iterator<number>); // OK
+
+// Return type is discarded: https://tc39.es/proposal-iterator-helpers/#sec-iteratorprototype.drop
+// "ii. If value is done, return undefined."
+declare const iteratorWithReturn: $Iterator<number, number, void>;
+(iteratorWithReturn.drop(2): $Iterator<number, void, void>); // OK

--- a/tests/iterator_helpers/every.js
+++ b/tests/iterator_helpers/every.js
@@ -1,0 +1,6 @@
+/* @flow */
+declare const iterator: Iterator<number>;
+declare const predicate: (number) => boolean;
+
+// Basic usage
+(iterator.every(predicate): boolean); // OK

--- a/tests/iterator_helpers/filter.js
+++ b/tests/iterator_helpers/filter.js
@@ -1,0 +1,20 @@
+/* @flow */
+declare const iterator: Iterator<number>;
+
+declare function check(x: number): boolean;
+
+// Basic usage
+(iterator.filter(check): Iterator<number>); // OK
+
+// Return type is discarded: https://tc39.es/proposal-iterator-helpers/#sec-iteratorprototype.filter
+// "ii. If value is done, return undefined."
+declare const iteratorWithReturn: $Iterator<number, number, void>;
+(iteratorWithReturn.filter(check): $Iterator<number, void, void>); // OK
+
+// Filters nullish values with Boolean
+declare const iteratorWithNullableValues: Iterator<?number>;
+(iteratorWithNullableValues.filter(Boolean): Iterator<number>); // OK
+
+// Propagates type guards
+declare function guarded(x: ?number): implies x is number;
+(iteratorWithNullableValues.filter(guarded): Iterator<number>); // OK

--- a/tests/iterator_helpers/find.js
+++ b/tests/iterator_helpers/find.js
@@ -1,0 +1,11 @@
+/* @flow */
+declare const iterator: Iterator<number>;
+declare const predicate: (number) => boolean;
+
+// Basic usage
+(iterator.find(predicate): ?number); // OK
+
+// Propagates type guards
+declare const mixedIterator: Iterator<number | string>;
+declare function guarded(x: number | string): implies x is number;
+(mixedIterator.find(guarded): ?number); // OK

--- a/tests/iterator_helpers/flatmap.js
+++ b/tests/iterator_helpers/flatmap.js
@@ -1,0 +1,11 @@
+/* @flow */
+declare const iterator: Iterator<number>;
+declare function mapper(number): $ReadOnlyArray<string>
+
+// Basic usage
+(iterator.flatMap(mapper): Iterator<string>); // OK
+
+// Return type is discarded: https://tc39.es/proposal-iterator-helpers/#sec-iteratorprototype.flatmap
+// "ii. If value is done, return undefined."
+declare const iteratorWithReturn: $Iterator<number, number, void>;
+(iteratorWithReturn.flatMap(mapper): $Iterator<string, void, void>); // OK

--- a/tests/iterator_helpers/foreach.js
+++ b/tests/iterator_helpers/foreach.js
@@ -1,0 +1,5 @@
+/* @flow */
+declare const iterator: Iterator<number>;
+
+// Basic usage
+(iterator.forEach((x: number): mixed => {}): void); // OK

--- a/tests/iterator_helpers/from.js
+++ b/tests/iterator_helpers/from.js
@@ -1,0 +1,7 @@
+/* @flow */
+// From a built-in iterable
+(Iterator.from([1]): Iterator<number>);
+
+// From a custom iterator implementation
+declare const iterator: $IteratorProtocol<number>;
+(Iterator.from(iterator): Iterator<number>);

--- a/tests/iterator_helpers/iterator_helpers.exp
+++ b/tests/iterator_helpers/iterator_helpers.exp
@@ -1,0 +1,1 @@
+Found 0 errors

--- a/tests/iterator_helpers/map.js
+++ b/tests/iterator_helpers/map.js
@@ -1,0 +1,10 @@
+/* @flow */
+declare const iterator: Iterator<number>;
+
+// Basic usage
+(iterator.map(String): Iterator<string>); // OK
+
+// Return type is discarded: https://tc39.es/proposal-iterator-helpers/#sec-iteratorprototype.map
+// "ii. If value is done, return undefined."
+declare const iteratorWithReturn: $Iterator<number, number, void>;
+(iteratorWithReturn.map(String): $Iterator<string, void, void>); // OK

--- a/tests/iterator_helpers/reduce.js
+++ b/tests/iterator_helpers/reduce.js
@@ -1,0 +1,15 @@
+/* @flow */
+declare const iterator: Iterator<number>;
+declare const numberReducer: (number,  number) => number;
+declare const stringReducer: (string,  number) => string;
+declare const flexibleReducer: (string | number,  number) => string;
+
+// Basic usage
+(iterator.reduce(numberReducer): number); // OK
+(iterator.reduce(flexibleReducer): string | number); // OK
+(iterator.reduce(stringReducer, ''): string); // OK
+
+// Return type is discarded: https://tc39.es/proposal-iterator-helpers/#sec-iteratorprototype.reduce
+// "ii. If value is done, return undefined."
+declare const iteratorWithReturn: $Iterator<number, number, void>;
+(iteratorWithReturn.map(numberReducer): $Iterator<number, void, void>); // OK

--- a/tests/iterator_helpers/some.js
+++ b/tests/iterator_helpers/some.js
@@ -1,0 +1,6 @@
+/* @flow */
+declare const iterator: Iterator<number>;
+declare const predicate: (number) => boolean;
+
+// Basic usage
+(iterator.some(predicate): boolean); // OK

--- a/tests/iterator_helpers/take.js
+++ b/tests/iterator_helpers/take.js
@@ -1,0 +1,10 @@
+/* @flow */
+declare const iterator: Iterator<number>;
+
+// Basic usage
+(iterator.take(2): Iterator<number>); // OK
+
+// Return type is discarded: https://tc39.es/proposal-iterator-helpers/#sec-iteratorprototype.take
+// "ii. If value is done, return undefined."
+declare const iteratorWithReturn: $Iterator<number, number, void>;
+(iteratorWithReturn.take(2): $Iterator<number, void, void>); // OK

--- a/tests/iterator_helpers/toarray.js
+++ b/tests/iterator_helpers/toarray.js
@@ -1,0 +1,5 @@
+/* @flow */
+declare const iterator: Iterator<number>;
+
+// Basic usage
+(iterator.toArray(): Array<number>); // OK

--- a/tests/local_inference_annotations/local_inference_annotations.exp
+++ b/tests/local_inference_annotations/local_inference_annotations.exp
@@ -63,8 +63,8 @@ Property `@@iterator` is missing in function [1] but exists in `$Iterable` [2]. 
                 ^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:1751:11
-   1751| interface $Iterable<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:1865:11
+   1865| interface $Iterable<+Yield,+Return,-Next> {
                    ^^^^^^^^^ [2]
 
 
@@ -546,8 +546,8 @@ Property `@@iterator` is missing in function [1] but exists in `$Iterable` [2]. 
                           ^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:1751:11
-   1751| interface $Iterable<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:1865:11
+   1865| interface $Iterable<+Yield,+Return,-Next> {
                    ^^^^^^^^^ [2]
 
 

--- a/tests/lti_friendly_errors/lti_friendly_errors.exp
+++ b/tests/lti_friendly_errors/lti_friendly_errors.exp
@@ -8,14 +8,14 @@ in type argument `R` [3]. [incompatible-cast]
           ^
 
 References:
-   <BUILTINS>/core.js:1984:28
-   1984| declare class Promise<+R = mixed> {
+   <BUILTINS>/core.js:2102:28
+   2102| declare class Promise<+R = mixed> {
                                     ^^^^^ [1]
    reason_of_inferred_targs.js:2:13
       2| (p: Promise<string>); // error
                      ^^^^^^ [2]
-   <BUILTINS>/core.js:1984:24
-   1984| declare class Promise<+R = mixed> {
+   <BUILTINS>/core.js:2102:24
+   2102| declare class Promise<+R = mixed> {
                                 ^ [3]
 
 

--- a/tests/mapped_type_utilities/mapped_type_utilities.exp
+++ b/tests/mapped_type_utilities/mapped_type_utilities.exp
@@ -153,8 +153,8 @@ Cannot cast `pickedO1.bar` to string because undefined [1] is incompatible with 
           ^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:2834:62
-   2834| type Pick<O: interface {}, Keys: $Keys<O>> = {[key in Keys]: O[key]};
+   <BUILTINS>/core.js:2952:62
+   2952| type Pick<O: interface {}, Keys: $Keys<O>> = {[key in Keys]: O[key]};
                                                                       ^^^^^^ [1]
    pick.js:9:16
       9| (pickedO1.bar: string); // ERROR bar is optional

--- a/tests/meta_property/meta_property.exp
+++ b/tests/meta_property/meta_property.exp
@@ -8,13 +8,13 @@ Cannot cast `import.meta` to number literal `1` because `Import$Meta` [1] is inc
           ^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:2767:20
+   <BUILTINS>/core.js:2885:20
                             v
-   2767| type Import$Meta = {
-   2768|   [string]: mixed,
-   2769|   url?: string,
-   2770|   ...
-   2771| };
+   2885| type Import$Meta = {
+   2886|   [string]: mixed,
+   2887|   url?: string,
+   2888|   ...
+   2889| };
          ^ [1]
    import_meta.js:5:15
       5| (import.meta: 1); // Error
@@ -31,8 +31,8 @@ Cannot cast `import.meta.XXX` to number literal `1` because mixed [1] is incompa
           ^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:2768:13
-   2768|   [string]: mixed,
+   <BUILTINS>/core.js:2886:13
+   2886|   [string]: mixed,
                      ^^^^^ [1]
    import_meta.js:6:19
       6| (import.meta.XXX: 1); // Error

--- a/tests/new_env/new_env.exp
+++ b/tests/new_env/new_env.exp
@@ -205,12 +205,12 @@ Cannot call `Promise` because function [1] requires another argument. [incompati
                      ^^^^^^^
 
 References:
-   <BUILTINS>/core.js:1985:5
+   <BUILTINS>/core.js:2103:5
              v----------------------
-   1985|     constructor(callback: (
-   1986|       resolve: (result: Promise<R> | R) => void,
-   1987|       reject: (error: any) => void
-   1988|     ) => mixed): void;
+   2103|     constructor(callback: (
+   2104|       resolve: (result: Promise<R> | R) => void,
+   2105|       reject: (error: any) => void
+   2106|     ) => mixed): void;
              ----------------^ [1]
 
 

--- a/tests/new_merge/new_merge.exp
+++ b/tests/new_merge/new_merge.exp
@@ -299,8 +299,8 @@ Cannot cast `f15()` to empty because `Promise` [1] is incompatible with empty [2
          ^^^^^
 
 References:
-   <BUILTINS>/core.js:1984:15
-   1984| declare class Promise<+R = mixed> {
+   <BUILTINS>/core.js:2102:15
+   2102| declare class Promise<+R = mixed> {
                        ^^^^^^^ [1]
    main.js:58:10
      58| f15() as empty;

--- a/tests/promises/promises.exp
+++ b/tests/promises/promises.exp
@@ -7,8 +7,8 @@ Cannot cast `a` to number because string [1] is incompatible with number [2]. [i
             ^
 
 References:
-   <BUILTINS>/core.js:2047:58
-   2047|       T extends $ReadOnlyArray<mixed> ? {[K in keyof T]: Awaited<T[K]>} :
+   <BUILTINS>/core.js:2165:58
+   2165|       T extends $ReadOnlyArray<mixed> ? {[K in keyof T]: Awaited<T[K]>} :
                                                                   ^^^^^^^^^^^^^ [1]
    all.js:11:7
      11|   (a: number);  // Error: string ~> number
@@ -24,8 +24,8 @@ Cannot cast `b` to boolean because number [1] is incompatible with boolean [2]. 
             ^
 
 References:
-   <BUILTINS>/core.js:2047:58
-   2047|       T extends $ReadOnlyArray<mixed> ? {[K in keyof T]: Awaited<T[K]>} :
+   <BUILTINS>/core.js:2165:58
+   2165|       T extends $ReadOnlyArray<mixed> ? {[K in keyof T]: Awaited<T[K]>} :
                                                                   ^^^^^^^^^^^^^ [1]
    all.js:12:7
      12|   (b: boolean); // Error: number ~> boolean
@@ -41,8 +41,8 @@ Cannot cast `c` to string because boolean [1] is incompatible with string [2]. [
             ^
 
 References:
-   <BUILTINS>/core.js:2047:58
-   2047|       T extends $ReadOnlyArray<mixed> ? {[K in keyof T]: Awaited<T[K]>} :
+   <BUILTINS>/core.js:2165:58
+   2165|       T extends $ReadOnlyArray<mixed> ? {[K in keyof T]: Awaited<T[K]>} :
                                                                   ^^^^^^^^^^^^^ [1]
    all.js:13:7
      13|   (c: string);  // Error: boolean ~> string
@@ -58,8 +58,8 @@ Cannot cast `x` to undefined because boolean [1] is incompatible with undefined 
               ^
 
 References:
-   <BUILTINS>/core.js:2047:58
-   2047|       T extends $ReadOnlyArray<mixed> ? {[K in keyof T]: Awaited<T[K]>} :
+   <BUILTINS>/core.js:2165:58
+   2165|       T extends $ReadOnlyArray<mixed> ? {[K in keyof T]: Awaited<T[K]>} :
                                                                   ^^^^^^^^^^^^^ [1]
    all.js:17:9
      17|     (x: void);  // Errors: string ~> void, number ~> void, boolean ~> void
@@ -75,8 +75,8 @@ Cannot cast `x` to undefined because number [1] is incompatible with undefined [
               ^
 
 References:
-   <BUILTINS>/core.js:2047:58
-   2047|       T extends $ReadOnlyArray<mixed> ? {[K in keyof T]: Awaited<T[K]>} :
+   <BUILTINS>/core.js:2165:58
+   2165|       T extends $ReadOnlyArray<mixed> ? {[K in keyof T]: Awaited<T[K]>} :
                                                                   ^^^^^^^^^^^^^ [1]
    all.js:17:9
      17|     (x: void);  // Errors: string ~> void, number ~> void, boolean ~> void
@@ -92,8 +92,8 @@ Cannot cast `x` to undefined because string [1] is incompatible with undefined [
               ^
 
 References:
-   <BUILTINS>/core.js:2047:58
-   2047|       T extends $ReadOnlyArray<mixed> ? {[K in keyof T]: Awaited<T[K]>} :
+   <BUILTINS>/core.js:2165:58
+   2165|       T extends $ReadOnlyArray<mixed> ? {[K in keyof T]: Awaited<T[K]>} :
                                                                   ^^^^^^^^^^^^^ [1]
    all.js:17:9
      17|     (x: void);  // Errors: string ~> void, number ~> void, boolean ~> void
@@ -109,12 +109,12 @@ Cannot call `Promise.all` because function [1] requires another argument. [incom
                  ^^^
 
 References:
-   <BUILTINS>/core.js:2046:5
+   <BUILTINS>/core.js:2164:5
              v----------------------------------------------------
-   2046|     static all<T: Iterable<mixed>>(promises: T): Promise<
-   2047|       T extends $ReadOnlyArray<mixed> ? {[K in keyof T]: Awaited<T[K]>} :
-   2048|       T extends Iterable<infer V> ? Array<Awaited<V>> : any
-   2049|     >;
+   2164|     static all<T: Iterable<mixed>>(promises: T): Promise<
+   2165|       T extends $ReadOnlyArray<mixed> ? {[K in keyof T]: Awaited<T[K]>} :
+   2166|       T extends Iterable<infer V> ? Array<Awaited<V>> : any
+   2167|     >;
              ^ [1]
 
 
@@ -142,12 +142,12 @@ Cannot call `Promise.allSettled` because function [1] requires another argument.
                  ^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:2056:5
+   <BUILTINS>/core.js:2174:5
              v-----------------------------------------------------------
-   2056|     static allSettled<T: Iterable<mixed>>(promises: T): Promise<
-   2057|       T extends $ReadOnlyArray<mixed> ? {[K in keyof T]: $SettledPromiseResult<Awaited<T[K]>>} :
-   2058|       T extends Iterable<infer V> ? Array<$SettledPromiseResult<Awaited<V>>> : any
-   2059|     >;
+   2174|     static allSettled<T: Iterable<mixed>>(promises: T): Promise<
+   2175|       T extends $ReadOnlyArray<mixed> ? {[K in keyof T]: $SettledPromiseResult<Awaited<T[K]>>} :
+   2176|       T extends Iterable<infer V> ? Array<$SettledPromiseResult<Awaited<V>>> : any
+   2177|     >;
              ^ [1]
 
 
@@ -176,8 +176,8 @@ Cannot cast `first.status` to empty because string literal `rejected` [1] is inc
                 ^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:2081:12
-   2081|   +status: 'rejected',
+   <BUILTINS>/core.js:2199:12
+   2199|   +status: 'rejected',
                     ^^^^^^^^^^ [1]
    allSettled.js:34:22
      34|       (first.status: empty) // Error: 'rejected' case was not covered
@@ -193,8 +193,8 @@ Cannot call `second.value.foo` because property `foo` is missing in `Bar` [1]. [
                                       ^^^
 
 References:
-   <BUILTINS>/core.js:2057:80
-   2057|       T extends $ReadOnlyArray<mixed> ? {[K in keyof T]: $SettledPromiseResult<Awaited<T[K]>>} :
+   <BUILTINS>/core.js:2175:80
+   2175|       T extends $ReadOnlyArray<mixed> ? {[K in keyof T]: $SettledPromiseResult<Awaited<T[K]>>} :
                                                                                         ^^^^^^^^^^^^^ [1]
 
 
@@ -207,8 +207,8 @@ Cannot use function type [1] with fewer than 2 type arguments. [missing-type-arg
          ^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:2074:15
-   2074|     static any<T, Elem: Promise<T> | T>(promises: Iterable<Elem>): Promise<T>;
+   <BUILTINS>/core.js:2192:15
+   2192|     static any<T, Elem: Promise<T> | T>(promises: Iterable<Elem>): Promise<T>;
                        ^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 
@@ -221,8 +221,8 @@ Cannot call `Promise.any` because function [1] requires another argument. [incom
                  ^^^
 
 References:
-   <BUILTINS>/core.js:2074:5
-   2074|     static any<T, Elem: Promise<T> | T>(promises: Iterable<Elem>): Promise<T>;
+   <BUILTINS>/core.js:2192:5
+   2192|     static any<T, Elem: Promise<T> | T>(promises: Iterable<Elem>): Promise<T>;
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 
@@ -235,8 +235,8 @@ Cannot use function type [1] with fewer than 2 type arguments. [missing-type-arg
          ^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:2074:15
-   2074|     static any<T, Elem: Promise<T> | T>(promises: Iterable<Elem>): Promise<T>;
+   <BUILTINS>/core.js:2192:15
+   2192|     static any<T, Elem: Promise<T> | T>(promises: Iterable<Elem>): Promise<T>;
                        ^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 
@@ -251,8 +251,8 @@ an interface. [incompatible-type]
                                    ^ [1]
 
 References:
-   <BUILTINS>/core.js:2074:51
-   2074|     static any<T, Elem: Promise<T> | T>(promises: Iterable<Elem>): Promise<T>;
+   <BUILTINS>/core.js:2192:51
+   2192|     static any<T, Elem: Promise<T> | T>(promises: Iterable<Elem>): Promise<T>;
                                                            ^^^^^^^^^^^^^^ [2]
 
 
@@ -637,8 +637,8 @@ References:
    resolve_void.js:1:29
       1| (Promise.resolve(): Promise<number>); // error
                                      ^^^^^^ [2]
-   <BUILTINS>/core.js:1984:24
-   1984| declare class Promise<+R = mixed> {
+   <BUILTINS>/core.js:2102:24
+   2102| declare class Promise<+R = mixed> {
                                 ^ [3]
 
 
@@ -655,8 +655,8 @@ References:
    resolve_void.js:3:38
       3| (Promise.resolve(undefined): Promise<number>); // error
                                               ^^^^^^ [2]
-   <BUILTINS>/core.js:1984:24
-   1984| declare class Promise<+R = mixed> {
+   <BUILTINS>/core.js:2102:24
+   2102| declare class Promise<+R = mixed> {
                                 ^ [3]
 
 

--- a/tests/react_16_6/react_16_6.exp
+++ b/tests/react_16_6/react_16_6.exp
@@ -101,8 +101,8 @@ References:
     671|           ...
     672|         }>,
                  ^ [2]
-   <BUILTINS>/core.js:1984:24
-   1984| declare class Promise<+R = mixed> {
+   <BUILTINS>/core.js:2102:24
+   2102| declare class Promise<+R = mixed> {
                                 ^ [3]
 
 
@@ -129,8 +129,8 @@ References:
     671|           ...
     672|         }>,
                  ^ [2]
-   <BUILTINS>/core.js:1984:24
-   1984| declare class Promise<+R = mixed> {
+   <BUILTINS>/core.js:2102:24
+   2102| declare class Promise<+R = mixed> {
                                 ^ [3]
 
 

--- a/tests/resolved_env/resolved_env.exp
+++ b/tests/resolved_env/resolved_env.exp
@@ -36,8 +36,8 @@ Cannot yield `42` because number [1], a primitive, cannot be used as a subtype o
                                    ^^ [1]
 
 References:
-   <BUILTINS>/core.js:1789:7
-   1789|     : $Iterable<Yield, Return, Next>;
+   <BUILTINS>/core.js:1907:7
+   1907|     : $Iterable<Yield, Return, Next>;
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [2]
 
 

--- a/tests/return/return.exp
+++ b/tests/return/return.exp
@@ -40,8 +40,8 @@ undefined in type argument `R` [2]. [incompatible-return]
                                       ^^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:1984:24
-   1984| declare class Promise<+R = mixed> {
+   <BUILTINS>/core.js:2102:24
+   2102| declare class Promise<+R = mixed> {
                                 ^ [2]
 
 

--- a/tests/signature_verification_failure/signature_verification_failure.exp
+++ b/tests/signature_verification_failure/signature_verification_failure.exp
@@ -176,8 +176,8 @@ References:
    misc.js:5:18
       5| export const c = {['a' + 'b']: 42};
                           ^^^^^^^^^^^^^^^^^ [1]
-   <BUILTINS>/core.js:1751:11
-   1751| interface $Iterable<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:1865:11
+   1865| interface $Iterable<+Yield,+Return,-Next> {
                    ^^^^^^^^^ [2]
 
 

--- a/tests/symbol/symbol.exp
+++ b/tests/symbol/symbol.exp
@@ -1,6 +1,6 @@
 Error -------------------------------------------------------------------------------------------------- iterator.js:6:2
 
-Cannot cast `foo[Symbol.iterator]` to boolean because `$Iterator` [1] is incompatible with boolean [2].
+Cannot cast `foo[Symbol.iterator]` to boolean because `Iterator` [1] is incompatible with boolean [2].
 [incompatible-cast]
 
    iterator.js:6:2

--- a/tests/type_at_pos_react/type_at_pos_react.exp
+++ b/tests/type_at_pos_react/type_at_pos_react.exp
@@ -11,7 +11,7 @@ lazy_ref.js:19:9 = Promise<
 
 'ExactReactElement_DEPRECATED' defined at (lib) react.js:179:13
 'Node' defined at (lib) react.js:367:22
-'Promise' defined at (lib) core.js:1984:14
+'Promise' defined at (lib) core.js:2102:14
 'Props' defined at exports-component.js:5:5
 
 lazy_ref.js:19:9,19:9

--- a/tests/type_guards/type_guards.exp
+++ b/tests/type_guards/type_guards.exp
@@ -1169,16 +1169,16 @@ Cannot declare a type guard on a(n) generator function. [function-predicate]
 
 Error ------------------------------------------------------------------------------------------------- invalid.js:19:32
 
-`Generator` [1] is incompatible with boolean [2]. [incompatible-type]
+`$Generator` [1] is incompatible with boolean [2]. [incompatible-type]
 
    invalid.js:19:32
      19| function *generator(x: mixed): x is number { // error
                                         ^^^^^^^^^^^ [2]
 
 References:
-   <BUILTINS>/core.js:1756:11
-   1756| interface Generator<+Yield,+Return,-Next> {
-                   ^^^^^^^^^ [1]
+   <BUILTINS>/core.js:1879:40
+   1879| type Generator<+Yield,+Return,-Next> = $Generator<Yield,Return,Next>;
+                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 
 Error ------------------------------------------------------------------------------------------------- invalid.js:19:32
@@ -1191,23 +1191,23 @@ it into an object and attempt to use it as a subtype of an interface. [incompati
                                         ^^^^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:1751:11
-   1751| interface $Iterable<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:1865:11
+   1865| interface $Iterable<+Yield,+Return,-Next> {
                    ^^^^^^^^^ [2]
 
 
 Error ------------------------------------------------------------------------------------------------- invalid.js:20:10
 
-Cannot return `(typeof x) == "number"` because `Generator` [1] is incompatible with boolean [2]. [incompatible-return]
+Cannot return `(typeof x) == "number"` because `$Generator` [1] is incompatible with boolean [2]. [incompatible-return]
 
    invalid.js:20:10
      20|   return typeof x == "number";
                   ^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:1756:11
-   1756| interface Generator<+Yield,+Return,-Next> {
-                   ^^^^^^^^^ [1]
+   <BUILTINS>/core.js:1879:40
+   1879| type Generator<+Yield,+Return,-Next> = $Generator<Yield,Return,Next>;
+                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
    invalid.js:19:32
      19| function *generator(x: mixed): x is number { // error
                                         ^^^^^^^^^^^ [2]
@@ -1247,8 +1247,8 @@ Cannot return `(typeof x) == "number"` because `Promise` [1] is incompatible wit
                   ^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:1984:15
-   1984| declare class Promise<+R = mixed> {
+   <BUILTINS>/core.js:2102:15
+   2102| declare class Promise<+R = mixed> {
                        ^^^^^^^ [1]
    invalid.js:28:33
      28| async function async(x: mixed): x is number { // error


### PR DESCRIPTION
Fixes #9230.

Includes tests: `$ make && bash runtests.sh bin/flow `.

## Changes

This PR is mostly additive, but there are some change. At least one is breaking.

### Iterators
- `Iterator` is now a class representing [the built-in](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator), instead of a type representing an `IterableIterator` protocol.
   - This is the breaking change. Places that were using `Iterator` to represent the protocol need to do one of: 
      - Switch to `$IteratorProtocol` to continue accepting custom implementations.
      - Wrap value with `Iterator.from` to get `Iterator`s if they want the new helper methods.
   - The class now has three generic args, like `$Iterator`. It has defaults for the last two type arguments for backwards compatibility and simple uses.
- `$Iterator` is now a type alias for this class. It can likely be deprecated and removed.
- `$IteratorProtocol` is comparable to the old `$Iterator`, but does not require implementors to also implement 
`$Iterable` so that it imposes no extra constraints on `Iterator.from`.

### Iterables
- `Iterable` and `$Iterable` now only constrain `@@iterator` to `$IteratorProtocol`. The return value does not need to be iterable. Note that `Iterator.@@iterator` returns an `Iterator` which  implements both the iterable and iterator protocols.

### Generators
- `Generator` is now a type alias for a subclass of `Iterator`, rather than an interface. I [don't believe it's possible to implement a custom Generator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Generator#constructor) so I believe this is correct.

## Consistency
I prioritized minimizing changes over internal consistency with this PR. One path back to consistency:
- Rename `$Iterable` to `$IterableProtocol` for consistency with `$IteratorProtocol` (optionally remove the $ prefix from both).
- Remove `$Iterator`.
These would have to be gradual migrations.

