### PR TITLE
[flow][oss][ci] Setup flow-estree publishing pipeline

### DIFF
--- a/.circleci/deploy_npm.sh
+++ b/.circleci/deploy_npm.sh
@@ -13,6 +13,9 @@ if [[ "$GITHUB_REF_NAME" = "" ]]; then exit 0; fi
 if [ -f ~/.npmrc ]; then mv ~/.npmrc ~/.npmrc.bak; fi
 echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
 
+echo "Publishing flow-estree";
+npm publish ./dist/npm-flow-estree.tgz;
+
 echo "Publishing flow-parser";
 npm publish ./dist/npm-flow-parser.tgz;
 

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -230,16 +230,13 @@ jobs:
     - name: Test packages
       working-directory: packages
       run: yarn test -- --testPathPatterns='flow-parser|babel-plugin-syntax-flow-parser|flow-eslint|flow-transform'
-    - name: Temporarily include Rust port artifacts in flow-parser package
-      working-directory: packages/flow-parser
-      run: npm pkg set 'files[1]=oxidized'
     - uses: actions/upload-artifact@v4.4.0
       with:
         name: build_js_packages
         path: |
           packages/flow-parser/flow_parser.js
-          packages/flow-parser/package.json
           packages/flow-parser/oxidized
+          packages/flow-estree/dist
   build_js_rust_port:
     runs-on: ubuntu-22.04
     env:
@@ -700,7 +697,22 @@ jobs:
     - uses: actions/download-artifact@v4.1.7
       with:
         name: build_js_packages
-        path: packages/flow-parser
+        path: ${{ runner.temp }}/build_js_packages
+    - name: Install generated package artifacts
+      run: |
+        test -f "${RUNNER_TEMP}/build_js_packages/flow-parser/flow_parser.js"
+        test -d "${RUNNER_TEMP}/build_js_packages/flow-parser/oxidized"
+        test -f "${RUNNER_TEMP}/build_js_packages/flow-estree/dist/index.js"
+        test ! -e packages/flow-parser/flow_parser.js
+        test ! -e packages/flow-parser/oxidized
+        test ! -e packages/flow-estree/dist
+        cp "${RUNNER_TEMP}/build_js_packages/flow-parser/flow_parser.js" packages/flow-parser/flow_parser.js
+        cp -R "${RUNNER_TEMP}/build_js_packages/flow-parser/oxidized" packages/flow-parser/oxidized
+        cp -R "${RUNNER_TEMP}/build_js_packages/flow-estree/dist" packages/flow-estree/dist
+    - name: Pack flow-estree
+      run: |
+        test -f packages/flow-estree/dist/index.js
+        make dist/npm-flow-estree.tgz
     - name: Pack flow-parser
       run: |
         test -f packages/flow-parser/flow_parser.js
@@ -725,6 +737,7 @@ jobs:
       with:
         name: npm_pack
         path: |
+          dist/npm-flow-estree.tgz
           dist/npm-flow-parser.tgz
           dist/npm-flow-node.tgz
           dist/npm-flow-remove-types.tgz

--- a/packages/flow-eslint/package.json
+++ b/packages/flow-eslint/package.json
@@ -24,7 +24,7 @@
   ],
   "dependencies": {
     "esrecurse": "^4.3.0",
-    "flow-estree": "0.0.1",
+    "flow-estree": "0.318.0",
     "flow-parser": "0.318.0"
   }
 }

--- a/packages/flow-estree/package.json
+++ b/packages/flow-estree/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flow-estree",
-  "version": "0.0.1",
+  "version": "0.318.0",
   "description": "Flow types for the Flow-ESTree spec produced by the Flow Rust parser, forked from hermes-estree.",
   "homepage": "https://flow.org",
   "license": "MIT",

--- a/packages/flow-parser/package.json
+++ b/packages/flow-parser/package.json
@@ -9,7 +9,8 @@
     "email": "flow@fb.com"
   },
   "files": [
-    "flow_parser.js"
+    "flow_parser.js",
+    "oxidized"
   ],
   "main": "flow_parser.js",
   "repository": {
@@ -21,7 +22,9 @@
     "test": "node test/run_tests.js",
     "build": "make js"
   },
-  "dependencies": {},
+  "dependencies": {
+    "flow-estree": "0.318.0"
+  },
   "devDependencies": {
     "@babel/generator": "7.7.4",
     "@babel/parser": "7.7.4",
@@ -29,7 +32,6 @@
     "chalk": "^4.1.2",
     "espree": "9.3.2",
     "flow-enums-runtime": "0.0.6",
-    "flow-estree": "0.0.1",
     "hermes-estree": "0.36.1",
     "hermes-parser": "0.36.1",
     "minimist": ">=1.2.6",

--- a/packages/flow-transform/package.json
+++ b/packages/flow-transform/package.json
@@ -14,7 +14,7 @@
     "esquery": "^1.4.0",
     "flow-enums-runtime": "^0.0.6",
     "flow-eslint": "0.0.1",
-    "flow-estree": "0.0.1",
+    "flow-estree": "0.318.0",
     "flow-parser": "0.318.0",
     "string-width": "4.2.3"
   },

--- a/scripts/bump_version.sh
+++ b/scripts/bump_version.sh
@@ -23,6 +23,10 @@ sed -i 's/^\(let version = "\)[^"]*\("\)/\1'"$VERSION"'\2/' src/common/flow_vers
 sed -i 's/^\(version: "\)[^"]*\("\)/\1'"$OPAM_VERSION"'\2/' flowtype.opam
 sed -i 's/^\(version: "\)[^"]*\("\)/\1'"$OPAM_VERSION"'\2/' flow_parser.opam
 sed -i 's/\("version": "\)[^"]*\("\)/\1'"$VERSION"'\2/' packages/flow-parser/package.json
+sed -i 's/\("version": "\)[^"]*\("\)/\1'"$VERSION"'\2/' packages/flow-estree/package.json
+sed -i 's/\("flow-estree": "\)[^"]*\("\)/\1'"$VERSION"'\2/' packages/flow-parser/package.json
+sed -i 's/\("flow-estree": "\)[^"]*\("\)/\1'"$VERSION"'\2/' packages/flow-eslint/package.json
+sed -i 's/\("flow-estree": "\)[^"]*\("\)/\1'"$VERSION"'\2/' packages/flow-transform/package.json
 sed -i 's/\("version": "\)[^"]*\("\)/\1'"$REMOVE_TYPES_VERSION"'\2/' packages/flow-remove-types/package.json
 sed -i 's/\("flow-parser": "\)[^"]*\("\)/\1^'"$VERSION"'\2/' packages/flow-remove-types/package.json
 


### PR DESCRIPTION
Summary:
flow-parser with the rust port part now depends on flow-estree, so we also need to publish flow-estree. This diff makes it follow the flow-parser versioning, and update the ci job to pack and publish it together with flow-parser.

Changelog: [internal]

Differential Revision: D108433986


