### PR TITLE
[DOCS] fix some typos

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,5 @@
 <!--
-  If this is a change to library defintions, please include links to relevant documentation.
+  If this is a change to library definitions, please include links to relevant documentation.
   If this is a documentation change, please prefix the title with [DOCS].
 
   If this is neither, ensure you opened a discussion issue and link it in the PR description.

--- a/Changelog.md
+++ b/Changelog.md
@@ -17,7 +17,7 @@ Likely to cause new Flow errors:
 ### 0.276.0
 
 Likely to cause new Flow errors:
-* Hook calls inside anonynous functions bound to a variable will get `react-rule-hook-definitely-not-in-component-or-hook` error, if the variable name doesn't conform to hook naming convention. [example](https://flow.org/try/#1N4Igxg9gdgZglgcxALlAIwIZoKYBsD6uEEAztvhgE6UYCe+JADpdhgCYowa5kA0I2KAFcAtiRQAXSkOz9sADwxgJ+NPTbYuQ3BMnTZA+Y2yU4IwRO4A6SFBIrGVDGM7c+h46fNRLuKxJIGWh8MeT0ZfhYlCStpHzNsFBAMIQkIEQwJODAQfiEyfBE4eWw2fDgofDBMsAALfAA3KjgsXGxxZC4eAw0G-GhcWn9aY3wWZldu-g1mbGqJUoBaCRHEzrcDEgBrbAk62kXhXFxJ923d-cPRHEpTgyEoMDaqZdW7vKgoOfaSKgOKpqmDA+d4gB5fMA-P6LCCMLLQbiLOoYCqgh6-GDYRYIXYLSgkRZkCR4jpddwPfJLZjpOBkUEKTwJEJ+DAkMiUFSwkyZCC3dbdAC+-EgGiSZkYvIkAAIAEqsZRSmCUdJSgDkUWUqoA3AAdKB62z2RXEKUAXilAAoAJRmgB8UuAeqlztl8pilIAypYFtatVKAPT+qWzBpwCD5QZSjUSRbSNqLWrELZSkzKyi8KVQCAAdyjbtj2ixiYgW0WGngUDgC0GhwgMYqSPSEq+PhhlATSZT1F5eoFetyIAaJhIYagSQaAAYrAAmADsABYZyABUA)
+* Hook calls inside anonymous functions bound to a variable will get `react-rule-hook-definitely-not-in-component-or-hook` error, if the variable name doesn't conform to hook naming convention. [example](https://flow.org/try/#1N4Igxg9gdgZglgcxALlAIwIZoKYBsD6uEEAztvhgE6UYCe+JADpdhgCYowa5kA0I2KAFcAtiRQAXSkOz9sADwxgJ+NPTbYuQ3BMnTZA+Y2yU4IwRO4A6SFBIrGVDGM7c+h46fNRLuKxJIGWh8MeT0ZfhYlCStpHzNsFBAMIQkIEQwJODAQfiEyfBE4eWw2fDgofDBMsAALfAA3KjgsXGxxZC4eAw0G-GhcWn9aY3wWZldu-g1mbGqJUoBaCRHEzrcDEgBrbAk62kXhXFxJ923d-cPRHEpTgyEoMDaqZdW7vKgoOfaSKgOKpqmDA+d4gB5fMA-P6LCCMLLQbiLOoYCqgh6-GDYRYIXYLSgkRZkCR4jpddwPfJLZjpOBkUEKTwJEJ+DAkMiUFSwkyZCC3dbdAC+-EgGiSZkYvIkAAIAEqsZRSmCUdJSgDkUWUqoA3AAdKB62z2RXEKUAXilAAoAJRmgB8UuAeqlztl8pilIAypYFtatVKAPT+qWzBpwCD5QZSjUSRbSNqLWrELZSkzKyi8KVQCAAdyjbtj2ixiYgW0WGngUDgC0GhwgMYqSPSEq+PhhlATSZT1F5eoFetyIAaJhIYagSQaAAYrAAmADsABYZyABUA)
 *
 
 IDE:
