### PR TITLE
[flow] partial backout of D91720108

### DIFF
--- a/src/common/files.ml
+++ b/src/common/files.ml
@@ -723,24 +723,6 @@ let watched_paths options =
          File_path.is_ancestor ~prefix:prev_stem stem
      )
 
-let make_path_relative_to_root ~root path =
-  (* Normalize path separators and ensure root ends with separator *)
-  let root =
-    let normalized = Sys_utils.normalize_filename_dir_sep root in
-    if String.ends_with ~suffix:"/" normalized then
-      normalized
-    else
-      normalized ^ "/"
-  in
-  let path = Sys_utils.normalize_filename_dir_sep path in
-  if String.starts_with ~prefix:root path then
-    Some (String_utils.lstrip path root)
-  else if path ^ "/" = root then
-    (* Path equals root (without trailing slash) *)
-    Some ""
-  else
-    None
-
 (**
  * Creates a "next" function (see also: `get_all`) for finding the files in a
  * given FlowConfig root. This means all the files under the root (if the implicit

--- a/src/common/files.mli
+++ b/src/common/files.mli
@@ -122,19 +122,6 @@ val absolute_path_regexp : Str.regexp
 
 val watched_paths : options -> File_path.t list
 
-(** [make_path_relative_to_root ~root path] returns [Some relative_path] if [path]
-    is under [root], or [None] if [path] is not under [root].
-    
-    This normalizes path separators and handles trailing slashes correctly.
-    Used by file watchers (Watchman and EdenFS) to compute relative paths from
-    absolute watched paths.
-    
-    Examples:
-    - [make_path_relative_to_root ~root:"/foo/bar" "/foo/bar/baz"] returns [Some "baz"]
-    - [make_path_relative_to_root ~root:"/foo/bar" "/foo/bar"] returns [Some ""]
-    - [make_path_relative_to_root ~root:"/foo/bar" "/other/path"] returns [None] *)
-val make_path_relative_to_root : root:string -> string -> string option
-
 (* given a root, make a filter for file names *)
 val wanted : options:options -> include_libdef:bool -> SSet.t -> string -> bool
 


### PR DESCRIPTION
Summary:
`make_path_relative_to_root` ended up only being used in one place and is a bit less efficient than before D91720108

Changelog: [internal]

Differential Revision: D91911938


