### PR TITLE
Add `shell: true` option for modern VSCode on Windows

### DIFF
--- a/packages/flow-for-vscode/src/FlowLanguageClient/FlowLanguageClient.ts
+++ b/packages/flow-for-vscode/src/FlowLanguageClient/FlowLanguageClient.ts
@@ -187,6 +187,7 @@ export default class FlowLanguageClient {
         // auto stop flow process
         config.stopFlowOnExit ? '--autostop' : null,
       ].filter((v) => v != null),
+      options: { shell: true },
 
       // see: clientOptions.workspaceFolder below
       // options: { cwd: flowconfigDir },


### PR DESCRIPTION
As reported automatically in https://github.com/flow/flow-for-vscode/issues/458, this plugin needs to engage the shell to launch the LSP on modern VSCode on Windows, because the script is generally installed as `flow-bin/cli.cmd` and only the shell can execute those.

(port of https://github.com/flow/flow-for-vscode/pull/464)

Personally I still have issues using this plugin in my setup, because of the use of [`bin-version`](https://www.npmjs.com/package/bin-version) which calls [`execa`](https://github.com/sindresorhus/execa) which calls [`cross-spawn`](https://github.com/moxystudio/node-cross-spawn), which doesn't seem to support Flow via `yarn` on Windows (which creates `.js` files but no `.cmd`/.bat` file) — not sure exactly why. In the future, I'd suggest moving away from this rather heavy chain of dependencies. Let me know if you'd like a PR to that effect.

To test: simply run this extension in development on a Windows machine, and load any Flow project. It should work with this PR, but fail to load without it.