@@ -873,7 +873,7 @@ Likely to cause new Flow errors:
 * `untyped-import` errors are now on the import source rather than imported names.
 
 New Features:
-* Under `files.implictly_include_root=false` (default is true, which is the current behavior), Flow will no longer include everything under the directory where the flowconfig is in by default.
+* Under `files.implicitly_include_root=false` (default is true, which is the current behavior), Flow will no longer include everything under the directory where the flowconfig is in by default.
 
 Notable bug fixes:
 * Fixed a category of spurious errors when using `Array.reduce` and returning a union type (e.g. [try-Flow](https://flow.org/try/#1N4Igxg9gdgZglgcxALlAIwIZoKYBsD6uEEAztvhgE6UYCe+JADpdhgCYowa5kA0I2KAFcAtiRQAXSkOz9sADwxgJ+NPTbYuQ3BMnTZA+Y2yU4IwRO4A6SFBIrGVDGM7c+h46fNRLuKxJIGWh8MeT0ZfhYlCStpHzNsFBAMIQkIEQwJODAQfiEyfBE4eWw2fDgofDBMsAALfAA3KjgsXGxxZC4eAw0G-GhcWn9aY3wWZldu-g1mbGqJUoBaCRHEzrcDEgBrbAk62kXhXFxJ923d-cPRHEpTgyEoMDaqZdW7vKgoOfaSKgOKpqmDA+d4gB5fMA-P6LCCMLLQbiLOoYCqgh6-GDYRYIXYLSgkRZkCR4jpddwPfJLZjpOBkO4AX34kA0SQ0Tyo2AABIDOQ84NBkJyAILUOgAHnspigCAAfJyAD7C0W0MXCEQ3GUAbgAOlA2bgOZzbPZOVRKIKRTQVZKKrKdVBdcaJJyWCRtBIAIycgC8puosVKQkhAApg0owBblRKpLaZbxOfJBTbpQBKH1y4CcgD0Wc5AHdoAByZ04U1QTkmSgQShl2giavYXWc5su3ZCSjlvnQe2MzkAbQAuin7Y7oCbXe6AEw+v2UANsIPYUPhyNW6NS2XxxOc5MINPejPZ3MFqDFzml4EV6jV2v1lhNltwGCc4MABk5Ys5HrTwAfLZbLASO25Z9lYYHhgO9r-vSf6tkBHb9mBVjhlukG6r2g4prquQgA0JgkPyUBJA0r5WJOADMADsZEgPSQA))
@@ -1080,7 +1080,7 @@ Likely to cause new Flow errors:
 
 New Features:
 * No longer trigger `method-unbinding` errors with indexed access types.
-* Add `relay_integration.esmodules` option. When this option, along with `relay_integration`, is enabled, Flow will treat `graphql` fragments/queries/etc. as `import default` rather than `require`. Use this when you ouput ESM from Relay's codegen (e.g. `eagerEsModules`).
+* Add `relay_integration.esmodules` option. When this option, along with `relay_integration`, is enabled, Flow will treat `graphql` fragments/queries/etc. as `import default` rather than `require`. Use this when you output ESM from Relay's codegen (e.g. `eagerEsModules`).
 
 Notable bug fixes:
 * Don't error when returning an array, map, etc when an `AsyncGenerator<T, void, void>` type is expected (e.g. [try-Flow](https://flow.org/try/#1N4Igxg9gdgZglgcxALlAIwIZoKYBsD6uEEAztvhgE6UYCe+JADpdhgCYowa5kA0I2KAFcAtiRQAXSkOz9sADwxgJ+NPTbYuQ3BMnTZA+Y2yU4IwRO4A6SFBIrGVDGM7c+IFkolXpUCWewUEAwhCQgRDH8wEH4hMnwROHlsNnw4KHwwSLAAC3wANyo4LFxscWQuHgMNZmwsiRSAWglaY1cq-hIAa2wJXNpG4Vxcdvdu3v7B0RxKUYMhKDBSqmbWwIq3eagoOrKSKgH0wtMMPznY7d2SfcoBiEZ-aG5G3Ix085AF-ZhsRoRehqUEiNMgSQHlSruBZxJrMcJwMhzAC+-EgGiCAB0JBioBgSLRFgACGALZRwaCEgBU-ygAEYABQASmQhIAgvjFgBxQQmSIQSgAHmEIhmvEJ+QgcDYYolUoAfITgDjCSrCbQ4Hg2JTCQBtWligBMYoAzABdADchIA9FbCQB3aAAcgkhJMlH5hNOtBE-OwOKROJxeIJYGJpMeUCpNINTJZ7JD3J2NDCguFovFkulGfliuVqvVmu1GDtbxdAAV3YkyFZuLh6XrDSbTYzLTb7U6XW6PV6fSx-YHcRzQyTFhGo4JjbG2UPE7yUwKdfZTFAEGK0yZTTLM1uc0rI-mNbgtYSdnbCQBZDCMAVL9Krk-TExypmt20OqDO13UbtQb2+-tQDEID5CYJDkoByDAQADFYBoGgAnLBIBIkAA))
@@ -1438,8 +1438,8 @@ Misc:
 * We slightly optimized Flow's performance of subtyping check between two union types.
 
 Library Definitions:
-* Add defintions `Array.prototype.findLastIndex()`, `String.prototype.at()`, `TypedArray.prototype.at()` and `Object.hasOwn()` (thanks @pascalduez).
-* Update `URL` defintions (thanks @pascalduez).
+* Add definitions `Array.prototype.findLastIndex()`, `String.prototype.at()`, `TypedArray.prototype.at()` and `Object.hasOwn()` (thanks @pascalduez).
+* Update `URL` definitions (thanks @pascalduez).
 * Add typing for cause option in Error constructor.
 
 ### 0.217.2
@@ -1510,7 +1510,7 @@ Library Definitions:
 
 Likely to cause new Flow errors:
 * Flow now has stricter behavior with `$Call`, `$ObjMap`, `$ObjMapi`, `$ObjMapConst`, `$TupleMap`. Previously hidden type errors might be revealed now.
-* You can no longer disable `tuple_ehancements`, `conditional_type`, `mapped_type`, `type_guards` in flowconfig, since these options have been removed. They were enabled by default since v0.212.0.
+* You can no longer disable `tuple_enhancements`, `conditional_type`, `mapped_type`, `type_guards` in flowconfig, since these options have been removed. They were enabled by default since v0.212.0.
 
 IDE:
 * We now provide a new refactor that extracts JSX elements into a new React component.
@@ -2535,7 +2535,7 @@ Parser:
 
 Likely to cause new Flow errors:
 * Fix a bug where refinements should be invalidated when going through multiple control flow branches (thanks @gnprice)
-* Make catch parameters explicitely `any` typed
+* Make catch parameters explicitly `any` typed
 * Ban object spreads of numbers and strings
 * Fix a bug that makes Flow consider some function names to have the empty type
 * Numbers, booleans, and enums are no longer subtypes of the empty interface `interface {}`
@@ -2940,7 +2940,7 @@ Parser:
 ### 0.157.0
 
 Likely to cause new Flow errors:
-* Add a new error for unreachable code occuring in a loop after a conditional with mixed `break` and `continue` branches.
+* Add a new error for unreachable code occurring in a loop after a conditional with mixed `break` and `continue` branches.
 
 New Features:
 * LSP extract to function/method/constant/class fields/type alias is enabled by default. These refactors will show up under after selecting some code. They can be disabled by adding `experimental.refactor=false` to the `.flowconfig`. (thanks to our intern, @SamChou19815)
@@ -2998,7 +2998,7 @@ Library Definitions:
 
 Misc:
 * Remove `experimental.this_annot` config option and permanently enable now that our core lib defs rely on this feature.
-* Remove prevously defaulted on `new_check` config option for the new check mode that uses significantly less RAM for large projects.
+* Remove previously defaulted on `new_check` config option for the new check mode that uses significantly less RAM for large projects.
 
 ### 0.153.0
 
@@ -3544,7 +3544,7 @@ against this type we would treat it like `$Exact<T> & $Exact<U>`, instead.
 * Fix to prevent infinitely expanding recursive type applications of arrays ([example](https://flow.org/try/#0C4TwDgpgBAqgPAFQHxQLxQIICcsEMSIoA+sc2eBySA3FFAFAAUA2gLpQBcpAdgK4C2AIwhYkASmpA)).
 
 Misc:
-* Improvements in comment attachement in various kinds of AST nodes. These will
+* Improvements in comment attachment in various kinds of AST nodes. These will
 help improve the accuracy of error suppression and various services that inspect
 comments (printing, showing documentation, etc.).
 * `$Exports<'m'>` will now lookup module 'm' directly in builtins, instead of the
@@ -3774,7 +3774,7 @@ Misc:
 * Improved performance for utility types and refinements in unions
 * Various improvements to autocomplete and get-def IDE services
 * Add `useDeferredValue` and `useTransition` to React library definitions
-* Add `bytesWritten` funciton to library definition (thanks @farzonl)
+* Add `bytesWritten` function to library definition (thanks @farzonl)
 
 ### 0.111.3
 
@@ -3837,7 +3837,7 @@ Notable bug fixes:
 Misc:
 * Added `--evaluate-type-destructors` to `type-at-pos` command.
 * Added `--evaluate-type-destructors` and `--expand-type-aliases` to `dump-types` command (thanks @goodmind!)
-* Changed `proceses.env` values from `?string` to `string|void` (thanks @FireyFly!)
+* Changed `process.env` values from `?string` to `string|void` (thanks @FireyFly!)
 * Improved detection of rebases when using watchman file watcher
 * Improved positions for error messages involving the deprecated `*` type
 
@@ -4373,7 +4373,7 @@ Many, many libdef fixes and improvements! Many thanks to the open source communi
 * #7358 Add `oncontextmenu` to `HTMLElement` (thanks @jasonLaster!)
 * #7363 Add `MediaDeviceInfo` declaration (thanks @ea167!)
 * #7367 Add `userSelect` to CSS declaration (thanks @shubhodeep9!)
-* #7368 Fix `fs.promises.readFile` being incorreclty overloaded (thanks @Macil!)
+* #7368 Fix `fs.promises.readFile` being incorrectly overloaded (thanks @Macil!)
 * #7381 add `EventSource` to dom libdef. Likely to cause new errors (thanks @SlIdE42!)
 * #7386 fix `XDomainRequest` in bom libdef. Likely to cause new errors (thanks @Mouvedia!)
 * #7387 Added optional `displayName` property to `React$Context` (thanks @bvaughn!)
@@ -6805,7 +6805,7 @@ Likely to cause new Flow errors:
 New Features:
 
 - Generators support, courtesy of [@samwgoldman](https://github.com/samwgoldman)
-- The number of worker processers is now configurable, defaults to the # of CPUs
+- The number of worker processors is now configurable, defaults to the # of CPUs
 - If Flow knows the value of a boolean expression, then it will know the value of that expression negated.
 - Flow can remember refinements for things like `if(x.y[a.b])`
 - `export type {type1, type2}` syntax

--- a/src/typing/exhaustive.ml
+++ b/src/typing/exhaustive.ml
@@ -33,7 +33,7 @@ let attempt_union_rep_optimization cx (rep : Type.UnionRep.t) : unit =
       ~find_props:(Context.find_props cx)
 
 (***********************)
-(* Datatype defintions *)
+(* Datatype definitions *)
 (***********************)
 
 type pattern_ast_list =

--- a/website/docs/editors/vim.md
+++ b/website/docs/editors/vim.md
@@ -38,7 +38,7 @@ let g:ale_linters = {
 set nocompatible
 filetype off
 
-" install coc.nvim using Plug or preffered plugin manager
+" install coc.nvim using Plug or preferred plugin manager
 call plug#begin('~/.vim/plugged')
 Plug 'neoclide/coc.nvim', {'branch': 'release'}
 call plug#end()
@@ -89,7 +89,7 @@ if !empty(s:languageservers)
 
 Another way to add support for Flow in Vim is to use [LanguageClient-neovim](https://github.com/autozimu/LanguageClient-neovim).
 
-* Suports vim 8 and neovim
+* Supports vim 8 and neovim
 * Adds completions to omnifunc
 * Checks JavaScript files for type errors on save
 * Look up types under cursor

--- a/website/docs/enums/defining-enums.md
+++ b/website/docs/enums/defining-enums.md
@@ -212,7 +212,7 @@ switch (status) {
 When this is used, Flow will always require a `default` when [switching over the enum](../using-enums/#toc-exhaustive-checking-with-unknown-members),
 even if all known enum members are checked. The `default` checks for "unknown" members you haven't explicitly listed.
 
-This feature is useful when an enum value crosses some boundary and the enum declaration on each side may have different memebers.
+This feature is useful when an enum value crosses some boundary and the enum declaration on each side may have different members.
 For example, an enum definition which is used on both the client and the server: an enum member could be added, which would be immediately seen by the server,
 but could be sent to an outdated client which isn't yet aware of the new member.
 

--- a/website/docs/enums/migrating-legacy-patterns.md
+++ b/website/docs/enums/migrating-legacy-patterns.md
@@ -188,7 +188,7 @@ Read more about [mapping enums to other values](../using-enums/#toc-mapping-enum
 You can't use a Flow Enum directly as its representation type (e.g. a `string`).
 If you get Flow errors about using an enum as its representation type, first try to refactor your code so that it expects the enum type instead of the representation type
 (e.g. change annotations from `string` to `Status`). If you really want to use the enum as its representation type, you can add in explicit casts.
-See [casting to represetation type](../using-enums/#toc-casting-to-representation-type).
+See [casting to representation type](../using-enums/#toc-casting-to-representation-type).
 
 
 #### Casting to the enum type {#toc-casting-to-the-enum-type}

--- a/website/docs/lang/nominal-structural.md
+++ b/website/docs/lang/nominal-structural.md
@@ -121,7 +121,7 @@ In a different file:
 import type {MyTypeAlias, MyOpaqueType} from "A.js";
 
 const x: MyTypeAlias = "hi"; // Works
-const y: MyOpaqueType = "hi"; // Error! `MyOpaqueType` is not interchangable with `string`
+const y: MyOpaqueType = "hi"; // Error! `MyOpaqueType` is not interchangeable with `string`
 //                      ^^^^ Cannot assign "hi" to y because string is incompatible with MyOpaqueType
 ```
 

--- a/website/docs/libdefs/creation.md
+++ b/website/docs/libdefs/creation.md
@@ -164,7 +164,7 @@ If you want to declare the types for a deeply nested module in a package like
 declare export const SECRET_INTERNALS_Foo: {...};
 ```
 
-This approach is preferrable to the approach described [below](#toc-declaring-a-module-globally),
+This approach is preferable to the approach described [below](#toc-declaring-a-module-globally),
 because editing these files will not trigger a restart of Flow server.
 
 ### Declaring a module in the global namespace  {#toc-declaring-a-module-globally}

--- a/website/docs/linting/flowlint-comments.md
+++ b/website/docs/linting/flowlint-comments.md
@@ -4,7 +4,7 @@ slug: /linting/flowlint-comments
 ---
 
 You can use `flowlint` comments to specify more granular lint settings within a file.
-These comments come in three froms:
+These comments come in three forms:
 * [flowlint](#toc-flowlint)
 * [flowlint-line](#toc-flowlint-line)
 * [flowlint-next-line](#toc-flowlint-next-line)

--- a/website/docs/linting/rule-reference.md
+++ b/website/docs/linting/rule-reference.md
@@ -36,7 +36,7 @@ type A = Array<bool>; // Error
 Like [`ambiguous-object-type`](#toc-ambiguous-object-type), except triggers even when the `exact_by_default` option is set to `false`.
 
 ### `nonstrict-import` {#toc-nonstrict-import}
-Used in conjuction with [Flow Strict](../../strict/). Triggers when importing a non `@flow strict` module. When enabled, dependencies of a `@flow strict` module must also be `@flow strict`.
+Used in conjunction with [Flow Strict](../../strict/). Triggers when importing a non `@flow strict` module. When enabled, dependencies of a `@flow strict` module must also be `@flow strict`.
 
 ### `sketchy-null` {#toc-sketchy-null}
 Triggers when you do an existence check on a value that can be either null/undefined or falsey.

--- a/website/docs/match/index.md
+++ b/website/docs/match/index.md
@@ -4,7 +4,7 @@ description: "match an input value against a series of patterns, which condition
 slug: /match
 ---
 
-*An experimental Flow langauge feature. See [adoption](#adoption) for how to enable.*
+*An experimental Flow language feature. See [adoption](#adoption) for how to enable.*
 
 `match` an input value against a series of [patterns](./patterns), which conditionally check the structure of the input and extract values, and either produce an expression (`match` expressions) or execute a block (`match` statements).
 

--- a/website/docs/types/arrays.md
+++ b/website/docs/types/arrays.md
@@ -184,7 +184,7 @@ arr4[0] = true; // Error!
 
 #### Nearer Scope Wins
 
-Shallow scope of assignment is prefered when there are multiple scopes where assignments happen:
+Shallow scope of assignment is preferred when there are multiple scopes where assignments happen:
 
 ``` js flow-check
 const arr5 = [];

--- a/website/docs/types/empty.md
+++ b/website/docs/types/empty.md
@@ -34,7 +34,7 @@ function f(x: 'a' | 'b'): number {
 If you had not checked for all members of the union (for example, changed `x` to be of type `'a' | 'b' | 'c'`),
 then `x` would no longer be `empty` in the `default`, and Flow would error.
 
-> Note: If you want exhaustively checked enums by defualt, without having to cast to `empty`,
+> Note: If you want exhaustively checked enums by default, without having to cast to `empty`,
 > you could enable and use [Flow Enums](../../enums) in your project.
 
 Since `empty` is the subtype of all types, all operations are permitted on something that has the `empty` type.

--- a/website/docs/types/type-guards.md
+++ b/website/docs/types/type-guards.md
@@ -219,7 +219,7 @@ function missing(param: mixed): prop is number {
 }
 ```
 
-It cannot be a parameter bound in a destructuring pattern, or a rest paramter:
+It cannot be a parameter bound in a destructuring pattern, or a rest parameter:
 ```js flow-check
 function destructuring({prop}: {prop: mixed}): prop is number {
   return typeof prop === "number";

--- a/website/docs/types/typeof.md
+++ b/website/docs/types/typeof.md
@@ -40,7 +40,7 @@ let str2: typeof str1 = 'world'; // Works!
 let str3: typeof str1 = false;   // Error!
 ```
 
-You can use any value with `typeof`, as long as the arugment itself is a variable or member access:
+You can use any value with `typeof`, as long as the argument itself is a variable or member access:
 
 ```js flow-check
 let obj1 = {foo: 1, bar: true, baz: 'three'};

--- a/website/src/try-flow/flow-grammar.json
+++ b/website/src/try-flow/flow-grammar.json
@@ -145,7 +145,7 @@
       ]
     },
     "ignore-long-lines": {
-      "comment": "so set at arbitary 1000 chars to avoid parsing minified files",
+      "comment": "so set at arbitrary 1000 chars to avoid parsing minified files",
       "patterns": [
         {
           "match": "^.{1000,}"
@@ -2044,7 +2044,7 @@
           ]
         },
         {
-          "comment": "GraphQL ( Relay.QL ) supprt. Use two forms of scopes! fixes some themes",
+          "comment": "GraphQL ( Relay.QL ) support. Use two forms of scopes! fixes some themes",
           "begin": "\\s*+(?:((Relay)(?:(\\?\\.)|(\\.))(QL))|(gql|graphql|graphql\\.experimental)|(/\\* GraphQL \\*/))\\s*((`))",
           "end": "\\s*((`))",
           "beginCaptures": {
@@ -2156,7 +2156,7 @@
       }
     },
     "literal-object": {
-      "comment": "obj lteral ({ or ,{ or [{ or ={ or return { or default {",
+      "comment": "obj literal ({ or ,{ or [{ or ={ or return { or default {",
       "begin": "(?:(?<=\\(|\\[|,)|(?:\\s*(?:(=)|\\b(default)\\b|\\b(return)\\b|(,))))\\s*({)",
       "end": "\\s*+(})",
       "beginCaptures": {
@@ -3805,7 +3805,7 @@
           ]
         },
         {
-          "comment": "getter/setter set [expresion]() or get 'literal-text'()",
+          "comment": "getter/setter set [expression]() or get 'literal-text'()",
           "name": "meta.accessor.js",
           "begin": "(?<=^|;|,|@@|}|{)\\s*+\\b(?:(static)\\s+)?(get|set)\\s+(?=((\\[(?:(?>[^\\[\\]]+)|\\g<-1>)*\\])|\\s*+(((')((?:[^']|\\\\')*)('))|\\s*+((\")((?:[^\"]|\\\\\")*)(\"))))\\s*+(\\())",
           "end": "\\s*(?={)|(?=;|}|,)",
@@ -4361,7 +4361,7 @@
           },
           "patterns": [
             {
-              "commnent": "decorator .property or .method which may be on a different line",
+              "comment": "decorator .property or .method which may be on a different line",
               "begin": "\\s*(?:(\\?\\.)|(\\.))",
               "end": "\\s*(\\#?)(?:((?:[\\p{Lu}\\p{Nl}]|\\\\u\\h{4}|\\\\u{\\h+})(?:[$_\\p{L}\\p{Mn}\\p{Mc}\\p{Nd}\\p{Nl}\\p{Pc}\\x{200C}\\x{200D}]|\\\\u\\h{4}|\\\\u{\\h+})*+)|((?:[$_\\p{L}\\p{Nl}]|\\\\u\\h{4}|\\\\u{\\h+})(?:[$_\\p{L}\\p{Mn}\\p{Mc}\\p{Nd}\\p{Nl}\\p{Pc}\\x{200C}\\x{200D}]|\\\\u\\h{4}|\\\\u{\\h+})*+))",
               "beginCaptures": {
@@ -4928,7 +4928,7 @@
     "jsx-entities": {
       "patterns": [
         {
-          "comment": "Embeded HTML entities &blah",
+          "comment": "Embedded HTML entities &blah",
           "match": "(&)([a-zA-Z0-9]+|#[0-9]+|#x[0-9a-fA-F]+)(;)",
           "captures": {
             "0": {
@@ -5807,7 +5807,7 @@
               "name": "keyword.other.declare.flowtype"
             },
             "2": {
-              "name": "keyword.constrol.module.flowtype"
+              "name": "keyword.control.module.flowtype"
             },
             "3": {
               "name": "storage.type.class.flowtype"


### PR DESCRIPTION
## Summary

Fix typos and correct misspellings across the project documentation and changelog

Documentation:
- Correct various typos and grammatical errors in [Changelog.md](https://github.com/JamBalaya56562/flow/blob/main/Changelog.md)
- Fix misspellings and wording in website documentation (editor guides, language references, enum docs, linting rules, etc.)
- Update [pull request template](https://github.com/JamBalaya56562/flow/blob/main/.github/pull_request_template.md) to correct 'defintions' to 'definitions'