### PR TITLE
[flow] Fix Windows crash: normalize path separators in File_key suffixes

### DIFF
--- a/rust_port/crates/flow_parser/src/file_key.rs
+++ b/rust_port/crates/flow_parser/src/file_key.rs
@@ -317,12 +317,14 @@ fn relative_path_from(root: &str, path: &str) -> String {
     result.join("/")
 }
 
+// The result always uses '/' separators for cross-platform consistency
+// (saved state generated on Linux must work on Windows and vice versa).
 pub fn strip_project_root(path: &str) -> String {
     let guard = PROJECT_ROOT.read().unwrap();
     match guard.as_deref() {
         Some(root) => {
             if let Some(stripped) = path.strip_prefix(root) {
-                stripped.to_string()
+                normalize_dir_sep_with(std::path::MAIN_SEPARATOR, stripped)
             } else if !is_relative(path) {
                 relative_path_from(root, path)
             } else {
@@ -437,7 +439,9 @@ impl FileKey {
         let guard = FLOWLIB_ROOT.read().unwrap();
         let suffix = match guard.as_deref() {
             Some(fl) if !fl.is_empty() && path.starts_with(fl) => {
-                format!("{}{}", FLOWLIB_MARKER, strip_prefix(fl, path))
+                let stripped =
+                    normalize_dir_sep_with(std::path::MAIN_SEPARATOR, strip_prefix(fl, path));
+                format!("{}{}", FLOWLIB_MARKER, stripped)
             }
             _ => {
                 drop(guard);

--- a/src/parser/file_key.ml
+++ b/src/parser/file_key.ml
@@ -272,12 +272,15 @@ let relative_path_from ?(dir_sep = Filename.dir_sep) root path =
    compute a relative path from the root — this ensures all suffixes are
    portable relative paths, which is critical for saved state portability
    across machines with different root paths.
-   If the root has not been set yet, returns the path unchanged. *)
+   If the root has not been set yet, returns the path unchanged.
+   The result always uses '/' separators for cross-platform consistency
+   (saved state generated on Linux must work on Windows and vice versa). *)
 let strip_project_root path =
   match !project_root with
   | Some root ->
     if String.starts_with ~prefix:root path then
-      String.sub path (String.length root) (String.length path - String.length root)
+      normalize_dir_sep
+        (String.sub path (String.length root) (String.length path - String.length root))
     else if not (Filename.is_relative path) then
       relative_path_from root path
     else
@@ -296,7 +299,7 @@ let resource_file_of_absolute path = ResourceFile (strip_project_root path)
 let lib_file_of_absolute path =
   match !flowlib_root with
   | Some fl when String.length fl > 0 && String.starts_with ~prefix:fl path ->
-    LibFile (flowlib_marker ^ strip_prefix fl path)
+    LibFile (flowlib_marker ^ normalize_dir_sep (strip_prefix fl path))
   | _ -> LibFile (strip_project_root path)
 
 module For_tests = struct


### PR DESCRIPTION
Summary:
Flow crashes on startup on Windows with `Graph.Make(Set)(Map).NodeNotFound(_)` during Tarjan SCC computation in `libdef_check_for_lazy_init`. The root cause is a path separator mismatch between file keys stored in the saved state dependency graph (generated on Linux with `/` separators) and file keys created locally on Windows (with `\` separators).

When saved state is loaded on Windows, the dependency graph retains Linux-style `/`-based file keys. However, `lib_file_of_absolute` (and other `*_of_absolute` functions) create new file keys from local filesystem paths using Windows `\` separators. Since `File_key.compare` compares suffixes as raw strings, `path\to\lib.js` != `path/to/lib.js`, causing lookups in the dependency graph to fail.

The fix normalizes directory separators to `/` in `strip_project_root` and `lib_file_of_absolute` (flowlib case) so that file key suffixes are always `/`-based regardless of platform, matching the saved state.

Changelog: [internal]

Differential Revision: D102255289


