### PR TITLE
[flow] Store relative path suffixes in File_key.t to eliminate saved state denormalization

### DIFF
--- a/src/codemods/annotate_exports.ml
+++ b/src/codemods/annotate_exports.ml
@@ -88,7 +88,7 @@ module SignatureVerification = struct
         Platform_set.available_platforms
           ~file_options:(Options.file_options options)
           ~projects_options:(Options.projects_options options)
-          ~filename:(File_key.to_string file)
+          ~filename:(File_key.suffix file)
           ~explicit_available_platforms:(Docblock.supportsPlatform docblock)
       in
       Type_sig_utils.parse_and_pack_module ~strict ~platform_availability_set sig_opts None ast

--- a/src/commands/astCommand.ml
+++ b/src/commands/astCommand.ml
@@ -171,6 +171,8 @@ let main
         let (ast, errors) =
           match file_type with
           | File_js ->
+            (* flow ast is a standalone parser — use the raw constructor
+               so paths are stored as-is without root stripping. *)
             let filekey = Base.Option.map filename ~f:(fun s -> File_key.SourceFile s) in
             let (ocaml_ast, errors) =
               Parser_flow.program_file ~fail:false ~parse_options ~token_sink content filekey

--- a/src/commands/autofixCommand.ml
+++ b/src/commands/autofixCommand.ml
@@ -50,7 +50,9 @@ module InsertType = struct
 
   let handle_error ?(code = Exit.Unknown_error) msg = Exit.(exit ~msg code)
 
-  let rec parse_args args : Loc.t =
+  (* Returns (loc, source_path_opt). The source path is a raw absolute string;
+     File_key construction is deferred until after roots are initialized. *)
+  let rec parse_args args : Loc.t * string option =
     let parse_pos line col : Loc.position =
       let (line, column) =
         try convert_input_pos (int_of_string line, int_of_string col) with
@@ -62,13 +64,13 @@ module InsertType = struct
     | [start_line; start_col; end_line; end_col] ->
       let start = parse_pos start_line start_col in
       let _end = parse_pos end_line end_col in
-      Loc.{ source = None; start; _end }
+      (Loc.{ source = None; start; _end }, None)
     | [start_line; start_col] ->
       let start = parse_pos start_line start_col in
-      Loc.{ source = None; start; _end = start }
+      (Loc.{ source = None; start; _end = start }, None)
     | file :: (([_; _] | [_; _; _; _]) as loc) ->
-      let loc = parse_args loc in
-      Loc.{ loc with source = Some (File_key.SourceFile (expand_path file)) }
+      let (loc, _) = parse_args loc in
+      (loc, Some (expand_path file))
     | [] -> handle_error "flow autofix insert-type: No position given"
     | _ -> handle_error "flow autofix insert-type: Invalid position given"
 
@@ -108,10 +110,17 @@ module InsertType = struct
       omit_targ_defaults
       args
       () =
-    let (Loc.{ source; _ } as target) = parse_args args in
-    let source_path = Base.Option.map ~f:File_key.to_string source in
+    let (target, source_path) = parse_args args in
     let input = get_file_from_filename_or_stdin ~cmd:spec.name path source_path in
     let root = get_the_root ~base_flags ~input root_arg in
+    (* Set root before constructing File_key so the suffix is root-relative,
+       matching the server's File_key values. *)
+    File_key.set_project_root (File_path.to_string root);
+    let target =
+      match source_path with
+      | Some abs -> Loc.{ target with source = Some (File_key.source_file_of_absolute abs) }
+      | None -> target
+    in
     (* TODO Figure out how to implement root striping *)
     let _strip_root =
       if strip_root_arg then

--- a/src/commands/checkCommands.ml
+++ b/src/commands/checkCommands.ml
@@ -351,7 +351,7 @@ module FocusCheckCommand = struct
     let focus_targets =
       SSet.fold
         (fun file acc ->
-          FilenameSet.add (File_key.SourceFile File_path.(to_string (make file))) acc)
+          FilenameSet.add (File_key.source_file_of_absolute File_path.(to_string (make file))) acc)
         filenames
         FilenameSet.empty
     in

--- a/src/commands/commandUtils.ml
+++ b/src/commands/commandUtils.ml
@@ -636,8 +636,8 @@ let remove_exclusion pattern =
 
 let file_options =
   let path_pattern_of_arg root pattern =
-    let expand_project_root_token = Files.expand_project_root_token ~root in
-    pattern |> remove_exclusion |> expand_project_root_token |> Str.regexp
+    let expand_project_root_token_as_absolute = Files.expand_project_root_token_as_absolute ~root in
+    pattern |> remove_exclusion |> expand_project_root_token_as_absolute |> Str.regexp
   in
   let path_patterns_of_args root patterns extras =
     let patterns = Base.List.rev_append extras patterns in
@@ -740,7 +740,10 @@ let file_options =
     in
     let module_declaration_dirnames =
       Base.List.map (FlowConfig.module_declaration_dirnames flowconfig) ~f:(fun dir ->
-          dir |> Files.expand_project_root_token ~root |> File_path.make |> File_path.to_string
+          dir
+          |> Files.expand_project_root_token_as_absolute ~root
+          |> File_path.make
+          |> File_path.to_string
       )
     in
     let module_file_exts = FlowConfig.module_file_exts flowconfig in
@@ -774,12 +777,12 @@ let file_options_of_flowconfig ~root flowconfig =
     ~implicitly_include_root:(FlowConfig.files_implicitly_include_root flowconfig)
     ~haste_paths_excludes:
       (Base.List.map
-         ~f:(fun f -> f |> Files.expand_project_root_token ~root |> Str.regexp)
+         ~f:(fun f -> f |> Files.expand_project_root_token_as_absolute ~root |> Str.regexp)
          (FlowConfig.haste_paths_excludes flowconfig)
       )
     ~haste_paths_includes:
       (Base.List.map
-         ~f:(fun f -> f |> Files.expand_project_root_token ~root |> Str.regexp)
+         ~f:(fun f -> f |> Files.expand_project_root_token_as_absolute ~root |> Str.regexp)
          (FlowConfig.haste_paths_includes flowconfig)
       )
     ~ignores:[]
@@ -1369,12 +1372,12 @@ let make_options
       ~includes
       ~haste_paths_excludes:
         (Base.List.map
-           ~f:(fun f -> f |> Files.expand_project_root_token ~root |> Str.regexp)
+           ~f:(fun f -> f |> Files.expand_project_root_token_as_absolute ~root |> Str.regexp)
            (FlowConfig.haste_paths_excludes flowconfig)
         )
       ~haste_paths_includes:
         (Base.List.map
-           ~f:(fun f -> f |> Files.expand_project_root_token ~root |> Str.regexp)
+           ~f:(fun f -> f |> Files.expand_project_root_token_as_absolute ~root |> Str.regexp)
            (FlowConfig.haste_paths_includes flowconfig)
         )
       ~ignores
@@ -1431,6 +1434,9 @@ let make_options
     | Flowlib.Prelude path -> path
     | Flowlib.Flowlib path -> path
   in
