### PR TITLE
prefer `Base.List.is_empty`

### DIFF
--- a/src/commands/envBuilderDebugCommand.ml
+++ b/src/commands/envBuilderDebugCommand.ml
@@ -86,7 +86,7 @@ let main path filename () =
     Parser_flow.program_file ~fail:false ~parse_options ~token_sink:None content filekey
   in
   let ast = Ast_loc_utils.loc_to_aloc_mapper#program ast in
-  if List.is_empty errors then
+  if Base.List.is_empty errors then
     (* Compute read -> write edges *)
     let (_, env) = Name_resolver.program_with_scope () ast in
     (* Compute write -> read edges *)

--- a/src/lsp/flowLsp.ml
+++ b/src/lsp/flowLsp.ml
@@ -763,7 +763,7 @@ let do_initialize params : Initialize.result =
       else
         supported_code_action_kinds
     in
-    if not (List.is_empty supported_code_action_kinds) then
+    if not (Base.List.is_empty supported_code_action_kinds) then
       CodeActionOptions { codeActionKinds = supported_code_action_kinds }
     else
       CodeActionBool false

--- a/src/parser/parser_common.ml
+++ b/src/parser/parser_common.ml
@@ -519,7 +519,7 @@ let is_start_of_type_guard env =
 
 let reparse_arguments_as_match_argument env (args_loc, args) =
   let { Expression.ArgList.arguments; _ } = args in
-  if List.is_empty arguments then Parser_env.error_at env (args_loc, Parse_error.MatchEmptyArgument);
+  if Base.List.is_empty arguments then Parser_env.error_at env (args_loc, Parse_error.MatchEmptyArgument);
   let filtered_args =
     List.filter_map
       (function

--- a/src/services/code_action/refactor_add_jsx_props.ml
+++ b/src/services/code_action/refactor_add_jsx_props.ml
@@ -81,7 +81,7 @@ let name_of_attribute attribute =
 let get_existing_attributes_names cx ~tast attributes children =
   let open Ast.JSX in
   let init_set =
-    if List.is_empty (snd children) then
+    if Base.List.is_empty (snd children) then
       SSet.empty
     else
       SSet.singleton "children"
@@ -162,7 +162,7 @@ class mapper cx ~snippets_enabled ~tast target_loc =
             |> Base.List.sort ~compare:String.compare
             |> Base.List.mapi ~f:(mk_attribute ~snippets_enabled)
           in
-          if not (List.is_empty new_attrs) then
+          if not (Base.List.is_empty new_attrs) then
             raise
               (Found
                  (concat_and_sort_attrs

--- a/src/typing/statement.ml
+++ b/src/typing/statement.ml
@@ -3033,7 +3033,7 @@ module Make
             Match { Flow_ast.Match.arg; cases = List.rev cases_rev; match_keyword_loc; comments }
           )
         in
-        if (not (List.is_empty cases)) && all_throws then
+        if (not (Base.List.is_empty cases)) && all_throws then
           Abnormal.throw_expr_control_flow_exception loc ast
         else
           ast


### PR DESCRIPTION
I'm having trouble building the parser with OCaml 4.14, and this seems to be the only dependency.

`List.is_empty` from the OCaml stdlib was added in 5.1.

The project already requires 5.2+, so you can ignore this. Alternatively, you can change other parts to prefer the OCaml stdlib for code consistency.