### PR TITLE
Revert D100184768

### DIFF
--- a/src/services/code_action/insert_type_imports.ml
+++ b/src/services/code_action/insert_type_imports.ml
@@ -53,10 +53,10 @@ module Modules = struct
         (* remove .js extension *)
         let local_file = Filename.chop_extension local_file in
         if dep_folder = this_folder then
-          Files.normalized_concat "./" local_file
+          Filename.concat "./" local_file
         else
           let relative_dir = Files.relative_path this_folder dep_folder in
-          Files.normalized_concat relative_dir local_file
+          Filename.concat relative_dir local_file
 end
 
 module AstHelper = struct

--- a/tests/annotate_exports_anonymous_class/.testconfig
+++ b/tests/annotate_exports_anonymous_class/.testconfig
@@ -1,2 +1,3 @@
 cmd: annotate-exports
 skip_rust_port: true
+skip_windows: true

--- a/tests/annotate_exports_array_literal/.testconfig
+++ b/tests/annotate_exports_array_literal/.testconfig
@@ -1,2 +1,3 @@
 cmd: annotate-exports
 skip_rust_port: true
+skip_windows: true

--- a/tests/annotate_exports_boolean_literals/.testconfig
+++ b/tests/annotate_exports_boolean_literals/.testconfig
@@ -1,2 +1,3 @@
 cmd: annotate-exports
 skip_rust_port: true
+skip_windows: true

--- a/tests/annotate_exports_class_extends/.testconfig
+++ b/tests/annotate_exports_class_extends/.testconfig
@@ -1,2 +1,3 @@
 cmd: annotate-exports
 skip_rust_port: true
+skip_windows: true

--- a/tests/annotate_exports_dotFlow/.testconfig
+++ b/tests/annotate_exports_dotFlow/.testconfig
@@ -1,2 +1,3 @@
 cmd: annotate-exports
 skip_rust_port: true
+skip_windows: true

--- a/tests/annotate_exports_duplicate_import_error/.testconfig
+++ b/tests/annotate_exports_duplicate_import_error/.testconfig
@@ -1,2 +1,3 @@
 cmd: annotate-exports
 skip_rust_port: true
+skip_windows: true

--- a/tests/annotate_exports_export_class_utility/.testconfig
+++ b/tests/annotate_exports_export_class_utility/.testconfig
@@ -1,2 +1,3 @@
 cmd: annotate-exports
 skip_rust_port: true
+skip_windows: true

--- a/tests/annotate_exports_fbt/.testconfig
+++ b/tests/annotate_exports_fbt/.testconfig
@@ -1,2 +1,3 @@
 cmd: annotate-exports
 skip_rust_port: true
+skip_windows: true

--- a/tests/annotate_exports_function/.testconfig
+++ b/tests/annotate_exports_function/.testconfig
@@ -1,2 +1,3 @@
 cmd: annotate-exports
 skip_rust_port: true
+skip_windows: true

--- a/tests/annotate_exports_graphql_fragments/.testconfig
+++ b/tests/annotate_exports_graphql_fragments/.testconfig
@@ -1,2 +1,3 @@
 cmd: annotate-exports
 skip_rust_port: true
+skip_windows: true

--- a/tests/annotate_exports_hard_coded_fixes/.testconfig
+++ b/tests/annotate_exports_hard_coded_fixes/.testconfig
@@ -1,2 +1,3 @@
 cmd: annotate-exports
 skip_rust_port: true
+skip_windows: true

--- a/tests/annotate_exports_import_class_direct/.testconfig
+++ b/tests/annotate_exports_import_class_direct/.testconfig
@@ -1,2 +1,3 @@
 cmd: annotate-exports
 skip_rust_port: true
+skip_windows: true

--- a/tests/annotate_exports_import_class_indirect/.testconfig
+++ b/tests/annotate_exports_import_class_indirect/.testconfig
@@ -1,2 +1,3 @@
 cmd: annotate-exports
 skip_rust_port: true
