### PR TITLE
[ci] Remove x86 mac build in dotslash config

### DIFF
--- a/.github/dotslash-config.json
+++ b/.github/dotslash-config.json
@@ -13,11 +13,6 @@
             "format": "zip",
             "path": "flow/flow"
           },
-          "macos-x86_64": {
-            "regex": "^flow-osx-v.*.zip$",
-            "format": "zip",
-            "path": "flow/flow"
-          },
           "windows-x86_64": {
             "regex": "^flow-win64-v.*.zip$",
             "format": "zip",


### PR DESCRIPTION
We will stop building it on CI soon. This diff removes it.

<!--
  If this is a change to library definitions, please include links to relevant documentation.
  If this is a documentation change, please prefix the title with [DOCS].

  If this is neither, ensure you opened a discussion issue and link it in the PR description.
-->
