### PR TITLE
[flow] Fix Windows crash: normalize path separators in File_key compare

### DIFF
--- a/rust_port/crates/flow_parser/src/file_key.rs
+++ b/rust_port/crates/flow_parser/src/file_key.rs
@@ -210,9 +210,14 @@ fn inner_as_str(inner: &FileKeyInner) -> &str {
     }
 }
 
+fn normalized_suffix(inner: &FileKeyInner) -> String {
+    normalize_dir_sep_with(std::path::MAIN_SEPARATOR, inner_as_str(inner))
+}
+
 impl PartialEq for FileKeyInner {
     fn eq(&self, other: &Self) -> bool {
-        order_of_inner(self) == order_of_inner(other) && inner_as_str(self) == inner_as_str(other)
+        order_of_inner(self) == order_of_inner(other)
+            && normalized_suffix(self) == normalized_suffix(other)
     }
 }
 
@@ -221,7 +226,7 @@ impl Eq for FileKeyInner {}
 impl Hash for FileKeyInner {
     fn hash<H: Hasher>(&self, state: &mut H) {
         order_of_inner(self).hash(state);
-        inner_as_str(self).hash(state);
+        normalized_suffix(self).hash(state);
     }
 }
 
@@ -263,7 +268,7 @@ impl Ord for FileKey {
         if k != std::cmp::Ordering::Equal {
             k
         } else {
-            self.suffix().cmp(other.suffix())
+            normalized_suffix(self.inner.as_ref()).cmp(&normalized_suffix(other.inner.as_ref()))
         }
     }
 }

--- a/src/parser/file_key.ml
+++ b/src/parser/file_key.ml
@@ -204,7 +204,7 @@ let compare =
     if k <> 0 then
       k
     else
-      String.compare (suffix a) (suffix b)
+      String.compare (normalize_dir_sep (suffix a)) (normalize_dir_sep (suffix b))
 
 let compare_opt a b =
   match (a, b) with


### PR DESCRIPTION
Summary:
Flow crashes on startup on Windows with `Graph.Make(Set)(Map).NodeNotFound(_)` during Tarjan SCC computation in `libdef_check_for_lazy_init`. The root cause is a path separator mismatch between file keys stored in the saved state dependency graph (generated on Linux with `/` separators) and file keys created locally on Windows (with `\` separators).

When saved state is loaded on Windows, the dependency graph retains Linux-style `/`-based file keys. However, `lib_file_of_absolute` (and other `*_of_absolute` functions) create new file keys from local filesystem paths using Windows `\` separators. Since `File_key.compare` compares suffixes as raw strings, `path\to\lib.js` != `path/to/lib.js`, causing lookups in the dependency graph to fail.

The fix normalizes directory separators to `/` in `File_key.compare` (and `Hash`/`Eq` in the Rust port) so that file keys with `/` and `\` separators are treated as equivalent. This is preferred over normalizing at creation time in `strip_project_root`, because `to_string`/`to_absolute` reconstructs paths by concatenating the native-separator root with the suffix — normalizing the suffix to `/` at creation time would produce mixed-separator paths (e.g., `C:\project\path/to/file.js`), breaking downstream code that does path prefix matching with native separators (e.g., `Files.is_prefix` in `batch_coverage`, module resolution dirname checks).

On Linux, `normalize_dir_sep` is a no-op since the separator is already `/`.

Changelog: [internal]

Reviewed By: panagosg7

Differential Revision: D102268877