+  (* Initialize File_key root prefixes for relative path storage *)
+  File_key.set_project_root (File_path.to_string root);
+  File_key.set_flowlib_root (File_path.to_string flowlib_dir);
   let opt_log_file = server_log_file ~flowconfig_name ~tmp_dir:opt_temp_dir root in
   {
     Options.opt_abstract_classes = FlowConfig.abstract_classes flowconfig;
@@ -1454,7 +1460,8 @@ let make_options
       Base.Option.value (FlowConfig.casting_syntax flowconfig) ~default:Options.CastingSyntax.Both;
     opt_casting_syntax_only_support_as_excludes =
       Base.List.map
-        ~f:(fun pattern -> pattern |> Files.expand_project_root_token ~root |> Str.regexp)
+        ~f:(fun pattern ->
+          pattern |> Files.expand_project_root_token_as_absolute ~root |> Str.regexp)
         (FlowConfig.casting_syntax_only_support_as_excludes flowconfig);
     opt_channel_mode = Base.Option.value ~default:`pipe (FlowConfig.channel_mode flowconfig);
     opt_async_component_syntax = FlowConfig.async_component_syntax flowconfig;
@@ -1464,14 +1471,15 @@ let make_options
       SMap.map
         (Base.List.map ~f:(fun s ->
              s
-             |> Files.expand_project_root_token ~root
+             |> Files.expand_project_root_token_as_absolute ~root
              |> Files.expand_builtin_root_token ~flowlib_dir
          )
         )
         (FlowConfig.deprecated_utilities flowconfig);
     opt_deprecated_utilities_excludes =
       Base.List.map
-        ~f:(fun pattern -> pattern |> Files.expand_project_root_token ~root |> Str.regexp)
+        ~f:(fun pattern ->
+          pattern |> Files.expand_project_root_token_as_absolute ~root |> Str.regexp)
         (FlowConfig.deprecated_utilities_excludes flowconfig);
     opt_dev_only_refinement_info_as_errors =
       FlowConfig.dev_only_refinement_info_as_errors flowconfig;
@@ -1518,11 +1526,13 @@ let make_options
     opt_hook_compatibility = FlowConfig.hook_compatibility flowconfig;
     opt_hook_compatibility_excludes =
       Base.List.map
-        ~f:(fun pattern -> pattern |> Files.expand_project_root_token ~root |> Str.regexp)
+        ~f:(fun pattern ->
+          pattern |> Files.expand_project_root_token_as_absolute ~root |> Str.regexp)
         (FlowConfig.hook_compatibility_excludes flowconfig);
     opt_hook_compatibility_includes =
       Base.List.map
-        ~f:(fun pattern -> pattern |> Files.expand_project_root_token ~root |> Str.regexp)
+        ~f:(fun pattern ->
+          pattern |> Files.expand_project_root_token_as_absolute ~root |> Str.regexp)
         (FlowConfig.hook_compatibility_includes flowconfig);
     opt_ignore_non_literal_requires = FlowConfig.ignore_non_literal_requires flowconfig;
     opt_include_suppressions = options_flags.include_suppressions;
@@ -1574,19 +1584,21 @@ let make_options
       Base.List.map
         (FlowConfig.node_resolver_root_relative_dirnames flowconfig)
         ~f:(fun (applicable_dir_opt, dirname) ->
-          (Base.Option.map ~f:(Files.expand_project_root_token ~root) applicable_dir_opt, dirname)
+          ( Base.Option.map ~f:Files.expand_project_root_token_as_relative applicable_dir_opt,
+            dirname
+          )
       );
     opt_opaque_type_new_bound_syntax = FlowConfig.opaque_type_new_bound_syntax flowconfig;
     opt_records_includes =
       Base.List.map
-        ~f:(Files.expand_project_root_token ~root)
+        ~f:(Files.expand_project_root_token_as_absolute ~root)
         (FlowConfig.records_includes flowconfig);
     opt_profile = options_flags.profile;
     opt_projects_options =
       Flow_projects.mk_options
         ~projects:(FlowConfig.projects flowconfig)
         ~projects_overlap_mapping:(FlowConfig.projects_overlap_mapping flowconfig)
-        ~map_path:(fun path -> Files.expand_project_root_token ~root path |> Str.regexp)
+        ~map_path:(fun path -> Files.expand_project_root_token_as_relative path |> Str.regexp)
         ~projects_path_mapping:(FlowConfig.projects_path_mapping flowconfig)
         ~projects_strict_boundary:(FlowConfig.projects_strict_boundary flowconfig)
         ~projects_strict_boundary_validate_import_pattern_opt_outs:
@@ -1604,12 +1616,14 @@ let make_options
     opt_relay_integration_esmodules = FlowConfig.relay_integration_esmodules flowconfig;
     opt_relay_integration_excludes =
       Base.List.map
-        ~f:(fun pattern -> pattern |> Files.expand_project_root_token ~root |> Str.regexp)
+        ~f:(fun pattern ->
+          pattern |> Files.expand_project_root_token_as_absolute ~root |> Str.regexp)
         (FlowConfig.relay_integration_excludes flowconfig);
     opt_relay_integration_module_prefix = FlowConfig.relay_integration_module_prefix flowconfig;
     opt_relay_integration_module_prefix_includes =
       Base.List.map
-        ~f:(fun pattern -> pattern |> Files.expand_project_root_token ~root |> Str.regexp)
+        ~f:(fun pattern ->
+          pattern |> Files.expand_project_root_token_as_absolute ~root |> Str.regexp)
         (FlowConfig.relay_integration_module_prefix_includes flowconfig);
     opt_root = root;
     opt_root_name = FlowConfig.root_name flowconfig;
@@ -1631,7 +1645,9 @@ let make_options
     opt_deprecated_colon_extends =
       Base.List.map
         ~f:(fun s ->
-          s |> Files.expand_project_root_token ~root |> Files.expand_builtin_root_token ~flowlib_dir)
+          s
+          |> Files.expand_project_root_token_as_absolute ~root
+          |> Files.expand_builtin_root_token ~flowlib_dir)
         (FlowConfig.deprecated_colon_extends flowconfig);
     opt_ts_utility_syntax = FlowConfig.ts_utility_syntax flowconfig;
     opt_tslib_syntax = FlowConfig.tslib_syntax flowconfig;
@@ -1961,6 +1977,14 @@ let rec connect_and_make_request flowconfig_name =
 
 (* If --timeout is set, wrap connect_and_make_request in a timeout *)
 let connect_and_make_request ?retries flowconfig_name connect_flags root request =
+  (* Set File_key root paths for this client process. Server responses
+     contain File_key.t values with relative suffixes; to_string needs
+     the roots to reconstruct absolute paths. *)
+  File_key.set_project_root (File_path.to_string root);
+  let temp_dir = File_path.make (get_temp_dir connect_flags.temp_dir) in
+  (match Flowlib.libdir ~no_flowlib:false temp_dir with
+  | Flowlib.Prelude path -> File_key.set_flowlib_root (File_path.to_string path)
+  | Flowlib.Flowlib path -> File_key.set_flowlib_root (File_path.to_string path));
   match connect_flags.timeout with
   | None -> connect_and_make_request ?retries flowconfig_name connect_flags root request
   | Some timeout ->

--- a/src/commands/findModuleCommand.ml
+++ b/src/commands/findModuleCommand.ml
@@ -62,13 +62,8 @@ let main
   let request = ServerProt.Request.FIND_MODULE { moduleref; filename; wait_for_recheck } in
   let (resolution_result, failed_candidates) =
     match connect_and_make_request flowconfig_name option_values root request with
-    | ServerProt.Response.FIND_MODULE
-        ( ( Some (File_key.LibFile file)
-          | Some (File_key.SourceFile file)
-          | Some (File_key.JsonFile file)
-          | Some (File_key.ResourceFile file) ),
-          failed_candidates
-        ) ->
+    | ServerProt.Response.FIND_MODULE (Some file_key, failed_candidates) ->
+      let file = File_key.to_string file_key in
       if strip_root then
         (Files.relative_path (File_path.to_string root) file, failed_candidates)
       else

--- a/src/commands/getDefCommand.ml
+++ b/src/commands/getDefCommand.ml
@@ -113,7 +113,7 @@ let main base_flags option_values json pretty root strip_root path wait_for_rech
       let file_str =
         match File_input.filename_of_file_input input with
         | "-" as s -> s
-        | s -> File_key.SourceFile s |> Reason.string_of_source ~strip_root
+        | s -> File_key.source_file_of_absolute s |> Reason.string_of_source ~strip_root
       in
       Utils_js.prerr_endlinef "Could not get definition for %s:%d:%d\n%s" file_str line char exn_msg
   | response -> failwith_bad_response ~request ~response

--- a/src/commands/glean/offset_cache.ml
+++ b/src/commands/glean/offset_cache.ml
@@ -12,10 +12,11 @@ type info = {
 
 let info_cache : info SMap.t ref = ref SMap.empty
 
-let info_of_file_key = function
-  | File_key.LibFile file
-  | File_key.SourceFile file
-  | File_key.JsonFile file ->
+let info_of_file_key file_key =
+  match file_key with
+  | File_key.ResourceFile _ -> None
+  | _ ->
+    let file = File_key.to_string file_key in
     (match SMap.find_opt file !info_cache with
     | Some info -> Some info
     | None ->
@@ -25,7 +26,6 @@ let info_of_file_key = function
       let info = { offsets; ends_in_newline } in
       info_cache := SMap.add file info !info_cache;
       Some info)
-  | File_key.ResourceFile _ -> None
 
 open Base.Option.Let_syntax
 

--- a/src/commands/lsCommand.ml
+++ b/src/commands/lsCommand.ml
@@ -142,12 +142,12 @@ let make_options ~flowconfig ~root ~ignore_flag ~include_flag ~untyped_flag ~dec
     ~temp_dir:(CommandUtils.get_temp_dir None |> File_path.make)
     ~haste_paths_excludes:
       (Base.List.map
-         ~f:(fun f -> f |> Files.expand_project_root_token ~root |> Str.regexp)
+         ~f:(fun f -> f |> Files.expand_project_root_token_as_absolute ~root |> Str.regexp)
          (FlowConfig.haste_paths_excludes flowconfig)
       )
     ~haste_paths_includes:
       (Base.List.map
-         ~f:(fun f -> f |> Files.expand_project_root_token ~root |> Str.regexp)
+         ~f:(fun f -> f |> Files.expand_project_root_token_as_absolute ~root |> Str.regexp)
          (FlowConfig.haste_paths_includes flowconfig)
       )
     ~ignores

--- a/src/common/errors/flow_errors_utils.ml
+++ b/src/common/errors/flow_errors_utils.ml
@@ -1114,7 +1114,8 @@ let read_lines_in_file loc filename stdin_file =
 
 let file_of_source source =
   match source with
-  | Some (File_key.LibFile filename) ->
+  | Some file_key ->
+    let filename = File_key.to_string file_key in
     let filename =
       if is_short_lib filename then
         let prefix_len = String.length lib_prefix in
@@ -1122,10 +1123,6 @@ let file_of_source source =
       else
         filename
     in
-    Some filename
-  | Some (File_key.SourceFile filename)
-  | Some (File_key.JsonFile filename)
-  | Some (File_key.ResourceFile filename) ->
     Some filename
   | None -> None
 
@@ -1454,17 +1451,16 @@ module Cli_output = struct
     let horizontal_line_length = flags.message_width - (String.length severity_name + 1) in
     let filename =
       Loc.(
-        File_key.(
-          let { source; start = { line; column; _ }; _ } = loc in
-          let pos = ":" ^ string_of_int line ^ ":" ^ string_of_int (column + 1) in
-          match source with
-          | Some (LibFile filename) -> relative_lib_path ~strip_root filename ^ pos
-          | Some (SourceFile filename)
-          | Some (JsonFile filename)
-          | Some (ResourceFile filename) ->
-            relative_path ~strip_root filename ^ pos
-          | None -> ""
-        )
+        let { source; start = { line; column; _ }; _ } = loc in
+        let pos = ":" ^ string_of_int line ^ ":" ^ string_of_int (column + 1) in
+        match source with
+        | Some (File_key.LibFile _ as fk) ->
+          relative_lib_path ~strip_root (File_key.to_string fk) ^ pos
+        | Some (File_key.SourceFile _ as fk)
+        | Some (File_key.JsonFile _ as fk)
+        | Some (File_key.ResourceFile _ as fk) ->
+          relative_path ~strip_root (File_key.to_string fk) ^ pos
+        | None -> ""
       )
     in
     (* If the filename is longer then the remaining horizontal line length we
@@ -2098,15 +2094,13 @@ module Cli_output = struct
 
   (* Prints a File_key.t to a string. *)
   let print_file_key ~strip_root file_key =
-    File_key.(
-      match file_key with
-      | Some (LibFile filename) -> relative_lib_path ~strip_root filename
-      | Some (SourceFile filename)
-      | Some (JsonFile filename)
-      | Some (ResourceFile filename) ->
-        relative_path ~strip_root filename
-      | None -> "(builtins)"
-    )
+    match file_key with
+    | Some (File_key.LibFile _ as fk) -> relative_lib_path ~strip_root (File_key.to_string fk)
+    | Some (File_key.SourceFile _ as fk)
+    | Some (File_key.JsonFile _ as fk)
+    | Some (File_key.ResourceFile _ as fk) ->
+      relative_path ~strip_root (File_key.to_string fk)
+    | None -> "(builtins)"
 
   exception Oh_no_file_contents_have_changed
 

--- a/src/common/files.ml
+++ b/src/common/files.ml
@@ -904,17 +904,18 @@ let absolute_path root =
 (* helper to get the full path to the "flow-typed" library dir *)
 let get_flowtyped_path root = make_path_absolute root "flow-typed"
 
-(* helper: make different kinds of File_key.t from a path string *)
+(* helper: make different kinds of File_key.t from an absolute path string,
+   stripping the root to store as a relative suffix *)
 let filename_from_string ~options ~consider_libdefs ~all_unordered_libs p =
   let resource_file_exts = options.module_resource_exts in
   match Utils_js.extension_of_filename p with
-  | Some ".json" -> File_key.JsonFile p
-  | Some ext when SSet.mem ext resource_file_exts -> File_key.ResourceFile p
+  | Some ".json" -> File_key.json_file_of_absolute p
+  | Some ext when SSet.mem ext resource_file_exts -> File_key.resource_file_of_absolute p
   | _ ->
     if consider_libdefs && SSet.mem p all_unordered_libs then
-      File_key.LibFile p
+      File_key.lib_file_of_absolute p
     else
-      File_key.SourceFile p
+      File_key.source_file_of_absolute p
 
 let mkdirp path_str perm =
   let parts = Str.split dir_sep path_str in
@@ -992,9 +993,16 @@ let canonicalize_filenames ~cwd ~handle_imaginary filenames =
       | None -> handle_imaginary filename)
     filenames
 
-let expand_project_root_token ~root =
+let expand_project_root_token_as_absolute ~root =
   let root = File_path.to_string root |> Sys_utils.normalize_filename_dir_sep in
   (fun str -> str |> Str.split_delim project_root_token |> String.concat root)
+
+let expand_project_root_token_as_relative str =
+  let s = str |> Str.split_delim project_root_token |> String.concat "" in
+  if String.length s > 0 && (s.[0] = '/' || s.[0] = '\\') then
+    String.sub s 1 (String.length s - 1)
+  else
+    s
 
 let expand_builtin_root_token ~flowlib_dir =
   let flowlib_dir_str = File_path.to_string flowlib_dir |> Sys_utils.normalize_filename_dir_sep in

--- a/src/common/files.mli
+++ b/src/common/files.mli
@@ -170,6 +170,8 @@ val imaginary_realpath : string -> string
 val canonicalize_filenames :
   cwd:string -> handle_imaginary:(string -> string) -> string list -> string list
 
-val expand_project_root_token : root:File_path.t -> string -> string
+val expand_project_root_token_as_absolute : root:File_path.t -> string -> string
+
+val expand_project_root_token_as_relative : string -> string
 
 val expand_builtin_root_token : flowlib_dir:File_path.t -> string -> string

--- a/src/common/reason.ml
+++ b/src/common/reason.ml
@@ -396,29 +396,31 @@ let in_range loc range =
     && (line < line2 || (line = line2 && loc._end.column <= range._end.column))
   )
 
-let string_of_source ?(strip_root = None) =
-  File_key.(
-    function
-    | LibFile file -> begin
-      match strip_root with
-      | Some root ->
-        let root_str = spf "%s%s" (File_path.to_string root) Filename.dir_sep in
-        if String.starts_with ~prefix:root_str file then
-          spf "[LIB] %s" (Files.relative_path root_str file)
-        else
-          spf "[LIB] %s" (Filename.basename file)
-      | None -> file
-    end
-    | SourceFile file
-    | JsonFile file
-    | ResourceFile file -> begin
-      match strip_root with
-      | Some root ->
-        let root_str = spf "%s%s" (File_path.to_string root) Filename.dir_sep in
-        Files.relative_path root_str file
-      | None -> file
-    end
-  )
+(* Note: to_string does root+suffix concat, then strip_root cases undo it
+   via Files.relative_path. This is a cold path (error formatting) so the
+   extra allocation is negligible. For hot paths, use File_key.suffix. *)
+let string_of_source ?(strip_root = None) src =
+  let file = File_key.to_string src in
+  match src with
+  | File_key.LibFile _ -> begin
+    match strip_root with
+    | Some root ->
+      let root_str = spf "%s%s" (File_path.to_string root) Filename.dir_sep in
+      if String.starts_with ~prefix:root_str file then
+        spf "[LIB] %s" (Files.relative_path root_str file)
+      else
+        spf "[LIB] %s" (Filename.basename file)
+    | None -> file
+  end
+  | File_key.SourceFile _
+  | File_key.JsonFile _
+  | File_key.ResourceFile _ -> begin
+    match strip_root with
+    | Some root ->
+      let root_str = spf "%s%s" (File_path.to_string root) Filename.dir_sep in
+      Files.relative_path root_str file
+    | None -> file
+  end
 
 let string_of_loc ?(strip_root = None) loc =
   Loc.(

--- a/src/flow_dot_js.ml
+++ b/src/flow_dot_js.ml
@@ -1097,6 +1097,10 @@ let () =
      )
     )
 
+(* flow.js runs without a project root — set empty root so File_key.to_string
+   works on File_key values created with raw constructors. *)
+let () = File_key.set_project_root ""
+
 let () = Js.Unsafe.set exports "initBuiltins" (Js.wrap_callback init_builtins_js)
 
 let () = Js.Unsafe.set exports "check" (Js.wrap_callback check_js)

--- a/src/lsp/flowLsp.ml
+++ b/src/lsp/flowLsp.ml
@@ -1198,7 +1198,9 @@ let parse_and_cache (state : server_state) (uri : Lsp.DocumentUri.t) :
       try
         let content = File_input.content_of_file_input_unsafe file in
         let filename_opt = File_input.path_of_file_input file in
-        let filekey = Base.Option.map filename_opt ~f:(fun fn -> File_key.SourceFile fn) in
+        let filekey =
+          Base.Option.map filename_opt ~f:(fun fn -> File_key.source_file_of_absolute fn)
+        in
         Parser_flow.program_file ~fail:false ~parse_options ~token_sink:None content filekey
       with
       | _ ->
@@ -2433,6 +2435,20 @@ and main_handle_unsafe flowconfig_name (state : state) (event : event) :
       Client_message (RequestMessage (id, InitializeRequest i_initialize_params), metadata)
     ) ->
     let i_root = Lsp_helpers.get_root i_initialize_params |> File_path.make in
+    (* Set File_key root paths for this LSP handler process. Server responses
+       contain File_key.t values with relative suffixes; to_string needs
+       the roots to reconstruct absolute paths. *)
+    File_key.set_project_root (File_path.to_string i_root);
+    let lsp_temp_dir =
+      File_path.make
+        (Base.Option.value
+           i_connect_params.CommandUtils.temp_dir
+           ~default:Server_files_js.default_temp_dir
+        )
+    in
+    (match Flowlib.libdir ~no_flowlib:false lsp_temp_dir with
+    | Flowlib.Prelude path -> File_key.set_flowlib_root (File_path.to_string path)
+    | Flowlib.Flowlib path -> File_key.set_flowlib_root (File_path.to_string path));
     (* TODO: use FlowConfig.get directly and send errors/warnings to the client instead
         of logging to stderr and exiting. *)
     let flowconfig = read_flowconfig_from_disk flowconfig_name i_root in

--- a/src/parser/estree_translator.ml
+++ b/src/parser/estree_translator.ml
@@ -49,11 +49,7 @@ with type t = Impl.t = struct
     let source =
       if Config.include_filename then
         match Loc.source location with
-        | Some (File_key.LibFile src)
-        | Some (File_key.SourceFile src)
-        | Some (File_key.JsonFile src)
-        | Some (File_key.ResourceFile src) ->
-          string src
+        | Some file_key -> string (File_key.suffix file_key)
         | None -> null
       else
         null

--- a/src/parser/file_key.ml
+++ b/src/parser/file_key.ml
@@ -5,6 +5,19 @@
  * LICENSE file in the root directory of this source tree.
  *)
 
+(* File_key.t stores relative path suffixes internally, following Hack's
+   Relative_path.t approach. The project root and flowlib root are set once
+   at startup via global refs. to_string returns the absolute path on demand.
+
+   LibFile paths under the flowlib root use a marker prefix internally to
+   distinguish them from project-root LibFiles. This marker is stripped in
+   to_string/to_absolute and replaced with the flowlib root.
+
+   IMPORTANT: The global root refs (project_root, flowlib_root) are plain
+   OCaml ref cells. This is safe with fork-based MultiWorkerLwt workers
+   (each gets a copy-on-write snapshot). If OCaml 5 domains are ever
+   introduced, these must become domain-local or atomic. *)
+
 type t =
   | LibFile of string
   | SourceFile of string
@@ -14,19 +27,102 @@ type t =
   | ResourceFile of string
 [@@deriving show, eq]
 
-let to_string = function
+(* Marker for flowlib LibFile paths. This is the single source of truth —
+   saved_state.ml uses File_key.flowlib_marker, not a separate constant. *)
+let flowlib_marker = "<BUILTIN_FLOW_LIB>///"
+
+(* Global root refs — set once at startup, before any File_key construction
+   or to_string calls. All roots have enforced trailing slashes so that
+   strip_prefix always splits at a directory boundary.
+
+   Using [string option ref] (not [string ref]) so that "not yet initialized"
+   is distinguishable from "set to empty". Following Hack's Relative_path
+   convention: accessing an unset root raises an immediate, descriptive error
+   rather than silently producing a broken path.
+
+   See set_project_root/set_flowlib_root for the setters. *)
+let project_root = ref None
+
+let flowlib_root = ref None
+
+let enforce_trailing_sep ~dir_sep s =
+  let len = String.length s in
+  if len > 0 && s.[len - 1] <> '/' && s.[len - 1] <> '\\' then
+    s ^ dir_sep
+  else
+    s
+
+let resolve_root_with ~is_relative get_root suffix =
+  let len = String.length suffix in
+  if len = 0 || suffix = "-" then
+    suffix
+  else if not (is_relative suffix) then
+    suffix
+  else
+    get_root () ^ suffix
+
+let enforce_trailing_slash s = enforce_trailing_sep ~dir_sep:Filename.dir_sep s
+
+let set_project_root root = project_root := Some (enforce_trailing_slash root)
+
+let set_flowlib_root root = flowlib_root := Some (enforce_trailing_slash root)
+
+(* Retrieve a root, crashing immediately if not set. Following Hack's
+   Relative_path convention: an unset root is a programmer error that
+   should be caught at the call site, not masked downstream. *)
+let get_project_root () =
+  match !project_root with
+  | Some r -> r
+  | None -> failwith "File_key: project_root has not been set"
+
+let get_flowlib_root () =
+  match !flowlib_root with
+  | Some r -> r
+  | None -> failwith "File_key: flowlib_root has not been set"
+
+(* Returns the relative suffix — used internally for comparison and
+   SharedMem hashing. For flowlib LibFiles, includes the flowlib_marker
+   prefix. This is the zero-cost path for hot operations like compare. *)
+let suffix = function
   | LibFile x
   | SourceFile x
   | JsonFile x
   | ResourceFile x ->
     x
 
-let to_path = function
-  | LibFile x
+(* Resolves a stored suffix back to an absolute path.
+   - Empty suffix ("") and the stdin sentinel ("-") are returned unchanged.
+   - Suffixes that are already absolute (Filename.is_relative returns false)
+     are returned unchanged — this handles out-of-root files whose absolute
+     path is stored directly as the suffix.
+   - Relative suffixes are prepended with get_root (). The root must have a
+     trailing separator (enforced by set_project_root/set_flowlib_root) so
+     concatenation produces a valid path. *)
+let resolve_root get_root suffix =
+  resolve_root_with ~is_relative:Filename.is_relative get_root suffix
+
+(* Returns the full absolute path — resolves the root on demand.
+   Allocates a new string via concatenation. Use suffix for hot paths
+   that don't need the absolute path (compare, SharedMem hashing). *)
+let to_absolute = function
+  | LibFile x ->
+    if String.starts_with ~prefix:flowlib_marker x then
+      let marker_len = String.length flowlib_marker in
+      resolve_root get_flowlib_root (String.sub x marker_len (String.length x - marker_len))
+    else
+      resolve_root get_project_root x
   | SourceFile x
   | JsonFile x
   | ResourceFile x ->
-    Ok x
+    resolve_root get_project_root x
+
+(* to_string returns the absolute path so all existing callers
+   (destructuring, file I/O, display, path manipulation) work correctly
+   without changes. For hot paths that only need identity/comparison,
+   use suffix instead to avoid the string allocation. *)
+let to_string = to_absolute
+
+let to_path t = Ok (to_absolute t)
 
 let compare =
   (* libs, then source and json files at the same priority since JSON files are
@@ -43,7 +139,7 @@ let compare =
     if k <> 0 then
       k
     else
-      String.compare (to_string a) (to_string b)
+      String.compare (suffix a) (suffix b)
 
 let compare_opt a b =
   match (a, b) with
@@ -71,8 +167,48 @@ let exists f = function
   | ResourceFile filename ->
     f filename
 
-let check_suffix filename suffix = exists (fun fn -> Filename.check_suffix fn suffix) filename
+let check_suffix filename sfx = exists (fun fn -> Filename.check_suffix fn sfx) filename
 
-let chop_suffix filename suffix = map (fun fn -> Filename.chop_suffix fn suffix) filename
+let chop_suffix filename sfx = map (fun fn -> Filename.chop_suffix fn sfx) filename
 
-let with_suffix filename suffix = map (fun fn -> fn ^ suffix) filename
+let with_suffix filename sfx = map (fun fn -> fn ^ sfx) filename
+
+(* Strip a root prefix from an absolute path. The prefix must have a
+   trailing slash (enforced by set_project_root/set_flowlib_root) so that
+   stripping always occurs at a directory boundary — e.g., root "/data/foo/"
+   won't match "/data/foobar/file.js". *)
+let strip_prefix prefix path =
+  let plen = String.length prefix in
+  if plen > 0 && String.starts_with ~prefix path then
+    String.sub path plen (String.length path - plen)
+  else
+    path
+
+(* Strip the project root from an absolute path. If the root has not been
+   set yet, returns the path unchanged — the suffix will be an absolute
+   path, and resolve_root handles that case correctly. *)
+let strip_project_root path =
+  match !project_root with
+  | Some root -> strip_prefix root path
+  | None -> path
+
+(* Create File_key values from absolute paths, stripping the appropriate root.
+   Safe to call before roots are initialized — the full path is stored as the
+   suffix, and to_absolute handles absolute suffixes correctly. *)
+let source_file_of_absolute path = SourceFile (strip_project_root path)
+
+let json_file_of_absolute path = JsonFile (strip_project_root path)
+
+let resource_file_of_absolute path = ResourceFile (strip_project_root path)
+
+let lib_file_of_absolute path =
+  match !flowlib_root with
+  | Some fl when String.length fl > 0 && String.starts_with ~prefix:fl path ->
+    LibFile (flowlib_marker ^ strip_prefix fl path)
+  | _ -> LibFile (strip_project_root path)
+
+module For_tests = struct
+  let enforce_trailing_sep = enforce_trailing_sep
+
+  let resolve_root_with = resolve_root_with
+end

--- a/src/parser_utils/__tests__/file_sig_test.ml
+++ b/src/parser_utils/__tests__/file_sig_test.ml
@@ -8,6 +8,8 @@
 open OUnit2
 open File_sig
 
+let () = File_key.set_project_root "/"
+
 let visit ?parse_options ?(opts = default_opts) source =
   (* allow parse errors. we still need file sigs on invalid ASTs in Type_contents. *)
   let fail = false in

--- a/src/parser_utils/aloc/__tests__/aloc_tests.ml
+++ b/src/parser_utils/aloc/__tests__/aloc_tests.ml
@@ -7,6 +7,8 @@
 
 open OUnit2
 
+let () = File_key.set_project_root "/"
+
 let compare_tests =
   [
     ( "keyed_vs_concrete_whole_file" >:: fun _ctxt ->
@@ -23,7 +25,7 @@ let compare_tests =
       let keyed = ALoc.ALocRepresentationDoNotUse.make_keyed (Some source) 1 in
       assert_raises
         (Invalid_argument
-           "Unable to compare a keyed location with a concrete one. loc1: \"test.js\": (1, 1) to (1, 2), loc2: \"test.js\": 1"
+           "Unable to compare a keyed location with a concrete one. loc1: \"/test.js\": (1, 1) to (1, 2), loc2: \"/test.js\": 1"
         )
         (fun () -> ALoc.compare concrete keyed
       )

--- a/src/parser_utils/file_sig.ml
+++ b/src/parser_utils/file_sig.ml
@@ -216,7 +216,7 @@ class requires_calculator ~file_key ~ast ~opts =
         && Base.Option.is_some (Files.haste_name_opt ~options:opts.file_options file_key)
       then
         let opts = opts.project_options in
-        let file = File_key.to_string file_key in
+        let file = File_key.suffix file_key in
         if Flow_projects.is_common_code_path ~opts file then
           Base.List.iter this#acc ~f:(function
               | Require { source; _ }
@@ -263,7 +263,7 @@ class requires_calculator ~file_key ~ast ~opts =
       | Some haste_name ->
         (match
            let opts = opts.project_options in
-           Flow_projects.projects_bitset_of_path ~opts (File_key.to_string file_key)
+           Flow_projects.projects_bitset_of_path ~opts (File_key.suffix file_key)
            |> Base.Option.bind
                 ~f:(Flow_projects.individual_projects_bitsets_from_common_project_bitset ~opts)
          with
@@ -288,7 +288,7 @@ class requires_calculator ~file_key ~ast ~opts =
             (Platform_set.available_platforms
                ~file_options:opts.file_options
                ~projects_options:opts.project_options
-               ~filename:(File_key.to_string file_key)
+               ~filename:(File_key.suffix file_key)
                ~explicit_available_platforms:opts.explicit_available_platforms
             )
           ~file:file_key

--- a/src/parsing/parsing_service_js.ml
+++ b/src/parsing/parsing_service_js.ml
@@ -159,7 +159,7 @@ let parse_type_sig options docblock locs_to_dirtify file ast =
     Platform_set.available_platforms
       ~file_options:(Options.file_options options)
       ~projects_options:(Options.projects_options options)
-      ~filename:(File_key.to_string file)
+      ~filename:(File_key.suffix file)
       ~explicit_available_platforms:(Docblock.supportsPlatform docblock)
   in
   Type_sig_utils.parse_and_pack_module ~strict ~platform_availability_set sig_opts (Some file) ast

--- a/src/server/command_handler/commandHandler.ml
+++ b/src/server/command_handler/commandHandler.ml
@@ -266,7 +266,9 @@ let mk_module_system_info =
   let is_package_file ~options ~reader ~module_path ~module_name =
     let dependency =
       match
-        Flow_projects.projects_bitset_of_path ~opts:(Options.projects_options options) module_path
+        Flow_projects.projects_bitset_of_path
+          ~opts:(Options.projects_options options)
+          (File_key.strip_project_root module_path)
       with
       | None -> None
       | Some ns ->
@@ -1207,7 +1209,7 @@ let collect_rage ~options ~reader ~env ~files =
         List.iter
           (fun file ->
             (* TODO - this isn't exactly right. It could be something else, right? *)
-            let file_key = File_key.SourceFile file in
+            let file_key = File_key.source_file_of_absolute file in
             let file_state =
               if not (FilenameSet.mem file_key env.ServerEnv.files) then
                 "FILE NOT PARSED BY FLOW (likely ignored implicitly or explicitly)"
@@ -1345,7 +1347,7 @@ let get_cycle ~env fn types_only =
     )
 
 let find_module ~options ~reader (moduleref, filename) =
-  let file = File_key.SourceFile filename in
+  let file = File_key.source_file_of_absolute filename in
   let phantom_acc = ref Modulename.Map.empty in
   let resolved_module =
     (* debug *)
@@ -1528,7 +1530,7 @@ let provide_document_paste ~options ~reader ~profiling ~params =
   in
   let (edits, extra_data) =
     let file_key =
-      File_key.SourceFile
+      File_key.source_file_of_absolute
         (Flow_lsp_conversions.lsp_DocumentIdentifier_to_flow_path { TextDocumentIdentifier.uri })
     in
     match Type_contents.parse_contents ~options ~profiling text file_key |> fst with
@@ -1860,7 +1862,7 @@ let handle_llm_context ~options ~reader ~profiling ~env input =
   let strip_root = Some (Options.root options) in
   let typed_files =
     Base.List.filter_map files ~f:(fun file_path ->
-        let file_key = File_key.SourceFile file_path in
+        let file_key = File_key.source_file_of_absolute file_path in
         let file_input = File_input.FileName file_path in
         match of_file_input ~options ~env file_input with
         | Error _ -> None
@@ -3110,10 +3112,9 @@ let handle_persistent_signaturehelp_lsp
   | Ok (filename, contents) ->
     let path =
       match filename with
-      | Some filename -> filename
-      | None -> "-"
+      | Some filename -> File_key.source_file_of_absolute filename
+      | None -> File_key.SourceFile "-"
     in
-    let path = File_key.SourceFile path in
     let (file_artifacts_result, did_hit_cache) =
       let parse_result = lazy (Type_contents.parse_contents ~options ~profiling contents path) in
       let type_parse_artifacts_cache =
@@ -3719,7 +3720,7 @@ let handle_persistent_llm_context ~options ~reader ~id ~params ~metadata ~client
   let typed_files =
     Base.List.filter_map editedFilePaths ~f:(fun file_uri_str ->
         let file_path = File_url.parse file_uri_str in
-        let file_key = File_key.SourceFile file_path in
+        let file_key = File_key.source_file_of_absolute file_path in
         let text_document = { TextDocumentIdentifier.uri = DocumentUri.of_string file_uri_str } in
         let file_input = file_input_of_text_document_identifier ~client text_document in
         match of_file_input ~options ~env file_input with

--- a/src/server/persistent_connection/persistent_connection.ml
+++ b/src/server/persistent_connection/persistent_connection.ml
@@ -52,9 +52,9 @@ type t = Prot.client_id list
 let cache_max_size = 10
 
 let remove_cache_entry ~autocomplete client filename =
-  (* get_def, coverage, etc. all construct a File_key.SourceFile, which is then used as a key
+  (* get_def, coverage, etc. all construct a SourceFile key, which is then used as a key
      * here. *)
-  let file_key = File_key.SourceFile filename in
+  let file_key = File_key.source_file_of_absolute filename in
   FilenameCache.remove_entry file_key client.type_parse_artifacts_cache;
   if autocomplete then FilenameCache.remove_entry file_key client.autocomplete_artifacts_cache
 
@@ -88,10 +88,10 @@ let send_errors =
       get_first_contained
         warn_map
         [
-          File_key.SourceFile filename;
-          File_key.LibFile filename;
-          File_key.JsonFile filename;
-          File_key.ResourceFile filename;
+          File_key.source_file_of_absolute filename;
+          File_key.lib_file_of_absolute filename;
+          File_key.json_file_of_absolute filename;
+          File_key.resource_file_of_absolute filename;
         ]
   in
   fun ~errors_reason ~errors ~warnings client ->

--- a/src/server/rechecker/recheck_updates.ml
+++ b/src/server/rechecker/recheck_updates.ml
@@ -26,7 +26,7 @@ let is_incompatible_package_json ~options ~reader =
    * specific extensions and files. Make sure to update the watchman_expression_terms in our
    * watchman file watcher! *)
   let is_incompatible filename_str =
-    let filename = File_key.JsonFile filename_str in
+    let filename = File_key.json_file_of_absolute filename_str in
     match Sys_utils.cat_or_failed filename_str with
     | None -> Module_js.Incompatible Module_js.Unknown (* Failed to read package.json *)
     | Some content ->
@@ -134,7 +134,7 @@ let check_for_package_json_changes ~is_incompatible_package_json ~skip_incompati
 
 (** Check if the file's hash has changed *)
 let did_content_change ~reader filename =
-  let file = File_key.LibFile filename in
+  let file = File_key.lib_file_of_absolute filename in
   match Sys_utils.cat_or_failed filename with
   | None -> true (* Failed to read lib file *)
   | Some content ->

--- a/src/server/server.ml
+++ b/src/server/server.ml
@@ -221,6 +221,14 @@ let on_compact () =
  * we look if env.modified changed.
  *)
 let create_program_init ~shared_mem_config ~init_id ?focus_targets options =
+  (* Initialize File_key root paths in the server process. These are set in
+     make_options in the client process, but the server is a separate daemon
+     that receives options via Marshal, so we must set them here too. *)
+  File_key.set_project_root (File_path.to_string (Options.root options));
+  (match Options.file_options options |> Files.default_lib_dir with
+  | Some (Files.Flowlib path | Files.Prelude path) ->
+    File_key.set_flowlib_root (File_path.to_string path)
+  | None -> ());
   SharedMem.on_compact := on_compact;
   let num_workers = Options.max_workers options in
   let handle =

--- a/src/server/serverWorker.ml
+++ b/src/server/serverWorker.ml
@@ -12,6 +12,8 @@ module ServerWorkerState = struct
     init_id: string;
     logger_level: Hh_logger.Level.t;
     log_filename: string option;
+    project_root: string;
+    flowlib_root: string;
   }
 
   let save ~init_id : t =
@@ -19,11 +21,18 @@ module ServerWorkerState = struct
       init_id;
       logger_level = Hh_logger.Level.min_level ();
       log_filename = Hh_logger.get_log_name ();
+      project_root = File_key.get_project_root ();
+      flowlib_root = File_key.get_flowlib_root ();
     }
 
-  let restore { init_id; logger_level; log_filename } ~(worker_id : int) =
+  let restore { init_id; logger_level; log_filename; project_root; flowlib_root } ~(worker_id : int)
+      =
     Hh_logger.set_id (Printf.sprintf "flow serverWorker %d" worker_id);
     Hh_logger.Level.set_min_level logger_level;
+
+    (* Restore File_key root paths in worker processes *)
+    File_key.set_project_root project_root;
+    File_key.set_flowlib_root flowlib_root;
 
     let init_id = init_id ^ "." ^ Random_id.short_string () in
     FlowEventLogger.init_worker ~init_id (Unix.gettimeofday ());

--- a/src/services/code_action/__tests__/code_action_service_tests.ml
+++ b/src/services/code_action/__tests__/code_action_service_tests.ml
@@ -8,6 +8,8 @@
 open OUnit2
 open Lsp_import_edits.For_tests
 
+let () = File_key.set_project_root "/"
+
 let source_modulename path = Modulename.Filename (File_key.SourceFile path)
 
 let string_opt = function
@@ -21,7 +23,7 @@ let module_declaration_dirnames = ["/path/to/root/@flowtyped"]
 let node_resolver_root_relative_dirnames =
   [
     (None, "/path/to/root/root_relative_for_all");
-    (Some "/path/to/root/some", "/path/to/root/root_relative_for_some");
+    (Some "path/to/root/some", "/path/to/root/root_relative_for_some");
   ]
 
 let resolves_to_real_path ~from:_ ~to_real_path:_ = true
@@ -47,7 +49,7 @@ let add_package mutator file_key pkg =
   ()
 
 let with_package fn pkg f =
-  let file_key = File_key.JsonFile fn in
+  let file_key = File_key.json_file_of_absolute fn in
   let file_set = Utils_js.FilenameSet.singleton file_key in
   let iter_files f = f file_key in
   let () =

--- a/src/services/code_action/__tests__/refactor_extract_tests.ml
+++ b/src/services/code_action/__tests__/refactor_extract_tests.ml
@@ -8,6 +8,8 @@
 open OUnit2
 open Refactor_extract_utils_tests
 
+let () = File_key.set_project_root "/"
+
 let assert_refactored
     ~ctxt ?(support_experimental_snippet_text_edit = false) expected source extract_range =
   let ast = parse source in

--- a/src/services/code_action/__tests__/refactor_extract_utils_tests.ml
+++ b/src/services/code_action/__tests__/refactor_extract_utils_tests.ml
@@ -10,6 +10,8 @@ open Ast_extraction_utils
 open Refactor_extract_utils
 open Loc_collections
 
+let () = File_key.set_project_root "/"
+
 let pretty_print layout =
   let source = Pretty_printer.print ~skip_endline:true layout in
   Source.contents source

--- a/src/services/code_action/document_paste.ml
+++ b/src/services/code_action/document_paste.ml
@@ -184,7 +184,7 @@ let provide_document_paste_edits ~layout_options ~module_system_info ~src_dir as
               ~module_system_info
               ~src_dir
               ( if import_source_is_resolved then
-                Export_index.File_key (File_key.SourceFile import_source)
+                Export_index.File_key (File_key.source_file_of_absolute import_source)
               else
                 Export_index.Builtin (Flow_import_specifier.userland import_source)
               )

--- a/src/services/code_action/lsp_import_edits.ml
+++ b/src/services/code_action/lsp_import_edits.ml
@@ -21,7 +21,7 @@ let is_available_autoimport_result cx =
     | File_key _ -> true
 
 let main_of_package ~get_package_info package_dir =
-  let file_key = File_key.JsonFile (package_dir ^ Filename.dir_sep ^ "package.json") in
+  let file_key = File_key.json_file_of_absolute (package_dir ^ Filename.dir_sep ^ "package.json") in
   match get_package_info file_key with
   | Some (Ok package) -> Package_json.main package
   | Some (Error _)
@@ -143,7 +143,9 @@ let node_path
       let package_dir_rev = package_dir :: ancestor_rev in
       (match
          get_package_info
-           (File_key.JsonFile (path_parts_rev_to_absolute ("package.json" :: package_dir_rev)))
+           (File_key.json_file_of_absolute
+              (path_parts_rev_to_absolute ("package.json" :: package_dir_rev))
+           )
        with
       | Some (Ok package_info)
         when can_import_as_node_package
@@ -167,7 +169,7 @@ let node_path
         if
           match src_prefix_opt with
           | None -> true
-          | Some prefix -> Files.is_prefix prefix src_dir
+          | Some prefix -> Files.is_prefix prefix (File_key.strip_project_root src_dir)
         then
           let root_relative_dirname_parts = Files.split_path root_relative_dirname in
           Base.Option.map

--- a/src/services/export/index/__tests__/export_index_tests.ml
+++ b/src/services/export/index/__tests__/export_index_tests.ml
@@ -7,6 +7,8 @@
 
 open OUnit2
 
+let () = File_key.set_project_root "/"
+
 let file_source name = Export_index.File_key (File_key.SourceFile name)
 
 let file_lib name = Export_index.File_key (File_key.LibFile name)

--- a/src/services/export/index/export_index.ml
+++ b/src/services/export/index/export_index.ml
@@ -31,9 +31,8 @@ let show_source = function
     extension is less important than the rest of the basename and we should suggest
     [import ... from 'Foo'] before [import ... from 'Foo.example']. *)
 let compare_file_key a b =
-  let open File_key in
-  let a = to_string a in
-  let b = to_string b in
+  let a = File_key.suffix a in
+  let b = File_key.suffix b in
   let k = String.compare (Filename.chop_extension a) (Filename.chop_extension b) in
   if k <> 0 then
     k

--- a/src/services/export/search/__tests__/export_search_tests.ml
+++ b/src/services/export/search/__tests__/export_search_tests.ml
@@ -9,6 +9,8 @@ open OUnit2
 open Export_search
 open Export_search_types
 
+let () = File_key.set_project_root "/"
+
 let default_type = Export_index.DefaultType
 
 let default = Export_index.Default

--- a/src/services/inference/check_service.ml
+++ b/src/services/inference/check_service.ml
@@ -108,8 +108,10 @@ let mk_check_file ~reader ~options ~master_cx ~cache () =
           )
       | Some dep_addr ->
         (match Parsing_heaps.read_file_key dep_addr with
-        | File_key.ResourceFile f as file_key ->
-          let (reason, lazy_module) = Merge.merge_resource_module_t cx file_key f in
+        | File_key.ResourceFile _ as file_key ->
+          let (reason, lazy_module) =
+            Merge.merge_resource_module_t cx file_key (File_key.to_string file_key)
+          in
           Context.TypedModule
             (Type.Constraint.ForcingState.of_lazy_module (reason, lazy_module)
             |> ConsGen.force_module_type_thunk cx

--- a/src/services/inference/init_js.ml
+++ b/src/services/inference/init_js.ml
@@ -16,7 +16,7 @@
 open Utils_js
 module ErrorSet = Flow_error.ErrorSet
 
-(* process all lib files: parse, infer, and add the symbols they define
+(* Process all lib files: parse, infer, and add the symbols they define
    to the builtins object.
 
    Note: we support overrides of definitions found earlier in the list of
@@ -31,7 +31,7 @@ let load_lib_files ~ccx ~options ~reader files =
     files
     |> Lwt_list.fold_left_s
          (fun (ok_acc, asts_with_scoped_dir_opt_acc) (scoped_dir_opt, file) ->
-           let lib_file = File_key.LibFile file in
+           let lib_file = File_key.lib_file_of_absolute file in
            match Parsing_heaps.Mutator_reader.get_ast ~reader lib_file with
            | Some ast ->
              (* construct ast list in reverse override order *)

--- a/src/services/inference/merge_service.ml
+++ b/src/services/inference/merge_service.ml
@@ -25,21 +25,15 @@ type 'a merge_job =
   File_key.t Nel.t ->
   bool * 'a
 
-let sig_hash ~check_dirty_set ~root =
+let sig_hash ~check_dirty_set ~root:_ =
   let open Type_sig_collections in
   let open Type_sig_hash in
   let module P = Type_sig_pack in
   let module Bin = Type_sig_bin in
   let hash_file_key file_key =
-    let file_string =
-      match file_key with
-      | File_key.LibFile path
-      | File_key.SourceFile path
-      | File_key.JsonFile path
-      | File_key.ResourceFile path ->
-        Files.relative_path (File_path.to_string root) path
-    in
-    Xx.hash file_string 0L
+    (* Use suffix directly — it's already the relative path, avoiding a
+       to_string (root concat) followed by relative_path (root strip). *)
+    Xx.hash (File_key.suffix file_key) 0L
   in
 
   let get_type_sig_buf_unsafe file_key parse =

--- a/src/services/inference/types_js.ml
+++ b/src/services/inference/types_js.ml
@@ -1809,7 +1809,10 @@ let init_with_initial_state
     parse ~options ~profiling ~workers ~reader (fun () ->
         if !additional_libdef_files_not_delivered then (
           let files =
-            SSet.fold (fun name acc -> File_key.LibFile name :: acc) all_unordered_libs []
+            SSet.fold
+              (fun name acc -> File_key.lib_file_of_absolute name :: acc)
+              all_unordered_libs
+              []
           in
           additional_libdef_files_not_delivered := false;
           Bucket.of_list files
@@ -2623,7 +2626,7 @@ let check_files_for_init ~profiling ~options ~workers ~focus_targets ~parsed ~me
 let libdef_check_for_lazy_init ~profiling ~options ~workers env =
   let parsed =
     SSet.fold
-      (fun n -> FilenameSet.add (File_key.LibFile n))
+      (fun n -> FilenameSet.add (File_key.lib_file_of_absolute n))
       env.ServerEnv.all_unordered_libs
       FilenameSet.empty
   in

--- a/src/services/module/module_js.ml
+++ b/src/services/module/module_js.ml
@@ -73,14 +73,14 @@ let choose_provider_and_warn_about_duplicates =
 let module_name_candidates ~options name =
   let mappers = Options.module_name_mappers options in
   let root = Options.root options in
-  let expand_project_root_token = Files.expand_project_root_token ~root in
+  let expand_project_root_token_as_absolute = Files.expand_project_root_token_as_absolute ~root in
   let map_name mapped_names (regexp, template) =
     let new_name =
       name
       (* First we apply the mapper *)
       |> Str.global_replace regexp template
       (* Then we replace the PROJECT_ROOT placeholder. *)
-      |> expand_project_root_token
+      |> expand_project_root_token_as_absolute
     in
     if new_name = name then
       mapped_names
@@ -233,7 +233,7 @@ module Node = struct
 
   let parse_package ~reader package_filename =
     let package_filename = resolve_symlinks package_filename in
-    let file_key = File_key.JsonFile package_filename in
+    let file_key = File_key.json_file_of_absolute package_filename in
     match Parsing_heaps.Reader_dispatcher.get_package_info ~reader file_key with
     | Some (Ok package) -> package
     | Some (Error ()) ->
@@ -364,7 +364,7 @@ module Node = struct
       ordered_allowed_implicit_platform_specific_import
         ~file_options
         ~projects_options
-        ~importing_file:(File_key.to_string importing_file)
+        ~importing_file:(File_key.suffix importing_file)
         ~explicit_available_platforms:None
     with
     | None ->
@@ -525,7 +525,7 @@ module Node = struct
         let applicable =
           Base.Option.value_map
             applicable_dirname_opt
-            ~f:(fun prefix -> Files.is_prefix prefix (File_key.to_string importing_file))
+            ~f:(fun prefix -> Files.is_prefix prefix (File_key.suffix importing_file))
             ~default:true
         in
         if applicable then
@@ -638,33 +638,36 @@ module Haste : MODULE_SYSTEM = struct
   let exported_module options =
     let haste_name_opt = Files.haste_name_opt ~options:(Options.file_options options) in
     let projects_options = Options.projects_options options in
-    let namespace_of_path path =
-      match path |> Flow_projects.projects_bitset_of_path ~opts:projects_options with
-      | None -> failwith ("Path " ^ path ^ " doesn't match any Haste namespace.")
+    let namespace_of_path file_key =
+      match
+        File_key.suffix file_key |> Flow_projects.projects_bitset_of_path ~opts:projects_options
+      with
+      | None -> failwith ("Path " ^ File_key.suffix file_key ^ " doesn't match any Haste namespace.")
       | Some bitset -> Flow_projects.to_bitset bitset
     in
     let is_within_node_modules = is_within_node_modules options in
     fun file ~package_info ->
+      let abs_path = File_key.to_string file in
       match file with
-      | File_key.SourceFile path ->
+      | File_key.SourceFile _ ->
         if is_mock file then
           Some
             (Haste_module_info.mk
                ~module_name:(short_module_name_of file)
-               ~namespace_bitset:(namespace_of_path path)
+               ~namespace_bitset:(namespace_of_path file)
             )
         else (
           match haste_name_opt file with
           | Some module_name ->
-            Some (Haste_module_info.mk ~module_name ~namespace_bitset:(namespace_of_path path))
+            Some (Haste_module_info.mk ~module_name ~namespace_bitset:(namespace_of_path file))
           | None -> None
         )
-      | File_key.JsonFile path ->
+      | File_key.JsonFile _ ->
         (match package_info with
-        | Some pkg when Package_json.haste_commonjs pkg || not (is_within_node_modules path) ->
+        | Some pkg when Package_json.haste_commonjs pkg || not (is_within_node_modules abs_path) ->
           Package_json.name pkg
           |> Option.map (fun module_name ->
-                 Haste_module_info.mk ~module_name ~namespace_bitset:(namespace_of_path path)
+                 Haste_module_info.mk ~module_name ~namespace_bitset:(namespace_of_path file)
              )
         | _ -> None)
       | _ ->
@@ -673,7 +676,7 @@ module Haste : MODULE_SYSTEM = struct
 
   let package_dir_opt ~reader addr =
     if Parsing_heaps.Reader_dispatcher.is_package_file ~reader addr then
-      Some (Parsing_heaps.read_file_name addr |> Filename.dirname)
+      Some (Parsing_heaps.read_file_key addr |> File_key.to_string |> Filename.dirname)
     else
       None
 
@@ -730,7 +733,7 @@ module Haste : MODULE_SYSTEM = struct
       | Some namespace -> [namespace]
       | None ->
         let opts = Options.projects_options options in
-        (match Flow_projects.projects_bitset_of_path ~opts (File_key.to_string importing_file) with
+        (match Flow_projects.projects_bitset_of_path ~opts (File_key.suffix importing_file) with
         | None -> []
         | Some bitset ->
           bitset
@@ -841,7 +844,7 @@ module Haste : MODULE_SYSTEM = struct
           Node.ordered_allowed_implicit_platform_specific_import
             ~file_options
             ~projects_options
-            ~importing_file:file
+            ~importing_file:(File_key.suffix importing_file)
             ~explicit_available_platforms:None
         with
         | None ->
@@ -979,7 +982,7 @@ module Haste : MODULE_SYSTEM = struct
              Node.ordered_allowed_implicit_platform_specific_import
                ~file_options:(Options.file_options options)
                ~projects_options:(Options.projects_options options)
-               ~importing_file:(File_key.to_string importing_file)
+               ~importing_file:(File_key.suffix importing_file)
                ~explicit_available_platforms:
                  (Flow_projects.multi_platform_ambient_supports_platform_for_project
                     ~opts:(Options.projects_options options)

--- a/src/services/saved_state/saved_state.ml
+++ b/src/services/saved_state/saved_state.ml
@@ -110,28 +110,6 @@ let saved_state_version () =
   assert (String.length version = saved_state_version_length);
   version
 
-let with_cache tbl key f =
-  match Hashtbl.find_opt tbl key with
-  | Some result -> result
-  | None ->
-    let result = f key in
-    Hashtbl.add tbl key result;
-    result
-
-let builtin_flow_lib_marker = "<BUILTIN_FLOW_LIB>///"
-
-let builtin_flowlib_root_of_options options =
-  options
-  |> Options.file_options
-  |> Files.default_lib_dir
-  |> Option.map (function
-         | Files.Flowlib p
-         | Files.Prelude p
-         ->
-         (* Ensure that the builtin lib path is fully real-path resolved *)
-         p |> File_path.to_string |> File_path.make |> File_path.to_string
-         )
-
 (* Saving the saved state generally consists of 3 things:
  *
  * 1. Collecting the various bits of data
@@ -153,12 +131,10 @@ module Save : sig
 end = struct
   type t = {
     root: string;
-    builtin_flowlib_root: string option;
     intern_tbl: (string, string) Hashtbl.t;
   }
 
-  let make ~root ~builtin_flowlib_root =
-    { root; builtin_flowlib_root; intern_tbl = Hashtbl.create (1 lsl 20) }
+  let make ~root = { root; intern_tbl = Hashtbl.create (1 lsl 20) }
 
   let intern t x =
     match Hashtbl.find_opt t.intern_tbl x with
@@ -180,21 +156,11 @@ end = struct
    * *)
   let normalize_path t path = intern t (Files.relative_path t.root path)
 
-  let normalize_libdef_path t p =
-    match t.builtin_flowlib_root with
-    | Some flowlib_root when String.starts_with ~prefix:flowlib_root p ->
-      intern t (builtin_flow_lib_marker ^ Files.relative_path flowlib_root p)
-    | _ -> normalize_path t p
-
-  let normalize_file_key t = function
-    | File_key.LibFile p -> File_key.LibFile (normalize_libdef_path t p)
-    | File_key.SourceFile p -> File_key.SourceFile (normalize_path t p)
-    | File_key.JsonFile p -> File_key.JsonFile (normalize_path t p)
-    | File_key.ResourceFile p -> File_key.ResourceFile (normalize_path t p)
-
-  (* A Flow_error.t is a complicated data structure with Loc.t's hidden everywhere. *)
-  let normalize_error t =
-    Flow_error.map_loc_of_error (ALoc.update_source (Base.Option.map ~f:(normalize_file_key t)))
+  (* With relative paths in File_key.t, normalization is identity.
+     LibFile values already have the flowlib marker prefix for flowlib files
+     (added by File_key.lib_file_of_absolute at construction time).
+     Non-flowlib LibFile values are already relative to the project root. *)
+  let normalize_file_key _t file_key = file_key
 
   (* We write the Flow version at the beginning of each saved state file. It's an easy way to assert
    * upon reading the file that the writer and reader are the same version of Flow *)
@@ -335,15 +301,12 @@ end = struct
       let relative_fn = normalize_file_key t fn in
       (relative_fn, relative_file_data) :: unparsed_heaps
 
-  let normalize_error_set t = Flow_error.ErrorSet.map (normalize_error t)
-
   (* Collect all the data for all the files *)
   let collect_data ~genv ~env ~profiling =
     let options = genv.ServerEnv.options in
     let reader = State_reader.create () in
     let root = Options.root options |> File_path.to_string in
-    let builtin_flowlib_root = builtin_flowlib_root_of_options options in
-    let t = make ~root ~builtin_flowlib_root in
+    let t = make ~root in
     let parsed_heaps =
       Profiling_js.with_timer profiling ~timer:"CollectParsed" ~f:(fun () ->
           FilenameSet.fold
@@ -379,15 +342,7 @@ end = struct
       |> SSet.filter (fun lib -> not (is_in_flowlib lib))
       |> SSet.map (normalize_path t)
     in
-    let local_errors =
-      FilenameMap.fold
-        (fun fn error_set acc ->
-          let normalized_fn = normalize_file_key t fn in
-          let normalized_error_set = normalize_error_set t error_set in
-          FilenameMap.add normalized_fn normalized_error_set acc)
-        env.ServerEnv.errors.ServerEnv.local_errors
-        FilenameMap.empty
-    in
+    let local_errors = env.ServerEnv.errors.ServerEnv.local_errors in
     let node_modules_containers =
       SMap.fold
         (fun key value acc -> SMap.add (normalize_path t key) value acc)
@@ -526,60 +481,6 @@ module Load : sig
 
   val denormalize_file_data : options:Options.t -> normalized_file_data -> denormalized_file_data
 end = struct
-  module FileDenormalizer : sig
-    type t
-
-    val make : root:string -> builtin_flowlib_root:string option -> t
-
-    val without_cache : t -> t
-
-    val denormalize_path : t -> string -> string
-
-    val denormalize_file_key_no_cache : t -> File_key.t -> File_key.t
-
-    val denormalize_file_key : t -> File_key.t -> File_key.t
-  end = struct
-    type t = {
-      root: string;
-      builtin_flowlib_root: string option;
-      file_key_cache: (File_key.t, File_key.t) Hashtbl.t;
-    }
-
-    let make ~root ~builtin_flowlib_root =
-      { root; builtin_flowlib_root; file_key_cache = Hashtbl.create 16 }
-
-    let without_cache t = { t with file_key_cache = Hashtbl.create 0 }
-
-    (* This could also have its own cache, but an October 2020 experiment showed that memoizing
-     * these calls does not even save a single word in the denormalized saved state object. *)
-    let denormalize_path { root; _ } path = Files.absolute_path root path
-
-    let denormalize_libdef_path t p =
-      match t.builtin_flowlib_root with
-      | Some flowlib_root ->
-        (match Base.String.chop_prefix ~prefix:builtin_flow_lib_marker p with
-        | Some p -> Files.absolute_path flowlib_root p
-        | None -> denormalize_path t p)
-      | None -> denormalize_path t p
-
-    let denormalize_file_key_no_cache t = function
-      | File_key.LibFile p -> File_key.LibFile (denormalize_libdef_path t p)
-      | File_key.SourceFile p -> File_key.SourceFile (denormalize_path t p)
-      | File_key.JsonFile p -> File_key.JsonFile (denormalize_path t p)
-      | File_key.ResourceFile p -> File_key.ResourceFile (denormalize_path t p)
-
-    let denormalize_file_key ({ file_key_cache; _ } as denormalizer) file_key =
-      with_cache file_key_cache file_key (denormalize_file_key_no_cache denormalizer)
-  end
-
-  let denormalize_dependency_graph ~denormalizer (files, impls, sigs) =
-    let files = Array.map (FileDenormalizer.denormalize_file_key denormalizer) files in
-    (files, impls, sigs)
-
-  let denormalize_error ~denormalizer =
-    Flow_error.map_loc_of_error
-      (ALoc.update_source (Base.Option.map ~f:(FileDenormalizer.denormalize_file_key denormalizer)))
-
   let verify_version =
     (* Flow_build_id should always be 16 bytes *)
     let rec read_version fd buf offset len =
@@ -623,72 +524,20 @@ end = struct
       else
         Lwt.return (assert_version version)
 
-  let denormalize_resolved_requires ~denormalizer resolved_modules phantom_dependencies =
-    let resolved_modules =
-      Array.map
-        (resolved_module_map_fn
-           ~on_file:(FileDenormalizer.denormalize_file_key_no_cache denormalizer)
-        )
-        resolved_modules
-    in
-    let phantom_dependencies =
-      Array.map
-        (modulename_map_fn ~on_file:(FileDenormalizer.denormalize_file_key_no_cache denormalizer))
-        phantom_dependencies
-    in
-    (* Sort after denormalizing because the denormalized file keys could be in a
-     * different sort order, specifically for paths outside of the root, i.e.,
-     * paths starting with `../` *)
-    Array.sort Modulename.compare phantom_dependencies;
-    (resolved_modules, phantom_dependencies)
+  (* With relative paths in File_key.t, denormalization is identity. The data
+     was already sorted on the save side, and no path transformation changes
+     the sort order. *)
+  let denormalize_file_data ~options:_ data = data
 
-  (** Turns all the relative paths in a file's data back into absolute paths. *)
-  let denormalize_file_data
-      ~options { requires; resolved_modules; phantom_dependencies; exports; hash; imports } =
-    let root = Options.root options |> File_path.to_string in
-    let builtin_flowlib_root = builtin_flowlib_root_of_options options in
-    let denormalizer = FileDenormalizer.make ~root ~builtin_flowlib_root in
-    let (resolved_modules, phantom_dependencies) =
-      denormalize_resolved_requires ~denormalizer resolved_modules phantom_dependencies
-    in
-    { requires; resolved_modules; phantom_dependencies; exports; hash; imports }
-
-  let progress_fn real_total ~total:_ ~start ~length:_ =
+  (* Validate saved state and prepare data for use.
+     With relative paths in File_key.t, the saved state's relative paths are used
+     directly — no per-file denormalization needed. Only raw string paths
+     (non_flowlib_libs, node_modules_containers) need root prepending. *)
+  let denormalize_data ~workers:_ ~options ~data =
+    (* Signal progress so the status state machine transitions to Loading_saved_state,
+       which is required before the Restoring_heaps_start event can fire. *)
     MonitorRPC.status_update
-      ~event:ServerStatus.(Load_saved_state_progress { total = Some real_total; finished = start })
-
-  (* Denormalize the data for all the parsed files. This is kind of slow :( *)
-  let denormalize_parsed_heaps ~denormalizer parsed_heaps =
-    Base.List.map
-      ~f:(fun (relative_fn, parsed_file_data) ->
-        let fn = FileDenormalizer.denormalize_file_key denormalizer relative_fn in
-        (fn, parsed_file_data))
-      parsed_heaps
-
-  (* Denormalize the data for all the unparsed files *)
-  let denormalize_unparsed_heaps ~workers ~denormalizer ~progress_fn unparsed_heaps =
-    let denormalizer = FileDenormalizer.without_cache denormalizer in
-    let next = MultiWorkerLwt.next ~progress_fn ~max_size:4000 workers unparsed_heaps in
-    let job acc (relative_fn, unparsed_file_data) =
-      let fn = FileDenormalizer.denormalize_file_key_no_cache denormalizer relative_fn in
-      (fn, unparsed_file_data) :: acc
-    in
-    MultiWorkerLwt.fold workers ~job ~neutral:[] ~merge:List.rev_append ~next
-
-  let denormalize_package_heaps ~denormalizer package_heaps =
-    Base.List.map
-      ~f:(fun (relative_fn, package) ->
-        let fn = FileDenormalizer.denormalize_file_key denormalizer relative_fn in
-        (fn, package))
-      package_heaps
-
-  let denormalize_error_set ~denormalizer = Flow_error.ErrorSet.map (denormalize_error ~denormalizer)
-
-  (* Denormalize all the data *)
-  let denormalize_data ~workers ~options ~data =
-    let root = Options.root options |> File_path.to_string in
-    let builtin_flowlib_root = builtin_flowlib_root_of_options options in
-    let denormalizer = FileDenormalizer.make ~root ~builtin_flowlib_root in
+      ~event:ServerStatus.(Load_saved_state_progress { total = None; finished = 0 });
     let {
       flowconfig_hash;
       parsed_heaps;
@@ -714,35 +563,16 @@ end = struct
       raise (Invalid_saved_state Flowconfig_mismatch)
     );
 
-    Hh_logger.info "Denormalizing the data for the package.json files";
-    let package_heaps = denormalize_package_heaps ~denormalizer package_heaps in
-    Hh_logger.info "Denormalizing the data for the parsed files";
-    let parsed_heaps = denormalize_parsed_heaps ~denormalizer parsed_heaps in
-    Hh_logger.info "Denormalizing the data for the unparsed files";
-    let%lwt unparsed_heaps =
-      let progress_fn = progress_fn (List.length unparsed_heaps) in
-      denormalize_unparsed_heaps ~workers ~denormalizer ~progress_fn unparsed_heaps
-    in
-    let non_flowlib_libs =
-      SSet.map (FileDenormalizer.denormalize_path denormalizer) non_flowlib_libs
-    in
-    let local_errors =
-      FilenameMap.fold
-        (fun normalized_fn normalized_error_set acc ->
-          let fn = FileDenormalizer.denormalize_file_key denormalizer normalized_fn in
-          let error_set = denormalize_error_set ~denormalizer normalized_error_set in
-          FilenameMap.add fn error_set acc)
-        local_errors
-        FilenameMap.empty
-    in
+    (* Raw string paths still need the root prepended *)
+    let root = Options.root options |> File_path.to_string in
+    let prepend_root path = Files.absolute_path root path in
+    let non_flowlib_libs = SSet.map prepend_root non_flowlib_libs in
     let node_modules_containers =
       SMap.fold
-        (fun key value acc ->
-          SMap.add (FileDenormalizer.denormalize_path denormalizer key) value acc)
+        (fun key value acc -> SMap.add (prepend_root key) value acc)
         node_modules_containers
         SMap.empty
     in
-    let dependency_graph = denormalize_dependency_graph ~denormalizer dependency_graph in
     Lwt.return
       {
         flowconfig_hash;

--- a/src/state/heaps/parsing/parsing_heaps.ml
+++ b/src/state/heaps/parsing/parsing_heaps.ml
@@ -9,9 +9,19 @@ open Utils_js
 module Heap = SharedMem.NewAPI
 module MSet = Modulename.Set
 
+(* Use File_key.suffix for SharedMem hashing — the relative path is the stable
+   identity key, independent of the project root. *)
+module FileKeyForHeap = struct
+  type t = File_key.t
+
+  let to_string = File_key.suffix
+
+  let compare = File_key.compare
+end
+
 module FileHeap =
   SharedMem.AddrHeap
-    (File_key)
+    (FileKeyForHeap)
     (struct
       type t = [ `file ]
     end)

