### PR TITLE
Make string method index arguments optional

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -1178,21 +1178,21 @@ declare class String {
      * @param index The index (position) of the string character to be returned.
      * Supports relative indexing from the end of the string when passed a negative index;
      * i.e. if a negative number is used, the character returned will be found by
-     * counting back from the end of the string.
+     * counting back from the end of the string. Defaults to 0.
      * @return A String consisting of the single UTF-16 code unit located at the specified position.
      * Returns undefined if the given index can not be found.
      */
-    at(index: number): string | void;
+    at(index?: number): string | void;
     /**
      * Returns the character at the specified index.
-     * @param pos The zero-based index of the desired character.
+     * @param pos The zero-based index of the desired character. Defaults to 0.
      */
-    charAt(pos: number): string;
+    charAt(pos?: number): string;
     /**
      * Returns the Unicode value of the character at the specified location.
-     * @param index The zero-based index of the desired character. If there is no character at the specified index, NaN is returned.
+     * @param index The zero-based index of the desired character. Defaults to 0. If there is no character at the specified index, NaN is returned.
      */
-    charCodeAt(index: number): number;
+    charCodeAt(index?: number): number;
     /**
      * Returns a nonnegative integer Number less than 1114112 (0x110000) that is the code point
      * value of the UTF-16 encoded code point starting at the string element at position index in
@@ -1200,7 +1200,7 @@ declare class String {
      * If there is no element at that position, the result is undefined.
      * If a valid UTF-16 surrogate pair does not begin at index, the result is the code unit at index.
      */
-    codePointAt(index: number): number | void;
+    codePointAt(index?: number): number | void;
     /**
      * Returns a string that contains the concatenation of two or more strings.
      * @param strings The strings to append to the end of the string.

--- a/tests/autocomplete_from_h_to_l/autocomplete_from_h_to_l.exp
+++ b/tests/autocomplete_from_h_to_l/autocomplete_from_h_to_l.exp
@@ -51,10 +51,10 @@ Flags: --pretty
   "result":[
     {"name":"[Symbol.iterator]","type":"() => Iterator<string>"},
     {"name":"anchor","type":"(name: string) => string"},
-    {"name":"at","type":"(index: number) => string | void"},
-    {"name":"charAt","type":"(pos: number) => string"},
-    {"name":"charCodeAt","type":"(index: number) => number"},
-    {"name":"codePointAt","type":"(index: number) => number | void"},
+    {"name":"at","type":"(index?: number) => string | void"},
+    {"name":"charAt","type":"(pos?: number) => string"},
+    {"name":"charCodeAt","type":"(index?: number) => number"},
+    {"name":"codePointAt","type":"(index?: number) => number | void"},
     {"name":"concat","type":"(...strings: Array<string>) => string"},
     {
       "name":"endsWith",

--- a/tests/autocomplete_from_r_to_z/autocomplete_from_r_to_z.exp
+++ b/tests/autocomplete_from_r_to_z/autocomplete_from_r_to_z.exp
@@ -804,10 +804,10 @@ Flags: --pretty
   "result":[
     {"name":"[Symbol.iterator]","type":"() => Iterator<string>"},
     {"name":"anchor","type":"(name: string) => string"},
-    {"name":"at","type":"(index: number) => string | void"},
-    {"name":"charAt","type":"(pos: number) => string"},
-    {"name":"charCodeAt","type":"(index: number) => number"},
-    {"name":"codePointAt","type":"(index: number) => number | void"},
+    {"name":"at","type":"(index?: number) => string | void"},
+    {"name":"charAt","type":"(pos?: number) => string"},
+    {"name":"charCodeAt","type":"(index?: number) => number"},
+    {"name":"codePointAt","type":"(index?: number) => number | void"},
     {"name":"concat","type":"(...strings: Array<string>) => string"},
     {
       "name":"endsWith",


### PR DESCRIPTION
## What?

Updates `String.prototype.{at, charAt, charCodeAt, codePointAt}` to not require a position argument. These default to 0. 

- [Described by MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/charCodeAt#parameters)
  > Zero-based index of the character to be returned. [Converted to an integer](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number#integer_conversion) — undefined is converted to 0.
- [Defined in the spec](https://tc39.es/ecma262/multipage/text-processing.html#sec-string.prototype.charcodeat)
  - Note that all 4 methods rely on [the `ToIntegerOrInfinity` definition](https://tc39.es/ecma262/multipage/abstract-operations.html#sec-tointegerorinfinity):
    > 1. Let number be ? [ToNumber]
    > 2. If number is one of NaN, +0𝔽, or -0𝔽, return 0.
  - `Number(undefined) -> NaN -> 0` 
- Implemented. Confirmed that MacOS latest Chrome, Safari, and Firefox all default to 0.
- Note that TypeScript library types [also have this bug](https://www.typescriptlang.org/play/?#code/OQQ2DoGMAsQJwMIHsAmBTAggFwBQEoBuIA). I may put up a fix there too. 

## Why?

Omitting the position argument is useful when we know we have a single character string. For example, converting a base64-encoded string to a `Uint8Array`:
```
Uint8Array.from(
  Iterator.from(
    atob(base64String)
  ).map(
    c => c.charCodeAt()
  )
)
```

## Is this a good idea?

I'm not sure. 

**Argument for**: I was surprised to see that common Stack Overflow suggestions ([example](https://stackoverflow.com/a/73147529/407845)) worked but did not typecheck. The default behavior is written in the spec and documented on MDN.

**Argument against**: Callsites are more readable with an argument. It's only one character. Even [this MDN example](https://developer.mozilla.org/en-US/docs/Web/API/Window/btoa#unicode_strings) adds the argument when it's not needed.
