### PR TITLE
Allow union types of string or any in computed properties

### DIFF
--- a/tests/computed_props/computed_props.exp
+++ b/tests/computed_props/computed_props.exp
@@ -192,50 +192,50 @@ References:
 
 Error --------------------------------------------------------------------------------------------------- union.js:20:13
 
-Cannot use `maybe` [1] as a computed property. Computed properties may only be primitive literal values, but the type of
-`maybe` [1] is a union. Can you add a literal type annotation to `maybe` [1]? See
+Cannot use `maybe` [1] to assign a computed property. Computed properties may only be numeric or string literal values,
+but this one is a null or undefined [2]. Can you add an appropriate type annotation to `maybe` [1]? See
 https://flow.org/en/docs/types/literals/ for more information on literal types. [invalid-computed-prop]
 
    union.js:20:13
    20| const c = {[maybe]: 3}; // ERROR
-                   ^^^^^
+                   ^^^^^ [1]
 
 References:
-   union.js:19:13
+   union.js:19:20
    19| declare var maybe: ?string;
-                   ^^^^^ [1]
+                          ^^^^^^^ [2]
 
 
 Error --------------------------------------------------------------------------------------------------- union.js:23:13
 
-Cannot use `several` [1] as a computed property. Computed properties may only be primitive literal values, but the type
-of `several` [1] is a union. Can you add a literal type annotation to `several` [1]? See
+Cannot use `several` [1] to assign a computed property. Computed properties may only be numeric or string literal
+values, but this one is a null or undefined [2]. Can you add an appropriate type annotation to `several` [1]? See
 https://flow.org/en/docs/types/literals/ for more information on literal types. [invalid-computed-prop]
 
    union.js:23:13
    23| const d = {[several]: 3}; // ERROR
-                   ^^^^^^^
+                   ^^^^^^^ [1]
 
 References:
-   union.js:22:13
+   union.js:22:22
    22| declare var several: ?string | key;
-                   ^^^^^^^ [1]
+                            ^^^^^^^ [2]
 
 
 Error ---------------------------------------------------------------------------------------------------- union.js:28:6
 
-Cannot use `several` [1] as a computed property. Computed properties may only be primitive literal values, but the type
-of `several` [1] is a union. Can you add a literal type annotation to `several` [1]? See
+Cannot use `several` [1] to assign a computed property. Computed properties may only be numeric or string literal
+values, but this one is a null or undefined [2]. Can you add an appropriate type annotation to `several` [1]? See
 https://flow.org/en/docs/types/literals/ for more information on literal types. [invalid-computed-prop]
 
    union.js:28:6
    28|     [several]: 3, // ERROR
-            ^^^^^^^
+            ^^^^^^^ [1]
 
 References:
-   union.js:22:13
+   union.js:22:22
    22| declare var several: ?string | key;
-                   ^^^^^^^ [1]
+                            ^^^^^^^ [2]
 
 
 


### PR DESCRIPTION
Pre-LTI, this is banned because we cannot make the decision of whether to make it a computed property or named property. However, now with LTI, we can make the decision by inspecting the types, and only make singleton literal types to named property and make everything else computed.

Therefore, in this PR, I have relaxed the restriction. We still do a validation to ensure that are no random types like `{...}` being used as the key. If any of the member of the union has an unsupported type, the property will continue to be ignored. Otherwise, we will support it.