--- a/src/typing/context.ml
+++ b/src/typing/context.ml
@@ -401,7 +401,7 @@ let docblock_overrides docblock_info file_key metadata =
       Platform_set.available_platforms
         ~file_options
         ~projects_options
-        ~filename:(File_key.to_string file_key)
+        ~filename:(File_key.suffix file_key)
         ~explicit_available_platforms
     in
     {
@@ -650,7 +650,7 @@ let is_checked cx = cx.metadata.checked
 let is_projects_strict_boundary_import_pattern_opt_outs cx import_specifier =
   if Base.Option.is_some (Files.haste_name_opt ~options:cx.metadata.file_options (file cx)) then
     let projects_options = cx.metadata.projects_options in
-    let file = File_key.to_string (file cx) in
+    let file = File_key.suffix (file cx) in
     let import_specifier = Flow_import_specifier.unwrap_userland import_specifier in
     Flow_projects.is_common_code_path ~opts:projects_options file
     && Flow_projects.is_import_specifier_that_opt_out_of_strict_boundary

--- a/src/typing/flow_js_utils.ml
+++ b/src/typing/flow_js_utils.ml
@@ -2136,7 +2136,7 @@ end = struct
       && Context.is_projects_strict_boundary_import_pattern_opt_outs cx import_specifier
     then
       let projects_options = Context.projects_options cx in
-      let file = File_key.to_string (Context.file cx) in
+      let file = File_key.suffix (Context.file cx) in
       let import_specifier = Flow_import_specifier.unwrap_userland import_specifier in
       match
         Flow_projects.projects_bitset_of_path ~opts:projects_options file

--- a/src/typing/merge_js.ml
+++ b/src/typing/merge_js.ml
@@ -837,7 +837,7 @@ let check_haste_provider_conflict cx tast =
   | Some haste_name ->
     (match
        let opts = Context.projects_options cx in
-       Flow_projects.projects_bitset_of_path ~opts (File_key.to_string filename)
+       Flow_projects.projects_bitset_of_path ~opts (File_key.suffix filename)
        |> Base.Option.bind
             ~f:(Flow_projects.individual_projects_bitsets_from_common_project_bitset ~opts)
      with
@@ -1043,7 +1043,7 @@ let validate_strict_boundary_import_pattern_opt_outs cx =
               Platform_set.available_platforms
                 ~file_options
                 ~projects_options
-                ~filename:(File_key.to_string (Context.file cx))
+                ~filename:(File_key.suffix (Context.file cx))
                 ~explicit_available_platforms:
                   (Flow_projects.multi_platform_ambient_supports_platform_for_project
                      ~opts:projects_options
@@ -1747,7 +1747,7 @@ let mk_builtins metadata master_cx =
       let project =
         Flow_projects.projects_bitset_of_path
           ~opts:metadata.Context.projects_options
-          (File_key.to_string (Context.file dst_cx))
+          (File_key.suffix (Context.file dst_cx))
       in
       (match
          (* With the scoped libdef feature,

--- a/src/typing/ty_normalizer.ml
+++ b/src/typing/ty_normalizer.ml
@@ -306,24 +306,22 @@ module Make (I : INPUT) : S = struct
     )
 
   let symbol_from_loc env sym_def_loc sym_name =
-    let open File_key in
     let symbol_source = ALoc.source sym_def_loc in
     let sym_provenance =
+      let current_source = Context.file Env.(get_cx env) in
       match symbol_source with
-      | Some (LibFile def_source) ->
-        let current_source = Context.file Env.(get_cx env) in
-        if File_key.to_string current_source = def_source then
+      | Some (File_key.LibFile _ as def_file) ->
+        if File_key.equal current_source def_file then
           Ty.Local
         else
           Ty.Library { Ty.imported_as = ALocMap.find_opt sym_def_loc (Env.imported_names env) }
-      | Some (SourceFile def_source) ->
-        let current_source = Context.file Env.(get_cx env) in
-        if File_key.to_string current_source = def_source then
+      | Some (File_key.SourceFile _ as def_file) ->
+        if File_key.equal current_source def_file then
           Ty.Local
         else
           Ty.Remote { Ty.imported_as = ALocMap.find_opt sym_def_loc (Env.imported_names env) }
-      | Some (JsonFile _)
-      | Some (ResourceFile _) ->
+      | Some (File_key.JsonFile _)
+      | Some (File_key.ResourceFile _) ->
         Ty.Local
       | None -> Ty.Local
     in


### PR DESCRIPTION
Summary:
Flow's saved state init spends ~13s single-threaded converting 1.87M relative paths back to absolute paths (the Denormalize phase). This is because `File_key.t` stores full absolute path strings internally, but the saved state stores relative paths for portability — so every load requires converting all paths back to absolute via string concatenation and allocation.

This diff applies Hack's `Relative_path.t` approach to Flow's `File_key.t`: paths are stored as relative suffixes internally, with the project root resolved on demand via `to_string`/`to_absolute`. The type shape is unchanged (`LibFile of string | SourceFile of string | ...`) to preserve OCaml Marshal compatibility with existing saved state files.

Performance (production build, `fbcode//mode/opt`):
- Benchmark: Denormalize phase drops from 15.2s to 0.0s. Total benchmark time 64.9s → 40.0s (38% faster).
- Real flow server on www: Total init 95.2s → 83.7s (11.5s faster, 12%). LoadSavedState 22.9s → 12.0s. RestoreHeaps, CommitModules, Indexing all within noise of baseline.
- perf profile confirms zero denormalization functions appear at any threshold. The remaining 4.8s in the Denormalize timer is OCaml major GC triggered by the preceding Decompress phase.

Potentially helps memory as well. From 10 samples each:
 {F1986414698}
So: shorter strings → less live data → smaller GC heap → 1.2 GB RSS reduction. The raw byte savings are ~240 MB; the GC amplifies it to ~1.2 GB.

Changelog: internal Improve saved state init performance.

Differential Revision: D95327604
