### PR TITLE
[flow|core] Add Float16Array type

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -592,6 +592,11 @@ declare var Math: {
      */
     floor(x: number): number,
     /**
+     * Returns the nearest 16-bit half precision float representation of a number.
+     * @param x A numeric expression.
+     */
+    f16round(x: number): number,
+    /**
      * Returns the nearest single precision float representation of a number.
      * @param x A numeric expression.
      */
@@ -2548,6 +2553,11 @@ declare class Int32Array extends $TypedArrayInternal<number> {}
  */
 declare class Uint32Array extends $TypedArrayInternal<number> {}
 /**
+ * A typed array of 16-bit float values. The contents are initialized to 0. If the requested number
+ * of bytes could not be allocated an exception is raised.
+ */
+declare class Float16Array extends $TypedArrayInternal<number> {}
+/**
  * A typed array of 32-bit float values. The contents are initialized to 0. If the requested number
  * of bytes could not be allocated an exception is raised.
  */
@@ -2612,6 +2622,12 @@ declare class DataView {
      */
     getUint32(byteOffset: number, littleEndian?: boolean): number;
     /**
+     * Gets the Float16 value at the specified byte offset from the start of the view. There is
+     * no alignment constraint; multi-byte values may be fetched from any offset.
+     * @param byteOffset The place in the buffer at which the value should be retrieved.
+     */
+    getFloat16(byteOffset: number, littleEndian?: boolean): number;
+    /**
      * Gets the Float32 value at the specified byte offset from the start of the view. There is
      * no alignment constraint; multi-byte values may be fetched from any offset.
      * @param byteOffset The place in the buffer at which the value should be retrieved.
@@ -2667,6 +2683,14 @@ declare class DataView {
      * otherwise a little-endian value should be written.
      */
     setUint32(byteOffset: number, value: number, littleEndian?: boolean): void;
+    /**
+     * Stores an Float16 value at the specified byte offset from the start of the view.
+     * @param byteOffset The place in the buffer at which the value should be set.
+     * @param value The value to set.
+     * @param littleEndian If false or undefined, a big-endian value should be written,
+     * otherwise a little-endian value should be written.
+     */
+    setFloat16(byteOffset: number, value: number, littleEndian?: boolean): void;
     /**
      * Stores an Float32 value at the specified byte offset from the start of the view.
      * @param byteOffset The place in the buffer at which the value should be set.

--- a/tests/arraylib/arraylib.exp
+++ b/tests/arraylib/arraylib.exp
@@ -107,8 +107,8 @@ References:
    array_lib.js:58:4
      58|   [''].reduce((acc, str) => acc * str.length); // error, string ~> number
             ^^ [1]
-   <BUILTINS>/core.js:1406:13
-   1406|     length: number;
+   <BUILTINS>/core.js:1411:13
+   1411|     length: number;
                      ^^^^^^ [2]
 
 
@@ -124,8 +124,8 @@ References:
    array_lib.js:59:4
      59|   [''].reduceRight((acc, str) => acc * str.length); // error, string ~> number
             ^^ [1]
-   <BUILTINS>/core.js:1406:13
-   1406|     length: number;
+   <BUILTINS>/core.js:1411:13
+   1411|     length: number;
                      ^^^^^^ [2]
 
 
@@ -139,8 +139,8 @@ Cannot cast `Array.from(...)` to array type because string [1] is incompatible w
            ^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:1139:37
-   1139|     static from(str: string): Array<string>;
+   <BUILTINS>/core.js:1144:37
+   1144|     static from(str: string): Array<string>;
                                              ^^^^^^ [1]
    array_lib.js:71:31
      71|   Array.from('abcd') as Array<empty>; // ERROR
@@ -184,8 +184,8 @@ Cannot call `arr.at` because function [1] requires another argument. [incompatib
             ^^
 
 References:
-   <BUILTINS>/core.js:710:5
-   710|     at(index: number): T | void;
+   <BUILTINS>/core.js:715:5
+   715|     at(index: number): T | void;
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 
@@ -198,8 +198,8 @@ Cannot call `arr.at` with `"1"` bound to `index` because string [1] is incompati
                ^^^ [1]
 
 References:
-   <BUILTINS>/core.js:710:15
-   710|     at(index: number): T | void;
+   <BUILTINS>/core.js:715:15
+   715|     at(index: number): T | void;
                       ^^^^^^ [2]
 
 
@@ -212,8 +212,8 @@ Cannot call `roArr.at` because function [1] requires another argument. [incompat
               ^^
 
 References:
-   <BUILTINS>/core.js:710:5
-   710|     at(index: number): T | void;
+   <BUILTINS>/core.js:715:5
+   715|     at(index: number): T | void;
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 
@@ -227,8 +227,8 @@ Cannot call `roArr.at` with `"1"` bound to `index` because string [1] is incompa
                  ^^^ [1]
 
 References:
-   <BUILTINS>/core.js:710:15
-   710|     at(index: number): T | void;
+   <BUILTINS>/core.js:715:15
+   715|     at(index: number): T | void;
                       ^^^^^^ [2]
 
 
@@ -364,8 +364,8 @@ Cannot assign `arr3.flat(...)` to `result3_2` because mixed [1] is incompatible 
                                          ^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:858:32
-   858|     flat(depth: number): Array<mixed>;
+   <BUILTINS>/core.js:863:32
+   863|     flat(depth: number): Array<mixed>;
                                        ^^^^^ [1]
    flat.js:20:24
     20| const result3_2: Array<number> = arr3.flat(2); // Error - don't support this
@@ -382,8 +382,8 @@ Cannot assign `arr2.flat(...)` to `result2_6` because mixed [1] is incompatible 
                                          ^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:858:32
-   858|     flat(depth: number): Array<mixed>;
+   <BUILTINS>/core.js:863:32
+   863|     flat(depth: number): Array<mixed>;
                                        ^^^^^ [1]
    flat.js:25:24
     25| const result2_6: Array<number> = arr2.flat(x); // Error - don't support this

--- a/tests/arrows/arrows.exp
+++ b/tests/arrows/arrows.exp
@@ -42,8 +42,8 @@ return value. [incompatible-call]
                                             ^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:1092:38
-   1092|     sort(compareFn?: (a: T, b: T) => number): Array<T>;
+   <BUILTINS>/core.js:1097:38
+   1097|     sort(compareFn?: (a: T, b: T) => number): Array<T>;
                                               ^^^^^^ [2]
 
 

--- a/tests/as_const/as_const.exp
+++ b/tests/as_const/as_const.exp
@@ -61,8 +61,8 @@ Cannot call `arr1.push` because property `push` is missing in `$ReadOnlyArray` [
                ^^^^
 
 References:
-   <BUILTINS>/core.js:700:15
-   700| declare class $ReadOnlyArray<+T> {
+   <BUILTINS>/core.js:705:15
+   705| declare class $ReadOnlyArray<+T> {
                       ^^^^^^^^^^^^^^ [1]
 
 

--- a/tests/async/async.exp
+++ b/tests/async/async.exp
@@ -10,8 +10,8 @@ References:
    async.js:9:30
       9| async function f1(): Promise<boolean> {
                                       ^^^^^^^ [2]
-   <BUILTINS>/core.js:2143:24
-   2143| declare class Promise<+R = mixed> {
+   <BUILTINS>/core.js:2148:24
+   2148| declare class Promise<+R = mixed> {
                                 ^ [3]
 
 
@@ -31,8 +31,8 @@ References:
    async.js:28:48
      28| async function f4(p: Promise<number>): Promise<boolean> {
                                                         ^^^^^^^ [2]
-   <BUILTINS>/core.js:2143:24
-   2143| declare class Promise<+R = mixed> {
+   <BUILTINS>/core.js:2148:24
+   2148| declare class Promise<+R = mixed> {
                                 ^ [3]
 
 
@@ -99,8 +99,8 @@ undefined in type argument `R` [2]. [incompatible-return]
                      ^^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:2143:24
-   2143| declare class Promise<+R = mixed> {
+   <BUILTINS>/core.js:2148:24
+   2148| declare class Promise<+R = mixed> {
                                 ^ [2]
 
 
@@ -142,8 +142,8 @@ References:
    async_return_void.js:1:32
       1| async function foo1(): Promise<string> {
                                         ^^^^^^ [2]
-   <BUILTINS>/core.js:2143:24
-   2143| declare class Promise<+R = mixed> {
+   <BUILTINS>/core.js:2148:24
+   2148| declare class Promise<+R = mixed> {
                                 ^ [3]
 
 
@@ -160,8 +160,8 @@ References:
    async_return_void.js:5:32
       5| async function foo2(): Promise<string> {
                                         ^^^^^^ [2]
-   <BUILTINS>/core.js:2143:24
-   2143| declare class Promise<+R = mixed> {
+   <BUILTINS>/core.js:2148:24
+   2148| declare class Promise<+R = mixed> {
                                 ^ [3]
 
 
@@ -181,8 +181,8 @@ References:
    async_return_void.js:9:32
       9| async function foo3(): Promise<string> {
                                         ^^^^^^ [2]
-   <BUILTINS>/core.js:2143:24
-   2143| declare class Promise<+R = mixed> {
+   <BUILTINS>/core.js:2148:24
+   2148| declare class Promise<+R = mixed> {
                                 ^ [3]
 
 
@@ -220,11 +220,11 @@ string [2] in type argument `Yield` [3]. [incompatible-return]
                                                      ^^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:2206:58
-   2206|       T extends $ReadOnlyArray<mixed> ? {[K in keyof T]: Awaited<T[K]>} :
+   <BUILTINS>/core.js:2211:58
+   2211|       T extends $ReadOnlyArray<mixed> ? {[K in keyof T]: Awaited<T[K]>} :
                                                                   ^^^^^^^^^^^^^ [2]
-   <BUILTINS>/core.js:1937:27
-   1937| interface AsyncGenerator<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:1942:27
+   1942| interface AsyncGenerator<+Yield,+Return,-Next> {
                                    ^^^^^ [3]
 
 
@@ -237,14 +237,14 @@ string [1] is incompatible with number [2] in type argument `Yield` [3]. [incomp
                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:2206:58
-   2206|       T extends $ReadOnlyArray<mixed> ? {[K in keyof T]: Awaited<T[K]>} :
+   <BUILTINS>/core.js:2211:58
+   2211|       T extends $ReadOnlyArray<mixed> ? {[K in keyof T]: Awaited<T[K]>} :
                                                                   ^^^^^^^^^^^^^ [1]
    generator.js:21:45
      21| async function *genError1(): AsyncGenerator<number, void, void> {
                                                      ^^^^^^ [2]
-   <BUILTINS>/core.js:1937:27
-   1937| interface AsyncGenerator<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:1942:27
+   1942| interface AsyncGenerator<+Yield,+Return,-Next> {
                                    ^^^^^ [3]
 
 
@@ -258,8 +258,8 @@ Cannot yield `1` because number [1], a primitive, cannot be used as a subtype of
                     ^ [1]
 
 References:
-   <BUILTINS>/core.js:1948:7
-   1948|     : $Iterable<Yield, Return, Next>;
+   <BUILTINS>/core.js:1953:7
+   1953|     : $Iterable<Yield, Return, Next>;
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [2]
 
 

--- a/tests/async_iteration/async_iteration.exp
+++ b/tests/async_iteration/async_iteration.exp
@@ -113,8 +113,8 @@ Cannot cast `result.value` to string because undefined [1] is incompatible with 
               ^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:1777:14
-   1777|     +value?: Return,
+   <BUILTINS>/core.js:1782:14
+   1782|     +value?: Return,
                       ^^^^^^ [1]
    return.js:20:20
      20|     (result.value: string); // error: number | void ~> string

--- a/tests/autocomplete_from_m_to_q/autocomplete_from_m_to_q.exp
+++ b/tests/autocomplete_from_m_to_q/autocomplete_from_m_to_q.exp
@@ -357,6 +357,7 @@ Flags: --pretty
     {"name":"EvalError","type":"typeof EvalError"},
     {"name":"exports","type":"{-[key: string]: mixed}"},
     {"name":"FinalizationRegistry","type":"typeof FinalizationRegistry"},
+    {"name":"Float16Array","type":"typeof Float16Array"},
     {"name":"Float32Array","type":"typeof Float32Array"},
     {"name":"Float64Array","type":"typeof Float64Array"},
     {"name":"Function","type":"typeof Function"},
@@ -376,7 +377,7 @@ Flags: --pretty
     {"name":"Map","type":"typeof Map"},
     {
       "name":"Math",
-      "type":"{E: number, LN10: number, LN2: number, LOG10E: number, LOG2E: number, PI: number, SQRT1_2: number, SQRT2: number, abs(x: number): number, acos(x: number): number, acosh(x: number): number, asin(x: number): number, asinh(x: number): number, atan(x: number): number, atan2(y: number, x: number): number, atanh(x: number): number, cbrt(x: number): number, ceil(x: number): number, clz32(x: number): number, cos(x: number): number, cosh(x: number): number, exp(x: number): number, expm1(x: number): number, floor(x: number): number, fround(x: number): number, hypot(...values: Array<number>): number, imul(x: number, y: number): number, log(x: number): number, log10(x: number): number, log1p(x: number): number, log2(x: number): number, max(...values: Array<number>): number, min(...values: Array<number>): number, pow(x: number, y: number): number, random(): number, round(x: number): number, sign(x: number): number, sin(x: number): number, sinh(x: number): number, sqrt(x: number): number, tan(x: number): number, tanh(x: number): number, trunc(x: number): number, ...}"
+      "type":"{E: number, LN10: number, LN2: number, LOG10E: number, LOG2E: number, PI: number, SQRT1_2: number, SQRT2: number, abs(x: number): number, acos(x: number): number, acosh(x: number): number, asin(x: number): number, asinh(x: number): number, atan(x: number): number, atan2(y: number, x: number): number, atanh(x: number): number, cbrt(x: number): number, ceil(x: number): number, clz32(x: number): number, cos(x: number): number, cosh(x: number): number, exp(x: number): number, expm1(x: number): number, f16round(x: number): number, floor(x: number): number, fround(x: number): number, hypot(...values: Array<number>): number, imul(x: number, y: number): number, log(x: number): number, log10(x: number): number, log1p(x: number): number, log2(x: number): number, max(...values: Array<number>): number, min(...values: Array<number>): number, pow(x: number, y: number): number, random(): number, round(x: number): number, sign(x: number): number, sin(x: number): number, sinh(x: number): number, sqrt(x: number): number, tan(x: number): number, tanh(x: number): number, trunc(x: number): number, ...}"
     },
     {
       "name":"module",

--- a/tests/babel_loose_array_spread/babel_loose_array_spread.exp
+++ b/tests/babel_loose_array_spread/babel_loose_array_spread.exp
@@ -26,11 +26,11 @@ property `@@iterator` of type argument `A`. [incompatible-call]
                        ^^
 
 References:
-   <BUILTINS>/core.js:1907:19
-   1907|     @@iterator(): $IteratorProtocol<Yield,Return,Next>;
+   <BUILTINS>/core.js:1912:19
+   1912|     @@iterator(): $IteratorProtocol<Yield,Return,Next>;
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
-   <BUILTINS>/core.js:1149:17
-   1149|   @@iterator(): Iterator<T>;
+   <BUILTINS>/core.js:1154:17
+   1154|   @@iterator(): Iterator<T>;
                          ^^^^^^^^^^^ [2]
 
 
@@ -46,8 +46,8 @@ References:
    iterables.js:1:11
      1| const it: Iterable<number> = [7,8,9];
                   ^^^^^^^^^^^^^^^^ [1]
-   <BUILTINS>/core.js:700:15
-   700| declare class $ReadOnlyArray<+T> {
+   <BUILTINS>/core.js:705:15
+   705| declare class $ReadOnlyArray<+T> {
                       ^^^^^^^^^^^^^^ [2]
 
 
@@ -63,8 +63,8 @@ References:
    iterables.js:1:11
      1| const it: Iterable<number> = [7,8,9];
                   ^^^^^^^^^^^^^^^^ [1]
-   <BUILTINS>/core.js:700:15
-   700| declare class $ReadOnlyArray<+T> {
+   <BUILTINS>/core.js:705:15
+   705| declare class $ReadOnlyArray<+T> {
                       ^^^^^^^^^^^^^^ [2]
 
 
@@ -80,8 +80,8 @@ References:
    iterables.js:1:11
      1| const it: Iterable<number> = [7,8,9];
                   ^^^^^^^^^^^^^^^^ [1]
-   <BUILTINS>/core.js:700:15
-   700| declare class $ReadOnlyArray<+T> {
+   <BUILTINS>/core.js:705:15
+   705| declare class $ReadOnlyArray<+T> {
                       ^^^^^^^^^^^^^^ [2]
 
 
@@ -97,8 +97,8 @@ References:
    opaque.js:6:30
      6| export const opaqueIterable: OpaqueIterable = [];
                                      ^^^^^^^^^^^^^^ [1]
-   <BUILTINS>/core.js:700:15
-   700| declare class $ReadOnlyArray<+T> {
+   <BUILTINS>/core.js:705:15
+   705| declare class $ReadOnlyArray<+T> {
                       ^^^^^^^^^^^^^^ [2]
 
 
@@ -114,8 +114,8 @@ References:
    opaque.js:6:30
      6| export const opaqueIterable: OpaqueIterable = [];
                                      ^^^^^^^^^^^^^^ [1]
-   <BUILTINS>/core.js:700:15
-   700| declare class $ReadOnlyArray<+T> {
+   <BUILTINS>/core.js:705:15
+   705| declare class $ReadOnlyArray<+T> {
                       ^^^^^^^^^^^^^^ [2]
 
 
@@ -131,8 +131,8 @@ References:
    opaque.js:6:30
      6| export const opaqueIterable: OpaqueIterable = [];
                                      ^^^^^^^^^^^^^^ [1]
-   <BUILTINS>/core.js:700:15
-   700| declare class $ReadOnlyArray<+T> {
+   <BUILTINS>/core.js:705:15
+   705| declare class $ReadOnlyArray<+T> {
                       ^^^^^^^^^^^^^^ [2]
 
 
@@ -148,8 +148,8 @@ References:
    maps.js:1:14
      1| const map1 = new Map<string, string>();
                      ^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
-   <BUILTINS>/core.js:700:15
-   700| declare class $ReadOnlyArray<+T> {
+   <BUILTINS>/core.js:705:15
+   705| declare class $ReadOnlyArray<+T> {
                       ^^^^^^^^^^^^^^ [2]
 
 
@@ -165,8 +165,8 @@ References:
    maps.js:2:14
      2| const map2 = new Map<string, string>();
                      ^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
-   <BUILTINS>/core.js:700:15
-   700| declare class $ReadOnlyArray<+T> {
+   <BUILTINS>/core.js:705:15
+   705| declare class $ReadOnlyArray<+T> {
                       ^^^^^^^^^^^^^^ [2]
 
 
@@ -182,8 +182,8 @@ References:
    maps.js:1:14
      1| const map1 = new Map<string, string>();
                      ^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
-   <BUILTINS>/core.js:700:15
-   700| declare class $ReadOnlyArray<+T> {
+   <BUILTINS>/core.js:705:15
+   705| declare class $ReadOnlyArray<+T> {
                       ^^^^^^^^^^^^^^ [2]
 
 
@@ -199,8 +199,8 @@ References:
    maps.js:2:14
      2| const map2 = new Map<string, string>();
                      ^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
-   <BUILTINS>/core.js:700:15
-   700| declare class $ReadOnlyArray<+T> {
+   <BUILTINS>/core.js:705:15
+   705| declare class $ReadOnlyArray<+T> {
                       ^^^^^^^^^^^^^^ [2]
 
 

--- a/tests/badly_positioned_func_proto/badly_positioned_func_proto.exp
+++ b/tests/badly_positioned_func_proto/badly_positioned_func_proto.exp
@@ -8,8 +8,8 @@ it into an object and attempt to use it as a subtype of an interface. [incompati
                       ^ [1]
 
 References:
-   <BUILTINS>/core.js:1906:11
-   1906| interface $Iterable<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:1911:11
+   1911| interface $Iterable<+Yield,+Return,-Next> {
                    ^^^^^^^^^ [2]
 
 
@@ -23,8 +23,8 @@ it into an object and attempt to use it as a subtype of an interface. [incompati
                         ^ [1]
 
 References:
-   <BUILTINS>/core.js:1906:11
-   1906| interface $Iterable<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:1911:11
+   1911| interface $Iterable<+Yield,+Return,-Next> {
                    ^^^^^^^^^ [2]
 
 

--- a/tests/bigint/bigint.exp
+++ b/tests/bigint/bigint.exp
@@ -30,23 +30,23 @@ Cannot call `BigInt` with `null` bound to `value` because: [incompatible-call]
                 ^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:2933:18
-   2933|   static (value: boolean | string | number | bigint | interface {} | $ReadOnlyArray<mixed>): bigint;
+   <BUILTINS>/core.js:2957:18
+   2957|   static (value: boolean | string | number | bigint | interface {} | $ReadOnlyArray<mixed>): bigint;
                           ^^^^^^^ [2]
-   <BUILTINS>/core.js:2933:28
-   2933|   static (value: boolean | string | number | bigint | interface {} | $ReadOnlyArray<mixed>): bigint;
+   <BUILTINS>/core.js:2957:28
+   2957|   static (value: boolean | string | number | bigint | interface {} | $ReadOnlyArray<mixed>): bigint;
                                     ^^^^^^ [3]
-   <BUILTINS>/core.js:2933:37
-   2933|   static (value: boolean | string | number | bigint | interface {} | $ReadOnlyArray<mixed>): bigint;
+   <BUILTINS>/core.js:2957:37
+   2957|   static (value: boolean | string | number | bigint | interface {} | $ReadOnlyArray<mixed>): bigint;
                                              ^^^^^^ [4]
-   <BUILTINS>/core.js:2933:46
-   2933|   static (value: boolean | string | number | bigint | interface {} | $ReadOnlyArray<mixed>): bigint;
+   <BUILTINS>/core.js:2957:46
+   2957|   static (value: boolean | string | number | bigint | interface {} | $ReadOnlyArray<mixed>): bigint;
                                                       ^^^^^^ [5]
-   <BUILTINS>/core.js:2933:55
-   2933|   static (value: boolean | string | number | bigint | interface {} | $ReadOnlyArray<mixed>): bigint;
+   <BUILTINS>/core.js:2957:55
+   2957|   static (value: boolean | string | number | bigint | interface {} | $ReadOnlyArray<mixed>): bigint;
                                                                ^^^^^^^^^^^^ [6]
-   <BUILTINS>/core.js:2933:70
-   2933|   static (value: boolean | string | number | bigint | interface {} | $ReadOnlyArray<mixed>): bigint;
+   <BUILTINS>/core.js:2957:70
+   2957|   static (value: boolean | string | number | bigint | interface {} | $ReadOnlyArray<mixed>): bigint;
                                                                               ^^^^^^^^^^^^^^^^^^^^^ [7]
 
 

--- a/tests/component_type/component_type.exp
+++ b/tests/component_type/component_type.exp
@@ -456,8 +456,8 @@ References:
    everything_implicit_instantiation.js:6:46
       6| declare component B(ref: React.RefSetter<Set<string>>, foo: string, bar: number) renders? A;
                                                       ^^^^^^ [2]
-   <BUILTINS>/core.js:2101:19
-   2101| declare class Set<T> extends $ReadOnlySet<T> {
+   <BUILTINS>/core.js:2106:19
+   2106| declare class Set<T> extends $ReadOnlySet<T> {
                            ^ [3]
    <BUILTINS>/react.js:139:19
     139|   type RefSetter<-T> = React$RefSetter<T>;
@@ -800,8 +800,8 @@ References:
    props_implicit_instantiation.js:7:46
       7| declare component A(ref: React.RefSetter<Set<string>>, foo: string, bar: number);
                                                       ^^^^^^ [2]
-   <BUILTINS>/core.js:2101:19
-   2101| declare class Set<T> extends $ReadOnlySet<T> {
+   <BUILTINS>/core.js:2106:19
+   2106| declare class Set<T> extends $ReadOnlySet<T> {
                            ^ [3]
    <BUILTINS>/react.js:139:19
     139|   type RefSetter<-T> = React$RefSetter<T>;

--- a/tests/computed_props/computed_props.exp
+++ b/tests/computed_props/computed_props.exp
@@ -452,8 +452,8 @@ Cannot assign `arr[0]()` to `y` because number [1] is incompatible with string [
                            ^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:1101:13
-   1101|     length: number;
+   <BUILTINS>/core.js:1106:13
+   1106|     length: number;
                      ^^^^^^ [1]
    test7.js:5:10
       5| const y: string = arr[0](); // error: number ~> string

--- a/tests/contextual_typing/contextual_typing.exp
+++ b/tests/contextual_typing/contextual_typing.exp
@@ -22,8 +22,8 @@ expression to your expected type. [underconstrained-implicit-instantiation]
                             ^^^
 
 References:
-   <BUILTINS>/core.js:2101:19
-   2101| declare class Set<T> extends $ReadOnlySet<T> {
+   <BUILTINS>/core.js:2106:19
+   2106| declare class Set<T> extends $ReadOnlySet<T> {
                            ^ [1]
    arr_rest.js:9:16
       9| const [...y] = new Set() // still error
@@ -339,8 +339,8 @@ Property `@@iterator` is missing in function [1] but exists in `$Iterable` [2]. 
                 ^^^^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:1906:11
-   1906| interface $Iterable<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:1911:11
+   1911| interface $Iterable<+Yield,+Return,-Next> {
                    ^^^^^^^^^ [2]
 
 
@@ -478,8 +478,8 @@ References:
    implicit_instantiation.js:147:11
     147|   (a: Set<empty>); // error Set<string> ~> Set<empty>
                    ^^^^^ [2]
-   <BUILTINS>/core.js:2101:19
-   2101| declare class Set<T> extends $ReadOnlySet<T> {
+   <BUILTINS>/core.js:2106:19
+   2106| declare class Set<T> extends $ReadOnlySet<T> {
                            ^ [3]
 
 
@@ -498,8 +498,8 @@ References:
    implicit_instantiation.js:148:11
     148|   (b: Set<empty>); // error Set<string> ~> Set<empty>
                    ^^^^^ [2]
-   <BUILTINS>/core.js:2101:19
-   2101| declare class Set<T> extends $ReadOnlySet<T> {
+   <BUILTINS>/core.js:2106:19
+   2106| declare class Set<T> extends $ReadOnlySet<T> {
                            ^ [3]
 
 
@@ -754,8 +754,8 @@ References:
    lits.js:52:27
      52|   s2.values() as Iterator<string>; // error number ~> string
                                    ^^^^^^ [2]
-   <BUILTINS>/core.js:1800:25
-   1800| declare class Iterator<+Yield,+Return=void,-Next=void> implements $IteratorProtocol<Yield,Return,Next>, $Iterable<Yield,Return,Next> {
+   <BUILTINS>/core.js:1805:25
+   1805| declare class Iterator<+Yield,+Return=void,-Next=void> implements $IteratorProtocol<Yield,Return,Next>, $Iterable<Yield,Return,Next> {
                                  ^^^^^ [3]
 
 
@@ -1030,8 +1030,8 @@ defined. [method-unbinding]
                                                          ^^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:985:5
-   985|     filter(callbackfn: typeof Boolean): Array<$NonMaybeType<T>>;
+   <BUILTINS>/core.js:990:5
+   990|     filter(callbackfn: typeof Boolean): Array<$NonMaybeType<T>>;
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [2]
 
 

--- a/tests/core_tests/core_tests.exp
+++ b/tests/core_tests/core_tests.exp
@@ -7,33 +7,33 @@ Cannot use `new` on object type [1]. Only classes can be constructed. [invalid-c
              ^^^^
 
 References:
-   <BUILTINS>/core.js:1746:19
+   <BUILTINS>/core.js:1751:19
                            v-
-   1746| declare var JSON: {|
-   1747|     /**
-   1748|      * Converts a JavaScript Object Notation (JSON) string into an object.
-   1749|      * @param text A valid JSON string.
-   1750|      * @param reviver A function that transforms the results. This function is called for each member of the object.
-   1751|      * If a member contains nested objects, the nested objects are transformed before the parent object is.
-   1752|      */
-   1753|     +parse: (text: string, reviver?: (key: any, value: any) => any) => any,
-   1754|     /**
-   1755|      * Converts a JavaScript value to a JavaScript Object Notation (JSON) string.
-   1756|      * @param value A JavaScript value, usually an object or array, to be converted.
-   1757|      * @param replacer A function that transforms the results or an array of strings and numbers that acts as a approved list for selecting the object properties that will be stringified.
-   1758|      * @param space Adds indentation, white space, and line break characters to the return-value JSON text to make it easier to read.
-   1759|      */
-   1760|     +stringify: ((
-   1761|         value: null | string | number | boolean | interface {} | $ReadOnlyArray<mixed>,
-   1762|         replacer?: ?((key: string, value: any) => any) | Array<any>,
-   1763|         space?: string | number
-   1764|       ) => string) &
-   1765|       (
-   1766|         value: mixed,
+   1751| declare var JSON: {|
+   1752|     /**
+   1753|      * Converts a JavaScript Object Notation (JSON) string into an object.
+   1754|      * @param text A valid JSON string.
+   1755|      * @param reviver A function that transforms the results. This function is called for each member of the object.
+   1756|      * If a member contains nested objects, the nested objects are transformed before the parent object is.
+   1757|      */
+   1758|     +parse: (text: string, reviver?: (key: any, value: any) => any) => any,
+   1759|     /**
+   1760|      * Converts a JavaScript value to a JavaScript Object Notation (JSON) string.
+   1761|      * @param value A JavaScript value, usually an object or array, to be converted.
+   1762|      * @param replacer A function that transforms the results or an array of strings and numbers that acts as a approved list for selecting the object properties that will be stringified.
+   1763|      * @param space Adds indentation, white space, and line break characters to the return-value JSON text to make it easier to read.
+   1764|      */
+   1765|     +stringify: ((
+   1766|         value: null | string | number | boolean | interface {} | $ReadOnlyArray<mixed>,
    1767|         replacer?: ?((key: string, value: any) => any) | Array<any>,
    1768|         space?: string | number
-   1769|       ) => string | void,
-   1770| |};
+   1769|       ) => string) &
+   1770|       (
+   1771|         value: mixed,
+   1772|         replacer?: ?((key: string, value: any) => any) | Array<any>,
+   1773|         space?: string | number
+   1774|       ) => string | void,
+   1775| |};
          -^ [1]
 
 
@@ -54,8 +54,8 @@ Cannot cast `JSON.stringify(...)` to string because undefined [1] is incompatibl
           ^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:1769:21
-   1769|       ) => string | void,
+   <BUILTINS>/core.js:1774:21
+   1774|       ) => string | void,
                              ^^^^ [1]
    json_stringify.js:7:24
       7| (JSON.stringify(bad1): string);