+skip_windows: true

--- a/tests/annotate_exports_import_cycle/.testconfig
+++ b/tests/annotate_exports_import_cycle/.testconfig
@@ -1,2 +1,3 @@
 cmd: annotate-exports
 skip_rust_port: true
+skip_windows: true

--- a/tests/annotate_exports_import_declare_class_type/.testconfig
+++ b/tests/annotate_exports_import_declare_class_type/.testconfig
@@ -1,2 +1,3 @@
 cmd: annotate-exports
 skip_rust_port: true
+skip_windows: true

--- a/tests/annotate_exports_import_default_exported_class/.testconfig
+++ b/tests/annotate_exports_import_default_exported_class/.testconfig
@@ -1,2 +1,3 @@
 cmd: annotate-exports
 skip_rust_port: true
+skip_windows: true

--- a/tests/annotate_exports_import_es6/.testconfig
+++ b/tests/annotate_exports_import_es6/.testconfig
@@ -1,2 +1,3 @@
 cmd: annotate-exports
 skip_rust_port: true
+skip_windows: true

--- a/tests/annotate_exports_import_instance_type_cast/.testconfig
+++ b/tests/annotate_exports_import_instance_type_cast/.testconfig
@@ -1,2 +1,3 @@
 cmd: annotate-exports
 skip_rust_port: true
+skip_windows: true

--- a/tests/annotate_exports_import_interface/.testconfig
+++ b/tests/annotate_exports_import_interface/.testconfig
@@ -1,2 +1,3 @@
 cmd: annotate-exports
 skip_rust_port: true
+skip_windows: true

--- a/tests/annotate_exports_import_multiple_kinds/.testconfig
+++ b/tests/annotate_exports_import_multiple_kinds/.testconfig
@@ -1,2 +1,3 @@
 cmd: annotate-exports
 skip_rust_port: true
+skip_windows: true

--- a/tests/annotate_exports_import_no_bounds/.testconfig
+++ b/tests/annotate_exports_import_no_bounds/.testconfig
@@ -1,2 +1,3 @@
 cmd: annotate-exports
 skip_rust_port: true
+skip_windows: true

--- a/tests/annotate_exports_import_no_duplicates/.testconfig
+++ b/tests/annotate_exports_import_no_duplicates/.testconfig
@@ -1,2 +1,3 @@
 cmd: annotate-exports
 skip_rust_port: true
+skip_windows: true

--- a/tests/annotate_exports_import_opaque_type/.testconfig
+++ b/tests/annotate_exports_import_opaque_type/.testconfig
@@ -1,2 +1,3 @@
 cmd: annotate-exports
 skip_rust_port: true
+skip_windows: true

--- a/tests/annotate_exports_import_paths/.testconfig
+++ b/tests/annotate_exports_import_paths/.testconfig
@@ -1,2 +1,3 @@
 cmd: annotate-exports
 skip_rust_port: true
+skip_windows: true

--- a/tests/annotate_exports_import_type_default/.testconfig
+++ b/tests/annotate_exports_import_type_default/.testconfig
@@ -1,2 +1,3 @@
 cmd: annotate-exports
 skip_rust_port: true
+skip_windows: true

--- a/tests/annotate_exports_import_typeof/.testconfig
+++ b/tests/annotate_exports_import_typeof/.testconfig
@@ -1,2 +1,3 @@
 cmd: annotate-exports
 skip_rust_port: true
+skip_windows: true

--- a/tests/annotate_exports_large_type/.testconfig
+++ b/tests/annotate_exports_large_type/.testconfig
@@ -1,2 +1,3 @@
 cmd: annotate-exports --max-type-size 10
 skip_rust_port: true
+skip_windows: true

--- a/tests/annotate_exports_library_import/.testconfig
+++ b/tests/annotate_exports_library_import/.testconfig
@@ -1,2 +1,3 @@
 cmd: annotate-exports
 skip_rust_port: true
