### PR TITLE
[flow] Use `File_url.create` and `File_url.parse` for document paste protocol

### DIFF
--- a/src/hack_forked/utils/lsp/lsp_fmt.ml
+++ b/src/hack_forked/utils/lsp/lsp_fmt.ml
@@ -1762,8 +1762,8 @@ module DocumentPasteFmt = struct
     let import_source = Jget.string_exn json "importSource" in
     let import_source_is_resolved = Jget.bool_exn json "importSourceIsResolved" in
     let import_source =
-      if import_source_is_resolved && String.starts_with ~prefix:"file://" import_source then
-        Base.String.chop_prefix_exn ~prefix:"file://" import_source
+      if import_source_is_resolved then
+        File_url.parse import_source
       else
         import_source
     in
@@ -1787,7 +1787,7 @@ module DocumentPasteFmt = struct
     in
     let import_source =
       if import_source_is_resolved then
-        "file://" ^ import_source
+        File_url.create import_source
       else
         import_source
     in


### PR DESCRIPTION
Summary:
This is a followup of D68132119. The scheme doesn't work for windows paths. This diff replaces it with `File_url.create` and `File_url.parse` pair (which is the underlying uri to file_key conversion code used everywhere else) so that the test can also succeed on windows.

Changelog: [internal]

Differential Revision: D68233875


