### PR TITLE
Fix "Setup Library Definitions" instructions

### DIFF
--- a/website/docs/getting-started.md
+++ b/website/docs/getting-started.md
@@ -188,7 +188,7 @@ following content:
 
 ```json
 {
-  "env": ["node", "dom", "bom", "intl", "cssom", "indexeddb", "serviceworkers", "webassembly", "jsx"]
+  "env": ["node", "geometry", "html", "streams", "web-animations", "dom", "bom", "intl", "cssom", "indexeddb", "serviceworkers", "webassembly", "jsx"]
 }
 ```
 


### PR DESCRIPTION
If you were to follow these instructions, you'd have been met with hundreds of errors, because the specified environment definitions reference classes from these missing environments: html, geometry, streams, web-animations. This commit adds them to the documented `flow-typed.config.json`.

Note that there's also a variance error in the jsx definition fixed by https://github.com/flow-typed/flow-typed/pull/4662.