### PR TITLE
[tests] Explicitly pass --yes for ounit install step

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ deps-js:
 
 .PHONY: deps-test
 deps-test:
-	opam install ounit$(OUNIT_VERSION)
+	opam install ounit$(OUNIT_VERSION) --yes
 
 clean:
 	if command -v dune >/dev/null; then dune clean; fi


### PR DESCRIPTION
CI jobs starts to fail because of lack of --yes recently.