### PR TITLE
Support `no_unchecked_indexed_access=true`

### DIFF
--- a/src/commands/commandUtils.ml
+++ b/src/commands/commandUtils.ml
@@ -1442,6 +1442,7 @@ let make_options
     opt_missing_module_generators = FlowConfig.missing_module_generators flowconfig;
     opt_natural_inference_exports_primitive_const =
       FlowConfig.natural_inference_exports_primitive_const flowconfig;
+    opt_no_unchecked_indexed_access = FlowConfig.no_unchecked_indexed_access flowconfig;
     opt_saved_state_fetcher;
     opt_saved_state_force_recheck = saved_state_options_flags.saved_state_force_recheck;
     opt_saved_state_no_fallback = saved_state_options_flags.saved_state_no_fallback;

--- a/src/commands/config/flowConfig.ml
+++ b/src/commands/config/flowConfig.ml
@@ -117,6 +117,7 @@ module Opts = struct
     munge_underscores: bool;
     natural_inference_exports_primitive_const: bool;
     no_flowlib: bool;
+    no_unchecked_indexed_access: bool;
     node_main_fields: string list;
     node_resolver_allow_root_relative: bool;
     node_resolver_dirnames: string list;
@@ -254,6 +255,7 @@ module Opts = struct
       munge_underscores = false;
       natural_inference_exports_primitive_const = false;
       no_flowlib = false;
+      no_unchecked_indexed_access = false;
       node_main_fields = ["main"];
       node_resolver_allow_root_relative = false;
       node_resolver_dirnames = ["node_modules"];
@@ -1093,6 +1095,9 @@ module Opts = struct
         boolean (fun opts v -> Ok { opts with natural_inference_exports_primitive_const = v })
       );
       ("no_flowlib", boolean (fun opts v -> Ok { opts with no_flowlib = v }));
+      ("no_unchecked_indexed_access", 
+        boolean (fun opts v -> Ok { opts with no_unchecked_indexed_access = v })
+      );
       ( "experimental.pattern_matching_expressions",
         boolean (fun opts v -> Ok { opts with pattern_matching_expressions = Some v })
       );
@@ -1822,6 +1827,8 @@ let natural_inference_exports_primitive_const c =
   c.options.Opts.natural_inference_exports_primitive_const
 
 let no_flowlib c = c.options.Opts.no_flowlib
+
+let no_unchecked_indexed_access c = c.options.Opts.no_unchecked_indexed_access
 
 let node_main_fields c = c.options.Opts.node_main_fields
 

--- a/src/commands/config/flowConfig.mli
+++ b/src/commands/config/flowConfig.mli
@@ -216,6 +216,8 @@ val natural_inference_exports_primitive_const : config -> bool
 
 val no_flowlib : config -> bool
 
+val no_unchecked_indexed_access : config -> bool
+
 val node_main_fields : config -> string list
 
 val node_resolver_allow_root_relative : config -> bool

