### PR TITLE
fix(typo): change `InstrinsicRenders` → `IntrinsicRenders`

### DIFF
--- a/src/typing/check_polarity.ml
+++ b/src/typing/check_polarity.ml
@@ -212,7 +212,7 @@ end = struct
       check_polarity cx ?trace seen tparams polarity renders_super
     | DefT (_, RendersT (StructuralRenders { renders_variant = _; renders_structural_type = t })) ->
       check_polarity cx ?trace seen tparams polarity t
-    | DefT (_, RendersT (InstrinsicRenders _ | DefaultRenders)) -> ()
+    | DefT (_, RendersT (IntrinsicRenders _ | DefaultRenders)) -> ()
     | KeysT (_, t) -> check_polarity cx ?trace seen tparams Polarity.Positive t
     | EvalT (t, TypeDestructorT (use_op, r, ReadOnlyType), id) ->
       if Eval.Set.mem id seen then

--- a/src/typing/convertTypes.ml
+++ b/src/typing/convertTypes.ml
@@ -313,8 +313,8 @@ and json_of_enum_info cx depth = function
 (* Convert canonical_renders_form to JSON *)
 and json_of_canonical_renders_form cx depth (renders : canonical_renders_form) =
   match renders with
-  | InstrinsicRenders name ->
-    JSON_Object [("kind", JSON_String "InstrinsicRenders"); ("name", JSON_String name)]
+  | IntrinsicRenders name ->
+    JSON_Object [("kind", JSON_String "IntrinsicRenders"); ("name", JSON_String name)]
   | NominalRenders { renders_id; renders_name; renders_super } ->
     JSON_Object
       [

--- a/src/typing/debug_js.ml
+++ b/src/typing/debug_js.ml
@@ -329,7 +329,7 @@ let rec dump_t_ (depth, tvars) cx t =
           )
         t
     | DefT (_, ReactAbstractComponentT _) -> p t
-    | DefT (_, RendersT (InstrinsicRenders n)) -> p t ~extra:(spf "instrinsic %s" n)
+    | DefT (_, RendersT (IntrinsicRenders n)) -> p t ~extra:(spf "instrinsic %s" n)
     | DefT (_, RendersT (NominalRenders { renders_name; _ })) ->
       p t ~extra:(spf "Nominal(%s)" renders_name)
     | DefT

--- a/src/typing/flow_js.ml
+++ b/src/typing/flow_js.ml
@@ -4907,10 +4907,10 @@ struct
         | (_, (DeepReadOnlyT (tout, _) | HooklikeT tout)) ->
           rec_flow_t ~use_op:unknown_use cx trace (l, OpenT tout)
         (* Render Type Misc Uses *)
-        | ( DefT (_, RendersT (InstrinsicRenders _ | NominalRenders _)),
+        | ( DefT (_, RendersT (IntrinsicRenders _ | NominalRenders _)),
             ExitRendersT { renders_reason; u }
           )
-        | (DefT (renders_reason, RendersT (InstrinsicRenders _ | NominalRenders _)), u) ->
+        | (DefT (renders_reason, RendersT (IntrinsicRenders _ | NominalRenders _)), u) ->
           let mixed_element =
             get_builtin_react_type
               cx
@@ -5785,7 +5785,7 @@ struct
           DefT
             ( _,
               RendersT
-                ( InstrinsicRenders _
+                ( IntrinsicRenders _
                 | NominalRenders { renders_id = _; renders_name = _; renders_super = _ }
                 | DefaultRenders )
             )

--- a/src/typing/flow_js_utils.ml
+++ b/src/typing/flow_js_utils.ml
@@ -3385,7 +3385,7 @@ end = struct
     | DefT (reason, SingletonStrT { value = OrdinaryName "svg"; _ }) ->
       TypeCollector.add
         normalization_cx.type_collector
-        (DefT (reason, RendersT (InstrinsicRenders "svg")))
+        (DefT (reason, RendersT (IntrinsicRenders "svg")))
     | OpaqueT
         ( element_r,
           {

--- a/src/typing/renders_kit.ml
+++ b/src/typing/renders_kit.ml
@@ -44,7 +44,7 @@ module Make (Flow : INPUT) : S = struct
 
   let rec rec_renders_to_renders cx trace ~use_op ((reasonl, l), (reasonu, u)) =
     match (l, u) with
-    | (InstrinsicRenders n1, InstrinsicRenders n2) ->
+    | (IntrinsicRenders n1, IntrinsicRenders n2) ->
       if n1 = n2 then
         ()
       else
@@ -58,7 +58,7 @@ module Make (Flow : INPUT) : S = struct
                explanation = None;
              }
           )
-    | (InstrinsicRenders _, StructuralRenders { renders_variant = _; renders_structural_type = t })
+    | (IntrinsicRenders _, StructuralRenders { renders_variant = _; renders_structural_type = t })
       ->
       if not (speculative_subtyping_succeeds cx (reconstruct_render_type reasonl l) t) then
         Flow_js_utils.add_output
@@ -71,8 +71,8 @@ module Make (Flow : INPUT) : S = struct
                explanation = None;
              }
           )
