### PR TITLE
[ci] Remove `git config --global --add safe.directory /cygdrive/c/a/flow/flow` to unbreak windows build

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -283,9 +283,7 @@ jobs:
           coreutils
           moreutils
     - name: Git Safe Directory
-      run: |
-        git config --global --add safe.directory /cygdrive/c/a/flow/flow
-        git config --global --add safe.directory /cygdrive/d/a/flow/flow
+      run: git config --global --add safe.directory /cygdrive/d/a/flow/flow
       shell: C:\cygwin\bin\bash.exe '{0}'
       env:
         PATH: /usr/local/bin:/usr/bin:/cygdrive/bin:/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/Wbem:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0


### PR DESCRIPTION
Somehow this works?!