### PR TITLE
Added RegExp.escape method to core.js

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -1463,6 +1463,11 @@ declare class RegExp {
      * @param string The String object or string literal on which to perform the search.
      */
     exec(string: string): RegExp$matchResult | null;
+    /** 
+    * Escapes any potential regex syntax characters in a string, and returns a new string that can be safely used as a literal
+    * pattern for the RegExp() constructor. 
+    */
+    static escape(string: string): string;
     /**
      * Returns a string indicating the flags of the regular expression in question. This field is read-only.
      * The characters in this string are sequenced and concatenated in the following order:


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/escape

<!--
  If this is a change to library definitions, please include links to relevant documentation.
  If this is a documentation change, please prefix the title with [DOCS].

  If this is neither, ensure you opened a discussion issue and link it in the PR description.
-->
