### PR TITLE
[DOCS]: update the URL to flow install and usage guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ There are [binary distributions](https://github.com/facebook/flow/releases) for 
 
 ## Using Flow
 
-Check out the [installation instructions](https://flow.org/en/docs/install/), and then [the usage docs](https://flow.org/en/docs/usage/).
+Check out the [installation instructions](https://flow.org/en/docs/getting-started/#toc-installation), and then [the usage docs](https://flow.org/en/docs/getting-started/#toc-usage).
 
 ## Using Flow's parser from JavaScript
 


### PR DESCRIPTION
the URLs to the flow install and flow usage guides are out of date as they were moved to https://flow.org/en/docs/getting-started/