--- a/src/common/options.ml
+++ b/src/common/options.ml
@@ -132,6 +132,7 @@ type t = {
   opt_modules_are_use_strict: bool;
   opt_munge_underscores: bool;
   opt_natural_inference_exports_primitive_const: bool;
+  opt_no_unchecked_indexed_access: bool;
   opt_node_main_fields: string list;
   opt_node_resolver_allow_root_relative: bool;
   opt_node_resolver_root_relative_dirnames: string list;
@@ -309,6 +310,8 @@ let modules_are_use_strict opts = opts.opt_modules_are_use_strict
 
 let natural_inference_exports_primitive_const opts =
   opts.opt_natural_inference_exports_primitive_const
+
+let no_unchecked_indexed_access opts = opts.opt_no_unchecked_indexed_access
 
 let node_main_fields opts = opts.opt_node_main_fields
 

--- a/src/flow_dot_js.ml
+++ b/src/flow_dot_js.ml
@@ -126,6 +126,7 @@ let stub_metadata ~root ~checked =
     max_workers = 0;
     missing_module_generators = [];
     natural_inference_exports_primitive_const = false;
+    no_unchecked_indexed_access = false;
     react_custom_jsx_typing = false;
     react_ref_as_prop = Options.ReactRefAsProp.Disabled;
     react_runtime = Options.ReactRuntimeAutomatic;

--- a/src/services/code_action/__tests__/refactor_extract_utils_tests.ml
+++ b/src/services/code_action/__tests__/refactor_extract_utils_tests.ml
@@ -59,6 +59,7 @@ let stub_metadata ~root ~checked =
     max_workers = 0;
     missing_module_generators = [];
     natural_inference_exports_primitive_const = false;
+    no_unchecked_indexed_access = false;
     react_custom_jsx_typing = false;
     react_ref_as_prop = Options.ReactRefAsProp.Disabled;
     react_runtime = Options.ReactRuntimeClassic;

--- a/src/typing/__tests__/type_hint_test.ml
+++ b/src/typing/__tests__/type_hint_test.ml
@@ -50,6 +50,7 @@ let metadata =
     max_workers = 0;
     missing_module_generators = [];
     natural_inference_exports_primitive_const = false;
+    no_unchecked_indexed_access = false;
     react_custom_jsx_typing = false;
     react_ref_as_prop = Options.ReactRefAsProp.Disabled;
     react_runtime = Options.ReactRuntimeClassic;

--- a/src/typing/__tests__/typed_ast_test.ml
+++ b/src/typing/__tests__/typed_ast_test.ml
@@ -48,6 +48,7 @@ let metadata =
     max_workers = 0;
     missing_module_generators = [];
     natural_inference_exports_primitive_const = false;
+    no_unchecked_indexed_access = false;
     react_custom_jsx_typing = false;
     react_ref_as_prop = Options.ReactRefAsProp.Disabled;
     react_runtime = Options.ReactRuntimeClassic;

--- a/src/typing/annotation_inference.ml
+++ b/src/typing/annotation_inference.ml
@@ -322,7 +322,7 @@ module rec ConsGen : S = struct
       ConsGen.elab_t
         cx
         t
-        (Annot_GetPropT (access_reason, use_op, mk_named_prop ~reason:prop_reason name))
+        (Annot_GetPropT {reason=access_reason; use_op;from_annot=false;prop_ref= mk_named_prop ~reason:prop_reason name})
 
     let mk_react_dro cx _use_op (props_loc, dro_t) t =
       ConsGen.elab_t cx t (Annot_DeepReadOnlyT (reason_of_t t, props_loc, dro_t))
@@ -516,7 +516,7 @@ module rec ConsGen : S = struct
         elab_t
           cx
           t
-          (Annot_GetPropT (reason_op, use_op, Named { reason; name; from_indexed_access = true }))
+         ( Annot_GetPropT {reason=reason_op; use_op; from_annot=true;prop_ref = Named { reason; name; from_indexed_access = true }})
       in
       elab_t cx t op
     | (EvalT (t, TypeDestructorT (use_op, reason, ElementType { index_type }), _), _) ->
@@ -945,7 +945,7 @@ module rec ConsGen : S = struct
         | DefT (_, ObjT o) -> o.flags.react_dro
         | _ -> None
       in
-      (match GetPropTKit.get_obj_prop cx dummy_trace unknown_use o propref reason_op with
+      (match GetPropTKit.get_obj_prop cx dummy_trace ~union_void_on_computed_prop_access:false unknown_use o propref reason_op with
       | Some (p, _) ->
         GetPropTKit.perform_read_prop_action cx dummy_trace use_op propref p reason_op react_dro
       | None -> Get_prop_helper.cg_lookup_ cx use_op o.proto_t reason_op propref objt)
@@ -1009,10 +1009,11 @@ module rec ConsGen : S = struct
           ~seen
           values_type
           (Annot_GetPropT
-             ( reason_op,
-               use_op,
-               Named { reason = prop_ref_reason; name = prop_name; from_indexed_access = false }
-             )
+             {reason=reason_op;
+               use_op;
+               from_annot=false;
+              prop_ref= Named { reason = prop_ref_reason; name = prop_name; from_indexed_access = false }
+             }
           ))
     | (NamespaceT { namespace_symbol = _; values_type; types_tmap = _ }, _) ->
       elab_t cx ~seen values_type op
@@ -1025,16 +1026,17 @@ module rec ConsGen : S = struct
         ~seen
         t
         (Annot_GetPropT
-           ( reason_op,
-             use_op,
-             Named { reason = prop_ref_reason; name = prop_name; from_indexed_access = false }
-           )
+           {reason= reason_op;
+             use_op;
+             from_annot = false;
+             prop_ref =  Named { reason = prop_ref_reason; name = prop_name; from_indexed_access = false }
+           }
         )
     (************)
     (* GetPropT *)
     (************)
     | ( DefT (reason_instance, InstanceT { super; inst; _ }),
-        Annot_GetPropT (reason_op, use_op, (Named _ as propref))
+        Annot_GetPropT {reason=reason_op; use_op;from_annot=_;prop_ref= (Named _ as propref)}
       ) ->
       GetPropTKit.read_instance_prop
         cx
@@ -1049,17 +1051,17 @@ module rec ConsGen : S = struct
         inst
         propref
         reason_op
-    | (DefT (reason, InstanceT _), Annot_GetPropT (_, _, Computed _)) ->
+    | (DefT (reason, InstanceT _), Annot_GetPropT {prop_ref=Computed _; _}) ->
       error_unsupported cx reason op
     | ( DefT (_, ObjT _),
-        Annot_GetPropT (reason_op, _, Named { name = OrdinaryName "constructor"; _ })
+        Annot_GetPropT {reason=reason_op; from_annot=_;use_op = _; prop_ref=Named { name = OrdinaryName "constructor"; _ }}
       ) ->
       Unsoundness.why Constructor reason_op
-    | (DefT (reason_obj, ObjT o), Annot_GetPropT (reason_op, use_op, propref)) ->
-      GetPropTKit.read_obj_prop cx dummy_trace ~use_op o propref reason_obj reason_op None
-    | (AnyT _, Annot_GetPropT (reason_op, _, _)) -> AnyT (reason_op, Untyped)
+    | (DefT (reason_obj, ObjT o), Annot_GetPropT {reason=reason_op; use_op;from_annot;prop_ref}) ->
+      GetPropTKit.read_obj_prop cx dummy_trace ~use_op ~from_annot o prop_ref reason_obj reason_op None
+    | (AnyT _, Annot_GetPropT{reason;_}) -> AnyT (reason, Untyped)
     | ( DefT (reason, ClassT instance),
-        Annot_GetPropT (_, _, Named { name = OrdinaryName "prototype"; _ })
+      Annot_GetPropT {prop_ref=Named { name = OrdinaryName "prototype"; _ };_}
       ) ->
       reposition cx (loc_of_reason reason) instance
     (**************)
@@ -1075,21 +1077,24 @@ module rec ConsGen : S = struct
       StrModuleT.why reason_op
     | ((DefT (_, (ObjT _ | ArrT _ | InstanceT _)) | AnyT _), Annot_GetElemT (reason_op, use_op, key))
       ->
-      elab_t cx key (Annot_ElemT (reason_op, use_op, t))
-    | (_, Annot_ElemT (reason_op, use_op, (DefT (_, (ObjT _ | InstanceT _)) as obj))) ->
-      let propref = Flow_js_utils.propref_for_elem_t t in
-      elab_t cx obj (Annot_GetPropT (reason_op, use_op, propref))
-    | (_, Annot_ElemT (reason_op, _use_op, (AnyT _ as _obj))) ->
+      elab_t cx key (Annot_ElemT {reason=reason_op; use_op;from_annot=false; source=t})
+    | (_, Annot_ElemT {reason=reason_op; use_op; from_annot;source=(DefT (_, (ObjT _ | InstanceT _)) as obj)}) ->
+      let prop_ref = Flow_js_utils.propref_for_elem_t t in
+      elab_t cx obj (Annot_GetPropT {reason=reason_op; from_annot; use_op; prop_ref})
+    | (_, Annot_ElemT {reason=reason_op; use_op=_use_op;from_annot=_; source=(AnyT _ as _obj)}) ->
       let value = AnyT.untyped reason_op in
       reposition cx (loc_of_reason reason_op) value
-    | (AnyT _, Annot_ElemT (reason_op, _, DefT (_, ArrT arrtype))) ->
+    | (AnyT _, Annot_ElemT {reason=reason_op; source= DefT (_, ArrT arrtype); _ }) ->
       let value = elemt_of_arrtype arrtype in
       reposition cx (loc_of_reason reason_op) value
     | ( DefT (_, (NumGeneralT _ | NumT_UNSOUND _)),
-        Annot_ElemT (reason_op, use_op, DefT (reason_tup, ArrT arrtype))
+        Annot_ElemT {reason=reason_op; use_op; from_annot; source= DefT (reason_tup, ArrT arrtype)}
       ) ->
       let (value, _, _, _) =
-        Flow_js_utils.array_elem_check ~write_action:false cx t use_op reason_op reason_tup arrtype
+        Flow_js_utils.array_elem_check 
+          ~write_action:false
+          ~union_void_on_computed_prop_access:(Context.no_unchecked_indexed_access cx && not from_annot) 
+          cx t use_op reason_op reason_tup arrtype
       in
       reposition cx (loc_of_reason reason_op) value
     | (DefT (_, ObjT o), Annot_ObjKeyMirror reason_op) ->
@@ -1145,7 +1150,7 @@ module rec ConsGen : S = struct
     (* Enums *)
     (*********)
     | ( DefT (enum_reason, EnumObjectT { enum_value_t; enum_info = ConcreteEnum enum_info }),
-        Annot_GetPropT (access_reason, use_op, Named { reason = prop_reason; name; _ })
+        Annot_GetPropT {reason=access_reason; use_op; from_annot=_;prop_ref= Named { reason = prop_reason; name; _ }}
       ) ->
       let access = (use_op, access_reason, None, (prop_reason, name)) in
       GetPropTKit.on_EnumObjectT
@@ -1205,7 +1210,7 @@ module rec ConsGen : S = struct
       let arr = get_builtin_typeapp cx reason "Array" [elem_t] in
       elab_t cx arr op
     | ( DefT (reason, ArrT (TupleAT { arity; inexact; _ })),
-        Annot_GetPropT (reason_op, _, Named { name = OrdinaryName "length"; _ })
+        Annot_GetPropT {reason=reason_op; prop_ref= Named { name = OrdinaryName "length"; _ }; _}
       ) ->
       GetPropTKit.on_array_length cx dummy_trace reason ~inexact arity reason_op
     | ( DefT (reason, ArrT ((TupleAT _ | ROArrayAT _) as arrtype)),
@@ -1276,7 +1281,7 @@ module rec ConsGen : S = struct
   and get_statics cx reason t = elab_t cx t (Annot_GetStaticsT reason)
 
   and get_prop cx use_op reason ?(op_reason = reason) name t =
-    elab_t cx t (Annot_GetPropT (op_reason, use_op, mk_named_prop ~reason name))
+    elab_t cx t (Annot_GetPropT {reason=op_reason; use_op; from_annot=false;prop_ref= mk_named_prop ~reason name})
 
   and get_elem cx use_op reason ~key t = elab_t cx t (Annot_GetElemT (reason, use_op, key))
 

--- a/src/typing/context.ml
+++ b/src/typing/context.ml
@@ -59,6 +59,7 @@ type metadata = {
   max_workers: int;
   missing_module_generators: (Str.regexp * string) list;
   natural_inference_exports_primitive_const: bool;
+  no_unchecked_indexed_access: bool;
   react_custom_jsx_typing: bool;
   react_ref_as_prop: Options.ReactRefAsProp.t;
   react_runtime: Options.react_runtime;
@@ -287,6 +288,7 @@ let metadata_of_options options =
     missing_module_generators = Options.missing_module_generators options;
     natural_inference_exports_primitive_const =
       Options.natural_inference_exports_primitive_const options;
+    no_unchecked_indexed_access = Options.no_unchecked_indexed_access options;
     react_custom_jsx_typing = Options.react_custom_jsx_typing options;
     react_ref_as_prop = Options.react_ref_as_prop options;
     react_runtime = Options.react_runtime options;
@@ -642,6 +644,8 @@ let missing_module_generators cx = cx.metadata.missing_module_generators
 
 let natural_inference_exports_primitive_const cx =
   cx.metadata.natural_inference_exports_primitive_const
+
+let no_unchecked_indexed_access cx = cx.metadata.no_unchecked_indexed_access
 
 let jsx cx = cx.metadata.jsx
 

--- a/src/typing/context.mli
+++ b/src/typing/context.mli
@@ -103,6 +103,7 @@ type metadata = {
   max_workers: int;
   missing_module_generators: (Str.regexp * string) list;
   natural_inference_exports_primitive_const: bool;
+  no_unchecked_indexed_access: bool;
   react_custom_jsx_typing: bool;
   react_ref_as_prop: Options.ReactRefAsProp.t;
   react_runtime: Options.react_runtime;
@@ -304,6 +305,8 @@ val max_workers : t -> int
 val missing_module_generators : t -> (Str.regexp * string) list
 
 val natural_inference_exports_primitive_const : t -> bool
+
+val no_unchecked_indexed_access : t -> bool
 
 val jsx : t -> Options.jsx_mode
 

--- a/src/typing/flow_js.ml
+++ b/src/typing/flow_js.ml
@@ -3602,7 +3602,7 @@ struct
                 ignore_dicts;
               }
           ) ->
-          (match GetPropTKit.get_obj_prop cx trace unknown_use o propref reason_op with
+          (match GetPropTKit.get_obj_prop cx trace unknown_use ~union_void_on_computed_prop_access:false o propref reason_op with
           | Some (p, target_kind) ->
             (match lookup_kind with
             | NonstrictReturning (_, Some (id, _)) -> Context.test_prop_hit cx id
@@ -3684,7 +3684,7 @@ struct
           ) ->
           rec_flow_t cx trace ~use_op:unknown_use (Unsoundness.why Constructor reason, OpenT tout)
         | ( DefT (reason_obj, ObjT o),
-            GetPropT { use_op; reason = reason_op; id; from_annot = _; propref; tout; hint = _ }
+            GetPropT { use_op; reason = reason_op; id; from_annot; propref; tout; hint = _ }
           ) ->
           let lookup_info =
             Base.Option.map id ~f:(fun id ->
@@ -3696,7 +3696,7 @@ struct
                 (id, lookup_default_tout)
             )
           in
-          GetPropTKit.read_obj_prop cx trace ~use_op o propref reason_obj reason_op lookup_info tout
+          GetPropTKit.read_obj_prop cx trace ~use_op ~from_annot o propref reason_obj reason_op lookup_info tout
         | ( AnyT (_, src),
             GetPropT { use_op = _; reason; id; from_annot = _; propref = _; tout; hint = _ }
           ) ->
@@ -3721,6 +3721,7 @@ struct
                   cx
                   trace
                   ~use_op
+                  ~from_annot:false
                   o
                   propref
                   reason_obj
@@ -3829,14 +3830,14 @@ struct
         | ( DefT (_, (NumGeneralT _ | NumT_UNSOUND _)),
             ElemT (use_op, reason, (DefT (reason_tup, ArrT arrtype) as arr), action)
           ) ->
-          let (write_action, read_action) =
+          let (write_action, read_action, union_void_on_computed_prop_access) =
             match action with
-            | ReadElem _ -> (false, true)
-            | CallElem _ -> (false, false)
-            | WriteElem _ -> (true, false)
+            | ReadElem {from_annot; _} -> (false, true, Context.no_unchecked_indexed_access cx && not from_annot)
+            | CallElem _ -> (false, false, Context.no_unchecked_indexed_access cx)
+            | WriteElem _ -> (true, false, false)
           in
           let (value, is_tuple, use_op, react_dro) =
-            array_elem_check ~write_action cx l use_op reason reason_tup arrtype
+            array_elem_check ~write_action ~union_void_on_computed_prop_access cx l use_op reason reason_tup arrtype
           in
           let value =
             match react_dro with
@@ -7239,7 +7240,7 @@ struct
   and write_obj_prop cx trace ~use_op ~mode o propref reason_obj reason_op tin prop_tout =
     let obj_t = DefT (reason_obj, ObjT o) in
     let action = WriteProp { use_op; obj_t; prop_tout; tin; write_ctx = Normal; mode } in
-    match GetPropTKit.get_obj_prop cx trace use_op o propref reason_op with
+    match GetPropTKit.get_obj_prop cx trace ~union_void_on_computed_prop_access:false use_op o propref reason_op with
     | Some (p, target_kind) ->
       perform_lookup_action cx trace propref p target_kind reason_obj reason_op action
     | None ->

--- a/src/typing/type.ml
+++ b/src/typing/type.ml
@@ -3385,9 +3385,9 @@ module AConstraint = struct
         prop_ref: Reason.t * name;
       }
     | Annot_GetEnumT of Reason.t
-    | Annot_GetPropT of Reason.t * TypeTerm.use_op * TypeTerm.propref
+    | Annot_GetPropT of {reason: Reason.t; use_op: TypeTerm.use_op; from_annot: bool; prop_ref:TypeTerm.propref}
     | Annot_GetElemT of Reason.t * TypeTerm.use_op * TypeTerm.t (* key *)
-    | Annot_ElemT of Reason.t * TypeTerm.use_op * TypeTerm.t (* read action only *)
+    | Annot_ElemT of {reason: Reason.t; use_op: TypeTerm.use_op; from_annot: bool; source: TypeTerm.t } (* read action only *)
     | Annot_GetStaticsT of Reason.t
     | Annot_LookupT of Reason.t * TypeTerm.use_op * TypeTerm.propref * TypeTerm.t
     | Annot_ObjKitT of Reason.t * TypeTerm.use_op * Object.resolve_tool * Object.tool
@@ -3519,10 +3519,10 @@ module AConstraint = struct
     | Annot_CopyNamedExportsT (r, _)
     | Annot_CopyTypeExportsT (r, _)
     | Annot_GetTypeFromNamespaceT { reason = r; _ }
-    | Annot_GetPropT (r, _, _)
+    | Annot_GetPropT {reason=r;_}
     | Annot_GetElemT (r, _, _)
     | Annot_GetEnumT r
-    | Annot_ElemT (r, _, _)
+    | Annot_ElemT {reason=r; _}
     | Annot_GetStaticsT r
     | Annot_LookupT (r, _, _, _)
     | Annot_ObjKitT (r, _, _, _)
@@ -3542,9 +3542,9 @@ module AConstraint = struct
   let use_op_of_operation = function
     | Annot_SpecializeT (use_op, _, _, _)
     | Annot_GetTypeFromNamespaceT { use_op; _ }
-    | Annot_GetPropT (_, use_op, _)
+    | Annot_GetPropT {use_op;_}
     | Annot_GetElemT (_, use_op, _)
-    | Annot_ElemT (_, use_op, _)
+    | Annot_ElemT { use_op; _ }
     | Annot_LookupT (_, use_op, _, _)
     | Annot_ObjKitT (_, use_op, _, _) ->
       Some use_op
@@ -3602,7 +3602,7 @@ module AConstraint = struct
     | Annot_MixinT r -> replace_desc_reason (RCustom "mixins") r
     | Annot_UnaryArithT (r, _) -> replace_desc_reason (RCustom "unary minus") r
     | Annot_NotT r -> replace_desc_reason (RCustom "unary not") r
-    | Annot_GetPropT (r, _, propref) -> replace_desc_reason (RProperty (name_of_propref propref)) r
+    | Annot_GetPropT {reason;prop_ref;_} -> replace_desc_reason (RProperty (name_of_propref prop_ref)) reason
     | Annot_ObjRestT (r, _) -> replace_desc_reason (RCustom "rest") r
     | r -> reason_of_op r
 

--- a/tests/no_unchecked_indexed_access/.flowconfig
+++ b/tests/no_unchecked_indexed_access/.flowconfig
@@ -1,0 +1,3 @@
+[options]
+all=true
+no_unchecked_indexed_access=true

--- a/tests/no_unchecked_indexed_access/arr_test.js
+++ b/tests/no_unchecked_indexed_access/arr_test.js
@@ -12,3 +12,6 @@ tuple[1] as 1;
 tuple[2] as 2;
 tuple[3] as number; // error: out of bound
 tuple[key] as number; // error: void ~> number
+
+declare const typeTest: (typeof roArray)[number];
+typeTest as string; // todo: the flag should not affect type-level acccess

--- a/tests/no_unchecked_indexed_access/arr_test.js
+++ b/tests/no_unchecked_indexed_access/arr_test.js
@@ -13,5 +13,5 @@ tuple[2] as 2;
 tuple[3] as number; // error: out of bound
 tuple[key] as number; // error: void ~> number
 
-declare const typeTest: (typeof roArray)[number];
-typeTest as string; // todo: the flag should not affect type-level acccess
+declare export const typeTest: (typeof roArray)[number];
+typeTest as string; // ok: the flag should not affect type-level acccess

--- a/tests/no_unchecked_indexed_access/arr_test.js
+++ b/tests/no_unchecked_indexed_access/arr_test.js
@@ -1,0 +1,14 @@
+declare const key: number;
+
+declare const roArray: $ReadOnlyArray<string>;
+roArray[0] as string; // error: void ~> string
+roArray[key] as string; // error: void ~> string
+declare const rwArray: Array<string>;
+rwArray[0] as string; // error: void ~> string
+rwArray[key] as string; // error: void ~> string
+declare const tuple: [0, 1, 2];
+tuple[0] as 0;
+tuple[1] as 1;
+tuple[2] as 2;
+tuple[3] as number; // error: out of bound
+tuple[key] as number; // error: void ~> number

--- a/tests/no_unchecked_indexed_access/exported_test.js
+++ b/tests/no_unchecked_indexed_access/exported_test.js
@@ -1,0 +1,4 @@
+require('./arr_test').typeTest as string; // ok
+require('./obj_test').typeTest as string; // ok
+require('./arr_test').typeTest as empty; // error: sanity check
+require('./obj_test').typeTest as empty; // error: sanity check

--- a/tests/no_unchecked_indexed_access/no_unchecked_indexed_access.exp
+++ b/tests/no_unchecked_indexed_access/no_unchecked_indexed_access.exp
@@ -97,21 +97,38 @@ References:
                      ^^^^^^ [2]
 
 
-Error ------------------------------------------------------------------------------------------------- arr_test.js:17:1
+Error --------------------------------------------------------------------------------------------- exported_test.js:3:1
 
-Cannot cast `typeTest` to string because undefined [1] is incompatible with string [2]. [incompatible-cast]
+Cannot cast `require(...).typeTest` to empty because string [1] is incompatible with empty [2]. [incompatible-cast]
 
-   arr_test.js:17:1
-   17| typeTest as string; // todo: the flag should not affect type-level acccess
-       ^^^^^^^^
+   exported_test.js:3:1
+   3| require('./arr_test').typeTest as empty; // error: sanity check
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
    arr_test.js:3:39
-    3| declare const roArray: $ReadOnlyArray<string>;
-                                             ^^^^^^ [1]
-   arr_test.js:17:13
-   17| typeTest as string; // todo: the flag should not affect type-level acccess
-                   ^^^^^^ [2]
+   3| declare const roArray: $ReadOnlyArray<string>;
+                                            ^^^^^^ [1]
+   exported_test.js:3:35
+   3| require('./arr_test').typeTest as empty; // error: sanity check
+                                        ^^^^^ [2]
+
+
+Error --------------------------------------------------------------------------------------------- exported_test.js:4:1
+
+Cannot cast `require(...).typeTest` to empty because string [1] is incompatible with empty [2]. [incompatible-cast]
+
+   exported_test.js:4:1
+   4| require('./obj_test').typeTest as empty; // error: sanity check
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+References:
+   obj_test.js:2:35
+   2| declare const dictObj: {[string]: string};
+                                        ^^^^^^ [1]
+   exported_test.js:4:35
+   4| require('./obj_test').typeTest as empty; // error: sanity check
+                                        ^^^^^ [2]
 
 
 Error ------------------------------------------------------------------------------------------------- obj_test.js:5:11
@@ -160,23 +177,6 @@ References:
    obj_test.js:7:19
    7| dictObj.hahaha as string; // error: void ~> string
                         ^^^^^^ [2]
-
-
-Error ------------------------------------------------------------------------------------------------- obj_test.js:10:1
-
-Cannot cast `typeTest` to string because undefined [1] is incompatible with string [2]. [incompatible-cast]
-
-   obj_test.js:10:1
-   10| typeTest as string; // todo: the flag should not affect type-level acccess
-       ^^^^^^^^
-
-References:
-   obj_test.js:2:35
-    2| declare const dictObj: {[string]: string};
-                                         ^^^^^^ [1]
-   obj_test.js:10:13
-   10| typeTest as string; // todo: the flag should not affect type-level acccess
-                   ^^^^^^ [2]
 
 
 

--- a/tests/no_unchecked_indexed_access/no_unchecked_indexed_access.exp
+++ b/tests/no_unchecked_indexed_access/no_unchecked_indexed_access.exp
@@ -1,0 +1,149 @@
+Error -------------------------------------------------------------------------------------------------- arr_test.js:4:1
+
+Cannot cast `roArray[0]` to string because undefined [1] is incompatible with string [2]. [incompatible-cast]
+
+   arr_test.js:4:1
+   4| roArray[0] as string; // error: void ~> string
+      ^^^^^^^^^^
+
+References:
+   arr_test.js:3:39
+   3| declare const roArray: $ReadOnlyArray<string>;
+                                            ^^^^^^ [1]
+   arr_test.js:4:15
+   4| roArray[0] as string; // error: void ~> string
+                    ^^^^^^ [2]
+
+
+Error -------------------------------------------------------------------------------------------------- arr_test.js:5:1
+
+Cannot cast `roArray[key]` to string because undefined [1] is incompatible with string [2]. [incompatible-cast]
+
+   arr_test.js:5:1
+   5| roArray[key] as string; // error: void ~> string
+      ^^^^^^^^^^^^
+
+References:
+   arr_test.js:3:39
+   3| declare const roArray: $ReadOnlyArray<string>;
+                                            ^^^^^^ [1]
+   arr_test.js:5:17
+   5| roArray[key] as string; // error: void ~> string
+                      ^^^^^^ [2]
+
+
+Error -------------------------------------------------------------------------------------------------- arr_test.js:7:1
+
+Cannot cast `rwArray[0]` to string because undefined [1] is incompatible with string [2]. [incompatible-cast]
+
+   arr_test.js:7:1
+   7| rwArray[0] as string; // error: void ~> string
+      ^^^^^^^^^^
+
+References:
+   arr_test.js:6:30
+   6| declare const rwArray: Array<string>;
+                                   ^^^^^^ [1]
+   arr_test.js:7:15
+   7| rwArray[0] as string; // error: void ~> string
+                    ^^^^^^ [2]
+
+
+Error -------------------------------------------------------------------------------------------------- arr_test.js:8:1
+
+Cannot cast `rwArray[key]` to string because undefined [1] is incompatible with string [2]. [incompatible-cast]
+
+   arr_test.js:8:1
+   8| rwArray[key] as string; // error: void ~> string
+      ^^^^^^^^^^^^
+
+References:
+   arr_test.js:6:30
+   6| declare const rwArray: Array<string>;
+                                   ^^^^^^ [1]
+   arr_test.js:8:17
+   8| rwArray[key] as string; // error: void ~> string
+                      ^^^^^^ [2]
+
+
+Error ------------------------------------------------------------------------------------------------- arr_test.js:13:1
+
+Cannot get `tuple[3]` because tuple type [1] only has 3 elements, so index 3 is out of bounds. [invalid-tuple-index]
+
+   arr_test.js:13:1
+   13| tuple[3] as number; // error: out of bound
+       ^^^^^^^^
+
+References:
+   arr_test.js:9:22
+    9| declare const tuple: [0, 1, 2];
+                            ^^^^^^^^^ [1]
+
+
+Error ------------------------------------------------------------------------------------------------- arr_test.js:14:1
+
+Cannot cast `tuple[key]` to number because undefined [1] is incompatible with number [2]. [incompatible-cast]
+
+   arr_test.js:14:1
+   14| tuple[key] as number; // error: void ~> number
+       ^^^^^^^^^^
+
+References:
+   arr_test.js:9:22
+    9| declare const tuple: [0, 1, 2];
+                            ^^^^^^^^^ [1]
+   arr_test.js:14:15
+   14| tuple[key] as number; // error: void ~> number
+                     ^^^^^^ [2]
+
+
+Error ------------------------------------------------------------------------------------------------- obj_test.js:5:11
+
+Cannot access object with computed property using string [1]. [invalid-computed-prop]
+
+   obj_test.js:5:11
+   5| recordObj[key] as string; // error: bad key
+                ^^^
+
+References:
+   obj_test.js:3:20
+   3| declare const key: string;
+                         ^^^^^^ [1]
+
+
+Error -------------------------------------------------------------------------------------------------- obj_test.js:6:1
+
+Cannot cast `dictObj[key]` to string because undefined [1] is incompatible with string [2]. [incompatible-cast]
+
+   obj_test.js:6:1
+   6| dictObj[key] as string; // error: void ~> string
+      ^^^^^^^^^^^^
+
+References:
+   obj_test.js:2:35
+   2| declare const dictObj: {[string]: string};
+                                        ^^^^^^ [1]
+   obj_test.js:6:17
+   6| dictObj[key] as string; // error: void ~> string
+                      ^^^^^^ [2]
+
+
+Error -------------------------------------------------------------------------------------------------- obj_test.js:7:1
+
+Cannot cast `dictObj.hahaha` to string because undefined [1] is incompatible with string [2]. [incompatible-cast]
+
+   obj_test.js:7:1
+   7| dictObj.hahaha as string; // error: void ~> string
+      ^^^^^^^^^^^^^^
+
+References:
+   obj_test.js:2:35
+   2| declare const dictObj: {[string]: string};
+                                        ^^^^^^ [1]
+   obj_test.js:7:19
+   7| dictObj.hahaha as string; // error: void ~> string
+                        ^^^^^^ [2]
+
+
+
+Found 9 errors

--- a/tests/no_unchecked_indexed_access/no_unchecked_indexed_access.exp
+++ b/tests/no_unchecked_indexed_access/no_unchecked_indexed_access.exp
@@ -97,6 +97,23 @@ References:
                      ^^^^^^ [2]
 
 
+Error ------------------------------------------------------------------------------------------------- arr_test.js:17:1
+
+Cannot cast `typeTest` to string because undefined [1] is incompatible with string [2]. [incompatible-cast]
+
+   arr_test.js:17:1
+   17| typeTest as string; // todo: the flag should not affect type-level acccess
+       ^^^^^^^^
+
+References:
+   arr_test.js:3:39
+    3| declare const roArray: $ReadOnlyArray<string>;
+                                             ^^^^^^ [1]
+   arr_test.js:17:13
+   17| typeTest as string; // todo: the flag should not affect type-level acccess
+                   ^^^^^^ [2]
+
+
 Error ------------------------------------------------------------------------------------------------- obj_test.js:5:11
 
 Cannot access object with computed property using string [1]. [invalid-computed-prop]
@@ -145,5 +162,22 @@ References:
                         ^^^^^^ [2]
 
 
+Error ------------------------------------------------------------------------------------------------- obj_test.js:10:1
 
-Found 9 errors
+Cannot cast `typeTest` to string because undefined [1] is incompatible with string [2]. [incompatible-cast]
+
+   obj_test.js:10:1
+   10| typeTest as string; // todo: the flag should not affect type-level acccess
+       ^^^^^^^^
+
+References:
+   obj_test.js:2:35
+    2| declare const dictObj: {[string]: string};
+                                         ^^^^^^ [1]
+   obj_test.js:10:13
+   10| typeTest as string; // todo: the flag should not affect type-level acccess
+                   ^^^^^^ [2]
+
+
+
+Found 11 errors

--- a/tests/no_unchecked_indexed_access/obj_test.js
+++ b/tests/no_unchecked_indexed_access/obj_test.js
@@ -6,5 +6,5 @@ recordObj[key] as string; // error: bad key
 dictObj[key] as string; // error: void ~> string
 dictObj.hahaha as string; // error: void ~> string
 
-declare const typeTest: (typeof dictObj)[string];
-typeTest as string; // todo: the flag should not affect type-level acccess
+declare export const typeTest: (typeof dictObj)[string];
+typeTest as string; // ok: the flag should not affect type-level acccess

--- a/tests/no_unchecked_indexed_access/obj_test.js
+++ b/tests/no_unchecked_indexed_access/obj_test.js
@@ -1,0 +1,7 @@
+declare const recordObj: {foo: string};
+declare const dictObj: {[string]: string};
+declare const key: string;
+
+recordObj[key] as string; // error: bad key
+dictObj[key] as string; // error: void ~> string
+dictObj.hahaha as string; // error: void ~> string

--- a/tests/no_unchecked_indexed_access/obj_test.js
+++ b/tests/no_unchecked_indexed_access/obj_test.js
@@ -5,3 +5,6 @@ declare const key: string;
 recordObj[key] as string; // error: bad key
 dictObj[key] as string; // error: void ~> string
 dictObj.hahaha as string; // error: void ~> string
+
+declare const typeTest: (typeof dictObj)[string];
+typeTest as string; // todo: the flag should not affect type-level acccess


### PR DESCRIPTION
Changelog: [feature] Flow now supports `no_unchecked_indexed_access=true`, which is equivalent to [noUncheckedIndexedAccess](https://www.typescriptlang.org/tsconfig/#noUncheckedIndexedAccess) from TS. It will add `| void` to every indexed access with general string key on dictionary objects or number key on arrays.