+skip_windows: true

--- a/tests/annotate_exports_no_import_on_error/.testconfig
+++ b/tests/annotate_exports_no_import_on_error/.testconfig
@@ -1,2 +1,3 @@
 cmd: annotate-exports
 skip_rust_port: true
+skip_windows: true

--- a/tests/annotate_exports_numeric_literals/.testconfig
+++ b/tests/annotate_exports_numeric_literals/.testconfig
@@ -1,2 +1,3 @@
 cmd: annotate-exports
 skip_rust_port: true
+skip_windows: true

--- a/tests/annotate_exports_object/.testconfig
+++ b/tests/annotate_exports_object/.testconfig
@@ -1,3 +1,4 @@
 all: false
 cmd: annotate-exports
 skip_rust_port: true
+skip_windows: true

--- a/tests/annotate_exports_object_dynamic_props/.testconfig
+++ b/tests/annotate_exports_object_dynamic_props/.testconfig
@@ -1,2 +1,3 @@
 cmd: annotate-exports
 skip_rust_port: true
+skip_windows: true

--- a/tests/annotate_exports_object_key/.testconfig
+++ b/tests/annotate_exports_object_key/.testconfig
@@ -1,2 +1,3 @@
 cmd: annotate-exports
 skip_rust_port: true
+skip_windows: true

--- a/tests/annotate_exports_object_spread/.testconfig
+++ b/tests/annotate_exports_object_spread/.testconfig
@@ -1,2 +1,3 @@
 cmd: annotate-exports
 skip_rust_port: true
+skip_windows: true

--- a/tests/annotate_exports_omit_targ_defaults/.testconfig
+++ b/tests/annotate_exports_omit_targ_defaults/.testconfig
@@ -1,2 +1,3 @@
 cmd: annotate-exports
 skip_rust_port: true
+skip_windows: true

--- a/tests/annotate_exports_react/.testconfig
+++ b/tests/annotate_exports_react/.testconfig
@@ -1,2 +1,3 @@
 cmd: annotate-exports
 skip_rust_port: true
+skip_windows: true

--- a/tests/annotate_exports_reuse_imports/.testconfig
+++ b/tests/annotate_exports_reuse_imports/.testconfig
@@ -1,2 +1,3 @@
 cmd: annotate-exports
 skip_rust_port: true
+skip_windows: true

--- a/tests/annotate_exports_simplify_hardcoded_fixes/.testconfig
+++ b/tests/annotate_exports_simplify_hardcoded_fixes/.testconfig
@@ -1,2 +1,3 @@
 cmd: annotate-exports
 skip_rust_port: true
+skip_windows: true

--- a/tests/annotate_exports_special_types/.testconfig
+++ b/tests/annotate_exports_special_types/.testconfig
@@ -1,2 +1,3 @@
 cmd: annotate-exports
 skip_rust_port: true
+skip_windows: true

--- a/tests/annotate_exports_string_literals/.testconfig
+++ b/tests/annotate_exports_string_literals/.testconfig
@@ -1,2 +1,3 @@
 cmd: annotate-exports
 skip_rust_port: true
+skip_windows: true

--- a/tests/annotate_exports_unclear_type_cycle/.testconfig
+++ b/tests/annotate_exports_unclear_type_cycle/.testconfig
@@ -1,2 +1,3 @@
 cmd: annotate-exports
 skip_rust_port: true
+skip_windows: true

--- a/tests/annotate_exports_validator/.testconfig
+++ b/tests/annotate_exports_validator/.testconfig
@@ -1,2 +1,3 @@
 cmd: annotate-exports
 skip_rust_port: true
+skip_windows: true


### PR DESCRIPTION
Summary:
This diff reverts D100184768
the stack breaks oss test on windows, which is not running internally. Try to back this one out first to see whether it can fix

Depends on D100184768

Differential Revision: D100385995