-    | (InstrinsicRenders _, NominalRenders _)
-    | (_, InstrinsicRenders _) ->
+    | (IntrinsicRenders _, NominalRenders _)
+    | (_, IntrinsicRenders _) ->
       Flow_js_utils.add_output
         cx
         (Error_message.EIncompatibleWithUseOp
@@ -179,7 +179,7 @@ module Make (Flow : INPUT) : S = struct
           ),
           (reasonu, u)
         )
-    | ( (InstrinsicRenders _ | NominalRenders _ | StructuralRenders _ | DefaultRenders),
+    | ( (IntrinsicRenders _ | NominalRenders _ | StructuralRenders _ | DefaultRenders),
         DefaultRenders
       ) ->
       ()
@@ -252,7 +252,7 @@ module Make (Flow : INPUT) : S = struct
                (elem_reason, SingletonStrT { from_annot = true; value = Reason.OrdinaryName "svg" })
             )
         then
-          ([DefT (elem_reason, RendersT (InstrinsicRenders "svg"))], false)
+          ([DefT (elem_reason, RendersT (IntrinsicRenders "svg"))], false)
         else
           ([], true))
     | _ -> ([], true)
@@ -295,7 +295,7 @@ module Make (Flow : INPUT) : S = struct
       ) ->
       rec_flow_t cx trace ~use_op (t, reconstruct_render_type renders_r upper_renders)
     (* Try to do structural subtyping. If that fails promote to a render type *)
-    | (OpaqueT (reason_opaque, ({ opaque_id; _ } as opq)), (InstrinsicRenders _ | NominalRenders _))
+    | (OpaqueT (reason_opaque, ({ opaque_id; _ } as opq)), (IntrinsicRenders _ | NominalRenders _))
       when Some opaque_id = Flow_js_utils.builtin_react_element_opaque_id cx ->
       try_promote_render_type_from_react_element_type
         cx
@@ -379,7 +379,7 @@ module Make (Flow : INPUT) : S = struct
               state
             | DefT (_, RendersT renders) ->
               (match renders with
-              | InstrinsicRenders _
+              | IntrinsicRenders _
               | NominalRenders _ ->
                 TypeCollector.add normalized_render_type_collector t;
                 state

--- a/src/typing/subtyping_kit.ml
+++ b/src/typing/subtyping_kit.ml
@@ -1718,7 +1718,7 @@ module Make (Flow : INPUT) : OUTPUT = struct
     | (l, DefT (renders_r, RendersT upper_renders)) ->
       RendersKit.non_renders_to_renders cx trace ~use_op l (renders_r, upper_renders)
     (* Exiting the renders world *)
-    | (DefT (r, RendersT (InstrinsicRenders _ | NominalRenders _)), u) ->
+    | (DefT (r, RendersT (IntrinsicRenders _ | NominalRenders _)), u) ->
       let mixed_element =
         get_builtin_react_type
           cx

--- a/src/typing/ty_normalizer.ml
+++ b/src/typing/ty_normalizer.ml
@@ -873,7 +873,7 @@ module Make (I : INPUT) : S = struct
           convert_component ~env config instance renders
         in
         return (Ty.Component { regular_props; ref_prop; renders })
-      | DefT (_, RendersT (InstrinsicRenders n)) -> return (Ty.StrLit (OrdinaryName n))
+      | DefT (_, RendersT (IntrinsicRenders n)) -> return (Ty.StrLit (OrdinaryName n))
       | DefT (_, RendersT (NominalRenders { renders_id; renders_name; _ })) ->
         let symbol =
           Reason_utils.component_symbol

--- a/src/typing/type.ml
+++ b/src/typing/type.ml
@@ -285,7 +285,7 @@ module rec TypeTerm : sig
    *  * renders number would produce a Structural number
    *)
   and canonical_renders_form =
-    | InstrinsicRenders of string
+    | IntrinsicRenders of string
     | NominalRenders of {
         renders_id: ALoc.id;
         renders_name: string;

--- a/src/typing/type_mapper.ml
+++ b/src/typing/type_mapper.ml
@@ -356,7 +356,7 @@ class virtual ['a] t =
 
     method private canonical_renders_form cx map_cx form =
       match form with
-      | InstrinsicRenders _ -> form
+      | IntrinsicRenders _ -> form
       | NominalRenders { renders_id; renders_name; renders_super } ->
         let renders_super' = self#type_ cx map_cx renders_super in
         if renders_super' == renders_super then

--- a/src/typing/type_visitor.ml
+++ b/src/typing/type_visitor.ml
@@ -143,7 +143,7 @@ class ['a] t =
         self#type_ cx pole acc renders_super
       | RendersT (StructuralRenders { renders_variant = _; renders_structural_type = t }) ->
         self#type_ cx pole acc t
-      | RendersT (InstrinsicRenders _ | DefaultRenders) -> acc
+      | RendersT (IntrinsicRenders _ | DefaultRenders) -> acc
 
     method targ cx pole acc =
       function


### PR DESCRIPTION
## Summary

Bug Fixes:
- Fix misspelling of `InstrinsicRenders` to `IntrinsicRenders` in type definitions and pattern matches