@@ -75,11 +75,11 @@ References:
    map.js:21:22
      21|     let x = new Map(['foo', 123]); // error
                               ^^^^^ [1]
-   <BUILTINS>/core.js:1974:38
-   1974|     constructor(iterable?: ?Iterable<[K, V]>): void;
+   <BUILTINS>/core.js:1979:38
+   1979|     constructor(iterable?: ?Iterable<[K, V]>): void;
                                               ^^^^^^ [2]
-   <BUILTINS>/core.js:1790:30
-   1790| interface $IteratorProtocol<+Yield,+Return=void,-Next=void> {
+   <BUILTINS>/core.js:1795:30
+   1795| interface $IteratorProtocol<+Yield,+Return=void,-Next=void> {
                                       ^^^^^ [3]
 
 
@@ -96,11 +96,11 @@ References:
    map.js:21:29
      21|     let x = new Map(['foo', 123]); // error
                                      ^^^ [1]
-   <BUILTINS>/core.js:1974:38
-   1974|     constructor(iterable?: ?Iterable<[K, V]>): void;
+   <BUILTINS>/core.js:1979:38
+   1979|     constructor(iterable?: ?Iterable<[K, V]>): void;
                                               ^^^^^^ [2]
-   <BUILTINS>/core.js:1790:30
-   1790| interface $IteratorProtocol<+Yield,+Return=void,-Next=void> {
+   <BUILTINS>/core.js:1795:30
+   1795| interface $IteratorProtocol<+Yield,+Return=void,-Next=void> {
                                       ^^^^^ [3]
 
 
@@ -120,8 +120,8 @@ References:
    map.js:22:16
      22|     let y: Map<number, string> = new Map([['foo', 123]]); // error
                         ^^^^^^ [2]
-   <BUILTINS>/core.js:1790:30
-   1790| interface $IteratorProtocol<+Yield,+Return=void,-Next=void> {
+   <BUILTINS>/core.js:1795:30
+   1795| interface $IteratorProtocol<+Yield,+Return=void,-Next=void> {
                                       ^^^^^ [3]
 
 
@@ -141,8 +141,8 @@ References:
    map.js:22:24
      22|     let y: Map<number, string> = new Map([['foo', 123]]); // error
                                 ^^^^^^ [2]
-   <BUILTINS>/core.js:1790:30
-   1790| interface $IteratorProtocol<+Yield,+Return=void,-Next=void> {
+   <BUILTINS>/core.js:1795:30
+   1795| interface $IteratorProtocol<+Yield,+Return=void,-Next=void> {
                                       ^^^^^ [3]
 
 
@@ -155,8 +155,8 @@ Cannot cast `x.get(...)` to boolean because undefined [1] is incompatible with b
               ^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:1982:22
-   1982|     get(key: K): V | void;
+   <BUILTINS>/core.js:1987:22
+   1987|     get(key: K): V | void;
                               ^^^^ [1]
    map.js:27:20
      27|     (x.get('foo'): boolean); // error, string | void
@@ -206,11 +206,11 @@ Cannot call `WeakRef` because in type argument `T`: [incompatible-call]
                                ^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:1999:28
-   1999| type WeaklyReferenceable = interface {} | $ReadOnlyArray<mixed>;
+   <BUILTINS>/core.js:2004:28
+   2004| type WeaklyReferenceable = interface {} | $ReadOnlyArray<mixed>;
                                     ^^^^^^^^^^^^ [2]
-   <BUILTINS>/core.js:1999:43
-   1999| type WeaklyReferenceable = interface {} | $ReadOnlyArray<mixed>;
+   <BUILTINS>/core.js:2004:43
+   2004| type WeaklyReferenceable = interface {} | $ReadOnlyArray<mixed>;
                                                    ^^^^^^^^^^^^^^^^^^^^^ [3]
 
 
@@ -226,11 +226,11 @@ Cannot call `WeakRef` because in type argument `T`: [incompatible-call]
                                ^^^ [1]
 
 References:
-   <BUILTINS>/core.js:1999:28
-   1999| type WeaklyReferenceable = interface {} | $ReadOnlyArray<mixed>;
+   <BUILTINS>/core.js:2004:28
+   2004| type WeaklyReferenceable = interface {} | $ReadOnlyArray<mixed>;
                                     ^^^^^^^^^^^^ [2]
-   <BUILTINS>/core.js:1999:43
-   1999| type WeaklyReferenceable = interface {} | $ReadOnlyArray<mixed>;
+   <BUILTINS>/core.js:2004:43
+   2004| type WeaklyReferenceable = interface {} | $ReadOnlyArray<mixed>;
                                                    ^^^^^^^^^^^^^^^^^^^^^ [3]
 
 
@@ -246,11 +246,11 @@ Cannot call `WeakRef` because in type argument `T`: [incompatible-call]
                                ^^^^^^^^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:1999:28
-   1999| type WeaklyReferenceable = interface {} | $ReadOnlyArray<mixed>;
+   <BUILTINS>/core.js:2004:28
+   2004| type WeaklyReferenceable = interface {} | $ReadOnlyArray<mixed>;
                                     ^^^^^^^^^^^^ [2]
-   <BUILTINS>/core.js:1999:43
-   1999| type WeaklyReferenceable = interface {} | $ReadOnlyArray<mixed>;
+   <BUILTINS>/core.js:2004:43
+   2004| type WeaklyReferenceable = interface {} | $ReadOnlyArray<mixed>;
                                                    ^^^^^^^^^^^^^^^^^^^^^ [3]
 
 
@@ -266,11 +266,11 @@ Cannot call `WeakSet` because in type argument `T`: [incompatible-call]
                                 ^ [1]
 
 References:
-   <BUILTINS>/core.js:1999:28
-   1999| type WeaklyReferenceable = interface {} | $ReadOnlyArray<mixed>;
+   <BUILTINS>/core.js:2004:28
+   2004| type WeaklyReferenceable = interface {} | $ReadOnlyArray<mixed>;
                                     ^^^^^^^^^^^^ [2]
-   <BUILTINS>/core.js:1999:43
-   1999| type WeaklyReferenceable = interface {} | $ReadOnlyArray<mixed>;
+   <BUILTINS>/core.js:2004:43
+   2004| type WeaklyReferenceable = interface {} | $ReadOnlyArray<mixed>;
                                                    ^^^^^^^^^^^^^^^^^^^^^ [3]
 
 
@@ -286,11 +286,11 @@ Cannot call `WeakSet` because in type argument `T`: [incompatible-call]
                                    ^ [1]
 
 References:
-   <BUILTINS>/core.js:1999:28
-   1999| type WeaklyReferenceable = interface {} | $ReadOnlyArray<mixed>;
+   <BUILTINS>/core.js:2004:28
+   2004| type WeaklyReferenceable = interface {} | $ReadOnlyArray<mixed>;
                                     ^^^^^^^^^^^^ [2]
-   <BUILTINS>/core.js:1999:43
-   1999| type WeaklyReferenceable = interface {} | $ReadOnlyArray<mixed>;
+   <BUILTINS>/core.js:2004:43
+   2004| type WeaklyReferenceable = interface {} | $ReadOnlyArray<mixed>;
                                                    ^^^^^^^^^^^^^^^^^^^^^ [3]
 
 
@@ -306,11 +306,11 @@ Cannot call `WeakSet` because in type argument `T`: [incompatible-call]
                                       ^ [1]
 
 References:
-   <BUILTINS>/core.js:1999:28
-   1999| type WeaklyReferenceable = interface {} | $ReadOnlyArray<mixed>;
+   <BUILTINS>/core.js:2004:28
+   2004| type WeaklyReferenceable = interface {} | $ReadOnlyArray<mixed>;
                                     ^^^^^^^^^^^^ [2]
-   <BUILTINS>/core.js:1999:43
-   1999| type WeaklyReferenceable = interface {} | $ReadOnlyArray<mixed>;
+   <BUILTINS>/core.js:2004:43
+   2004| type WeaklyReferenceable = interface {} | $ReadOnlyArray<mixed>;
                                                    ^^^^^^^^^^^^^^^^^^^^^ [3]
 
 
@@ -329,11 +329,11 @@ References:
    weakset.js:24:31
      24| function* numbers(): Iterable<number> {
                                        ^^^^^^ [1]
-   <BUILTINS>/core.js:1999:28
-   1999| type WeaklyReferenceable = interface {} | $ReadOnlyArray<mixed>;
+   <BUILTINS>/core.js:2004:28
+   2004| type WeaklyReferenceable = interface {} | $ReadOnlyArray<mixed>;
                                     ^^^^^^^^^^^^ [2]
-   <BUILTINS>/core.js:1999:43
-   1999| type WeaklyReferenceable = interface {} | $ReadOnlyArray<mixed>;
+   <BUILTINS>/core.js:2004:43
+   2004| type WeaklyReferenceable = interface {} | $ReadOnlyArray<mixed>;
                                                    ^^^^^^^^^^^^^^^^^^^^^ [3]
 
 

--- a/tests/date/date.exp
+++ b/tests/date/date.exp
@@ -7,8 +7,8 @@ Cannot assign `d.getTime()` to `x` because number [1] is incompatible with strin
                         ^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:1503:16
-   1503|     getTime(): number;
+   <BUILTINS>/core.js:1508:16
+   1508|     getTime(): number;
                         ^^^^^^ [1]
    date.js:2:7
       2| var x:string = d.getTime(); // expect error
@@ -46,11 +46,11 @@ References:
    date.js:18:10
      18| new Date({});
                   ^^ [1]
-   <BUILTINS>/core.js:1485:23
-   1485|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
+   <BUILTINS>/core.js:1490:23
+   1490|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
                                ^^^^^^ [2]
-   <BUILTINS>/core.js:1483:5
-   1483|     constructor(): void;
+   <BUILTINS>/core.js:1488:5
+   1488|     constructor(): void;
              ^^^^^^^^^^^^^^^^^^^ [3]
 
 
@@ -68,11 +68,11 @@ References:
    date.js:19:16
      19| new Date(2015, '6');
                         ^^^ [1]
-   <BUILTINS>/core.js:1485:38
-   1485|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
+   <BUILTINS>/core.js:1490:38
+   1490|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
                                               ^^^^^^ [2]
-   <BUILTINS>/core.js:1483:5
-   1483|     constructor(): void;
+   <BUILTINS>/core.js:1488:5
+   1488|     constructor(): void;
              ^^^^^^^^^^^^^^^^^^^ [3]
 
 
@@ -90,11 +90,11 @@ References:
    date.js:20:19
      20| new Date(2015, 6, '18');
                            ^^^^ [1]
-   <BUILTINS>/core.js:1485:52
-   1485|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
+   <BUILTINS>/core.js:1490:52
+   1490|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
                                                             ^^^^^^ [2]
-   <BUILTINS>/core.js:1483:5
-   1483|     constructor(): void;
+   <BUILTINS>/core.js:1488:5
+   1488|     constructor(): void;
              ^^^^^^^^^^^^^^^^^^^ [3]
 
 
@@ -112,11 +112,11 @@ References:
    date.js:21:23
      21| new Date(2015, 6, 18, '11');
                                ^^^^ [1]
-   <BUILTINS>/core.js:1485:67
-   1485|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
+   <BUILTINS>/core.js:1490:67
+   1490|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
                                                                            ^^^^^^ [2]
-   <BUILTINS>/core.js:1483:5
-   1483|     constructor(): void;
+   <BUILTINS>/core.js:1488:5
+   1488|     constructor(): void;
              ^^^^^^^^^^^^^^^^^^^ [3]
 
 
@@ -134,11 +134,11 @@ References:
    date.js:22:27
      22| new Date(2015, 6, 18, 11, '55');
                                    ^^^^ [1]
-   <BUILTINS>/core.js:1485:84
-   1485|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
+   <BUILTINS>/core.js:1490:84
+   1490|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
                                                                                             ^^^^^^ [2]
-   <BUILTINS>/core.js:1483:5
-   1483|     constructor(): void;
+   <BUILTINS>/core.js:1488:5
+   1488|     constructor(): void;
              ^^^^^^^^^^^^^^^^^^^ [3]
 
 
@@ -156,11 +156,11 @@ References:
    date.js:23:31
      23| new Date(2015, 6, 18, 11, 55, '42');
                                        ^^^^ [1]
-   <BUILTINS>/core.js:1485:101
-   1485|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
+   <BUILTINS>/core.js:1490:101
+   1490|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
                                                                                                              ^^^^^^ [2]
-   <BUILTINS>/core.js:1483:5
-   1483|     constructor(): void;
+   <BUILTINS>/core.js:1488:5
+   1488|     constructor(): void;
              ^^^^^^^^^^^^^^^^^^^ [3]
 
 
@@ -178,11 +178,11 @@ References:
    date.js:24:35
      24| new Date(2015, 6, 18, 11, 55, 42, '999');
                                            ^^^^^ [1]
-   <BUILTINS>/core.js:1485:123
-   1485|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
+   <BUILTINS>/core.js:1490:123
+   1490|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
                                                                                                                                    ^^^^^^ [2]
-   <BUILTINS>/core.js:1483:5
-   1483|     constructor(): void;
+   <BUILTINS>/core.js:1488:5
+   1488|     constructor(): void;
              ^^^^^^^^^^^^^^^^^^^ [3]
 
 
@@ -198,14 +198,14 @@ Cannot call `Date` because: [incompatible-call]
              ^^^^
 
 References:
-   <BUILTINS>/core.js:1483:5
-   1483|     constructor(): void;
+   <BUILTINS>/core.js:1488:5
+   1488|     constructor(): void;
              ^^^^^^^^^^^^^^^^^^^ [1]
-   <BUILTINS>/core.js:1484:5
-   1484|     constructor(value: number | Date | string): void;
+   <BUILTINS>/core.js:1489:5
+   1489|     constructor(value: number | Date | string): void;
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [2]
-   <BUILTINS>/core.js:1485:5
-   1485|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
+   <BUILTINS>/core.js:1490:5
+   1490|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [3]
 
 
@@ -223,11 +223,11 @@ References:
    date.js:26:10
      26| new Date('2015', 6);
                   ^^^^^^ [1]
-   <BUILTINS>/core.js:1485:23
-   1485|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
+   <BUILTINS>/core.js:1490:23
+   1490|     constructor(year: number, month: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number): void;
                                ^^^^^^ [2]
-   <BUILTINS>/core.js:1483:5
-   1483|     constructor(): void;
+   <BUILTINS>/core.js:1488:5
+   1488|     constructor(): void;
              ^^^^^^^^^^^^^^^^^^^ [3]
 
 

--- a/tests/declare_namespace/declare_namespace.exp
+++ b/tests/declare_namespace/declare_namespace.exp
@@ -493,8 +493,8 @@ Cannot cast `Array` to `Node` because: [incompatible-cast]
           ^^^^^
 
 References:
-   <BUILTINS>/core.js:946:15
-   946| declare class Array<T> extends $ReadOnlyArray<T> {
+   <BUILTINS>/core.js:951:15
+   951| declare class Array<T> extends $ReadOnlyArray<T> {
                       ^^^^^ [1]
    <BUILTINS>/react.js:21:5
     21|   | React$Element<any>
@@ -519,8 +519,8 @@ Cannot cast `Array` to `Node` because: [incompatible-cast]
           ^^^^^
 
 References:
-   <BUILTINS>/core.js:946:15
-   946| declare class Array<T> extends $ReadOnlyArray<T> {
+   <BUILTINS>/core.js:951:15
+   951| declare class Array<T> extends $ReadOnlyArray<T> {
                       ^^^^^ [1]
    <BUILTINS>/react.js:21:5
     21|   | React$Element<any>

--- a/tests/enums/enums.exp
+++ b/tests/enums/enums.exp
@@ -48,20 +48,20 @@ Cannot instantiate `EnumValue` because in type argument `TRepresentationType`: [
                           ^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:3017:32
-   3017| type EnumRepresentationTypes = string | number | symbol | boolean | bigint;
+   <BUILTINS>/core.js:3041:32
+   3041| type EnumRepresentationTypes = string | number | symbol | boolean | bigint;
                                         ^^^^^^ [2]
-   <BUILTINS>/core.js:3017:41
-   3017| type EnumRepresentationTypes = string | number | symbol | boolean | bigint;
+   <BUILTINS>/core.js:3041:41
+   3041| type EnumRepresentationTypes = string | number | symbol | boolean | bigint;
                                                  ^^^^^^ [3]
-   <BUILTINS>/core.js:3017:50
-   3017| type EnumRepresentationTypes = string | number | symbol | boolean | bigint;
+   <BUILTINS>/core.js:3041:50
+   3041| type EnumRepresentationTypes = string | number | symbol | boolean | bigint;
                                                           ^^^^^^ [4]
-   <BUILTINS>/core.js:3017:59
-   3017| type EnumRepresentationTypes = string | number | symbol | boolean | bigint;
+   <BUILTINS>/core.js:3041:59
+   3041| type EnumRepresentationTypes = string | number | symbol | boolean | bigint;
                                                                    ^^^^^^^ [5]
-   <BUILTINS>/core.js:3017:69
-   3017| type EnumRepresentationTypes = string | number | symbol | boolean | bigint;
+   <BUILTINS>/core.js:3041:69
+   3041| type EnumRepresentationTypes = string | number | symbol | boolean | bigint;
                                                                              ^^^^^^ [6]
 
 
@@ -143,8 +143,8 @@ Cannot cast `x` to `EnumValue` because number [1] is incompatible with boolean [
            ^
 
 References:
-   <BUILTINS>/core.js:3031:16
-   3031| > = $EnumValue<TRepresentationType>;
+   <BUILTINS>/core.js:3055:16
+   3055| > = $EnumValue<TRepresentationType>;
                         ^^^^^^^^^^^^^^^^^^^ [1]
    abstract-enum-value.js:35:18
      35|   x as EnumValue<boolean>; // ERROR
@@ -161,8 +161,8 @@ Cannot cast `x` to `EnumValue` because string [1] is incompatible with boolean [
            ^
 
 References:
-   <BUILTINS>/core.js:3031:16
-   3031| > = $EnumValue<TRepresentationType>;
+   <BUILTINS>/core.js:3055:16
+   3055| > = $EnumValue<TRepresentationType>;
                         ^^^^^^^^^^^^^^^^^^^ [1]
    abstract-enum-value.js:35:18
      35|   x as EnumValue<boolean>; // ERROR
@@ -232,8 +232,8 @@ Cannot instantiate `Enum` because boolean [1] is incompatible with `EnumValue` [
                        ^^^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:3048:24
-   3048| type Enum<+TEnumValue: EnumValue<> = EnumValue<>> = $Enum<TEnumValue>;
+   <BUILTINS>/core.js:3072:24
+   3072| type Enum<+TEnumValue: EnumValue<> = EnumValue<>> = $Enum<TEnumValue>;
                                 ^^^^^^^^^^^ [2]
 
 
@@ -270,11 +270,11 @@ References:
    abstract-enum.js:19:23
      19|   x as Enum<EnumValue<boolean>>; // ERROR
                                ^^^^^^^ [2]
-   <BUILTINS>/core.js:3030:4
-   3030|   +TRepresentationType: EnumRepresentationTypes = EnumRepresentationTypes
+   <BUILTINS>/core.js:3054:4
+   3054|   +TRepresentationType: EnumRepresentationTypes = EnumRepresentationTypes
             ^^^^^^^^^^^^^^^^^^^ [3]
-   <BUILTINS>/core.js:3048:12
-   3048| type Enum<+TEnumValue: EnumValue<> = EnumValue<>> = $Enum<TEnumValue>;
+   <BUILTINS>/core.js:3072:12
+   3072| type Enum<+TEnumValue: EnumValue<> = EnumValue<>> = $Enum<TEnumValue>;
                     ^^^^^^^^^^ [4]
 
 
@@ -294,8 +294,8 @@ References:
    abstract-enum.js:20:13
      20|   x as Enum<E>; // ERROR
                      ^ [2]
-   <BUILTINS>/core.js:3048:12
-   3048| type Enum<+TEnumValue: EnumValue<> = EnumValue<>> = $Enum<TEnumValue>;
+   <BUILTINS>/core.js:3072:12
+   3072| type Enum<+TEnumValue: EnumValue<> = EnumValue<>> = $Enum<TEnumValue>;
                     ^^^^^^^^^^ [3]
 
 
@@ -338,8 +338,8 @@ Cannot call `f` because boolean [1] is incompatible with `EnumValue` [2] in type
            ^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:3048:24
-   3048| type Enum<+TEnumValue: EnumValue<> = EnumValue<>> = $Enum<TEnumValue>;
+   <BUILTINS>/core.js:3072:24
+   3072| type Enum<+TEnumValue: EnumValue<> = EnumValue<>> = $Enum<TEnumValue>;
                                 ^^^^^^^^^^^ [2]
 
 
@@ -1738,8 +1738,8 @@ implicitly-returned undefined in type argument `Return` [2]. [incompatible-retur
                                             ^^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:1920:24
-   1920| type Generator<+Yield,+Return,-Next> = $Generator<Yield,Return,Next>;
+   <BUILTINS>/core.js:1925:24
+   1925| type Generator<+Yield,+Return,-Next> = $Generator<Yield,Return,Next>;
                                 ^^^^^^ [2]
 
 
@@ -1768,8 +1768,8 @@ undefined in type argument `R` [2]. [incompatible-return]
                                          ^^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:2143:24
-   2143| declare class Promise<+R = mixed> {
+   <BUILTINS>/core.js:2148:24
+   2148| declare class Promise<+R = mixed> {
                                 ^ [2]
 
 
@@ -1903,8 +1903,8 @@ References:
    exhaustive-check.js:3:6
       3| enum E {
               ^ [2]
-   <BUILTINS>/core.js:2818:3
-   2818|   isValid(this: TEnum, input: ?TRepresentationType | TEnumValue): boolean,
+   <BUILTINS>/core.js:2842:3
+   2842|   isValid(this: TEnum, input: ?TRepresentationType | TEnumValue): boolean,
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [3]
 
 
@@ -2622,15 +2622,15 @@ Cannot get `E.nonExistent` because property `nonExistent` is missing in `$EnumPr
            ^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:2815:59
+   <BUILTINS>/core.js:2839:59
                                                                    v-
-   2815| type $EnumProto<TEnum, TEnumValue, TRepresentationType> = {|
-   2816|   cast(this: TEnum, input: ?TRepresentationType): void | TEnumValue,
-   2817|   getName(this: TEnum, input: TEnumValue): string,
-   2818|   isValid(this: TEnum, input: ?TRepresentationType | TEnumValue): boolean,
-   2819|   members(this: TEnum): Iterator<TEnumValue>,
-   2820|   __proto__: null,
-   2821| |}
+   2839| type $EnumProto<TEnum, TEnumValue, TRepresentationType> = {|
+   2840|   cast(this: TEnum, input: ?TRepresentationType): void | TEnumValue,
+   2841|   getName(this: TEnum, input: TEnumValue): string,
+   2842|   isValid(this: TEnum, input: ?TRepresentationType | TEnumValue): boolean,
+   2843|   members(this: TEnum): Iterator<TEnumValue>,
+   2844|   __proto__: null,
+   2845| |}
          -^ [1]
 
 
@@ -2643,15 +2643,15 @@ Cannot call `E.nonExistent` because property `nonExistent` is missing in `$EnumP
            ^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:2815:59
+   <BUILTINS>/core.js:2839:59
                                                                    v-
-   2815| type $EnumProto<TEnum, TEnumValue, TRepresentationType> = {|
-   2816|   cast(this: TEnum, input: ?TRepresentationType): void | TEnumValue,
-   2817|   getName(this: TEnum, input: TEnumValue): string,
-   2818|   isValid(this: TEnum, input: ?TRepresentationType | TEnumValue): boolean,
-   2819|   members(this: TEnum): Iterator<TEnumValue>,
-   2820|   __proto__: null,
-   2821| |}
+   2839| type $EnumProto<TEnum, TEnumValue, TRepresentationType> = {|
+   2840|   cast(this: TEnum, input: ?TRepresentationType): void | TEnumValue,
+   2841|   getName(this: TEnum, input: TEnumValue): string,
+   2842|   isValid(this: TEnum, input: ?TRepresentationType | TEnumValue): boolean,
+   2843|   members(this: TEnum): Iterator<TEnumValue>,
+   2844|   __proto__: null,
+   2845| |}
          -^ [1]
 
 
@@ -2678,15 +2678,15 @@ Cannot call `E.A` because property `A` is missing in `$EnumProto` [1]. [prop-mis
            ^
 
 References:
-   <BUILTINS>/core.js:2815:59
+   <BUILTINS>/core.js:2839:59
                                                                    v-
-   2815| type $EnumProto<TEnum, TEnumValue, TRepresentationType> = {|
-   2816|   cast(this: TEnum, input: ?TRepresentationType): void | TEnumValue,
-   2817|   getName(this: TEnum, input: TEnumValue): string,
-   2818|   isValid(this: TEnum, input: ?TRepresentationType | TEnumValue): boolean,
-   2819|   members(this: TEnum): Iterator<TEnumValue>,
-   2820|   __proto__: null,
-   2821| |}
+   2839| type $EnumProto<TEnum, TEnumValue, TRepresentationType> = {|
+   2840|   cast(this: TEnum, input: ?TRepresentationType): void | TEnumValue,
+   2841|   getName(this: TEnum, input: TEnumValue): string,
+   2842|   isValid(this: TEnum, input: ?TRepresentationType | TEnumValue): boolean,
+   2843|   members(this: TEnum): Iterator<TEnumValue>,
+   2844|   __proto__: null,
+   2845| |}
          -^ [1]
 
 
@@ -2699,15 +2699,15 @@ Cannot call `E.toString` because property `toString` is missing in `$EnumProto` 
            ^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:2815:59
+   <BUILTINS>/core.js:2839:59
                                                                    v-
-   2815| type $EnumProto<TEnum, TEnumValue, TRepresentationType> = {|
-   2816|   cast(this: TEnum, input: ?TRepresentationType): void | TEnumValue,
-   2817|   getName(this: TEnum, input: TEnumValue): string,
-   2818|   isValid(this: TEnum, input: ?TRepresentationType | TEnumValue): boolean,
-   2819|   members(this: TEnum): Iterator<TEnumValue>,
-   2820|   __proto__: null,
-   2821| |}
+   2839| type $EnumProto<TEnum, TEnumValue, TRepresentationType> = {|
+   2840|   cast(this: TEnum, input: ?TRepresentationType): void | TEnumValue,
+   2841|   getName(this: TEnum, input: TEnumValue): string,
+   2842|   isValid(this: TEnum, input: ?TRepresentationType | TEnumValue): boolean,
+   2843|   members(this: TEnum): Iterator<TEnumValue>,
+   2844|   __proto__: null,
+   2845| |}
          -^ [1]
 
 
@@ -2720,8 +2720,8 @@ Cannot cast `E.getName(...)` to boolean because string [1] is incompatible with 
          ^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:2817:44
-   2817|   getName(this: TEnum, input: TEnumValue): string,
+   <BUILTINS>/core.js:2841:44
+   2841|   getName(this: TEnum, input: TEnumValue): string,
                                                     ^^^^^^ [1]
    methods.js:44:19
      44| E.getName(E.B) as boolean; // Error - wrong type

--- a/tests/forof/forof.exp
+++ b/tests/forof/forof.exp
@@ -45,8 +45,8 @@ References:
    forof.js:23:26
      23| function testString(str: string): void {
                                   ^^^^^^ [1]
-   <BUILTINS>/core.js:1906:11
-   1906| interface $Iterable<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:1911:11
+   1911| interface $Iterable<+Yield,+Return,-Next> {
                    ^^^^^^^^^ [2]
 
 
@@ -59,8 +59,8 @@ Cannot cast `elem` to number because tuple type [1] is incompatible with number 
              ^^^^
 
 References:
-   <BUILTINS>/core.js:1973:28
-   1973|     @@iterator(): Iterator<[K, V]>;
+   <BUILTINS>/core.js:1978:28
+   1978|     @@iterator(): Iterator<[K, V]>;
                                     ^^^^^^ [1]
    forof.js:32:13
      32|     elem as number; // Error - tuple ~> number

--- a/tests/function/function.exp
+++ b/tests/function/function.exp
@@ -43,8 +43,8 @@ it into an object and attempt to use it as a subtype of an interface. [incompati
                         ^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:1906:11
-   1906| interface $Iterable<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:1911:11
+   1911| interface $Iterable<+Yield,+Return,-Next> {
                    ^^^^^^^^^ [2]
 
 
@@ -111,8 +111,8 @@ argument `A`. [prop-missing]
                         ^^^^^
 
 References:
-   <BUILTINS>/core.js:1920:40
-   1920| type Generator<+Yield,+Return,-Next> = $Generator<Yield,Return,Next>;
+   <BUILTINS>/core.js:1925:40
+   1925| type Generator<+Yield,+Return,-Next> = $Generator<Yield,Return,Next>;
                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
    <BUILTINS>/core.js:362:29
     362|     proto apply: (<T, R, A: $ArrayLike<mixed> = []>(this: (this: T, ...args: A) => R, thisArg: T, args?: A) => R);
@@ -242,8 +242,8 @@ it into an object and attempt to use it as a subtype of an interface. [incompati
                         ^^^^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:1906:11
-   1906| interface $Iterable<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:1911:11
+   1911| interface $Iterable<+Yield,+Return,-Next> {
                    ^^^^^^^^^ [2]
 
 

--- a/tests/generators/generators.exp
+++ b/tests/generators/generators.exp
@@ -42,8 +42,8 @@ References:
    class.js:23:39
      23|   *stmt_return_err(): Generator<void, number, void> {
                                                ^^^^^^ [2]
-   <BUILTINS>/core.js:1920:24
-   1920| type Generator<+Yield,+Return,-Next> = $Generator<Yield,Return,Next>;
+   <BUILTINS>/core.js:1925:24
+   1925| type Generator<+Yield,+Return,-Next> = $Generator<Yield,Return,Next>;
                                 ^^^^^^ [3]
 
 
@@ -125,14 +125,14 @@ of property `@@iterator`. [incompatible-type-arg]
                     ^^
 
 References:
-   <BUILTINS>/core.js:1800:50
-   1800| declare class Iterator<+Yield,+Return=void,-Next=void> implements $IteratorProtocol<Yield,Return,Next>, $Iterable<Yield,Return,Next> {
+   <BUILTINS>/core.js:1805:50
+   1805| declare class Iterator<+Yield,+Return=void,-Next=void> implements $IteratorProtocol<Yield,Return,Next>, $Iterable<Yield,Return,Next> {
                                                           ^^^^ [1]
    class.js:71:71
      71|   *delegate_next_iterable(xs: Array<number>): Generator<number, void, string> {
                                                                                ^^^^^^ [2]
-   <BUILTINS>/core.js:1790:50
-   1790| interface $IteratorProtocol<+Yield,+Return=void,-Next=void> {
+   <BUILTINS>/core.js:1795:50
+   1795| interface $IteratorProtocol<+Yield,+Return=void,-Next=void> {
                                                           ^^^^ [3]
 
 
@@ -374,8 +374,8 @@ References:
    generators.js:22:46
      22| function *stmt_return_err(): Generator<void, number, void> {
                                                       ^^^^^^ [2]
-   <BUILTINS>/core.js:1920:24
-   1920| type Generator<+Yield,+Return,-Next> = $Generator<Yield,Return,Next>;
+   <BUILTINS>/core.js:1925:24
+   1925| type Generator<+Yield,+Return,-Next> = $Generator<Yield,Return,Next>;
                                 ^^^^^^ [3]
 
 
@@ -679,8 +679,8 @@ Cannot cast `refuse_return_result.value` to string because undefined [1] is inco
             ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:1777:14
-   1777|     +value?: Return,
+   <BUILTINS>/core.js:1782:14
+   1782|     +value?: Return,
                       ^^^^^^ [1]
    return.js:20:32
      20|   (refuse_return_result.value: string); // error: number | void ~> string

--- a/tests/generic_escape/generic_escape.exp
+++ b/tests/generic_escape/generic_escape.exp
@@ -431,8 +431,8 @@ the expression to your expected type. [underconstrained-implicit-instantiation]
                     ^^^^^
 
 References:
-   <BUILTINS>/core.js:946:21
-   946| declare class Array<T> extends $ReadOnlyArray<T> {
+   <BUILTINS>/core.js:951:21
+   951| declare class Array<T> extends $ReadOnlyArray<T> {
                             ^ [1]
    misc.js:3:9
      3| var e = new Array(10);

--- a/tests/generic_zeroed/generic_zeroed.exp
+++ b/tests/generic_zeroed/generic_zeroed.exp
@@ -77,11 +77,11 @@ References:
    reduce.js:7:22
       7|   return nums.reduce<T>(
                               ^ [2]
-   <BUILTINS>/core.js:1055:5
+   <BUILTINS>/core.js:1060:5
              v------
-   1055|     reduce(
-   1056|       callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: Array<T>) => T,
-   1057|     ): T;
+   1060|     reduce(
+   1061|       callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: Array<T>) => T,
+   1062|     ): T;
              ---^ [3]
 
 

--- a/tests/get_def_enums/get_def_enums.exp
+++ b/tests/get_def_enums/get_def_enums.exp
@@ -28,9 +28,9 @@ library.js:4:3,4:5
 
 main.js:27:13
 Flags:
-[LIB] core.js:2816:3,2816:6
+[LIB] core.js:2840:3,2840:6
 
 main.js:30:13
 Flags:
-[LIB] core.js:2818:3,2818:9
+[LIB] core.js:2842:3,2842:9
 

--- a/tests/global_this/global_this.exp
+++ b/tests/global_this/global_this.exp
@@ -79,8 +79,8 @@ Cannot cast `Array` to `Node` because: [incompatible-cast]
         ^^^^^
 
 References:
-   <BUILTINS>/core.js:946:15
-   946| declare class Array<T> extends $ReadOnlyArray<T> {
+   <BUILTINS>/core.js:951:15
+   951| declare class Array<T> extends $ReadOnlyArray<T> {
                       ^^^^^ [1]
    <BUILTINS>/react.js:21:5
     21|   | React$Element<any>

--- a/tests/interface/interface.exp
+++ b/tests/interface/interface.exp
@@ -884,8 +884,8 @@ References:
    string.js:1:18
       1| declare const s: string;
                           ^^^^^^ [1]
-   <BUILTINS>/core.js:1906:11
-   1906| interface $Iterable<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:1911:11
+   1911| interface $Iterable<+Yield,+Return,-Next> {
                    ^^^^^^^^^ [2]
 
 

--- a/tests/iterable/iterable.exp
+++ b/tests/iterable/iterable.exp
@@ -14,8 +14,8 @@ References:
    array.js:7:20
       7| ['hi'] as Iterable<number>; // Error string ~> number
                             ^^^^^^ [2]
-   <BUILTINS>/core.js:1790:30
-   1790| interface $IteratorProtocol<+Yield,+Return=void,-Next=void> {
+   <BUILTINS>/core.js:1795:30
+   1795| interface $IteratorProtocol<+Yield,+Return=void,-Next=void> {
                                       ^^^^^ [3]
 
 
@@ -35,8 +35,8 @@ References:
    array.js:8:23
       8| ['hi', 1] as Iterable<string>; // Error number ~> string
                                ^^^^^^ [2]
-   <BUILTINS>/core.js:1790:30
-   1790| interface $IteratorProtocol<+Yield,+Return=void,-Next=void> {
+   <BUILTINS>/core.js:1795:30
+   1795| interface $IteratorProtocol<+Yield,+Return=void,-Next=void> {
                                       ^^^^^ [3]
 
 
@@ -56,8 +56,8 @@ References:
    caching_bug.js:21:62
      21| function miss_the_cache(x: Array<string | number>): Iterable<string> { return x; }
                                                                       ^^^^^^ [2]
-   <BUILTINS>/core.js:1790:30
-   1790| interface $IteratorProtocol<+Yield,+Return=void,-Next=void> {
+   <BUILTINS>/core.js:1795:30
+   1795| interface $IteratorProtocol<+Yield,+Return=void,-Next=void> {
                                       ^^^^^ [3]
 
 
@@ -86,13 +86,13 @@ Cannot return object literal because property `value` is missing in object liter
                         ^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:1780:5
+   <BUILTINS>/core.js:1785:5
              v
-   1780|   | {
-   1781|     done: false,
-   1782|     +value: Yield,
-   1783|     ...
-   1784| };
+   1785|   | {
+   1786|     done: false,
+   1787|     +value: Yield,
+   1788|     ...
+   1789| };
          ^ [2]
 
 
@@ -106,14 +106,14 @@ value of property `@@iterator`. [incompatible-return]
                   ^^^
 
 References:
-   <BUILTINS>/core.js:1973:28
-   1973|     @@iterator(): Iterator<[K, V]>;
+   <BUILTINS>/core.js:1978:28
+   1978|     @@iterator(): Iterator<[K, V]>;
                                     ^^^^^^ [1]
    map.js:13:55
      13| function mapTest4(map: Map<number, string>): Iterable<string> {
                                                                ^^^^^^ [2]
-   <BUILTINS>/core.js:1790:30
-   1790| interface $IteratorProtocol<+Yield,+Return=void,-Next=void> {
+   <BUILTINS>/core.js:1795:30
+   1795| interface $IteratorProtocol<+Yield,+Return=void,-Next=void> {
                                       ^^^^^ [3]
 
 
@@ -133,8 +133,8 @@ References:
    set.js:13:47
      13| function setTest4(set: Set<string>): Iterable<number> {
                                                        ^^^^^^ [2]
-   <BUILTINS>/core.js:1790:30
-   1790| interface $IteratorProtocol<+Yield,+Return=void,-Next=void> {
+   <BUILTINS>/core.js:1795:30
+   1795| interface $IteratorProtocol<+Yield,+Return=void,-Next=void> {
                                       ^^^^^ [3]
 
 
@@ -148,14 +148,14 @@ Cannot cast `new String(...)` to `Iterable` because string [1] is incompatible w
           ^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:1209:28
-   1209|     @@iterator(): Iterator<string>;
+   <BUILTINS>/core.js:1214:28
+   1214|     @@iterator(): Iterator<string>;
                                     ^^^^^^ [1]
    string.js:3:29
       3| (new String("hi"): Iterable<number>); // Error - string is a Iterable<string>
                                      ^^^^^^ [2]
-   <BUILTINS>/core.js:1790:30
-   1790| interface $IteratorProtocol<+Yield,+Return=void,-Next=void> {
+   <BUILTINS>/core.js:1795:30
+   1795| interface $IteratorProtocol<+Yield,+Return=void,-Next=void> {
                                       ^^^^^ [3]
 
 

--- a/tests/lib/lib.exp
+++ b/tests/lib/lib.exp
@@ -41,8 +41,8 @@ Cannot assign `(new TypeError()).name` to `z` because string [1] is incompatible
                         ^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:1689:11
-   1689|     name: string;
+   <BUILTINS>/core.js:1694:11
+   1694|     name: string;
                    ^^^^^^ [1]
    libtest.js:3:7
       3| var z:number = new TypeError().name;

--- a/tests/local_inference_annotations/local_inference_annotations.exp
+++ b/tests/local_inference_annotations/local_inference_annotations.exp
@@ -63,8 +63,8 @@ Property `@@iterator` is missing in function [1] but exists in `$Iterable` [2]. 
                 ^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:1906:11
-   1906| interface $Iterable<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:1911:11
+   1911| interface $Iterable<+Yield,+Return,-Next> {
                    ^^^^^^^^^ [2]
 
 
@@ -546,8 +546,8 @@ Property `@@iterator` is missing in function [1] but exists in `$Iterable` [2]. 
                           ^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:1906:11
-   1906| interface $Iterable<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:1911:11
+   1911| interface $Iterable<+Yield,+Return,-Next> {
                    ^^^^^^^^^ [2]
 
 

--- a/tests/lti_friendly_errors/lti_friendly_errors.exp
+++ b/tests/lti_friendly_errors/lti_friendly_errors.exp
@@ -8,14 +8,14 @@ in type argument `R` [3]. [incompatible-cast]
           ^
 
 References:
-   <BUILTINS>/core.js:2143:28
-   2143| declare class Promise<+R = mixed> {
+   <BUILTINS>/core.js:2148:28
+   2148| declare class Promise<+R = mixed> {
                                     ^^^^^ [1]
    reason_of_inferred_targs.js:2:13
       2| (p: Promise<string>); // error
                      ^^^^^^ [2]
-   <BUILTINS>/core.js:2143:24
-   2143| declare class Promise<+R = mixed> {
+   <BUILTINS>/core.js:2148:24
+   2148| declare class Promise<+R = mixed> {
                                 ^ [3]
 
 

--- a/tests/lti_implicit_instantiation/lti_implicit_instantiation.exp
+++ b/tests/lti_implicit_instantiation/lti_implicit_instantiation.exp
@@ -292,8 +292,8 @@ the expression to your expected type. [underconstrained-implicit-instantiation]
             ^^^^^
 
 References:
-   <BUILTINS>/core.js:946:21
-   946| declare class Array<T> extends $ReadOnlyArray<T> {
+   <BUILTINS>/core.js:951:21
+   951| declare class Array<T> extends $ReadOnlyArray<T> {
                             ^ [1]
    underconstrained_class_constructor.js:18:1
     18| new Array(1); // Error
@@ -811,8 +811,8 @@ Cannot get `r1.bad` because property `bad` is missing in `Array` [1]. [prop-miss
              ^^^
 
 References:
-   <BUILTINS>/core.js:946:15
-   946| declare class Array<T> extends $ReadOnlyArray<T> {
+   <BUILTINS>/core.js:951:15
+   951| declare class Array<T> extends $ReadOnlyArray<T> {
                       ^^^^^ [1]
 
 
@@ -859,8 +859,8 @@ Cannot get `r2.bad` because property `bad` is missing in `Array` [1]. [prop-miss
              ^^^
 
 References:
-   <BUILTINS>/core.js:946:15
-   946| declare class Array<T> extends $ReadOnlyArray<T> {
+   <BUILTINS>/core.js:951:15
+   951| declare class Array<T> extends $ReadOnlyArray<T> {
                       ^^^^^ [1]
 
 

--- a/tests/mapped_type_utilities/mapped_type_utilities.exp
+++ b/tests/mapped_type_utilities/mapped_type_utilities.exp
@@ -153,8 +153,8 @@ Cannot cast `pickedO1.bar` to string because undefined [1] is incompatible with 
           ^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:2993:62
-   2993| type Pick<O: interface {}, Keys: $Keys<O>> = {[key in Keys]: O[key]};
+   <BUILTINS>/core.js:3017:62
+   3017| type Pick<O: interface {}, Keys: $Keys<O>> = {[key in Keys]: O[key]};
                                                                       ^^^^^^ [1]
    pick.js:9:16
       9| (pickedO1.bar: string); // ERROR bar is optional

--- a/tests/meta_property/meta_property.exp
+++ b/tests/meta_property/meta_property.exp
@@ -8,13 +8,13 @@ Cannot cast `import.meta` to number literal `1` because `Import$Meta` [1] is inc
           ^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:2926:20
+   <BUILTINS>/core.js:2950:20
                             v
-   2926| type Import$Meta = {
-   2927|   [string]: mixed,
-   2928|   url?: string,
-   2929|   ...
-   2930| };
+   2950| type Import$Meta = {
+   2951|   [string]: mixed,
+   2952|   url?: string,
+   2953|   ...
+   2954| };
          ^ [1]
    import_meta.js:5:15
       5| (import.meta: 1); // Error
@@ -31,8 +31,8 @@ Cannot cast `import.meta.XXX` to number literal `1` because mixed [1] is incompa
           ^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:2927:13
-   2927|   [string]: mixed,
+   <BUILTINS>/core.js:2951:13
+   2951|   [string]: mixed,
                      ^^^^^ [1]
    import_meta.js:6:19
       6| (import.meta.XXX: 1); // Error

--- a/tests/natural_inference_primitive/natural_inference_primitive.exp
+++ b/tests/natural_inference_primitive/natural_inference_primitive.exp
@@ -2509,8 +2509,8 @@ References:
    local.js:643:77
     643|     fn: (...args: Parameters<() => Set<'A' | 'B'>>) => ReturnType<() => Set<'A' | 'B'>>,
                                                                                      ^^^^^^^^^ [2]
-   <BUILTINS>/core.js:1790:30
-   1790| interface $IteratorProtocol<+Yield,+Return=void,-Next=void> {
+   <BUILTINS>/core.js:1795:30
+   1795| interface $IteratorProtocol<+Yield,+Return=void,-Next=void> {
                                       ^^^^^ [3]
 
 

--- a/tests/new_env/new_env.exp
+++ b/tests/new_env/new_env.exp
@@ -205,12 +205,12 @@ Cannot call `Promise` because function [1] requires another argument. [incompati
                      ^^^^^^^
 
 References:
-   <BUILTINS>/core.js:2144:5
+   <BUILTINS>/core.js:2149:5
              v----------------------
-   2144|     constructor(callback: (
-   2145|       resolve: (result: Promise<R> | R) => void,
-   2146|       reject: (error: any) => void
-   2147|     ) => mixed): void;
+   2149|     constructor(callback: (
+   2150|       resolve: (result: Promise<R> | R) => void,
+   2151|       reject: (error: any) => void
+   2152|     ) => mixed): void;
              ----------------^ [1]
 
 

--- a/tests/new_generics/new_generics.exp
+++ b/tests/new_generics/new_generics.exp
@@ -973,11 +973,11 @@ References:
    misc.js:69:32
      69|     <K: $Keys<TFormData>>(acc: {[K in keyof TFormData]: ?string}, k: K): {[K in keyof TFormData]: ?string} =>
                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [2]
-   <BUILTINS>/core.js:1055:5
+   <BUILTINS>/core.js:1060:5
              v------
-   1055|     reduce(
-   1056|       callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: Array<T>) => T,
-   1057|     ): T;
+   1060|     reduce(
+   1061|       callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: Array<T>) => T,
+   1062|     ): T;
              ---^ [3]
 
 

--- a/tests/new_merge/new_merge.exp
+++ b/tests/new_merge/new_merge.exp
@@ -299,8 +299,8 @@ Cannot cast `f15()` to empty because `Promise` [1] is incompatible with empty [2
          ^^^^^
 
 References:
-   <BUILTINS>/core.js:2143:15
-   2143| declare class Promise<+R = mixed> {
+   <BUILTINS>/core.js:2148:15
+   2148| declare class Promise<+R = mixed> {
                        ^^^^^^^ [1]
    main.js:58:10
      58| f15() as empty;

--- a/tests/no_source_error/no_source_error.exp
+++ b/tests/no_source_error/no_source_error.exp
@@ -18,8 +18,8 @@ References:
    no_source.js:13:8
     13|   +z : (x: FooPlus) => boolean = (x) => { return true; }
                ^^^^^^^^^^^^^^^^^^^^^^^ [3]
-   <BUILTINS>/core.js:985:24
-   985|     filter(callbackfn: typeof Boolean): Array<$NonMaybeType<T>>;
+   <BUILTINS>/core.js:990:24
+   990|     filter(callbackfn: typeof Boolean): Array<$NonMaybeType<T>>;
                                ^^^^^^^^^^^^^^ [4]
 
 

--- a/tests/object_api/object_api.exp
+++ b/tests/object_api/object_api.exp
@@ -975,8 +975,8 @@ Cannot assign `x.valueOf` to `xValueOf` because function type [1] is incompatibl
                                  ^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:1644:5
-   1644|     valueOf(): number;
+   <BUILTINS>/core.js:1649:5
+   1649|     valueOf(): number;
              ^^^^^^^^^^^^^^^^^ [1]
    object_prototype.js:122:16
     122| var xValueOf : number = x.valueOf; // error
@@ -993,8 +993,8 @@ Cannot get `x.valueOf` because property `valueOf` [1] cannot be unbound from the
                                    ^^^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:1644:5
-   1644|     valueOf(): number;
+   <BUILTINS>/core.js:1649:5
+   1649|     valueOf(): number;
              ^^^^^^^^^^^^^^^^^ [2]
 
 
@@ -1070,8 +1070,8 @@ Cannot assign `x.toLocaleString` to `xToLocaleString` because function type [1] 
                                         ^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:1632:5
-   1632|     toLocaleString(locales?: string | Array<string>, options?: Intl$DateTimeFormatOptions): string;
+   <BUILTINS>/core.js:1637:5
+   1637|     toLocaleString(locales?: string | Array<string>, options?: Intl$DateTimeFormatOptions): string;
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
    object_prototype.js:150:23
     150| var xToLocaleString : number = x.toLocaleString; // error
@@ -1088,8 +1088,8 @@ defined. [method-unbinding]
                                           ^^^^^^^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:1632:5
-   1632|     toLocaleString(locales?: string | Array<string>, options?: Intl$DateTimeFormatOptions): string;
+   <BUILTINS>/core.js:1637:5
+   1637|     toLocaleString(locales?: string | Array<string>, options?: Intl$DateTimeFormatOptions): string;
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [2]
 
 
@@ -1103,8 +1103,8 @@ value. [incompatible-type]
                                                ^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:1632:93
-   1632|     toLocaleString(locales?: string | Array<string>, options?: Intl$DateTimeFormatOptions): string;
+   <BUILTINS>/core.js:1637:93
+   1637|     toLocaleString(locales?: string | Array<string>, options?: Intl$DateTimeFormatOptions): string;
                                                                                                      ^^^^^^ [1]
    object_prototype.js:151:30
     151| var xToLocaleString2 : () => number = x.toLocaleString; // error
@@ -1121,8 +1121,8 @@ defined. [method-unbinding]
                                                  ^^^^^^^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:1632:5
-   1632|     toLocaleString(locales?: string | Array<string>, options?: Intl$DateTimeFormatOptions): string;
+   <BUILTINS>/core.js:1637:5
+   1637|     toLocaleString(locales?: string | Array<string>, options?: Intl$DateTimeFormatOptions): string;
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [2]
 
 

--- a/tests/overload/overload.exp
+++ b/tests/overload/overload.exp
@@ -29,8 +29,8 @@ Cannot assign `"".match(...)[0]` to `x1` because string [1] is incompatible with
                           ^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:1153:33
-   1153| type RegExp$matchResult = Array<string> & {
+   <BUILTINS>/core.js:1158:33
+   1158| type RegExp$matchResult = Array<string> & {
                                          ^^^^^^ [1]
    overload.js:7:9
       7| var x1: number = "".match(0)[0];
@@ -46,8 +46,8 @@ Cannot get `"".match(...)[0]` because null [1] does not have properties. [incomp
                                       ^
 
 References:
-   <BUILTINS>/core.js:1290:58
-   1290|     match(regexp: string | RegExp): RegExp$matchResult | null;
+   <BUILTINS>/core.js:1295:58
+   1295|     match(regexp: string | RegExp): RegExp$matchResult | null;
                                                                   ^^^^ [1]
 
 
@@ -62,11 +62,11 @@ Cannot call `"".match` with `0` bound to `regexp` because: [incompatible-call]
                                    ^ [1]
 
 References:
-   <BUILTINS>/core.js:1290:19
-   1290|     match(regexp: string | RegExp): RegExp$matchResult | null;
+   <BUILTINS>/core.js:1295:19
+   1295|     match(regexp: string | RegExp): RegExp$matchResult | null;
                            ^^^^^^ [2]
-   <BUILTINS>/core.js:1290:28
-   1290|     match(regexp: string | RegExp): RegExp$matchResult | null;
+   <BUILTINS>/core.js:1295:28
+   1295|     match(regexp: string | RegExp): RegExp$matchResult | null;
                                     ^^^^^^ [3]
 
 
@@ -79,8 +79,8 @@ Cannot assign `"".match(...)[0]` to `x2` because string [1] is incompatible with
                           ^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:1153:33
-   1153| type RegExp$matchResult = Array<string> & {
+   <BUILTINS>/core.js:1158:33
+   1158| type RegExp$matchResult = Array<string> & {
                                          ^^^^^^ [1]
    overload.js:8:9
       8| var x2: number = "".match(/pattern/)[0];
@@ -96,8 +96,8 @@ Cannot get `"".match(...)[0]` because null [1] does not have properties. [incomp
                                               ^
 
 References:
-   <BUILTINS>/core.js:1290:58
-   1290|     match(regexp: string | RegExp): RegExp$matchResult | null;
+   <BUILTINS>/core.js:1295:58
+   1295|     match(regexp: string | RegExp): RegExp$matchResult | null;
                                                                   ^^^^ [1]
 
 
@@ -110,8 +110,8 @@ Cannot assign `"".split(...)[0]` to `x4` because string [1] is incompatible with
                           ^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:1363:63
-   1363|     split(separator?: string | RegExp, limit?: number): Array<string>;
+   <BUILTINS>/core.js:1368:63
+   1368|     split(separator?: string | RegExp, limit?: number): Array<string>;
                                                                        ^^^^^^ [1]
    overload.js:10:9
      10| var x4: number = "".split(/pattern/)[0];

--- a/tests/promises/promises.exp
+++ b/tests/promises/promises.exp
@@ -7,8 +7,8 @@ Cannot cast `a` to number because string [1] is incompatible with number [2]. [i
             ^
 
 References:
-   <BUILTINS>/core.js:2206:58
-   2206|       T extends $ReadOnlyArray<mixed> ? {[K in keyof T]: Awaited<T[K]>} :
+   <BUILTINS>/core.js:2211:58
+   2211|       T extends $ReadOnlyArray<mixed> ? {[K in keyof T]: Awaited<T[K]>} :
                                                                   ^^^^^^^^^^^^^ [1]
    all.js:11:7
      11|   (a: number);  // Error: string ~> number
@@ -24,8 +24,8 @@ Cannot cast `b` to boolean because number [1] is incompatible with boolean [2]. 
             ^
 
 References:
-   <BUILTINS>/core.js:2206:58
-   2206|       T extends $ReadOnlyArray<mixed> ? {[K in keyof T]: Awaited<T[K]>} :
+   <BUILTINS>/core.js:2211:58
+   2211|       T extends $ReadOnlyArray<mixed> ? {[K in keyof T]: Awaited<T[K]>} :
                                                                   ^^^^^^^^^^^^^ [1]
    all.js:12:7
      12|   (b: boolean); // Error: number ~> boolean
@@ -41,8 +41,8 @@ Cannot cast `c` to string because boolean [1] is incompatible with string [2]. [
             ^
 
 References:
-   <BUILTINS>/core.js:2206:58
-   2206|       T extends $ReadOnlyArray<mixed> ? {[K in keyof T]: Awaited<T[K]>} :
+   <BUILTINS>/core.js:2211:58
+   2211|       T extends $ReadOnlyArray<mixed> ? {[K in keyof T]: Awaited<T[K]>} :
                                                                   ^^^^^^^^^^^^^ [1]
    all.js:13:7
      13|   (c: string);  // Error: boolean ~> string
@@ -58,8 +58,8 @@ Cannot cast `x` to undefined because boolean [1] is incompatible with undefined 
               ^
 
 References:
-   <BUILTINS>/core.js:2206:58
-   2206|       T extends $ReadOnlyArray<mixed> ? {[K in keyof T]: Awaited<T[K]>} :
+   <BUILTINS>/core.js:2211:58
+   2211|       T extends $ReadOnlyArray<mixed> ? {[K in keyof T]: Awaited<T[K]>} :
                                                                   ^^^^^^^^^^^^^ [1]
    all.js:17:9
      17|     (x: void);  // Errors: string ~> void, number ~> void, boolean ~> void
@@ -75,8 +75,8 @@ Cannot cast `x` to undefined because number [1] is incompatible with undefined [
               ^
 
 References:
-   <BUILTINS>/core.js:2206:58
-   2206|       T extends $ReadOnlyArray<mixed> ? {[K in keyof T]: Awaited<T[K]>} :
+   <BUILTINS>/core.js:2211:58
+   2211|       T extends $ReadOnlyArray<mixed> ? {[K in keyof T]: Awaited<T[K]>} :
                                                                   ^^^^^^^^^^^^^ [1]
    all.js:17:9
      17|     (x: void);  // Errors: string ~> void, number ~> void, boolean ~> void
@@ -92,8 +92,8 @@ Cannot cast `x` to undefined because string [1] is incompatible with undefined [
               ^
 
 References:
-   <BUILTINS>/core.js:2206:58
-   2206|       T extends $ReadOnlyArray<mixed> ? {[K in keyof T]: Awaited<T[K]>} :
+   <BUILTINS>/core.js:2211:58
+   2211|       T extends $ReadOnlyArray<mixed> ? {[K in keyof T]: Awaited<T[K]>} :
                                                                   ^^^^^^^^^^^^^ [1]
    all.js:17:9
      17|     (x: void);  // Errors: string ~> void, number ~> void, boolean ~> void
@@ -109,12 +109,12 @@ Cannot call `Promise.all` because function [1] requires another argument. [incom
                  ^^^
 
 References:
-   <BUILTINS>/core.js:2205:5
+   <BUILTINS>/core.js:2210:5
              v----------------------------------------------------
-   2205|     static all<T: Iterable<mixed>>(promises: T): Promise<
-   2206|       T extends $ReadOnlyArray<mixed> ? {[K in keyof T]: Awaited<T[K]>} :
-   2207|       T extends Iterable<infer V> ? Array<Awaited<V>> : any
-   2208|     >;
+   2210|     static all<T: Iterable<mixed>>(promises: T): Promise<
+   2211|       T extends $ReadOnlyArray<mixed> ? {[K in keyof T]: Awaited<T[K]>} :
+   2212|       T extends Iterable<infer V> ? Array<Awaited<V>> : any
+   2213|     >;
              ^ [1]
 
 
@@ -142,12 +142,12 @@ Cannot call `Promise.allSettled` because function [1] requires another argument.
                  ^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:2215:5
+   <BUILTINS>/core.js:2220:5
              v-----------------------------------------------------------
-   2215|     static allSettled<T: Iterable<mixed>>(promises: T): Promise<
-   2216|       T extends $ReadOnlyArray<mixed> ? {[K in keyof T]: $SettledPromiseResult<Awaited<T[K]>>} :
-   2217|       T extends Iterable<infer V> ? Array<$SettledPromiseResult<Awaited<V>>> : any
-   2218|     >;
+   2220|     static allSettled<T: Iterable<mixed>>(promises: T): Promise<
+   2221|       T extends $ReadOnlyArray<mixed> ? {[K in keyof T]: $SettledPromiseResult<Awaited<T[K]>>} :
+   2222|       T extends Iterable<infer V> ? Array<$SettledPromiseResult<Awaited<V>>> : any
+   2223|     >;
              ^ [1]
 
 
@@ -176,8 +176,8 @@ Cannot cast `first.status` to empty because string literal `rejected` [1] is inc
                 ^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:2240:12
-   2240|   +status: 'rejected',
+   <BUILTINS>/core.js:2245:12
+   2245|   +status: 'rejected',
                     ^^^^^^^^^^ [1]
    allSettled.js:34:22
      34|       (first.status: empty) // Error: 'rejected' case was not covered
@@ -193,8 +193,8 @@ Cannot call `second.value.foo` because property `foo` is missing in `Bar` [1]. [
                                       ^^^
 
 References:
-   <BUILTINS>/core.js:2216:80
-   2216|       T extends $ReadOnlyArray<mixed> ? {[K in keyof T]: $SettledPromiseResult<Awaited<T[K]>>} :
+   <BUILTINS>/core.js:2221:80
+   2221|       T extends $ReadOnlyArray<mixed> ? {[K in keyof T]: $SettledPromiseResult<Awaited<T[K]>>} :
                                                                                         ^^^^^^^^^^^^^ [1]
 
 
@@ -207,8 +207,8 @@ Cannot use function type [1] with fewer than 2 type arguments. [missing-type-arg
          ^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:2233:15
-   2233|     static any<T, Elem: Promise<T> | T>(promises: Iterable<Elem>): Promise<T>;
+   <BUILTINS>/core.js:2238:15
+   2238|     static any<T, Elem: Promise<T> | T>(promises: Iterable<Elem>): Promise<T>;
                        ^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 
@@ -221,8 +221,8 @@ Cannot call `Promise.any` because function [1] requires another argument. [incom
                  ^^^
 
 References:
-   <BUILTINS>/core.js:2233:5
-   2233|     static any<T, Elem: Promise<T> | T>(promises: Iterable<Elem>): Promise<T>;
+   <BUILTINS>/core.js:2238:5
+   2238|     static any<T, Elem: Promise<T> | T>(promises: Iterable<Elem>): Promise<T>;
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 
@@ -235,8 +235,8 @@ Cannot use function type [1] with fewer than 2 type arguments. [missing-type-arg
          ^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:2233:15
-   2233|     static any<T, Elem: Promise<T> | T>(promises: Iterable<Elem>): Promise<T>;
+   <BUILTINS>/core.js:2238:15
+   2238|     static any<T, Elem: Promise<T> | T>(promises: Iterable<Elem>): Promise<T>;
                        ^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 
@@ -251,8 +251,8 @@ an interface. [incompatible-type]
                                    ^ [1]
 
 References:
-   <BUILTINS>/core.js:2233:51
-   2233|     static any<T, Elem: Promise<T> | T>(promises: Iterable<Elem>): Promise<T>;
+   <BUILTINS>/core.js:2238:51
+   2238|     static any<T, Elem: Promise<T> | T>(promises: Iterable<Elem>): Promise<T>;
                                                            ^^^^^^^^^^^^^^ [2]
 
 
@@ -637,8 +637,8 @@ References:
    resolve_void.js:1:29
       1| (Promise.resolve(): Promise<number>); // error
                                      ^^^^^^ [2]
-   <BUILTINS>/core.js:2143:24
-   2143| declare class Promise<+R = mixed> {
+   <BUILTINS>/core.js:2148:24
+   2148| declare class Promise<+R = mixed> {
                                 ^ [3]
 
 
@@ -655,8 +655,8 @@ References:
    resolve_void.js:3:38
       3| (Promise.resolve(undefined): Promise<number>); // error
                                               ^^^^^^ [2]
-   <BUILTINS>/core.js:2143:24
-   2143| declare class Promise<+R = mixed> {
+   <BUILTINS>/core.js:2148:24
+   2148| declare class Promise<+R = mixed> {
                                 ^ [3]
 
 

--- a/tests/react_16_6/react_16_6.exp
+++ b/tests/react_16_6/react_16_6.exp
@@ -93,8 +93,8 @@ References:
     549|           ...
     550|         }>,
                  ^ [2]
-   <BUILTINS>/core.js:2143:24
-   2143| declare class Promise<+R = mixed> {
+   <BUILTINS>/core.js:2148:24
+   2148| declare class Promise<+R = mixed> {
                                 ^ [3]
 
 
@@ -118,8 +118,8 @@ References:
     549|           ...
     550|         }>,
                  ^ [2]
-   <BUILTINS>/core.js:2143:24
-   2143| declare class Promise<+R = mixed> {
+   <BUILTINS>/core.js:2148:24
+   2148| declare class Promise<+R = mixed> {
                                 ^ [3]
 
 

--- a/tests/rec/rec.exp
+++ b/tests/rec/rec.exp
@@ -392,8 +392,8 @@ defined. [method-unbinding]
                                   ^^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:716:5
-   716|     concat<S = T>(...items: Array<$ReadOnlyArray<S> | S>): Array<T | S>;
+   <BUILTINS>/core.js:721:5
+   721|     concat<S = T>(...items: Array<$ReadOnlyArray<S> | S>): Array<T | S>;
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [2]
 
 

--- a/tests/regexp/regexp.exp
+++ b/tests/regexp/regexp.exp
@@ -7,8 +7,8 @@ Cannot assign `patt.test(...)` to `match` because boolean [1] is incompatible wi
                             ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:1476:27
-   1476|     test(string: string): boolean;
+   <BUILTINS>/core.js:1481:27
+   1481|     test(string: string): boolean;
                                    ^^^^^^^ [1]
    regexp.js:2:11
       2| var match:number = patt.test("Hello world!");

--- a/tests/render_types/render_types.exp
+++ b/tests/render_types/render_types.exp
@@ -78,8 +78,8 @@ Cannot cast `<StarFoo />` to renders `Foo` because `$ReadOnlyArray` [1] does not
          ^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:700:15
-   700| declare class $ReadOnlyArray<+T> {
+   <BUILTINS>/core.js:705:15
+   705| declare class $ReadOnlyArray<+T> {
                       ^^^^^^^^^^^^^^ [1]
    import.js:14:15
     14| (<StarFoo />: renders Foo); // ERROR
@@ -110,8 +110,8 @@ Cannot cast `<StarFoo />` to renders? `Foo` because `$ReadOnlyArray` [1] does no
          ^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:700:15
-   700| declare class $ReadOnlyArray<+T> {
+   <BUILTINS>/core.js:705:15
+   705| declare class $ReadOnlyArray<+T> {
                       ^^^^^^^^^^^^^^ [1]
    import.js:15:15
     15| (<StarFoo />: renders? Foo); // ERROR

--- a/tests/resolved_env/resolved_env.exp
+++ b/tests/resolved_env/resolved_env.exp
@@ -36,8 +36,8 @@ Cannot yield `42` because number [1], a primitive, cannot be used as a subtype o
                                    ^^ [1]
 
 References:
-   <BUILTINS>/core.js:1948:7
-   1948|     : $Iterable<Yield, Return, Next>;
+   <BUILTINS>/core.js:1953:7
+   1953|     : $Iterable<Yield, Return, Next>;
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [2]
 
 

--- a/tests/return/return.exp
+++ b/tests/return/return.exp
@@ -40,8 +40,8 @@ undefined in type argument `R` [2]. [incompatible-return]
                                       ^^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:2143:24
-   2143| declare class Promise<+R = mixed> {
+   <BUILTINS>/core.js:2148:24
+   2148| declare class Promise<+R = mixed> {
                                 ^ [2]
 
 

--- a/tests/signature_verification_failure/signature_verification_failure.exp
+++ b/tests/signature_verification_failure/signature_verification_failure.exp
@@ -192,8 +192,8 @@ References:
    misc.js:5:32
       5| export const c = {['a' + 'b']: 42};
                                         ^^ [1]
-   <BUILTINS>/core.js:1907:5
-   1907|     @@iterator(): $IteratorProtocol<Yield,Return,Next>;
+   <BUILTINS>/core.js:1912:5
+   1912|     @@iterator(): $IteratorProtocol<Yield,Return,Next>;
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [2]
 
 

--- a/tests/template/template.exp
+++ b/tests/template/template.exp
@@ -49,8 +49,8 @@ Cannot cast `quasis.raw` to empty because read-only array type [1] is incompatib
               ^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:1161:9
-   1161|   +raw: $ReadOnlyArray<string>;
+   <BUILTINS>/core.js:1166:9
+   1166|   +raw: $ReadOnlyArray<string>;
                  ^^^^^^^^^^^^^^^^^^^^^^ [1]
    tagged_template.js:25:18
      25|     (quasis.raw: empty); // ERROR
@@ -66,8 +66,8 @@ Cannot cast `x` to empty because string [1] is incompatible with empty [2]. [inc
             ^
 
 References:
-   <BUILTINS>/core.js:1423:114
-   1423|     static raw: (callSite: interface {+raw: $ReadOnlyArray<string>}, ...substitutions: $ReadOnlyArray<mixed>) => string;
+   <BUILTINS>/core.js:1428:114
+   1428|     static raw: (callSite: interface {+raw: $ReadOnlyArray<string>}, ...substitutions: $ReadOnlyArray<mixed>) => string;
                                                                                                                           ^^^^^^ [1]
    tagged_template.js:34:7
      34|   (x: empty); // ERROR
@@ -85,8 +85,8 @@ subtype of an interface. [incompatible-type]
                       ^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:1423:28
-   1423|     static raw: (callSite: interface {+raw: $ReadOnlyArray<string>}, ...substitutions: $ReadOnlyArray<mixed>) => string;
+   <BUILTINS>/core.js:1428:28
+   1428|     static raw: (callSite: interface {+raw: $ReadOnlyArray<string>}, ...substitutions: $ReadOnlyArray<mixed>) => string;
                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [2]
 
 
@@ -99,8 +99,8 @@ Cannot cast `x` to empty because string [1] is incompatible with empty [2]. [inc
             ^
 
 References:
-   <BUILTINS>/core.js:1423:114
-   1423|     static raw: (callSite: interface {+raw: $ReadOnlyArray<string>}, ...substitutions: $ReadOnlyArray<mixed>) => string;
+   <BUILTINS>/core.js:1428:114
+   1428|     static raw: (callSite: interface {+raw: $ReadOnlyArray<string>}, ...substitutions: $ReadOnlyArray<mixed>) => string;
                                                                                                                           ^^^^^^ [1]
    tagged_template.js:45:7
      45|   (x: empty); // ERROR

--- a/tests/tuples/tuples.exp
+++ b/tests/tuples/tuples.exp
@@ -1568,8 +1568,8 @@ Cannot call `readOnlyRef.push` because property `push` is missing in `$ReadOnlyA
                         ^^^^
 
 References:
-   <BUILTINS>/core.js:793:77
-   793|     forEach<This>(callbackfn: (this : This, value: T, index: number, array: $ReadOnlyArray<T>) => mixed, thisArg: This): void;
+   <BUILTINS>/core.js:798:77
+   798|     forEach<This>(callbackfn: (this : This, value: T, index: number, array: $ReadOnlyArray<T>) => mixed, thisArg: This): void;
                                                                                     ^^^^^^^^^^^^^^^^^ [1]
 
 

--- a/tests/type_at_pos_react/type_at_pos_react.exp
+++ b/tests/type_at_pos_react/type_at_pos_react.exp
@@ -13,7 +13,7 @@ lazy_ref.js:19:9 = Promise<
 
 'ExactReactElement_DEPRECATED' defined at (lib) react.js:87:13
 'Node' defined at (lib) react.js:270:22
-'Promise' defined at (lib) core.js:2143:14
+'Promise' defined at (lib) core.js:2148:14
 'Props' defined at exports-component.js:5:5
 
 lazy_ref.js:19:9,19:9

--- a/tests/type_at_pos_type_destructors/type_at_pos_type_destructors.exp
+++ b/tests/type_at_pos_type_destructors/type_at_pos_type_destructors.exp
@@ -62,7 +62,7 @@ type T5 = string extends {bar: String, foo: infer String, ...} ? string : number
 = number
 
 'String' defined at conditional-types.js:17:37
-'String' defined at (lib) core.js:1208:14
+'String' defined at (lib) core.js:1213:14
 'T5' defined at conditional-types.js:17:5
 
 conditional-types.js:17:6,17:7

--- a/tests/type_guards/type_guards.exp
+++ b/tests/type_guards/type_guards.exp
@@ -1423,8 +1423,8 @@ Error --------------------------------------------------------------------------
                                         ^^^^^^^^^^^ [2]
 
 References:
-   <BUILTINS>/core.js:1920:40
-   1920| type Generator<+Yield,+Return,-Next> = $Generator<Yield,Return,Next>;
+   <BUILTINS>/core.js:1925:40
+   1925| type Generator<+Yield,+Return,-Next> = $Generator<Yield,Return,Next>;
                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 
@@ -1438,8 +1438,8 @@ it into an object and attempt to use it as a subtype of an interface. [incompati
                                         ^^^^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:1906:11
-   1906| interface $Iterable<+Yield,+Return,-Next> {
+   <BUILTINS>/core.js:1911:11
+   1911| interface $Iterable<+Yield,+Return,-Next> {
                    ^^^^^^^^^ [2]
 
 
@@ -1452,8 +1452,8 @@ Cannot return `(typeof x) == "number"` because `$Generator` [1] is incompatible 
                   ^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:1920:40
-   1920| type Generator<+Yield,+Return,-Next> = $Generator<Yield,Return,Next>;
+   <BUILTINS>/core.js:1925:40
+   1925| type Generator<+Yield,+Return,-Next> = $Generator<Yield,Return,Next>;
                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
    invalid.js:19:32
      19| function *generator(x: mixed): x is number { // error
@@ -1494,8 +1494,8 @@ Cannot return `(typeof x) == "number"` because `Promise` [1] is incompatible wit
                   ^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:2143:15
-   2143| declare class Promise<+R = mixed> {
+   <BUILTINS>/core.js:2148:15
+   2148| declare class Promise<+R = mixed> {
                        ^^^^^^^ [1]
    invalid.js:28:33
      28| async function async(x: mixed): x is number { // error
@@ -2483,8 +2483,8 @@ References:
    refinement.js:231:7
    231|   fn: (x: mixed) => implies x is number,
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [3]
-   <BUILTINS>/core.js:734:24
-   734|     filter(callbackfn: typeof Boolean): Array<$NonMaybeType<T>>;
+   <BUILTINS>/core.js:739:24
+   739|     filter(callbackfn: typeof Boolean): Array<$NonMaybeType<T>>;
                                ^^^^^^^^^^^^^^ [4]
 
 
@@ -2508,8 +2508,8 @@ References:
    refinement.js:231:7
    231|   fn: (x: mixed) => implies x is number,
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [3]
-   <BUILTINS>/core.js:734:24
-   734|     filter(callbackfn: typeof Boolean): Array<$NonMaybeType<T>>;
+   <BUILTINS>/core.js:739:24
+   739|     filter(callbackfn: typeof Boolean): Array<$NonMaybeType<T>>;
                                ^^^^^^^^^^^^^^ [4]
 
 

--- a/tests/type_param_variance2/type_param_variance2.exp
+++ b/tests/type_param_variance2/type_param_variance2.exp
@@ -8,8 +8,8 @@ surprising behaviors. [libdef-override]
                        ^^^^^^^
 
 References:
-   <BUILTINS>/core.js:2143:15
-   2143| declare class Promise<+R = mixed> {
+   <BUILTINS>/core.js:2148:15
+   2148| declare class Promise<+R = mixed> {
                        ^^^^^^^ [1]
 
 

--- a/tests/union_new/union_new.exp
+++ b/tests/union_new/union_new.exp
@@ -175,8 +175,8 @@ References:
    test20.js:14:2
      14| [""].reduce((acc,str) => acc * str.length);
           ^^ [1]
-   <BUILTINS>/core.js:1406:13
-   1406|     length: number;
+   <BUILTINS>/core.js:1411:13
+   1411|     length: number;
                      ^^^^^^ [2]
 
 


### PR DESCRIPTION
This type is relatively new but appears to have broad browser support:

- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Float16Array
- https://tc39.es/proposal-float16array/#sec-float16array

Test Plan:
- `make test`