### PR TITLE
[flow] Support `edenfs` file watcher in dune builds with silent Watchman fallback

### DIFF
--- a/rust_port/Cargo.lock
+++ b/rust_port/Cargo.lock
@@ -480,6 +480,7 @@ dependencies = [
  "flow_daemon",
  "flow_data_structure_wrapper",
  "flow_dfind",
+ "flow_edenfs_watcher",
  "flow_env_builder",
  "flow_env_builder_resolver",
  "flow_event_logger",

--- a/rust_port/crates/flow_cli/Cargo.toml
+++ b/rust_port/crates/flow_cli/Cargo.toml
@@ -35,6 +35,7 @@ flow_config = { path = "../flow_config" }
 flow_daemon = { path = "../flow_daemon" }
 flow_data_structure_wrapper = { path = "../flow_data_structure_wrapper" }
 flow_dfind = { path = "../flow_dfind" }
+flow_edenfs_watcher = { path = "../flow_edenfs_watcher" }
 flow_env_builder = { path = "../flow_env_builder" }
 flow_env_builder_resolver = { path = "../flow_env_builder_resolver" }
 flow_event_logger = { path = "../flow_event_logger" }

--- a/rust_port/crates/flow_cli/src/command_utils.rs
+++ b/rust_port/crates/flow_cli/src/command_utils.rs
@@ -32,6 +32,7 @@ use flow_common_vcs::vcs::Vcs;
 use flow_config::FlowConfig;
 use flow_config::LazyMode;
 use flow_data_structure_wrapper::smol_str::FlowSmolStr;
+use flow_edenfs_watcher;
 use flow_flowlib::LibDir as FlowlibDir;
 use flow_monitor_rpc::monitor_prot::MonitorToClientMessage;
 use flow_server_env::file_watcher_status;
@@ -1786,10 +1787,15 @@ pub(crate) fn file_watcher_flag() -> arg_spec::FlagType<Option<flow_config::File
 }
 
 pub(crate) fn add_file_watcher_flag(spec: command_spec::Spec) -> command_spec::Spec {
+    let watcher_names = if flow_edenfs_watcher::is_available() {
+        "none, dfind, watchman, edenfs"
+    } else {
+        "none, dfind, watchman"
+    };
     spec.flag(
         "--file-watcher",
         &arg_spec::optional(file_watcher_flag()),
-        "Which file watcher Flow should use (none, dfind, watchman, edenfs). Flow will ignore file system events if this is set to none. (default: dfind)",
+        &format!("Which file watcher Flow should use ({}). Flow will ignore file system events if this is set to none. (default: dfind)", watcher_names),
         None,
     )
     .flag(
@@ -3436,6 +3442,9 @@ pub(crate) fn choose_file_watcher(
                 defer_states: defer_states.clone(),
                 sync_timeout,
             };
+            if !flow_edenfs_watcher::is_available() {
+                return FlowServerMonitorOptions::Watchman(watchman_fallback);
+            }
             // Watchman natively defers during hg operations via Defer_changes subscribe mode.
             // EdenFS requires explicit state names, so we hardcode the hg states here.
             let mut edenfs_defer_states =

--- a/rust_port/crates/flow_config/src/flowconfig.rs
+++ b/rust_port/crates/flow_config/src/flowconfig.rs
@@ -1328,12 +1328,6 @@ pub mod opts {
     ) -> Result<(), OptError> {
         parse_uint(
             |opts, v| {
-                if v > 0 && !opts.saved_state_restart_on_reinit {
-                    return Err(
-                        "file_watcher.edenfs.max_commit_distance requires saved_state_restart_on_reinit=true"
-                            .to_string(),
-                    );
-                }
                 opts.file_watcher_edenfs_max_commit_distance = v;
                 Ok(())
             },

--- a/src/commands/commandUtils.ml
+++ b/src/commands/commandUtils.ml
@@ -1217,25 +1217,23 @@ let file_watcher_flag prev =
       ("watchman", FlowConfig.Watchman);
     ]
   in
-  let options =
+  let options = base_options @ [("edenfs", FlowConfig.EdenFS)] in
+  let watcher_names =
+    "none, dfind, watchman"
+    ^
     if Edenfs_watcher.is_available () then
-      base_options @ [("edenfs", FlowConfig.EdenFS)]
+      ", edenfs"
     else
-      base_options
+      ""
   in
   prev
   |> flag
        "--file-watcher"
        (enum options)
        ~doc:
-         ("Which file watcher Flow should use (none, dfind, watchman"
-         ^ ( if Edenfs_watcher.is_available () then
-             ", edenfs"
-           else
-             ""
-           )
-         ^ "). "
-         ^ "Flow will ignore file system events if this is set to none. (default: dfind)"
+         ("Which file watcher Flow should use ("
+         ^ watcher_names
+         ^ "). Flow will ignore file system events if this is set to none. (default: dfind)"
          )
   |> flag
        "--file-watcher-debug"
@@ -2126,25 +2124,29 @@ let choose_file_watcher ~flowconfig ~lazy_mode ~file_watcher ~file_watcher_debug
     let watchman_fallback =
       { FlowServerMonitorOptions.debug = file_watcher_debug; defer_states; sync_timeout }
     in
-    (* Watchman natively defers during hg operations via Defer_changes subscribe mode.
-       EdenFS requires explicit state names, so we hardcode the hg states here. *)
-    let edenfs_defer_states = ["hg.update"; "hg.transaction"] @ defer_states in
-    FlowServerMonitorOptions.EdenFS
-      {
-        FlowServerMonitorOptions.edenfs_debug = file_watcher_debug;
-        edenfs_timeout_secs = FlowConfig.file_watcher_edenfs_timeout flowconfig;
-        edenfs_throttle_time_ms = FlowConfig.file_watcher_edenfs_throttle_time_ms flowconfig;
-        edenfs_defer_states;
-        edenfs_max_commit_distance =
-          (match Sys.getenv_opt "FLOW_EDENFS_MAX_COMMIT_DISTANCE" with
-          | Some v ->
-            (try int_of_string v with
-            | Failure _ -> 0)
-          | None -> FlowConfig.file_watcher_edenfs_max_commit_distance flowconfig);
-        edenfs_force_subprocess_mergebase =
-          FlowConfig.file_watcher_edenfs_subprocess_mergebase flowconfig;
-        edenfs_watchman_fallback = watchman_fallback;
-      }
+    if not (Edenfs_watcher.is_available ()) then
+      FlowServerMonitorOptions.Watchman watchman_fallback
+    else begin
+      (* Watchman natively defers during hg operations via Defer_changes subscribe mode.
+         EdenFS requires explicit state names, so we hardcode the hg states here. *)
+      let edenfs_defer_states = ["hg.update"; "hg.transaction"] @ defer_states in
+      FlowServerMonitorOptions.EdenFS
+        {
+          FlowServerMonitorOptions.edenfs_debug = file_watcher_debug;
+          edenfs_timeout_secs = FlowConfig.file_watcher_edenfs_timeout flowconfig;
+          edenfs_throttle_time_ms = FlowConfig.file_watcher_edenfs_throttle_time_ms flowconfig;
+          edenfs_defer_states;
+          edenfs_max_commit_distance =
+            (match Sys.getenv_opt "FLOW_EDENFS_MAX_COMMIT_DISTANCE" with
+            | Some v ->
+              (try int_of_string v with
+              | Failure _ -> 0)
+            | None -> FlowConfig.file_watcher_edenfs_max_commit_distance flowconfig);
+          edenfs_force_subprocess_mergebase =
+            FlowConfig.file_watcher_edenfs_subprocess_mergebase flowconfig;
+          edenfs_watchman_fallback = watchman_fallback;
+        }
+    end
 
 let choose_file_watcher_mergebase_with ~flowconfig vcs mergebase_with =
   match mergebase_with with

--- a/src/commands/config/flowConfig.ml
+++ b/src/commands/config/flowConfig.ml
@@ -753,13 +753,7 @@ module Opts = struct
     uint (fun opts v -> Ok { opts with file_watcher_edenfs_timeout = v })
 
   let file_watcher_edenfs_max_commit_distance_parser =
-    uint (fun opts v ->
-        if v > 0 && not opts.saved_state_restart_on_reinit then
-          Error
-            "file_watcher.edenfs.max_commit_distance requires saved_state_restart_on_reinit=true"
-        else
-          Ok { opts with file_watcher_edenfs_max_commit_distance = v }
-    )
+    uint (fun opts v -> Ok { opts with file_watcher_edenfs_max_commit_distance = v })
 
   let file_watcher_edenfs_subprocess_mergebase_parser =
     boolean (fun opts v -> Ok { opts with file_watcher_edenfs_subprocess_mergebase = v })

--- a/src/commands/config/flowConfig.ml
+++ b/src/commands/config/flowConfig.ml
@@ -737,12 +737,8 @@ module Opts = struct
     boolean (fun opts v -> Ok { opts with facebook_module_interop = v })
 
   let file_watcher_parser =
-    let base_options = [("none", NoFileWatcher); ("dfind", DFind); ("watchman", Watchman)] in
     let options =
-      if Edenfs_watcher.is_available () then
-        base_options @ [("edenfs", EdenFS)]
-      else
-        base_options
+      [("none", NoFileWatcher); ("dfind", DFind); ("watchman", Watchman); ("edenfs", EdenFS)]
     in
     enum options (fun opts v -> Ok { opts with file_watcher = Some v })
 


### PR DESCRIPTION
Summary:
In dune builds (non-Meta), `Edenfs_watcher.is_available()` returns false and the `edenfs` option was previously excluded from the `--file-watcher` CLI enum and from the `file_watcher` `.flowconfig` option, causing errors when either was set to `edenfs`.

This change makes `edenfs` always a valid accepted value in both the CLI flag and the `.flowconfig` parser. The advertised CLI help text still omits `edenfs` when EdenFS is not available. When `edenfs` is requested but `is_available()` is false, `choose_file_watcher` silently returns a Watchman watcher instead of propagating the EdenFS path into the monitor where it would fail noisily. On Meta (non-dune) builds, behavior is unchanged.

Changelog: [internal]

Differential Revision: D107978157


