### PR TITLE
[ci] Use `ubuntu-22.04` instead of `ubuntu-20.04` runner

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -66,7 +66,7 @@ jobs:
         name: build_js_packages
         path: packages/flow-parser/flow_parser.js
   build_linux:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       TERM: dumb
       OPAMYES: true


### PR DESCRIPTION
The older runner is removed by GitHub today.