### PR TITLE
Remove libflowparser build and upload steps

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -97,12 +97,6 @@ jobs:
       run: |-
         opam exec -- make bin/flow dist/flow.zip
         mkdir -p bin/linux && cp bin/flow bin/linux/flow
-    - name: Build libflowparser
-      run: opam exec -- make -C src/parser dist/libflowparser.zip
-    - name: Create artifacts
-      run: |-
-        cp dist/flow.zip dist/flow-linux64.zip
-        cp src/parser/dist/libflowparser.zip dist/libflowparser-linux64.zip
     - uses: actions/upload-artifact@v4.4.0
       with:
         name: build_linux_bin
@@ -112,7 +106,6 @@ jobs:
         name: build_linux_dist
         path: |
           dist/flow-linux64.zip
-          dist/libflowparser-linux64.zip
   build_linux_arm64:
     runs-on: 4-core-ubuntu-arm
     env:
@@ -147,12 +140,6 @@ jobs:
       run: |-
         opam exec -- make bin/flow dist/flow.zip
         mkdir -p bin/linux && cp bin/flow bin/linux/flow
-    - name: Build libflowparser
-      run: opam exec -- make -C src/parser dist/libflowparser.zip
-    - name: Create artifacts
-      run: |-
-        cp dist/flow.zip dist/flow-linux64-arm64.zip
-        cp src/parser/dist/libflowparser.zip dist/libflowparser-linux64-arm64.zip
     - uses: actions/upload-artifact@v4.4.0
       with:
         name: build_linux_arm64_dist
@@ -189,22 +176,10 @@ jobs:
       run: |-
         arch --x86_64 opam exec -- make bin/flow dist/flow.zip
         mkdir -p bin/macos && cp bin/flow bin/macos/flow
-    - name: Build libflowparser
-      run: arch --x86_64 opam exec -- make -C src/parser dist/libflowparser.zip
-    - name: Create artifacts
-      run: |-
-        cp dist/flow.zip dist/flow-osx.zip
-        cp src/parser/dist/libflowparser.zip dist/libflowparser-osx.zip
     - uses: actions/upload-artifact@v4.4.0
       with:
         name: build_macos_bin
         path: bin/macos/flow
-    - uses: actions/upload-artifact@v4.4.0
-      with:
-        name: build_macos_dist
-        path: |
-          dist/flow-osx.zip
-          dist/libflowparser-osx.zip
   build_macos_arm64:
     runs-on: macos-13-xlarge
     steps:
@@ -236,22 +211,10 @@ jobs:
       run: |-
         opam exec -- make bin/flow dist/flow.zip
         mkdir -p bin/macos-arm64 && cp bin/flow bin/macos-arm64/flow
-    - name: Build libflowparser
-      run: opam exec -- make -C src/parser dist/libflowparser.zip
-    - name: Create artifacts
-      run: |-
-        cp dist/flow.zip dist/flow-osx-arm64.zip
-        cp src/parser/dist/libflowparser.zip dist/libflowparser-osx-arm64.zip
     - uses: actions/upload-artifact@v4.4.0
       with:
         name: build_macos_arm64_bin
         path: bin/macos-arm64/flow
-    - uses: actions/upload-artifact@v4.4.0
-      with:
-        name: build_macos_arm64_dist
-        path: |
-          dist/flow-osx-arm64.zip
-          dist/libflowparser-osx-arm64.zip
   build_win:
     runs-on: windows-2022
     env:
@@ -547,12 +510,6 @@ jobs:
         ls -lR .
         cp dist/flow_parser.js packages/flow-parser/dist/flow_parser.js
         make dist/npm-flow-parser.tgz
-    - name: Pack flow-parser-bin
-      run: |
-        mkdir -p packages/flow-parser-bin/dist/release/
-        cp dist/libflowparser-linux64.zip packages/flow-parser-bin/dist/release/libflowparser-linux64.zip
-        cp dist/libflowparser-osx.zip packages/flow-parser-bin/dist/release/libflowparser-osx.zip
-        make dist/npm-flow-parser-bin.tgz
     - name: Pack flow-remove-types and flow-node
       run: |
         rm -rf packages/flow-node
@@ -622,26 +579,18 @@ jobs:
         path: dist
     - name: Upload Linux binary (x86_64)
       run: .circleci/github_upload.sh dist/flow-linux64.zip "flow-linux64-${{ github.ref_name }}.zip"
-    - name: Upload Linux libflowparser (x86_64)
-      run: .circleci/github_upload.sh dist/libflowparser-linux64.zip "libflowparser-linux64-${{ github.ref_name }}.zip"
     - uses: actions/download-artifact@v4.1.7
       with:
         name: build_linux_arm64_dist
         path: dist
     - name: Upload Linux binary (arm64)
       run: .circleci/github_upload.sh dist/flow-linux64-arm64.zip "flow-linux-arm64-${{ github.ref_name }}.zip"
-    - name: Upload Linux libflowparser (arm64)
-      run: .circleci/github_upload.sh dist/libflowparser-linux64-arm64.zip "libflowparser-linux-arm64-${{ github.ref_name }}.zip"
-    - name: Upload Mac libflowparser (x86_64)
-      run: .circleci/github_upload.sh dist/libflowparser-osx.zip "libflowparser-osx-${{ github.ref_name }}.zip"
     - uses: actions/download-artifact@v4.1.7
       with:
         name: build_macos_arm64_dist
         path: dist
     - name: Upload Mac binary (arm64)
       run: .circleci/github_upload.sh dist/flow-osx-arm64.zip "flow-osx-arm64-${{ github.ref_name }}.zip"
-    - name: Upload Mac libflowparser (arm64)
-      run: .circleci/github_upload.sh dist/libflowparser-osx-arm64.zip "libflowparser-osx-arm64-${{ github.ref_name }}.zip"
     - uses: actions/download-artifact@v4.1.7
       with:
         name: build_win_dist


### PR DESCRIPTION
We stopped publishing `flow-parser-bin` since 0.287. Let's remove the CI steps to build it.

<!--
  If this is a change to library definitions, please include links to relevant documentation.
  If this is a documentation change, please prefix the title with [DOCS].

  If this is neither, ensure you opened a discussion issue and link it in the PR description.
-->
