### PR TITLE
[flow] fix typos in src directory

### DIFF
--- a/src/analysis/env_builder/find_providers.ml
+++ b/src/analysis/env_builder/find_providers.ml
@@ -98,7 +98,7 @@ end = struct
     | ArrInitialized of int
     | Uninitialized
 
-  (* This describes a single assingment/initialization of a var (rather than the var's state as a whole). ints are
+  (* This describes a single assignment/initialization of a var (rather than the var's state as a whole). ints are
      number of scopes deeper than the variable's declaration that the assignment occurs *)
   type write_state =
     | Annotation of { contextual: bool }
@@ -127,7 +127,7 @@ end = struct
         case, we exclude declarations--declare_locs and def_locs should be disjoint.
       * provider_locs are the candidate providers we're calculating in this module, and can be either declares or defs.
         Initially, in this module, 'locs will be instantiated as `write_state L.LMap.t`, recording what kind
-        of write an indvidual candidate provider is. Later on, in provider_api, this will be simplified and filtered
+        of write an individual candidate provider is. Later on, in provider_api, this will be simplified and filtered
         into a single `L.LSet.t` of providers
 
         We expect that the keys/elements of provider_locs are a subset of the union of def_locs and declare_locs.

--- a/src/analysis/env_builder/name_resolver.ml
+++ b/src/analysis/env_builder/name_resolver.ml
@@ -2294,7 +2294,7 @@ module Make (Context : C) (FlowAPIUtils : F with type cx = Context.t) :
             env_state <- { env_state with current_bindings = old_val }
         )
 
-      (* Override the object type constuctor to disable the EReferenceInAnnotation check
+      (* Override the object type constructor to disable the EReferenceInAnnotation check
        * since this is a common and safe way to encode recursive object types. *)
       method! object_type loc ot =
         let old_val = env_state.current_bindings in
@@ -2689,7 +2689,7 @@ module Make (Context : C) (FlowAPIUtils : F with type cx = Context.t) :
                        because the type should be computed from the array providers. *)
                     EnvMap.add_ordinary name_loc write_kind env_state.write_entries
                   ) else
-                    (* All of the providers are aleady in the map. We don't want to overwrite them with
+                    (* All of the providers are already in the map. We don't want to overwrite them with
                      * a non-assigning write. We _do_ want to enter regular function declarations as
                      * non-assigning writes so that they are not checked against the providers in
                      * Env.set_env_entry *)
@@ -5073,7 +5073,7 @@ module Make (Context : C) (FlowAPIUtils : F with type cx = Context.t) :
           Compare that to
             if {x.y} { } else { }
           For this case, we will call commit_refinement only once, with a map that contains both the refinement x HasProp(y) and
-          x.y Truthy. When we negate this, because we only called commit_refinement once and therefore our refinement propositon
+          x.y Truthy. When we negate this, because we only called commit_refinement once and therefore our refinement proposition
           contains just a single set of refinements (not multiple ones conjuncted together), we'll end up with
           x NotHasProp(y) and x.y Falsey--which is what we want.
       *)
@@ -5266,7 +5266,7 @@ module Make (Context : C) (FlowAPIUtils : F with type cx = Context.t) :
         in
         this#merge_self_refinement_scope new_latest_refinements
 
-      (* Refines an expr if that expr has a refinement key, othewise does nothing *)
+      (* Refines an expr if that expr has a refinement key, otherwise does nothing *)
       method add_refinement_to_expr expr ~refining_locs refi_kind =
         match RefinementKey.of_expression expr with
         | None -> ()
@@ -5931,7 +5931,7 @@ module Make (Context : C) (FlowAPIUtils : F with type cx = Context.t) :
           ignore @@ this#arg_list arguments;
           this#havoc_current_env ~invalidation_reason:Refinement_invalidation.FunctionCall ~loc;
           let refis = LookupMap.empty in
-          (* Paremeter type-guard refinements *)
+          (* Parameter type-guard refinements *)
           (* Function calls may introduce refinements if the function called is a
            * type-guard function. The EnvBuilder has no idea if a function is a
            * type-guard function or not. To handle that, we encode that a variable

--- a/src/analysis/ssa_builder.ml
+++ b/src/analysis/ssa_builder.ml
@@ -7,7 +7,7 @@
 
 (* This module is responsible for building a mapping from variable reads to the
  * writes those reads. This is used in type checking to determine if a variable is
- * const-like, but the name_resolver is used to build the type checking envrionment.
+ * const-like, but the name_resolver is used to build the type checking environment.
  * The name_resolver copied much of the implementation here, but with sufficient divergence
  * to warrant forking the implementation.
  * If you're here to add support for a new syntax feature, you'll likely

--- a/src/commands/applyCodeActionCommand.ml
+++ b/src/commands/applyCodeActionCommand.ml
@@ -14,7 +14,7 @@ let handle_error ?(code = Exit.Unknown_error) msg = Exit.(exit ~msg code)
 module SourceAddMissingImports = struct
   let spec =
     {
-      name = "Add mising imports";
+      name = "Add missing imports";
       doc = "Runs the 'source.addMissingImports' code action";
       usage =
         Printf.sprintf

--- a/src/commands/config/flowConfig.ml
+++ b/src/commands/config/flowConfig.ml
@@ -1294,7 +1294,7 @@ module Opts = struct
               Ok opts
         )
       );
-      ( "unsuppported.windows",
+      ( "unsupported.windows",
         boolean (fun opts v ->
             if Sys.win32 && v then
               Error "Windows is not supported under this flowconfig."

--- a/src/common/errors/error_codes.ml
+++ b/src/common/errors/error_codes.ml
@@ -10,7 +10,7 @@ type error_code =
   | ReactRuleUnsafeMutation
   | ReactRuleHookConditional
   | ReactRuleHookDefinitelyNotInComponentOrHook
-  | ReactRuleHookMixedWithNonHoook
+  | ReactRuleHookMixedWithNonHook
   | ReactRuleHookMutation
   | ReactRuleHookNamingConvention
   | ReactRuleHookNonHookSyntax
@@ -228,7 +228,7 @@ let require_specific : error_code -> bool = function
   | ReactRuleUnsafeMutation
   | ReactRuleHookConditional
   | ReactRuleHookDefinitelyNotInComponentOrHook
-  | ReactRuleHookMixedWithNonHoook
+  | ReactRuleHookMixedWithNonHook
   | ReactRuleHookMutation
   | ReactRuleHookNamingConvention
   | ReactRuleHookNonHookSyntax
@@ -246,7 +246,7 @@ let string_of_code : error_code -> string = function
   | ReactRuleHookConditional -> "react-rule-hook-conditional"
   | ReactRuleHookDefinitelyNotInComponentOrHook ->
     "react-rule-hook-definitely-not-in-component-or-hook"
-  | ReactRuleHookMixedWithNonHoook -> "react-rule-hook-mixed-with-non-hook"
+  | ReactRuleHookMixedWithNonHook -> "react-rule-hook-mixed-with-non-hook"
   | ReactRuleHookMutation -> "react-rule-hook-mutation"
   | ReactRuleHookNamingConvention -> "react-rule-hook-naming-convention"
   | ReactRuleHookNonHookSyntax -> "react-rule-hook-non-hook-syntax"

--- a/src/common/errors/flow_errors_utils.ml
+++ b/src/common/errors/flow_errors_utils.ml
@@ -2632,7 +2632,7 @@ module Cli_output = struct
       in
       (* Go through a very similar process as primary locations to add a reference
        * for the root location and record its id. If a reference already exists
-       * then we will not higlight our root location any differently! *)
+       * then we will not highlight our root location any differently! *)
       let (next_id, loc_to_id, id_to_loc, root_id, custom_root_color) =
         match LocMap.find_opt root_loc loc_to_id with
         | Some id -> (next_id, loc_to_id, id_to_loc, Some id, false)

--- a/src/common/lints/exactCover.mli
+++ b/src/common/lints/exactCover.mli
@@ -15,7 +15,7 @@
  * ExactCover.t is a read-only structure for efficient querying.
  *
  * ExactCover.builder is a write-only structure for efficient construction
- * (under some assuptions) that can be baked into an ExactCover.t.
+ * (under some assumptions) that can be baked into an ExactCover.t.
  *)
 
 open Lints

--- a/src/common/reason.ml
+++ b/src/common/reason.ml
@@ -15,7 +15,7 @@ module Ast = Flow_ast
 
 (* Eventually, trace information should be printed out only in verbose mode,
    since Flow reports all errors it finds and the trace for every error can get
-   quite detailed dependening on how far apart the "source" and "sink" are and
+   quite detailed depending on how far apart the "source" and "sink" are and
    how convoluted the flow between them is. *)
 
 open Utils_js
@@ -1309,7 +1309,7 @@ let mk_initial_arguments_reason =
 let mk_pattern_reason ((loc, _) as patt) = mk_reason (RCode (code_desc_of_pattern patt)) loc
 
 (* Classifies a reason description. These classifications can be used to
- * implement various asthetic behaviors in error messages when we would like to
+ * implement various aesthetic behaviors in error messages when we would like to
  * distinguish between different error "classes".
  *
  * The classifications we currently support:

--- a/src/common/ty/ty.ml
+++ b/src/common/ty/ty.ml
@@ -435,7 +435,7 @@ class ['A] comparator_ty =
       with
       | Difference n -> n
 
-    (* Take advantage of pointer equality at type nodes to short circut *)
+    (* Take advantage of pointer equality at type nodes to short circuit *)
     method! private on_t env x y =
       if x == y then
         ()

--- a/src/common/ty/ty_utils.mli
+++ b/src/common/ty/ty_utils.mli
@@ -21,7 +21,7 @@ val unmaybe_ty : Ty.t -> Ty.t
 
 val elt_equal : Ty.elt -> Ty.elt -> bool
 
-(** Utility useful for codemods/type insertion. When the element we infered is a
+(** Utility useful for codemods/type insertion. When the element we inferred is a
     declaration we can't directly print/insert in code. This utility helps convert
     it to an equivalent type. For example it will convert `class C` to `typeof C`,
     `enum E` to `typeof E`. *)

--- a/src/common/utils/utils_js.ml
+++ b/src/common/utils/utils_js.ml
@@ -229,7 +229,7 @@ let ordinal = function
   | 5 -> "fifth"
   | 6 -> "sixth"
   | 7 -> "seventh"
-  | 8 -> "eigth"
+  | 8 -> "eighth"
   | 9 -> "ninth"
   | n ->
     let n = string_of_int n in

--- a/src/hack_forked/fsevents/fsevents_stubs.c
+++ b/src/hack_forked/fsevents/fsevents_stubs.c
@@ -133,7 +133,7 @@ struct env {
  * The pipes are only used signal the other thread that something is ready. So
  * writing '.' to the pipe is sufficient. In theory, you could get away with
  * only having pipes and not using the linked lists at all. pthreads can
- * automically write to and read from pipes up to N bytes (which I think is
+ * automatically write to and read from pipes up to N bytes (which I think is
  * usually 512). In the case where we have large paths, though, it gets a
  * little tricker, and I like writing lockless data structures :P
  */
@@ -169,7 +169,7 @@ static void clear_pipe(int fd) {
 }
 
 /**
- * This callback is called whenver an FSEvents watch is triggered
+ * This callback is called whenever an FSEvents watch is triggered
  */
 static void watch_callback(
     ConstFSEventStreamRef streamRef,

--- a/src/hack_forked/fsnotify_win/fsnotify.ml
+++ b/src/hack_forked/fsnotify_win/fsnotify.ml
@@ -44,7 +44,7 @@ type event = {
 external raw_init : Unix.file_descr -> fsenv = "caml_fsnotify_init"
 
 (* [raw_add_watch out_fd dir] creates a thread that monitor [dir] and
-   push a single charactes into the pipe 'out_fd' whenever a events is
+   push a single characters into the pipe 'out_fd' whenever a events is
    ready to be read with [raw_read_events].
 
    The return value is an opaque `watcher_id`, currently it contains

--- a/src/hack_forked/test/utils/asserter/asserter.ml
+++ b/src/hack_forked/test/utils/asserter/asserter.ml
@@ -70,10 +70,10 @@ module type Pattern_substitutions = sig
   (** List of key-value pairs. We perform these key to value
    * substitutions in-order.
    *
-   * For example, consider the substitions:
+   * For example, consider the substitutions:
    *   [ ("foo", "bar"); ("bar", "world"); ]
    *
-   * being appied to the string:
+   * being applied to the string:
    *   "hello {{foo}}"
    *
    * which gets transformed to:
@@ -103,7 +103,7 @@ module Pattern_comparator (Substitutions : Pattern_substitutions) = struct
   (** Argh, due to the signature of Comparator, the "expected" and
    * "actual" have the same type, even though for this Pattern_comparator
    * we would really like them to be different. We'd like "actual" to
-   * be type string, and "epxected" to be type "pattern", and
+   * be type string, and "expected" to be type "pattern", and
    * so we can apply the substitutions to only the pattern. But splitting
    * them out into different types for all the modules only because this module
    * needs it isn't really worth it. Oh well. So we treat actual as a pattern

--- a/src/hack_forked/utils/core/fast_compare.c
+++ b/src/hack_forked/utils/core/fast_compare.c
@@ -8,7 +8,7 @@
 /**
  * This file exports a customized fast comparison function
  * for most common cases, it does not cover edge cases like OCaml's built-in
- * ones. And its string comparision is based on length first, and content later.
+ * ones. And its string comparison is based on length first, and content later.
  *
  * The restrictions are documented in the
  * exported functions.
@@ -79,7 +79,7 @@ static void resize_stack(stack* stk, item** sp) {
   } while (0)
 
 /**
- * comapre [v1] [v2] assuming they are
+ * compare [v1] [v2] assuming they are
  * immediate numbers
  */
 #define SIMPLE_COMPARE(v1, v2) \
@@ -137,7 +137,7 @@ static void resize_stack(stack* stk, item** sp) {
 
 /**
  * POP_STACK(sp,stk,val1,val2)
- * POP the stack the poped value is put inside [val1]
+ * POP the stack the popped value is put inside [val1]
  * and [val2]
  */
 #define POP_STACK(sp, stk, val1, val2) \
@@ -192,7 +192,7 @@ static value compare_with_stack(value v1, value v2, stack* stk, item* sp) {
 }
 
 /**
- * compare two values [v1] and [v2] which foucs on performance
+ * compare two values [v1] and [v2] which focus on performance
  * restrictions:
  * - The entry point of [v1] and [v2] should not be an
  *   array, string or double

--- a/src/hack_forked/utils/disk/disk.mli
+++ b/src/hack_forked/utils/disk/disk.mli
@@ -21,7 +21,7 @@ val file_exists : string -> bool
 
 val mkdir_p : string -> unit
 
-(* Delete the given path - if it is a directory, delete recurisvely. *)
+(* Delete the given path - if it is a directory, delete recursively. *)
 val rm_dir_tree : string -> unit
 
 val is_directory : string -> bool

--- a/src/hack_forked/utils/lsp/lsp.ml
+++ b/src/hack_forked/utils/lsp/lsp.ml
@@ -593,7 +593,7 @@ module Initialize = struct
   }
 
   and workspaceClientCapabilities = {
-    applyEdit: bool;  (** client supports appling batch edits *)
+    applyEdit: bool;  (** client supports applying batch edits *)
     configuration: bool;  (** client supports workspace/configuration requests *)
     workspaceEdit: workspaceEdit;
     didChangeConfiguration: dynamicRegistration;

--- a/src/hack_forked/utils/sys/daemon.ml
+++ b/src/hack_forked/utils/sys/daemon.ml
@@ -17,7 +17,7 @@ type ('in_, 'out) handle = {
 }
 
 (* Windows: ensure that the serialize/deserialize functions
-   for the custom block of "Unix.file_descr" are registred. *)
+   for the custom block of "Unix.file_descr" are registered. *)
 let () = Lazy.force Handle.init
 
 let to_channel : 'a out_channel -> ?flags:Marshal.extern_flags list -> ?flush:bool -> 'a -> unit =
@@ -141,7 +141,7 @@ let exec entry param ic oc =
    * process image has been replaced. We're using "exec" here to mean
    * running the proper entry.
    *
-   * Since Linux's "exec" has already completed, we can actaully set
+   * Since Linux's "exec" has already completed, we can actually set
    * FD_CLOEXEC on the opened channels.
    *)
   let () = Unix.set_close_on_exec (descr_of_in_channel ic) in

--- a/src/hack_forked/utils/sys/sys_utils.ml
+++ b/src/hack_forked/utils/sys/sys_utils.ml
@@ -273,7 +273,7 @@ let nbr_procs = nproc ()
   more than one handle that points to a single process (unlike
   pids, where there is a single pid for a process).
 
-  This isn't a problem normally, since functons like Unix.waitpid()
+  This isn't a problem normally, since functions like Unix.waitpid()
   will take the process handle on Windows. But if you want to print
   or log the pid, then you need to dereference the handle and get
   the pid. And that's what this function does. *)

--- a/src/hack_forked/utils/sys/sysinfo.c
+++ b/src/hack_forked/utils/sys/sysinfo.c
@@ -87,7 +87,7 @@ CAMLprim value hh_sysinfo_uptime(value unit) {
  * more than one handle that points to a single process (unlike
  * pids, where there is a single pid for a process).
  *
- * This isn't a problem normally, since functons like Unix.waitpid()
+ * This isn't a problem normally, since functions like Unix.waitpid()
  * will take the process handle on Windows. But if you want to print
  * or log the pid, then you need to dereference the handle and get
  * the pid. And that's what this function does.

--- a/src/hack_forked/utils/sys/timer.ml
+++ b/src/hack_forked/utils/sys/timer.ml
@@ -15,7 +15,7 @@
  *    building a cross-platform feature, you'll need a Windows-specific implementation. For example,
  *    Timeout uses select instead of timers to implement timeouts on Windows.
  * 2. Timer is built using signals, which can cause your Unix calls to error with EINTR, since
- *    you are interupting them. Not a huge deal, just worth being aware of.
+ *    you are interrupting them. Not a huge deal, just worth being aware of.
  *
  * The Timer implementation generally works as follows:
  *

--- a/src/hack_forked/utils/sys/timer.mli
+++ b/src/hack_forked/utils/sys/timer.mli
@@ -15,7 +15,7 @@
  *    building a cross-platform feature, you'll need a Windows-specific implementation. For example,
  *    Timeout uses select instead of timers to implement timeouts on Windows.
  * 2. Timer is built using signals, which can cause your Unix calls to error with EINTR, since
- *    you are interupting them. Not a huge deal, just worth being aware of.
+ *    you are interrupting them. Not a huge deal, just worth being aware of.
  *)
 
 type t

--- a/src/heap/__tests__/heap_tests.ml
+++ b/src/heap/__tests__/heap_tests.ml
@@ -562,7 +562,7 @@ let sklist_barrier_test _ =
    * objects to blue. *)
   collect_full ();
 
-  (* Reload the set from the root, in case it moved due to compation. *)
+  (* Reload the set from the root, in case it moved due to compaction. *)
   let set = Option.get (get_file_dependents (Option.get (Files.get "root"))) in
 
   (* The set should contain "a" "b" and "d" -- the write barrier on

--- a/src/heap/hh_shared.c
+++ b/src/heap/hh_shared.c
@@ -746,7 +746,7 @@ CAMLprim value hh_shared_init(value config_val, value num_workers_val) {
   /* The info page contains (1) size information describing the layout of the
    * rest of the shared file; (2) values which are atomically updated by
    * workers, like the heap pointer; and (3) various configuration which is
-   * conventient to stick here, like the log level. */
+   * convenient to stick here, like the log level. */
   map_info_page(page_bsize);
   memfd_reserve((char*)info, (char*)info, page_bsize);
 
@@ -927,7 +927,7 @@ CAMLprim value hh_check_should_cancel(value unit) {
  * another slice.
  *
  * Because the program can modify the heap between slices of mark and sweep, we
- * need to be careful that all reachable objects are marked. We use a shapshot-
+ * need to be careful that all reachable objects are marked. We use a snapshot-
  * at-the-beginning approach, which ensures that all reachable objects at the
  * beginning of GC pass are marked. We also use an "allocate black" strategy,
  * meaning that any new objects allocated during a collection are considered
@@ -1769,7 +1769,7 @@ CAMLprim value hh_remove(value key) {
 /*****************************************************************************/
 /* Blits an OCaml string representation into the shared heap.
  *
- * Note that, like OCaml's heap, the shared heap is word-addressible. Like
+ * Note that, like OCaml's heap, the shared heap is word-addressable. Like
  * OCaml's strings, strings in the shared heap are encoded with a header
  * containing the size in words, where the last byte of the last word contains
  * an offset used to calculate the exact bytes size. */

--- a/src/heap/sharedMem.ml
+++ b/src/heap/sharedMem.ml
@@ -194,7 +194,7 @@ external hash_stats : unit -> table_stats = "hh_hash_stats"
 external get_next_version : unit -> int = "hh_next_version" [@@noalloc]
 
 (* Any entities which were advanced since the last commit will be committed
- * after this. Committing the transaction requries synchronization with readers
+ * after this. Committing the transaction requires synchronization with readers
  * and writers. *)
 external commit_transaction : unit -> unit = "hh_commit_transaction"
 

--- a/src/lsp/flowLsp.ml
+++ b/src/lsp/flowLsp.ml
@@ -1062,7 +1062,7 @@ let track_to_server (state : server_state) (c : Lsp.lsp_message) : server_state 
          right now ourselves, since all editors take care of that; but if ever we
          re-send the server's existing diagnostics for this file then that should take
          into account any user edits since then. This isn't perfect - e.g. if the user
-         modifies a file we'll update squiggles, but if the user subsquently closes the
+         modifies a file we'll update squiggles, but if the user subsequently closes the
          file unsaved and then re-opens it then we'll be left with wrong squiggles.
          It also doesn't compensate if the flow server starts a typecheck, then receives
          a DidChange, then sends error spans from as it was at the start of the typecheck.

--- a/src/monitor/flowServerMonitorServer.ml
+++ b/src/monitor/flowServerMonitorServer.ml
@@ -529,7 +529,7 @@ module KeepAliveLoop = LwtLoop.Make (struct
         | Invalid_flowconfig
         (* Parse/version/etc error. Server will never start correctly. *)
         | Path_is_not_a_file
-        (* Required a file but privided path was not a file *)
+        (* Required a file but provided path was not a file *)
         | Flowconfig_changed
         (* We could survive some config changes, but it's too hard to tell *)
         | Invalid_saved_state

--- a/src/monitor/socketAcceptor.ml
+++ b/src/monitor/socketAcceptor.ml
@@ -31,10 +31,10 @@ end
 (** A loop that sends the Server's busy status to a waiting connection every 0.5 seconds *)
 module StatusLoop (Writer : STATUS_WRITER) = struct
   let rec run conn =
-    (* it is important that we not yield between wait_for_signficant_status and the
+    (* it is important that we not yield between wait_for_significant_status and the
        next iteration of this loop, where we wait again. if we are not waiting when
        a status is sent, we'll miss it! *)
-    let%lwt status = StatusStream.wait_for_signficant_status ~timeout:0.5 in
+    let%lwt status = StatusStream.wait_for_significant_status ~timeout:0.5 in
     if not (Writer.write status conn) then
       (* The connection closed its write stream, likely it is closed or closing *)
       Lwt.return_unit

--- a/src/monitor/status/serverStatus.ml
+++ b/src/monitor/status/serverStatus.ml
@@ -178,7 +178,7 @@ let string_of_event = function
   | GC_start -> "GC_start"
   | Collating_errors_start -> "Collating_errors_start"
   | Watchman_wait_start _deadline -> "Watchman_wait_start"
-  | Load_libraries_start -> "Loading_libaries_start"
+  | Load_libraries_start -> "Loading_libraries_start"
 
 (** As a general rule, use past tense for status updates that show progress and present perfect
     progressive for those that don't. *)
@@ -344,7 +344,7 @@ let is_significant_transition old_status new_status =
           they take a long time for some reason. *)
        false
      | (Typechecking (old_mode, old_tc_status), Typechecking (new_mode, new_tc_status)) ->
-       (* A change in mode is always signifcant *)
+       (* A change in mode is always significant *)
        old_mode <> new_mode
        || begin
             match (old_tc_status, new_tc_status) with

--- a/src/monitor/statusStream.ml
+++ b/src/monitor/statusStream.ml
@@ -145,7 +145,7 @@ let get_status () =
 
 let ever_been_free () = !current_status.ever_been_free
 
-let wait_for_signficant_status ~timeout =
+let wait_for_significant_status ~timeout =
   (* If there is a significant transition before the timeout, the cancel the sleep and return the
    * new status. Otherwise, stop waiting on the condition variable and return the current status *)
   Lwt.pick

--- a/src/monitor/statusStream.mli
+++ b/src/monitor/statusStream.mli
@@ -18,7 +18,7 @@ val call_on_free : f:(unit -> unit Lwt.t) -> unit Lwt.t
 
 val get_status : unit -> ServerStatus.status * FileWatcherStatus.status
 
-val wait_for_signficant_status :
+val wait_for_significant_status :
   timeout:float -> (ServerStatus.status * FileWatcherStatus.status) Lwt.t
 
 val ever_been_free : unit -> bool

--- a/src/parser/jsx_parser.ml
+++ b/src/parser/jsx_parser.ml
@@ -546,7 +546,7 @@ module JSX (Parse : Parser_common.PARSER) (Expression : Parser_common.EXPRESSION
               frag_closing_element =
                 (match closing_element with
                 | `Fragment loc -> loc
-                (* the following are parse erros *)
+                (* the following are parse errors *)
                 | `Element (loc, _) -> loc
                 | _ -> end_loc);
               frag_children = children;

--- a/src/parser/parser_common.ml
+++ b/src/parser/parser_common.ml
@@ -431,7 +431,7 @@ let private_identifier env =
     error_at env (loc, Parse_error.WhitespaceInPrivateName);
   (loc, { PrivateName.name; comments })
 
-(** The operation IsSimpleParamterList
+(** The operation IsSimpleParameterList
     https://tc39.es/ecma262/#sec-static-semantics-issimpleparameterlist *)
 let is_simple_parameter_list =
   let is_simple_param = function

--- a/src/parser_utils/__tests__/flow_ast_differ_test.ml
+++ b/src/parser_utils/__tests__/flow_ast_differ_test.ml
@@ -1470,12 +1470,12 @@ let tests =
              ~mapper:(new useless_mapper)
          );
          ( "with_body" >:: fun ctxt ->
-           let source = "with (objct) { rename; };" in
+           let source = "with (object) { rename; };" in
            assert_edits_equal
              ctxt
              ~edits:[((15, 21), "gotRenamed")]
              ~source
-             ~expected:"with (objct) { gotRenamed; };"
+             ~expected:"with (object) { gotRenamed; };"
              ~mapper:(new useless_mapper)
          );
          ( "function_expression" >:: fun ctxt ->

--- a/src/parser_utils/export_condition_map.ml
+++ b/src/parser_utils/export_condition_map.ml
@@ -24,19 +24,19 @@ let create_from_shorthand_value ~value =
 
 let create_from_shorthand ~path = create_from_shorthand_value ~value:(Path path)
 
-let is_targeted_condition valid_conditions canidate_condition =
-  List.mem canidate_condition valid_conditions || canidate_condition = "default"
+let is_targeted_condition valid_conditions candidate_condition =
+  List.mem candidate_condition valid_conditions || candidate_condition = "default"
 
 let rec pick_target valid_conditions pattern_match = function
-  | (canidate_condition, Nested child_condition_map) :: rest ->
-    if is_targeted_condition valid_conditions canidate_condition then
+  | (candidate_condition, Nested child_condition_map) :: rest ->
+    if is_targeted_condition valid_conditions candidate_condition then
       match pick_target valid_conditions pattern_match child_condition_map with
       | Some t -> Some t
       | None -> pick_target valid_conditions pattern_match rest
     else
       pick_target valid_conditions pattern_match rest
-  | (canidate_condition, Path target_path) :: rest ->
-    if is_targeted_condition valid_conditions canidate_condition then
+  | (candidate_condition, Path target_path) :: rest ->
+    if is_targeted_condition valid_conditions candidate_condition then
       match pattern_match with
       | Some pattern_match ->
         Some (Base.String.substr_replace_first ~pattern:"*" ~with_:pattern_match target_path)

--- a/src/parser_utils/flow_ast_contains_mapper.ml
+++ b/src/parser_utils/flow_ast_contains_mapper.ml
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *)
 
-(* This mapper prunes expression and statements that are not relevent
+(* This mapper prunes expression and statements that are not relevant
    to a target from being mapped over and rebuilt. It doesn't prune the
    space as much as is possible, but doing so results in a much less
    maintainable piece of code. *)

--- a/src/parser_utils/flow_ast_differ.ml
+++ b/src/parser_utils/flow_ast_differ.ml
@@ -46,7 +46,7 @@ let change_compare (pos1, chg1) (pos2, chg2) =
 
 (* diffs based on http://www.xmailserver.org/diff2.pdf on page 6 *)
 let list_diff (old_list : 'a list) (new_list : 'a list) : 'a diff_result list option =
-  (* Lots of acccesses in this algorithm so arrays are faster *)
+  (* Lots of accesses in this algorithm so arrays are faster *)
   let (old_arr, new_arr) = (Array.of_list old_list, Array.of_list new_list) in
   let (n, m) = (Array.length old_arr, Array.length new_arr) in
   (* The shortest edit sequence problem is equivalent to finding the longest

--- a/src/parser_utils/output/__tests__/js_layout_generator/jsx_test.ml
+++ b/src/parser_utils/output/__tests__/js_layout_generator/jsx_test.ml
@@ -268,7 +268,7 @@ let tests =
       ignore ctxt
     );
     ( "valueless_attribute" >:: fun ctxt ->
-      (* TODO: valueless attributes shouldnt print trailing spaces when last *)
+      (* TODO: valueless attributes shouldn't print trailing spaces when last *)
       assert_expression_string ~ctxt "<A a />"
     );
     ("namespaced_valueluess_attribute" >:: fun ctxt -> assert_expression_string ~ctxt "<A a:a />");

--- a/src/parser_utils/output/__tests__/js_layout_generator_test.ml
+++ b/src/parser_utils/output/__tests__/js_layout_generator_test.ml
@@ -62,7 +62,7 @@ let tests =
            let ast = E.plus x (E.mult plus_y y) in
            assert_expression ~ctxt "x+(+y)*y" ast;
 
-           (* parens are necessary around the inner `+y+y`, but would be reundant
+           (* parens are necessary around the inner `+y+y`, but would be redundant
               around the multiplication. that is, we don't need `x+((+y+y)*y)`. *)
            let ast = E.plus x (E.mult (E.plus plus_y y) y) in
            assert_expression ~ctxt "x+(+y+y)*y" ast

--- a/src/parser_utils/output/js_layout_generator.ml
+++ b/src/parser_utils/output/js_layout_generator.ml
@@ -1166,7 +1166,7 @@ and expression ?(ctxt = normal_context) ~opts (root_expr : (Loc.t, Loc.t) Ast.Ex
       | E.Logical { E.Logical.operator; left; right; comments } ->
         let expression_with_parens ~precedence ~ctxt ~opts expr =
           match (operator, expr) with
-          (* Logical expressions inside a nullish coalese expression must be wrapped in parens *)
+          (* Logical expressions inside a nullish coalesce expression must be wrapped in parens *)
           | ( E.Logical.NullishCoalesce,
               (_, E.Logical { E.Logical.operator = E.Logical.And | E.Logical.Or; _ })
             ) ->

--- a/src/parser_utils/type_sig/type_sig.ml
+++ b/src/parser_utils/type_sig/type_sig.ml
@@ -597,7 +597,7 @@ type 'a op =
  * which are all conflated in this type.
  *
  * 1. If there are insufficient annotations to extract a signature, we should
- *    should inform the user and proceeed as if the unknown type was any.
+ *    should inform the user and proceed as if the unknown type was any.
  * 2. If some unsupported or unexpected syntax was detected, we should proceed
  *    as if the type was any, but not inform the user. The checking phase will
  *    uncover the same error.

--- a/src/parser_utils/type_sig/type_sig_utils.ml
+++ b/src/parser_utils/type_sig/type_sig_utils.ml
@@ -12,7 +12,7 @@ module Pack = Type_sig_pack
 
 (* For builtins, each lib file is parsed separately into an unresolved global
    scope. The parsed lib files are then combined before resolving names. The
-   proceses of combining deals with overridden definitions. Finally, the
+   processes of combining deals with overridden definitions. Finally, the
    resolved builtins are merged. Declared modules can depend on each other, so
    they are treated like a cycle. *)
 let parse_lib opts scope tbls ast =

--- a/src/parsing/docblock_parser.ml
+++ b/src/parsing/docblock_parser.ml
@@ -207,7 +207,7 @@ let extract_docblock =
     fun ~max_tokens ~file_options filename content ->
       (* Consume tokens in the file until we get a comment. This is a hack to
        * support Nuclide, which needs 'use babel' as the first token due to
-       * contstraints with Atom (see https://github.com/atom/atom/issues/8416 for
+       * constraints with Atom (see https://github.com/atom/atom/issues/8416 for
        * more context). At some point this should change back to consuming only
        * the first token. *)
       let lb =

--- a/src/server/rechecker/rechecker.ml
+++ b/src/server/rechecker/rechecker.ml
@@ -73,7 +73,7 @@ let start_parallelizable_workloads genv env =
   (* Allow this stop function to be called multiple times for the same loop *)
   let already_woken = ref false in
   fun () ->
-    (* Tell the loop to cancel at its earliest convinience *)
+    (* Tell the loop to cancel at its earliest convenience *)
     if not !already_woken then Lwt.wakeup wakener ();
     already_woken := true;
 

--- a/src/services/autocomplete/autocompleteService_js.ml
+++ b/src/services/autocomplete/autocompleteService_js.ml
@@ -629,7 +629,7 @@ let quote_kind token =
     | _ -> None
 
 (* Use the given token to tweak the edit range to respect existing quotations
- * and avoid overridding existing quotations *)
+ * and avoid overriding existing quotations *)
 let autocomplete_create_string_literal_edit_controls ~prefer_single_quotes ~edit_locs ~token =
   let prefer_single_quotes =
     (* If the user already typed a quote, use that kind regardless of the config option *)
@@ -640,7 +640,7 @@ let autocomplete_create_string_literal_edit_controls ~prefer_single_quotes ~edit
   in
   let edit_locs =
     (* When completing a string literal, always replace. Inserting is likely to produce
-       an invalid string which is probably not what the user wnats. *)
+       an invalid string which is probably not what the user wants. *)
     match quote_kind token with
     | Some _ -> (snd edit_locs, snd edit_locs)
     | None -> edit_locs
@@ -2055,7 +2055,7 @@ let autocomplete_object_key ~typing ~edit_locs ~token ~used_keys ~spreads obj_ty
   let exclude_keys =
     Base.List.fold ~init:used_keys spreads ~f:(fun acc (spread_loc, spread_type) ->
         (* Only exclude the keys of spreads after our prop. If the spread is before our
-           insertion we do not use it to exclude properties from our autcomplete
+           insertion we do not use it to exclude properties from our autocomplete
            suggestions. It is a common pattern to use a spread to set default values and
            then override some of those defaults. *)
         if Loc.compare spread_loc insert_loc < 0 then

--- a/src/services/autocomplete/autocomplete_sigil.ml
+++ b/src/services/autocomplete/autocomplete_sigil.ml
@@ -46,7 +46,7 @@ end
  * prefixes before the sigil. Having a single form to represent all these forms
  * enables caching of typing artifacts for autocomplete.
  *
- * When this function succeds in adding a canonical form for the token under
+ * When this function succeeds in adding a canonical form for the token under
  * cursor, it will return a [canon_token] structure. This structure includes
  * information used in typechecking the canonical form of the contents, and also
  * in restoring the results of `Autocomplete_js.process_location` to a form that

--- a/src/services/code_action/__tests__/refactor_extract_tests.ml
+++ b/src/services/code_action/__tests__/refactor_extract_tests.ml
@@ -474,7 +474,7 @@ function newFunction(): void {
       while (true) {
         // selection start
         switch (true) {default:continue;}
-        // seletion end
+        // selection end
       }
 
       |}

--- a/src/services/code_action/__tests__/refactor_extract_utils_tests.ml
+++ b/src/services/code_action/__tests__/refactor_extract_utils_tests.ml
@@ -299,7 +299,7 @@ let b = 4;
       |} in
       assert_extracted ~ctxt ~expected_statements source (mk_loc (2, 0) (4, 0))
     );
-    (* Partially select a statement is not alllowed. *)
+    (* Partially select a statement is not allowed. *)
     ( "extract_statements_linear_partial" >:: fun ctxt ->
       let source =
         {|

--- a/src/services/code_action/insert_type.ml
+++ b/src/services/code_action/insert_type.ml
@@ -28,7 +28,7 @@ type expected =
       location: Loc.t;
       error_message: string;
     }
-  | MulipleTypesPossibleAtPoint of {
+  | MultipleTypesPossibleAtPoint of {
       generalized: (Loc.t, Loc.t) Flow_ast.Type.t;
       specialized: (Loc.t, Loc.t) Flow_ast.Type.t;
     }
@@ -161,7 +161,7 @@ let remove_ambiguous_types
     | Some t -> Ok t
     | None ->
       Error
-        (MulipleTypesPossibleAtPoint
+        (MultipleTypesPossibleAtPoint
            {
              specialized =
                serialize
@@ -329,7 +329,7 @@ class mapper ~strict ~synth_type ~casting_syntax target =
         node
       else
         match (patt, kind) with
-        (* In `const x = exp;` for signature varification errors the error appears on the exp portion.
+        (* In `const x = exp;` for signature verification errors the error appears on the exp portion.
            When strict we only look for that error. *)
         | (Identifier _, Const) when strict -> super#variable_declarator_pattern ~kind node
         | (Identifier ({ name; annot; _ } as id), (Var | Let | Const))
@@ -458,7 +458,7 @@ let unexpected_error_to_string = function
 
 let expected_error_to_string = function
   | TypeAnnotationAtPoint { location; type_ast } ->
-    "Preexisiting type annotation at "
+    "Preexisting type annotation at "
     ^ Loc.to_string_no_source location
     ^ ": "
     ^ type_to_string type_ast
@@ -467,7 +467,7 @@ let expected_error_to_string = function
   | UnsupportedAnnotation { location; error_message } ->
     error_message ^ " found at " ^ Loc.to_string_no_source location ^ " is not currently supported"
   | FailedToTypeCheck _ -> "Failed to typecheck file"
-  | MulipleTypesPossibleAtPoint { generalized; specialized } ->
+  | MultipleTypesPossibleAtPoint { generalized; specialized } ->
     "Multiple types possible at point:\n"
     ^ "    generalized type: "
     ^ type_to_string generalized

--- a/src/services/code_action/insert_type.mli
+++ b/src/services/code_action/insert_type.mli
@@ -24,7 +24,7 @@ type expected =
       location: Loc.t;
       error_message: string;
     }
-  | MulipleTypesPossibleAtPoint of {
+  | MultipleTypesPossibleAtPoint of {
       generalized: (Loc.t, Loc.t) Flow_ast.Type.t;
       specialized: (Loc.t, Loc.t) Flow_ast.Type.t;
     }

--- a/src/services/code_action/insert_type_imports.ml
+++ b/src/services/code_action/insert_type_imports.ml
@@ -400,7 +400,7 @@ end = struct
   (* Mapping from imported names to lists of imports (ImportInfo). Here we hold
    * information of symbols that have been successfully imported. Only the symbols
    * that appear here will be used to add the necessary imports at the end of
-   * the tranformation.
+   * the transformation.
    *)
   module ImportedNameMap : sig
     type t
@@ -662,8 +662,8 @@ end = struct
               let { import_kind; source; default; named_specifier } = import_declaration in
               let specifiers =
                 match named_specifier with
-                | Some specifer ->
-                  Some (Ast.Statement.ImportDeclaration.ImportNamedSpecifiers [specifer])
+                | Some specifier ->
+                  Some (Ast.Statement.ImportDeclaration.ImportNamedSpecifiers [specifier])
                 | None -> None
               in
               ( dummy_loc,

--- a/src/services/code_action/insert_type_utils.ml
+++ b/src/services/code_action/insert_type_utils.ml
@@ -506,7 +506,7 @@ end
 (** Add named type parameter to ensure a Flow_ast.Type can be parsed after being
   * pretty printed.
   *
-  * This was originally in annotate exports and may not be necissary now if this
+  * This was originally in annotate exports and may not be necessary now if this
   * issue with the pretty-printer/parser has been fixed.
   *)
 
@@ -863,7 +863,7 @@ end = struct
     match get_ast_from_shared_mem graphql_file with
     | None -> None
     | Some graphql_ast ->
-      (* Collect information about imports in currect file to accurately compute
+      (* Collect information about imports in current file to accurately compute
        * wether the base GraphQL type is imported in the current file. *)
       let defs =
         Ty_normalizer_imports.extract_types cx file_sig (Some typed_ast)
@@ -1228,7 +1228,7 @@ module MakeHardcodedFixes (Extra : BASE_STATS) = struct
 
   (* Converts types like 'Array<T> | Array<S> | R' to '$ReadOnlyArray<T | S> | R'
    * In certain kinds of codemods this has shown to cause fewer [ambiguous-speculation]
-   * errros. *)
+   * errors. *)
   let array_simplification t =
     let open Ty in
     let arr_elts ts =

--- a/src/services/export/index/__tests__/export_index_tests.ml
+++ b/src/services/export/index/__tests__/export_index_tests.ml
@@ -31,7 +31,7 @@ let find_tests =
 
       (* - libs are mixed together with source files
          - a.js comes before a.bar.js which comes before a.foo.js, even
-           though .j is lexographically after .b. *)
+           though .j is lexicographically after .b. *)
       let expected =
         [
           (file_a, Export_index.Default);

--- a/src/services/saved_state/fetcher/saved_state_scm_fetcher.ml
+++ b/src/services/saved_state/fetcher/saved_state_scm_fetcher.ml
@@ -69,7 +69,7 @@ let pick_saved_state options root merge_base timestamp =
       (* if two saved states have the same timestamp, then we have to worry
          about whether one of them is the merge base. normally it doesn't
          really matter which one ACTUALLY comes first so we just sort the
-         hashes lexographically. but if one of them is the mergebase itself,
+         hashes lexicographically. but if one of them is the mergebase itself,
          we want it to be the first one. below, when we binary search for
          the best saved state, we will pessimistically assume any saved state
          with the same timestamp but different hash as the mergebase is
@@ -119,7 +119,7 @@ let pick_saved_state options root merge_base timestamp =
   file like the "local" fetcher requires.
 
   If multiple commits have the same timestamp, the chosen one is stable but
-  unspecified (currently, it's the first one lexographically, but this is
+  unspecified (currently, it's the first one lexicographically, but this is
   subject to change). However, if one of them is the current mergebase, it
   is selected.
 

--- a/src/third-party/lz4/lz4hc.c
+++ b/src/third-party/lz4/lz4hc.c
@@ -713,9 +713,9 @@ LZ4_FORCE_INLINE int LZ4HC_compress_generic_internal (
     const dictCtx_directive dict
     )
 {
-    typedef enum { lz4hc, lz4opt } lz4hc_strat_e;
+    typedef enum { lz4hc, lz4opt } lz4hc_start_e;
     typedef struct {
-        lz4hc_strat_e strat;
+        lz4hc_start_e start;
         U32 nbSearches;
         U32 targetLength;
     } cParams_t;
@@ -745,11 +745,11 @@ LZ4_FORCE_INLINE int LZ4HC_compress_generic_internal (
     cLevel = MIN(LZ4HC_CLEVEL_MAX, cLevel);
     {   cParams_t const cParam = clTable[cLevel];
         HCfavor_e const favor = ctx->favorDecSpeed ? favorDecompressionSpeed : favorCompressionRatio;
-        if (cParam.strat == lz4hc)
+        if (cParam.start == lz4hc)
             return LZ4HC_compress_hashChain(ctx,
                                 src, dst, srcSizePtr, dstCapacity,
                                 cParam.nbSearches, limit, dict);
-        assert(cParam.strat == lz4opt);
+        assert(cParam.start == lz4opt);
         return LZ4HC_compress_optimal(ctx,
                             src, dst, srcSizePtr, dstCapacity,
                             cParam.nbSearches, cParam.targetLength, limit,

--- a/src/third-party/lz4/lz4hc.h
+++ b/src/third-party/lz4/lz4hc.h
@@ -240,7 +240,7 @@ LZ4_DEPRECATED("use LZ4_resetStreamHC() instead") LZ4LIB_API  int   LZ4_resetStr
  * They should not be linked from DLL,
  * as there is no guarantee of API stability yet.
  * Prototypes will be promoted to "stable" status
- * after successfull usage in real-life scenarios.
+ * after successful usage in real-life scenarios.
  ***************************************************/
 #ifdef LZ4_HC_STATIC_LINKING_ONLY   /* protection macro */
 #ifndef LZ4_HC_SLO_098092834

--- a/src/third-party/sedlex-ppx/sedlex_cset.ml
+++ b/src/third-party/sedlex-ppx/sedlex_cset.ml
@@ -3,7 +3,7 @@
 (* Copyright 2005, 2013 by Alain Frisch and LexiFi.                       *)
 
 (* Character sets are represented as lists of intervals.  The
-   intervals must be non-overlapping and not collapsable, and the list
+   intervals must be non-overlapping and not collapsible, and the list
    must be ordered in increasing order. *)
 
 type t = (int * int) list

--- a/src/third-party/sedlex/flow_sedlexing.ml
+++ b/src/third-party/sedlex/flow_sedlexing.ml
@@ -28,7 +28,7 @@ type lexbuf = {
   mutable pos: int;
   (* bol is the index in the input stream but not buffer *)
   mutable curr_bol: int;
-  (* start from 1, if it is 0, we would not track postion info for you *)
+  (* start from 1, if it is 0, we would not track position info for you *)
   mutable curr_line: int;
   (* First char we need to keep visible *)
   mutable start_pos: int;

--- a/src/third-party/sedlex/flow_sedlexing.mli
+++ b/src/third-party/sedlex/flow_sedlexing.mli
@@ -1,5 +1,5 @@
 
-(** This is a module provides the minimal Sedlexing suppport
+(** This is a module provides the minimal Sedlexing support
   It is mostly a subset of Sedlexing with two functions for performance reasons:
   - Utf8.lexeme_to_buffer
   - Utf8.lexeme_to_buffer2

--- a/src/typing/annotation_inference.ml
+++ b/src/typing/annotation_inference.ml
@@ -191,7 +191,7 @@ module rec ConsGen : S = struct
    * is what the input `cx` in elab_t etc. represents). However, in order to be
    * able to raise errors during annotation inference, we need to have access to the
    * destination context. This is what this reference is for. `dst_cx_ref` is set
-   * Check_serivce.mk_check_file once per file right after the destination context
+   * Check_service.mk_check_file once per file right after the destination context
    * is created. *)
   let dst_cx_ref = ref None
 
@@ -478,7 +478,7 @@ module rec ConsGen : S = struct
          * attempt to force the constraint for `x.p`. *)
         let resolved =
           lazy
-            ((* resolved ids definitelly appear in the type graph *)
+            ((* resolved ids definitely appear in the type graph *)
              let t = get_fully_resolved_type cx id in
              elab_t cx ~seen:(ISet.add id seen) t op
             )
@@ -642,7 +642,7 @@ module rec ConsGen : S = struct
       AnyT.error reason
     | (l, Annot_UseT_TypeT (reason_use, _)) ->
       (match l with
-      (* Short-circut as we already error on the unresolved name. *)
+      (* Short-circuit as we already error on the unresolved name. *)
       | AnyT (_, AnyError _) -> ()
       | AnyT _ -> Flow_js_utils.add_output cx Error_message.(EAnyValueUsedAsType { reason_use })
       | _ -> Flow_js_utils.add_output cx Error_message.(EValueUsedAsType { reason_use }));

--- a/src/typing/class_sig.ml
+++ b/src/typing/class_sig.ml
@@ -741,7 +741,7 @@ module Make
     let open TypeUtil in
     (* NOTE: SuperT ignores the constructor anyway, so we don't pass it here.
        Call properties are also ignored, so we ignore that result. *)
-    (* The this parameter of a class method is irrelvant for class subtyping, since
+    (* The this parameter of a class method is irrelevant for class subtyping, since
        dynamic dispatch enforces that the method is called on the right subclass
        at runtime even if the static type is a supertype. *)
     let inst_loc = loc_of_reason reason in

--- a/src/typing/debug_js.ml
+++ b/src/typing/debug_js.ml
@@ -329,7 +329,7 @@ let rec dump_t_ (depth, tvars) cx t =
           )
         t
     | DefT (_, ReactAbstractComponentT _) -> p t
-    | DefT (_, RendersT (IntrinsicRenders n)) -> p t ~extra:(spf "instrinsic %s" n)
+    | DefT (_, RendersT (IntrinsicRenders n)) -> p t ~extra:(spf "intrinsic %s" n)
     | DefT (_, RendersT (NominalRenders { renders_name; _ })) ->
       p t ~extra:(spf "Nominal(%s)" renders_name)
     | DefT

--- a/src/typing/env_resolution.ml
+++ b/src/typing/env_resolution.ml
@@ -167,7 +167,7 @@ let mk_selector_reason_has_default cx loc = function
     )
   | Selector.ArrRest n -> (Type.ArrRest n, mk_reason RArrayPatternRestProp loc, false)
   | Selector.ObjRest { used_props; after_computed = _ } ->
-    (* TODO: eveyrthing after a computed prop should be optional *)
+    (* TODO: everything after a computed prop should be optional *)
     (Type.ObjRest used_props, mk_reason RObjectPatternRestProp loc, false)
   | Selector.Computed { expression = exp; has_default } ->
     let t = expression cx ~encl_ctx:IndexContext exp in

--- a/src/typing/errors/error_message.ml
+++ b/src/typing/errors/error_message.ml
@@ -3209,7 +3209,7 @@ let friendly_message_of_msg = function
   | EIllegalAssertOperator { obj; specialized; _ } ->
     Normal (MessageIllegalAssertOperator { obj; specialized })
 
-let defered_in_speculation = function
+let deferred_in_speculation = function
   | EUntypedTypeImport _
   | EMethodUnbinding _
   | EUntypedImport _
@@ -3570,7 +3570,7 @@ let error_code_of_message ~updated_error_code err : error_code option =
   | EHookRuleViolation { hook_rule = HookHasIllegalName; _ } -> Some ReactRuleHookNamingConvention
   | EHookRuleViolation { hook_rule = HookDefinitelyNotInComponentOrHook; _ } ->
     Some ReactRuleHookDefinitelyNotInComponentOrHook
-  | EHookRuleViolation { hook_rule = MaybeHook _; _ } -> Some ReactRuleHookMixedWithNonHoook
+  | EHookRuleViolation { hook_rule = MaybeHook _; _ } -> Some ReactRuleHookMixedWithNonHook
   | EHookRuleViolation { hook_rule = NotHookSyntaxHook; _ } -> Some ReactRuleHookNonHookSyntax
   | EHookRuleViolation
       { hook_rule = HookInUnknownContext | HookNotInComponentSyntaxComponentOrHookSyntaxHook; _ } ->

--- a/src/typing/errors/flow_error.ml
+++ b/src/typing/errors/flow_error.ml
@@ -50,4 +50,4 @@ let error_of_msg ~source_file (msg : 'loc Error_message.t') : 'loc t =
   { loc = loc_of_msg msg; msg; source_file }
 
 let is_lint_only_errorset =
-  ErrorSet.for_all (fun e -> Error_message.defered_in_speculation (msg_of_error e))
+  ErrorSet.for_all (fun e -> Error_message.deferred_in_speculation (msg_of_error e))

--- a/src/typing/errors/flow_intermediate_error.ml
+++ b/src/typing/errors/flow_intermediate_error.ml
@@ -121,7 +121,7 @@ let score_of_use_op use_op =
  *
  * This scoring mechanism is useful for union and intersection error messages
  * where we want to approximate which branch the user meant to target with
- * their code. Branches with higher scores have a higher liklihood of being
+ * their code. Branches with higher scores have a higher likelihood of being
  * the branch the user was targeting. *)
 let score_of_msg msg =
   (* Start by getting the score based off the use_op of our error message. If

--- a/src/typing/exhaustive.ml
+++ b/src/typing/exhaustive.ml
@@ -33,7 +33,7 @@ let attempt_union_rep_optimization cx (rep : Type.UnionRep.t) : unit =
       ~find_props:(Context.find_props cx)
 
 (***********************)
-(* Datatype defintions *)
+(* Datatype definitions *)
 (***********************)
 
 type pattern_ast_list =
@@ -482,7 +482,7 @@ end = struct
         ( if last then
           let loc = Reason.loc_of_reason reason in
           (* We avoid more complex analysis by simply erroring when there is a
-             guarded wilcard which is in the last case. *)
+             guarded wildcard which is in the last case. *)
           Flow_js.add_output cx (Error_message.EMatchInvalidGuardedWildcard loc)
         );
         pattern_union

--- a/src/typing/flow_js.ml
+++ b/src/typing/flow_js.ml
@@ -4867,7 +4867,7 @@ struct
           rec_flow cx trace (instance, GetStaticsT statics);
           rec_flow cx trace (OpenT statics, u)
         | (DefT (_, NullT), ExtendsUseT (use_op, reason, next :: try_ts_on_failure, l, u)) ->
-          (* When seaching for a nominal superclass fails, we always try to look it
+          (* When searching for a nominal superclass fails, we always try to look it
              up in the next element in the list try_ts_on_failure. *)
           rec_flow cx trace (next, ExtendsUseT (use_op, reason, try_ts_on_failure, l, u))
         | ( DefT (_, NullT),
@@ -5589,7 +5589,7 @@ struct
      Note: we can get away with a shallow (i.e. non-recursive) expansion here because the flow between
      the any-expanded type and the original will handle the any-propagation to any relevant positions,
      some of which may invoke this function when they hit the any propagation functions in the
-     recusive call to __flow. *)
+     recursive call to __flow. *)
   and expand_any _cx any t =
     let only_any _ = any in
     match t with
@@ -7400,7 +7400,7 @@ struct
 
     4. When roots are unresolved (they have lower bounds and upper bounds,
     possibly consisting of concrete types as well as type variables), we
-    maintain the invarant that every lower bound has already been propagated to
+    maintain the invariant that every lower bound has already been propagated to
     every upper bound. We also maintain the invariant that the bounds are
     transitively closed modulo equivalence: for every type variable in the
     bounds, all the bounds of its root are also included.
@@ -8488,7 +8488,7 @@ struct
              this keeps the element type "open," at least locally.[*]
 
              Using a union pins down the element type prematurely, and moreover,
-             might lead to speculative matching when setting elements or caling
+             might lead to speculative matching when setting elements or calling
              contravariant methods (`push`, `concat`, etc.) on the array.
 
              In any case, using a union doesn't quite work as intended today
@@ -9041,7 +9041,7 @@ struct
             )
         end
       | MaybeT (r, t) ->
-        (* repositions both the MaybeT and the nested type. MaybeT represets `?T`.
+        (* repositions both the MaybeT and the nested type. MaybeT represents `?T`.
            elsewhere, when we decompose into T | NullT | VoidT, we use the reason
            of the MaybeT for NullT and VoidT but don't reposition `t`, so that any
            errors on the NullT or VoidT point at ?T, but errors on the T point at

--- a/src/typing/flow_js_utils.ml
+++ b/src/typing/flow_js_utils.ml
@@ -490,7 +490,7 @@ exception SpeculationSingletonError
  * in which it is recorded. *)
 let add_output_generic ~src_cx:cx ~dst_cx msg =
   if Speculation.speculating cx then
-    if Error_message.defered_in_speculation msg then
+    if Error_message.deferred_in_speculation msg then
       Speculation.defer_error cx msg
     else (
       if Context.is_verbose cx then
@@ -1266,7 +1266,7 @@ module ValueToTypeReferenceTransform = struct
       add_output cx Error_message.(EValueUsedAsType { reason_use = reason_op });
       AnyT.error r
     | AnyT (_, AnyError _) as l ->
-      (* Short-circut as we already error on the unresolved name. *)
+      (* Short-circuit as we already error on the unresolved name. *)
       l
     | AnyT (r, _) ->
       add_output cx Error_message.(EAnyValueUsedAsType { reason_use = reason_op });
@@ -3504,10 +3504,10 @@ end = struct
       data.speculative_candidates <- (l, id) :: data.speculative_candidates
     | _ -> data.finalized <- l :: data.finalized
 
-  (* For signature-help, we are intereseted in all branches of intersections, so
+  (* For signature-help, we are interested in all branches of intersections, so
    * we include intersections in the accumulated result. Note that we discard nested
    * intersection types. These would appear under speculation, so we can effectively
-   * enforce this constraint by checking that we are not in a speculation enviornment.
+   * enforce this constraint by checking that we are not in a speculation environment.
    * Also we skip voided out results in case of optional chaining. *)
   let add_signature_help cx l (Specialized_callee data) =
     if Base.Option.is_none (Context.speculation_id cx) then data.sig_help <- l :: data.sig_help

--- a/src/typing/generics/generic.ml
+++ b/src/typing/generics/generic.ml
@@ -185,7 +185,7 @@ type sat_result =
    multiple possible results. For example, suppose X and Y are generics, and Y's upper
    bound is X. Then the Generic.id for Y is "Y:X". When a GenericT for Y flows into a
    GenericT for X, we check "Y:X" against "X" to see if it's satisfied. Y =/= X,
-   so we "strip off" Y from Y:X and check X against X, which succeds, so we return
+   so we "strip off" Y from Y:X and check X against X, which succeeds, so we return
    Satisfied.
 
    If Z:W is not bounded by X, and we check if Z:W satisfies X, we first strip off

--- a/src/typing/implicit_instantiation.ml
+++ b/src/typing/implicit_instantiation.ml
@@ -200,7 +200,7 @@ module Make (Observer : OBSERVER) (Flow : Flow_common.S) : S = struct
 
       method private typeapp =
         let rec loop cx pole seen = function
-          (* Any arity erors are already handled in Flow_js *)
+          (* Any arity errors are already handled in Flow_js *)
           | (_, []) -> seen
           | (Some [], _) -> seen
           | (None, targ :: targs) ->

--- a/src/typing/merge_js.ml
+++ b/src/typing/merge_js.ml
@@ -376,7 +376,7 @@ let condition_banned_and_FALSY =
 let condition_allowed = ConditionAllowed
 
 let use_type_to_check_conditional cx ttype =
-  (* We always show warning for errors generated from type inferrence *)
+  (* We always show warning for errors generated from type inference *)
   match try_eval_type_truthyness cx ttype with
   | ConstCond_Truthy { constant_condition_kind; reason } ->
     ConditionBanned { is_truthy = true; show_warning = true; constant_condition_kind; reason }
@@ -1248,7 +1248,7 @@ let check_multiplatform_conformance cx ast tast =
      with
     | Context.MissingModule
     | Context.UncheckedModule _ ->
-      (* It's ok if a platform speicific implementation file doesn't have an interface.
+      (* It's ok if a platform specific implementation file doesn't have an interface.
        * It just makes the module non-importable without platform extension. *)
       ()
     | Context.TypedModule interface_module_f ->
@@ -1634,7 +1634,7 @@ let post_merge_checks cx ast tast metadata =
  * transitive dependency's context, then copied into the dependency's context,
  * and so on.
  *
- * Finally, due to cycles, it's possile that src_cx and dst_cx share the same
+ * Finally, due to cycles, it's possible that src_cx and dst_cx share the same
  * component cx, and thus have the same tvar graph, property maps, etc. Happily,
  * this does not complicate the implementation, as the mem checks and early
  * returns on each method override are sufficient.
@@ -1792,12 +1792,12 @@ let merge_lib_files ~project_opts ~sig_opts ordered_asts_with_scoped_projects =
           in
           match Base.List.Assoc.find acc ~equal:scoped_project_key_equal scoped_project_key with
           | None -> Base.List.Assoc.add ~equal:scoped_project_key_equal acc scoped_project_key [ast]
-          | Some exisiting_list ->
+          | Some existing_list ->
             Base.List.Assoc.add
               ~equal:scoped_project_key_equal
               acc
               scoped_project_key
-              (ast :: exisiting_list)
+              (ast :: existing_list)
       )
     in
     let non_scoped_asts =

--- a/src/typing/primitive_literal.ml
+++ b/src/typing/primitive_literal.ml
@@ -237,7 +237,7 @@ class implicit_instantiation_literal_mapper ~singleton_action =
           t
 
     (* The EvalT case is the only case that calls this function. We've explicitly
-     * overrided it in all cases, so this should never be called *)
+     * overridden it in all cases, so this should never be called *)
     method eval_id _cx _map_cx _id = assert false
   end
 

--- a/src/typing/react_kit.ml
+++ b/src/typing/react_kit.ml
@@ -746,7 +746,7 @@ module Kit (Flow : Flow_common.S) : REACT = struct
           "React$Element"
           [component; Tvar.mk_where cx reason_op props_to_tout]
       in
-      (* Concretize to an ObjT so that we can asssociate the monomorphized component with the props id *)
+      (* Concretize to an ObjT so that we can associate the monomorphized component with the props id *)
       let elem =
         let result = Flow.singleton_concrete_type_for_inspection cx elem_reason elem in
         match result with

--- a/src/typing/slice_utils.ml
+++ b/src/typing/slice_utils.ml
@@ -1002,7 +1002,7 @@ let object_rest
       ~reason
       ~invalidate_aliases:true
       ~interface
-        (* Keep the reachable targs from o1, because we don't know whether all appearences of them were removed *)
+        (* Keep the reachable targs from o1, because we don't know whether all appearances of them were removed *)
       ~reachable_targs
       ~kind:Subst_name.Spread
       flags
@@ -1474,7 +1474,7 @@ let resolve
         }
     in
     resolved ~next ~recurse cx use_op reason resolve_tool tool x
-  (* TODO(jmbrown): Investigate if these cases can be used for ReactConfig/ObjecRep/Rest.
+  (* TODO(jmbrown): Investigate if these cases can be used for ReactConfig/ObjectRep/Rest.
    * In principle, we should be able to use it for Rest, but right now
    * `const {x, ...y} = 3;` tries to get `x` from Number.
    * They don't make sense with $ReadOnly's semantics, since $ReadOnly doesn't model

--- a/src/typing/statement.ml
+++ b/src/typing/statement.ml
@@ -309,7 +309,7 @@ module Make
 
   let snd_fst ((_, x), _) = x
 
-  let translate_identifer_or_literal_key t =
+  let translate_identifier_or_literal_key t =
     let module P = Ast.Expression.Object.Property in
     function
     | P.Identifier (loc, name) -> P.Identifier ((loc, t), name)
@@ -2320,14 +2320,14 @@ module Make
           let frozen = Utils_js.ite frozen FrozenProp NotFrozen in
           if Type_inference_hooks_js.dispatch_obj_prop_decl_hook cx name loc then
             let t = Unsoundness.at InferenceHooks loc in
-            let key = translate_identifer_or_literal_key t key in
+            let key = translate_identifier_or_literal_key t key in
             (* don't add `name` to `acc` because `name` is the autocomplete token *)
             let acc = ObjectExpressionAcc.set_obj_key_autocomplete acc in
             let (((_, _t), _) as value) = expression cx ~as_const ~frozen ~has_hint v in
             (acc, key, value)
           else
             let (((_, t), _) as value) = expression cx ~as_const ~frozen ~has_hint v in
-            let key = translate_identifer_or_literal_key t key in
+            let key = translate_identifier_or_literal_key t key in
             let acc =
               ObjectExpressionAcc.add_prop
                 (Properties.add_field
@@ -2365,7 +2365,7 @@ module Make
           Property
             ( prop_loc,
               Property.Method
-                { key = translate_identifer_or_literal_key t key; value = (fn_loc, func) }
+                { key = translate_identifier_or_literal_key t key; value = (fn_loc, func) }
             )
         ))
     (* We enable some unsafe support for getters and setters. The main unsafe bit
@@ -2403,7 +2403,7 @@ module Make
             ( loc,
               Property.Get
                 {
-                  key = translate_identifer_or_literal_key return_t key;
+                  key = translate_identifier_or_literal_key return_t key;
                   value = (vloc, func);
                   comments;
                 }
@@ -2441,7 +2441,7 @@ module Make
             ( loc,
               Property.Set
                 {
-                  key = translate_identifer_or_literal_key param_t key;
+                  key = translate_identifier_or_literal_key param_t key;
                   value = (vloc, func);
                   comments;
                 }
@@ -2666,7 +2666,7 @@ module Make
                 ( prop_loc,
                   Property.Init
                     {
-                      key = translate_identifer_or_literal_key vt key;
+                      key = translate_identifier_or_literal_key vt key;
                       value = v;
                       shorthand = false;
                     }
@@ -5674,7 +5674,7 @@ module Make
             "exports"
           )
           when not (Type_env.local_scope_entry_exists cx id_loc) ->
-          (* module.exports has type `any` in theory, but shouldnt be treated as uncovered *)
+          (* module.exports has type `any` in theory, but shouldn't be treated as uncovered *)
           t
         | _ -> prop_t
       in

--- a/src/typing/subtyping_kit.ml
+++ b/src/typing/subtyping_kit.ml
@@ -1128,7 +1128,7 @@ module Make (Flow : INPUT) : OUTPUT = struct
       when union_optimization_guard cx TypeUtil.quick_subtype l u
            = UnionOptimizationGuardResult.True ->
       if Context.is_verbose cx then prerr_endline "UnionT ~> UnionT fast path (via an opaque type)"
-    (* Optimization to treat maybe and optional types as special unions for subset comparision *)
+    (* Optimization to treat maybe and optional types as special unions for subset comparison *)
     | (UnionT (reason, rep), MaybeT (r, maybe)) ->
       let quick_subtype = TypeUtil.quick_subtype in
       let void = VoidT.why r in

--- a/src/typing/ty_normalizer.ml
+++ b/src/typing/ty_normalizer.ml
@@ -11,7 +11,7 @@ open Loc_collections
 module Env = Ty_normalizer_env
 module T = Type
 
-(* The type normalizer converts infered types (of type `Type.t`) under a context
+(* The type normalizer converts inferred types (of type `Type.t`) under a context
    cx to the simplified form of type `Ty.t`. It is called by various modules,
    e.g. type-at-pos, coverage, dump-types, and so is parameterized by a
    configuration struct, instantiated by the client.
@@ -69,7 +69,7 @@ let error_to_string (kind, msg) = spf "[%s] %s" (error_kind_to_string kind) msg
 
 (* Utility that determines the next immediate concrete constructor, ie. reads
  * through OpenTs and AnnotTs. This is useful in determining, for example, the
- * toplevel cosntructor and adjusting the logic accordingly. *)
+ * toplevel constructor and adjusting the logic accordingly. *)
 module Lookahead = struct
   type t =
     | Recursive

--- a/src/typing/ty_normalizer_env.ml
+++ b/src/typing/ty_normalizer_env.ml
@@ -15,7 +15,7 @@ type evaluate_type_destructors_mode =
 type options = {
   (* If this flag is set to `true` then the normalizer will attempt to reuse the
    * cached results of evaluated type-destructors. If this is set to `false`, then
-   * instread it will try to use:
+   * instead it will try to use:
    *  - a potentially attendant type-alias annotation, or
    *  - reuse the utility type that corresponds to this the specific type-destructor.
    *

--- a/src/typing/type.ml
+++ b/src/typing/type.ml
@@ -604,7 +604,7 @@ module rec TypeTerm : sig
     (* The boolean flag indicates whether or not it is a static lookup. We cannot know this when
      * we generate the constraint, since the lower bound may be an unresolved OpenT. If it
      * resolves to a ClassT, we flip the flag to true, which causes us to check the private static
-     * fields when the InstanceT ~> SetPrivatePropT constraint is processsed *)
+     * fields when the InstanceT ~> SetPrivatePropT constraint is processed *)
     | SetPrivatePropT of
         use_op * reason * string * set_mode * class_binding list * bool * write_ctx * t * t option
     | GetTypeFromNamespaceT of {
@@ -1011,7 +1011,7 @@ module rec TypeTerm : sig
     | PropNonVoidP of string * reason
     (* `if (a.b?.c)` yields `flow (a, PredicateT(PropNonMaybeP ("b"), tout))` *)
     | PropNonMaybeP of string * reason
-    (* Encondes the latent predicate associated with the [index]-th parameter
+    (* Encodes the latent predicate associated with the [index]-th parameter
        of the function in type [t]. We also include information for all type arguments
        and argument types of the call, to enable polymorphic calls. *)
     | LatentP of pred_funcall_info Lazy.t * index list
@@ -3498,7 +3498,7 @@ module AConstraint = struct
         type for its body yet.
 
       - [Annot_op { op; id; _ }] expresses the fact that the current variable is the
-        result of applying the opereation [op] on the type that another annotation
+        result of applying the operation [op] on the type that another annotation
         variable [id] will resolve to.
 
       An annotation variable starts off in the Annot_unresolved or Annot_op state

--- a/src/typing/typeUtil.ml
+++ b/src/typing/typeUtil.ml
@@ -520,7 +520,7 @@ let nominal_id_have_same_logical_module
     || (* Regardless of which namespace the Haste module has or what platform they have, if they have
         * the same name, we assume it's the same logical module. It's impossible to happen in normal
         * circumstances due to uniqueness guarantee. It's only possible to happen during multiplatform
-        * conformance check, but in tihs case we already enforced uniqueness guarantee elsewhere. *)
+        * conformance check, but in this case we already enforced uniqueness guarantee elsewhere. *)
     a_src <> b_src
     &&
     match (haste_name_opt a_src, haste_name_opt b_src) with

--- a/src/typing/type_annotation.ml
+++ b/src/typing/type_annotation.ml
@@ -667,7 +667,7 @@ module Make (Statement : Statement_sig.S) : Type_annotation_sig.S = struct
             comments;
           }
       ) as t_ast ->
-      (* Comments are innecessary, so they can be stripped to meet the generic requirements *)
+      (* Comments are unnecessary, so they can be stripped to meet the generic requirements *)
       let convert_type_params ?(env = env) () =
         match targs with
         | None -> ([], None)

--- a/src/typing/type_operation_utils.ml
+++ b/src/typing/type_operation_utils.ml
@@ -582,7 +582,7 @@ module SpecialCasedFunctions = struct
       match to_obj with
       | AnyT _ ->
         (* Special case any. Otherwise this will lead to confusing errors when
-         * any tranforms to an object type. *)
+         * any transforms to an object type. *)
         Flow.flow_t cx (to_obj, t)
       | to_obj ->
         Base.List.iter

--- a/src/typing/type_subst.ml
+++ b/src/typing/type_subst.ml
@@ -445,7 +445,7 @@ let substituter =
             }
       | _ -> super#destructor cx map_cx t
 
-    (* The EvalT case is the only case that calls this function. We've explicitly overrided it
+    (* The EvalT case is the only case that calls this function. We've explicitly overridden it
      * in all cases, so this should never be called *)
     method eval_id _cx _map_cx _id = assert false
   end

--- a/src/typing/type_visitor.ml
+++ b/src/typing/type_visitor.ml
@@ -347,7 +347,7 @@ class ['a] t =
 
     method private obj_type cx pole acc o =
       (* We intentionally do not visit reachable_targs. By definition, they are already reachable
-       * by traversing the other fields. Until substitution keeps track of polarity, visitng the
+       * by traversing the other fields. Until substitution keeps track of polarity, visiting the
        * other fields will be more accurate *)
       let { props_tmap; proto_t; call_t; flags; reachable_targs = _ } = o in
       let acc = self#obj_flags cx pole acc flags in


### PR DESCRIPTION
## Summary

This pull request fixes various typographical errors found in the [src](https://github.com/facebook/flow/tree/main/src) directory.
These corrections improve code readability and maintain consistency across the codebase.

## Motivation
Maintaining clear and correct code comments and identifiers helps future contributors understand the codebase and reduces confusion.
