### PR TITLE
[flow] flow_parser.js is dead, long live the rust port parser

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -175,8 +175,6 @@ jobs:
   build_js:
     runs-on: ubuntu-22.04
     env:
-      TERM: dumb
-      OPAMYES: true
       NODE_VERSION: 24.14.1
       NPM_VERSION: 11.11.0
       YARN_VERSION: 1.22.21
@@ -189,32 +187,6 @@ jobs:
       RUST_MIN_STACK: 5242880
     steps:
     - uses: actions/checkout@v3.6.0
-    - name: Install OPAM
-      uses: ./.github/actions/install-opam-linux
-      with:
-        arch: x86_64
-    - name: Create cache breaker
-      run: .circleci/make_opam_cachebreaker.sh > .circleci/opamcachebreaker
-      shell: bash
-    - name: opam cache
-      uses: actions/cache@v4
-      with:
-        path: |-
-          ~/.opam
-          _opam
-        key: v1-opam-cache-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.circleci/opamcachebreaker') }}
-    - name: Init opam
-      run: .circleci/opam_init.sh
-    - name: Install deps from opam
-      run: make deps
-      shell: bash
-    - name: Install extra deps from opam
-      run: make deps-js
-    - name: Build flow_parser.js
-      run: opam exec -- make -C src/parser js
-    - name: Create package artifact inputs
-      run: |-
-        cp src/parser/flow_parser.js packages/flow-parser/flow_parser.js
     - name: Install Node
       uses: actions/setup-node@v4.4.0
       with:
@@ -264,13 +236,15 @@ jobs:
     - name: Test packages
       working-directory: packages
       run: yarn test -- --testPathPatterns='flow-parser|babel-plugin-syntax-flow-parser|flow-eslint|flow-transform'
+    - name: Create package artifact
+      run: |
+        mkdir -p "${RUNNER_TEMP}/build_js_packages/flow-parser" "${RUNNER_TEMP}/build_js_packages/flow-estree"
+        cp -R packages/flow-parser/dist "${RUNNER_TEMP}/build_js_packages/flow-parser/dist"
+        cp -R packages/flow-estree/dist "${RUNNER_TEMP}/build_js_packages/flow-estree/dist"
     - uses: actions/upload-artifact@v4.4.0
       with:
         name: build_js_packages
-        path: |
-          packages/flow-parser/flow_parser.js
-          packages/flow-parser/oxidized
-          packages/flow-estree/dist
+        path: ${{ runner.temp }}/build_js_packages
   build_flow_js:
     runs-on: ubuntu-22.04
     env:
@@ -400,14 +374,11 @@ jobs:
         path: ${{ runner.temp }}/build_js_packages
     - name: Install generated package artifacts
       run: |
-        test -f "${RUNNER_TEMP}/build_js_packages/flow-parser/flow_parser.js"
-        test -d "${RUNNER_TEMP}/build_js_packages/flow-parser/oxidized"
+        test -f "${RUNNER_TEMP}/build_js_packages/flow-parser/dist/index.js"
         test -f "${RUNNER_TEMP}/build_js_packages/flow-estree/dist/index.js"
-        test ! -e packages/flow-parser/flow_parser.js
-        test ! -e packages/flow-parser/oxidized
+        test ! -e packages/flow-parser/dist
         test ! -e packages/flow-estree/dist
-        cp "${RUNNER_TEMP}/build_js_packages/flow-parser/flow_parser.js" packages/flow-parser/flow_parser.js
-        cp -R "${RUNNER_TEMP}/build_js_packages/flow-parser/oxidized" packages/flow-parser/oxidized
+        cp -R "${RUNNER_TEMP}/build_js_packages/flow-parser/dist" packages/flow-parser/dist
         cp -R "${RUNNER_TEMP}/build_js_packages/flow-estree/dist" packages/flow-estree/dist
     - name: Pack flow-estree
       run: |
@@ -415,8 +386,7 @@ jobs:
         make dist/npm-flow-estree.tgz
     - name: Pack flow-parser
       run: |
-        test -f packages/flow-parser/flow_parser.js
-        test -d packages/flow-parser/oxidized
+        test -f packages/flow-parser/dist/index.js
         make dist/npm-flow-parser.tgz
     - name: Pack flow-remove-types and flow-node
       run: |

--- a/packages/.gitignore
+++ b/packages/.gitignore
@@ -1,8 +1,8 @@
 node_modules/
 dist/
 
-# Generated WASM wrapper for flow-parser/oxidized. Written into oxidized-src/ by
-# scripts/runContractTests.sh and into oxidized/ by scripts/build.sh. Never
+# Generated WASM wrapper for flow-parser. Written into oxidized-src/ by
+# scripts/runContractTests.sh and into dist/ by scripts/build.sh. Never
 # commit this - it's a copy of the buck-built emcc artifact and would bloat
 # the repo.
 flow-parser/oxidized/
@@ -10,6 +10,6 @@ flow-parser/oxidized-src/FlowParserWASM.js
 flow-parser/oxidized-src/FlowParserWASM.js.lock.d/
 
 # Lock file used by scripts/runContractTests.sh to serialize concurrent
-# `yarn build` rebuilds of oxidized/ when buck schedules wasm_parser_contract_test
-# and oxidized_jest_test in parallel.
+# `yarn build` rebuilds of generated parser output when buck schedules
+# wasm_parser_contract_test and oxidized_jest_test in parallel.
 flow-parser/.dist.flock

--- a/packages/babel-plugin-syntax-flow-parser/README.md
+++ b/packages/babel-plugin-syntax-flow-parser/README.md
@@ -1,6 +1,6 @@
 # babel-plugin-syntax-flow-parser
 
-Hermes parser plugin for [Babel](https://babeljs.io/). This plugin switches Babel to use `flow-parser/oxidized` instead of the `@babel/parser`. Since Hermes parser uses C++ compiled to WASM it is significantly faster and provides full syntax support for Flow.
+Hermes parser plugin for [Babel](https://babeljs.io/). This plugin switches Babel to use `flow-parser` instead of the `@babel/parser`. The Flow parser uses Rust compiled to WASM for full Flow syntax support.
 
 ## Install
 

--- a/packages/babel-plugin-syntax-flow-parser/__tests__/babel-plugin-syntax-hermes-parser-test.js
+++ b/packages/babel-plugin-syntax-flow-parser/__tests__/babel-plugin-syntax-hermes-parser-test.js
@@ -14,7 +14,7 @@
 import {transformSync} from '@babel/core';
 
 import hermesParserPlugin from '../src';
-import * as HermesParser from 'flow-parser/oxidized';
+import * as HermesParser from 'flow-parser';
 
 const MODULE_PREAMBLE = '// @flow\n\n"use strict";\n\n';
 const NON_FLOW_MODULE_PREAMBLE = '"use strict";\n\n';

--- a/packages/babel-plugin-syntax-flow-parser/package.json
+++ b/packages/babel-plugin-syntax-flow-parser/package.json
@@ -1,7 +1,7 @@
 {
   "name": "babel-plugin-syntax-flow-parser",
   "version": "0.0.1",
-  "description": "Babel plugin which switches Babel to use the flow-parser/oxidized parser.",
+  "description": "Babel plugin which switches Babel to use flow-parser.",
   "homepage": "https://flow.org",
   "main": "dist/index.js",
   "license": "MIT",

--- a/packages/babel-plugin-syntax-flow-parser/src/index.js
+++ b/packages/babel-plugin-syntax-flow-parser/src/index.js
@@ -10,9 +10,9 @@
 
 'use strict';
 
-import type {ParserOptions} from 'flow-parser/oxidized';
+import type {ParserOptions} from 'flow-parser';
 
-import * as HermesParser from 'flow-parser/oxidized';
+import * as HermesParser from 'flow-parser';
 
 type Options = {
   /**

--- a/packages/babel.config.js
+++ b/packages/babel.config.js
@@ -35,7 +35,7 @@ module.exports = {
   overrides: overrideEnabled()
     ? [
         {
-          // Use flow-parser/oxidized as Babel's parser so it understands newer
+          // Use flow-parser as Babel's parser so it understands newer
           // Flow syntax (e.g. `as` casts) beyond what the bundled @babel/parser
           // supports. Disabled by `SKIP_HERMES_PARSER_OVERRIDE=1` during the
           // build's bootstrap phase — `babel-plugin-syntax-flow-parser`

--- a/packages/flow-eslint/__tests__/hermes-scope/component-test.js
+++ b/packages/flow-eslint/__tests__/hermes-scope/component-test.js
@@ -186,7 +186,7 @@ describe('Component', () => {
       const scope = scopeManager.scopes[1];
 
       expect(scope.variables).toHaveLength(1); // [Foo]
-      // flow-parser/oxidized respects the OCaml flow_parser AST and emits
+      // flow-parser respects the OCaml flow_parser AST and emits
       // `declare component` params as the value-position `ComponentParameter`
       // (with `name` + `local` Identifier slots), unlike upstream
       // hermes-parser which emits the type-position `ComponentTypeParameter`

--- a/packages/flow-eslint/src/index.js
+++ b/packages/flow-eslint/src/index.js
@@ -11,10 +11,10 @@
 'use strict';
 
 import type {Program} from 'flow-estree';
-import type {VisitorKeysType} from 'flow-parser/oxidized';
+import type {VisitorKeysType} from 'flow-parser';
 import type {PartialAnalyzeOptions, ScopeManager} from './scope-manager';
 
-import * as HermesParser from 'flow-parser/oxidized';
+import * as HermesParser from 'flow-parser';
 import {analyze} from './scope-manager';
 
 type ParseForESLintOptions = Readonly<{

--- a/packages/flow-eslint/src/scope-manager/analyze.js
+++ b/packages/flow-eslint/src/scope-manager/analyze.js
@@ -12,7 +12,7 @@
 
 import type {Program} from 'flow-estree';
 
-import {FlowVisitorKeys} from 'flow-parser/oxidized';
+import {FlowVisitorKeys} from 'flow-parser';
 import {Referencer} from './referencer';
 import {ScopeManager} from './ScopeManager';
 

--- a/packages/flow-eslint/src/scope-manager/referencer/VisitorBase.js
+++ b/packages/flow-eslint/src/scope-manager/referencer/VisitorBase.js
@@ -11,9 +11,9 @@
 'use strict';
 
 import type {ESNode} from 'flow-estree';
-import type {VisitorKeysType} from 'flow-parser/oxidized';
+import type {VisitorKeysType} from 'flow-parser';
 
-import {FlowVisitorKeys} from 'flow-parser/oxidized';
+import {FlowVisitorKeys} from 'flow-parser';
 
 type VisitorOptions = Readonly<{
   childVisitorKeys?: VisitorKeysType | null,

--- a/packages/flow-parser/README.md
+++ b/packages/flow-parser/README.md
@@ -1,6 +1,6 @@
 # The flow-parser package
 
-This package contains the Flow parser in its compiled-to-JavaScript form.
+This package contains the Flow parser in its JavaScript package form.
 
 # What is Flow
 
@@ -8,42 +8,30 @@ See [flow.org](https://flow.org/). The code for the Flow parser [lives on GitHub
 
 # What is the Flow Parser
 
-The Flow Parser is a JavaScript parser written in OCaml. It produces an AST that conforms to the [ESTree spec](https://github.com/estree/estree) and that mostly matches what [esprima](http://esprima.org/) produces. The Flow Parser can be compiled to native code or can be compiled to JavaScript using [js_of_ocaml](http://ocsigen.org/js_of_ocaml/). This npm package contains the Flow parser compiled to JavaScript.
+The Flow Parser is a JavaScript parser for Flow syntax. It produces an AST that conforms to the [ESTree spec](https://github.com/estree/estree). This npm package contains the Flow Rust parser compiled to WASM with JavaScript bindings.
 
 # Usage
 
-You can use the Flow parser in your browser or in node. To use in node you can just do
+You can use the Flow parser in node:
 
 ```JavaScript
-require('flow-parser').parse('1+1', {});
-```
-
-To use in the browser, you can add
-
-```HTML
-<script src="flow_parser.js"></script>
-```
-
-which will make the `flow` object available to use like so:
-
-```JavaScript
-flow.parse('1+1', {});
+const {parse} = require('flow-parser');
+parse('1+1', {});
 ```
 
 ## Options
 
-The second argument to `flow.parse` is the options object. Currently supported options:
+The second argument to `parse` is the options object. Common options:
 
 ### Basic options
-* `types` (boolean, default `true`) - enable parsing of Flow types
-* `use_strict` (boolean, default `false`) - treat the file as strict, without needing a "use strict" directive
-* `comments` (boolean, default `true`) - attach comments to AST nodes (`leadingComments` and `trailingComments`)
-* `all_comments` (boolean, default `true`) - include a list of all comments from the whole program
+* `flow` (`'detect'` or `'all'`, default `'detect'`) - parse Flow syntax only with an `@flow` pragma, or always parse Flow syntax
+* `sourceType` (`'module'`, `'script'`, or `'unambiguous'`) - parse the file as a module, script, or infer it from the contents
 * `tokens` (boolean, default `false`) - include a list of all parsed tokens in a top-level `tokens` property
+* `babel` (boolean, default `false`) - return a Babel-shaped AST
 
 ### Language features
-* `enums` (boolean, default `false`) - enable parsing of [enums](https://flow.org/en/docs/enums/)
-* `match` (boolean, default `false`) - enable parsing of [match expressions and match statements](https://flow.org/en/docs/match/)
-* `components` (boolean, default `false`) - enable parsing of [component syntax](https://flow.org/en/docs/react/component-syntax/)
-* `assert_operator` (boolean, default `false`) - enable parsing of the assert operator
-* `esproposal_decorators` (boolean, default `false`) - enable parsing of decorators
+* `enableEnums` (boolean, default `true`) - enable parsing of [enums](https://flow.org/en/docs/enums/)
+* `enableExperimentalFlowMatchSyntax` (boolean, default `true`) - enable parsing of [match expressions and match statements](https://flow.org/en/docs/match/)
+* `enableExperimentalComponentSyntax` (boolean, default `true`) - enable parsing of [component syntax](https://flow.org/en/docs/react/component-syntax/)
+* `assertOperator` (boolean, default `false`) - enable parsing of the assert operator
+* `enableExperimentalDecorators` (boolean, default `true`) - enable parsing of decorators

--- a/packages/flow-parser/__tests__/APISurface-test.js
+++ b/packages/flow-parser/__tests__/APISurface-test.js
@@ -12,7 +12,7 @@
 
 // Phase D1 / task #13 sub-test 1: API-surface diff.
 //
-// `flow-parser/oxidized` is intended as a drop-in replacement for
+// `flow-parser` is intended as a drop-in replacement for
 // `hermes-parser`. This suite asserts that the public export surface of our
 // package is a superset of upstream: every name upstream exports is also
 // exported by us, and the `typeof` of each shared export agrees.
@@ -34,11 +34,11 @@ type ModuleExports = interface {
   +[string]: unknown,
 };
 
-const ours: ModuleExports = require('flow-parser/oxidized');
+const ours: ModuleExports = require('flow-parser');
 const upstream: ModuleExports = require('hermes-parser');
 
 describe('Public export surface vs hermes-parser', () => {
-  test('every upstream export name is present on flow-parser/oxidized', () => {
+  test('every upstream export name is present on flow-parser', () => {
     const upstreamNames = Object.keys(upstream).sort();
     const ourNames = new Set(Object.keys(ours));
     const missing = upstreamNames.filter(name => !ourNames.has(name));

--- a/packages/flow-parser/__tests__/runContractTests.sh
+++ b/packages/flow-parser/__tests__/runContractTests.sh
@@ -74,14 +74,14 @@ trap '
 cd "$WORKSPACE_DIR"
 
 # Serialize dist/ rebuilds + reads against runOxidizedJestTests.sh, which
-# rebuilds the oxidized parser output and then `require()`s
-# `flow-parser/oxidized`. Buck
+# rebuilds the generated parser output and then `require()`s
+# `flow-parser`. Buck
 # schedules `wasm_parser_contract_test` and `oxidized_jest_test` in
 # parallel; without this flock, target A's jest can read a torn
-# `oxidized/index.js` (un-stripped Flow `import type` lines from the copy
+# `index.js` (un-stripped Flow `import type` lines from the copy
 # step) while target B's `yarn build` is mid-flight. Hold the lock through
 # both `yarn build` AND the jest run so a concurrent target can't clobber
-# `oxidized/` while we're reading from it.
+# generated parser output while we're reading from it.
 DIST_FLOCK="$PKG_DIR/.dist.flock"
 exec 9> "$DIST_FLOCK"
 echo "==> waiting for exclusive lock on $DIST_FLOCK"
@@ -93,8 +93,8 @@ echo "==> acquired lock on $DIST_FLOCK"
 # right mode here.
 yarn install --offline
 
-# Build oxidized/ from oxidized-src/: contract tests `require()` the public
-# entry `flow-parser/oxidized`. Without this build, jest sees the ESM
+# Build dist/ output from oxidized-src/: contract tests `require()` the
+# public entry `flow-parser`. Without this build, jest sees the ESM
 # `oxidized-src/` files directly and node can't `require()` them.
 yarn build
 

--- a/packages/flow-parser/__tests__/runWasmFixtures.js
+++ b/packages/flow-parser/__tests__/runWasmFixtures.js
@@ -15,17 +15,17 @@ const fs = require('node:fs');
 const path = require('node:path');
 const util = require('node:util');
 
-// Bypasses the public `../oxidized` (i.e. `index.js`) entry on purpose. The
+// Bypasses the public `../dist/index.js` entry on purpose. The
 // fixtures under flow/src/parser/test/flow/ exercise the parser boundary with
 // fixture-supplied parser options, so we go straight to the underlying
-// deserializer here. Don't "fix" this back to `require('../oxidized')`.
-// We reach into the babel-stripped oxidized/ build (populated by the workspace
+// deserializer here. Don't "fix" this back to `require('..')`.
+// We reach into the babel-stripped dist/ build (populated by the workspace
 // `yarn build` step in runWasmFixtures.sh) because oxidized-src/FlowParser.js
 // uses ES module + `import type` syntax and node's native `--test` runner has
 // no babel transform. Drop-in / contract parity with hermes-parser is
 // exercised separately by the jest tests under this directory; that suite goes
 // through index.js.
-const FlowParser = require('../oxidized/FlowParser');
+const FlowParser = require('../dist/FlowParser');
 
 // Upstream hermes-parser package tests snapshot the public package AST surface
 // directly and record public parse errors explicitly. This full Flow

--- a/packages/flow-parser/__tests__/runWasmFixtures.sh
+++ b/packages/flow-parser/__tests__/runWasmFixtures.sh
@@ -7,9 +7,9 @@
 # Drives the parser fixture suite under flow/src/parser/test/flow against the
 # wasm-built Flow parser. After the workspace consolidation, src/ files use ES
 # module syntax (matching upstream xplat/static_h hermes-parser shape), so the
-# JS driver must require the babel-transformed oxidized/ build. oxidized/ is populated
+# JS driver must require the babel-transformed dist/ build. dist/ is populated
 # by the workspace-root `yarn build`, which itself invokes the FB-only wasm
-# build script and writes flow-parser/oxidized/FlowParserWASM.js.
+# build script and writes flow-parser/dist/FlowParserWASM.js.
 
 set -e -o pipefail
 
@@ -25,12 +25,12 @@ PKG_DIR="$WORKSPACE_DIR/flow-parser"
 cd "$WORKSPACE_DIR"
 
 # Serialize dist/ rebuilds + reads against runOxidizedJestTests.sh and
-# runContractTests.sh, which also rebuild the oxidized parser output
+# runContractTests.sh, which also rebuild the generated parser output
 # under `yarn build`. Buck schedules these targets in parallel; without this
-# flock, target A's node test can read a torn `oxidized/FlowParser.js` while
+# flock, target A's node test can read a torn `dist/FlowParser.js` while
 # target B's `yarn build` is mid-flight. Hold the lock through both
-# `yarn build` AND the node run so a concurrent target can't clobber `oxidized/`
-# while we're reading from it.
+# `yarn build` AND the node run so a concurrent target can't clobber generated
+# output while we're reading from it.
 DIST_FLOCK="$PKG_DIR/.dist.flock"
 exec 9> "$DIST_FLOCK"
 echo "==> waiting for exclusive lock on $DIST_FLOCK"
@@ -43,9 +43,9 @@ echo "==> acquired lock on $DIST_FLOCK"
 yarn install --offline
 
 # Build output for each package (and embed the WASM parser into
-# flow-parser/oxidized/FlowParserWASM.js). The fixture runner requires
-# `../oxidized/FlowParser` directly so it can pass fixture-specific parser
-# options without the public `oxidized/index.js` defaults.
+# flow-parser/dist/FlowParserWASM.js). The fixture runner requires
+# `../dist/FlowParser` directly so it can pass fixture-specific parser options
+# without the public `index.js` defaults.
 yarn build
 
 # Use the fbsource third-party Node toolchain (24.x). The system Node may be

--- a/packages/flow-parser/package.json
+++ b/packages/flow-parser/package.json
@@ -9,10 +9,10 @@
     "email": "flow@fb.com"
   },
   "files": [
-    "flow_parser.js",
-    "oxidized"
+    "dist",
+    "README.md"
   ],
-  "main": "flow_parser.js",
+  "main": "dist/index.js",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/facebook/flow.git",

--- a/packages/flow-transform/README.md
+++ b/packages/flow-transform/README.md
@@ -4,7 +4,7 @@ A package for traversing and transforming a Flow AST. Forked from upstream
 [`hermes-transform`](https://github.com/facebook/hermes/tree/main/tools/hermes-parser/js/hermes-transform)
 with the sibling deps rewired:
 
-- `hermes-parser` -> `flow-parser/oxidized`
+- `hermes-parser` -> `flow-parser`
 - `hermes-estree` -> `flow-estree`
 - `hermes-eslint` -> `flow-eslint`
 - `prettier-plugin-hermes-parser` -> `prettier-plugin-flow-parser`
@@ -31,7 +31,7 @@ This package is pieced together and inspired by code from:
   `Symbol.for('hermes-transform - ...')` runtime markers. These are private
   to this package (not import paths), preserved verbatim from upstream to
   keep the fork a pure literal rename.
-- **Partial vendor in flow-parser/oxidized**: an early-Phase-E vendor of the
+- **Partial vendor in flow-parser**: an early-Phase-E vendor of the
   print/comments pipeline lives at
   `flow/packages/flow-parser/oxidized-src/transform/print/` (with `print.js`,
   `detachedNodeTypes.js`, `comments/`). It predates this fork and is left

--- a/packages/flow-transform/__tests__/traverse/NodeEventGenerator-test.js
+++ b/packages/flow-transform/__tests__/traverse/NodeEventGenerator-test.js
@@ -13,7 +13,7 @@
 import type {ESNode, Program} from 'flow-estree';
 
 import {parseForESLint} from 'flow-eslint';
-import {SimpleTraverser} from 'flow-parser/oxidized';
+import {SimpleTraverser} from 'flow-parser';
 import {SafeEmitter} from '../../src/traverse/SafeEmitter';
 import {NodeEventGenerator} from '../../src/traverse/NodeEventGenerator';
 

--- a/packages/flow-transform/src/detachedNode.js
+++ b/packages/flow-transform/src/detachedNode.js
@@ -10,7 +10,7 @@
 
 import type {BaseNode, ESNode} from 'flow-estree';
 
-import {astNodeMutationHelpers} from 'flow-parser/oxidized';
+import {astNodeMutationHelpers} from 'flow-parser';
 
 export opaque type DetachedNode<+T> = T;
 export type MaybeDetachedNode<+T> = T | DetachedNode<T>;

--- a/packages/flow-transform/src/index.js
+++ b/packages/flow-transform/src/index.js
@@ -15,7 +15,7 @@ export type {TransformVisitor} from './transform/transform';
 export type {TransformContext} from './transform/TransformContext';
 export type {DetachedNode, MaybeDetachedNode} from './detachedNode';
 
-export {SimpleTraverser} from 'flow-parser/oxidized';
+export {SimpleTraverser} from 'flow-parser';
 export {traverse, traverseWithContext} from './traverse/traverse';
 export {transform} from './transform/transform';
 export {parse} from './transform/parse';

--- a/packages/flow-transform/src/transform/TransformContext.js
+++ b/packages/flow-transform/src/transform/TransformContext.js
@@ -37,7 +37,7 @@ import type {
 } from './mutations/ReplaceStatementWithMany';
 
 import {asDetachedNode, deepCloneNode, shallowCloneNode} from '../detachedNode';
-import {isNode} from 'flow-parser/oxidized';
+import {isNode} from 'flow-parser';
 import {
   CommentPlacement,
   getCommentsForNode,

--- a/packages/flow-transform/src/transform/mutations/InsertStatement.js
+++ b/packages/flow-transform/src/transform/mutations/InsertStatement.js
@@ -12,7 +12,7 @@ import type {ESNode, ModuleDeclaration, Statement} from 'flow-estree';
 import type {MutationContext} from '../MutationContext';
 import type {DetachedNode} from '../../detachedNode';
 
-import {astArrayMutationHelpers} from 'flow-parser/oxidized';
+import {astArrayMutationHelpers} from 'flow-parser';
 import {getStatementParent} from './utils/getStatementParent';
 import {isValidModuleDeclarationParent} from './utils/isValidModuleDeclarationParent';
 import {InvalidInsertionError} from '../Errors';

--- a/packages/flow-transform/src/transform/mutations/ModifyNodeInPlace.js
+++ b/packages/flow-transform/src/transform/mutations/ModifyNodeInPlace.js
@@ -11,7 +11,7 @@
 import type {ESNode} from 'flow-estree';
 import type {MutationContext} from '../MutationContext';
 
-import {isNode} from 'flow-parser/oxidized';
+import {isNode} from 'flow-parser';
 
 export type ModifyNodeInPlaceMutation = Readonly<{
   type: 'modifyNodeInPlace',

--- a/packages/flow-transform/src/transform/mutations/RemoveComment.js
+++ b/packages/flow-transform/src/transform/mutations/RemoveComment.js
@@ -10,7 +10,7 @@
 
 import type {Comment, Program} from 'flow-estree';
 
-import {SimpleTraverser, SimpleTraverserBreak} from 'flow-parser/oxidized';
+import {SimpleTraverser, SimpleTraverserBreak} from 'flow-parser';
 import {getCommentsForNode, setCommentsOnNode} from '../comments/comments';
 
 export type RemoveCommentMutation = Readonly<{

--- a/packages/flow-transform/src/transform/mutations/RemoveNode.js
+++ b/packages/flow-transform/src/transform/mutations/RemoveNode.js
@@ -32,7 +32,7 @@ import type {
 import type {MutationContext} from '../MutationContext';
 import type {DetachedNode} from '../../detachedNode';
 
-import {astArrayMutationHelpers} from 'flow-parser/oxidized';
+import {astArrayMutationHelpers} from 'flow-parser';
 import {InvalidRemovalError} from '../Errors';
 
 export type RemoveNodeMutation = Readonly<{

--- a/packages/flow-transform/src/transform/mutations/RemoveStatement.js
+++ b/packages/flow-transform/src/transform/mutations/RemoveStatement.js
@@ -12,7 +12,7 @@ import type {ESNode, ModuleDeclaration, Statement} from 'flow-estree';
 import type {MutationContext} from '../MutationContext';
 import type {DetachedNode} from '../../detachedNode';
 
-import {astArrayMutationHelpers} from 'flow-parser/oxidized';
+import {astArrayMutationHelpers} from 'flow-parser';
 import {getStatementParent} from './utils/getStatementParent';
 import * as t from '../../generated/node-types';
 

--- a/packages/flow-transform/src/transform/mutations/ReplaceNode.js
+++ b/packages/flow-transform/src/transform/mutations/ReplaceNode.js
@@ -12,11 +12,7 @@ import type {ESNode} from 'flow-estree';
 import type {MutationContext} from '../MutationContext';
 import type {DetachedNode} from '../../detachedNode';
 
-import {
-  getVisitorKeys,
-  isNode,
-  astArrayMutationHelpers,
-} from 'flow-parser/oxidized';
+import {getVisitorKeys, isNode, astArrayMutationHelpers} from 'flow-parser';
 import {moveCommentsToNewNode} from '../comments/comments';
 import {InvalidReplacementError} from '../Errors';
 import {getOriginalNode} from '../../detachedNode';

--- a/packages/flow-transform/src/transform/mutations/ReplaceStatementWithMany.js
+++ b/packages/flow-transform/src/transform/mutations/ReplaceStatementWithMany.js
@@ -12,7 +12,7 @@ import type {ESNode, ModuleDeclaration, Statement} from 'flow-estree';
 import type {MutationContext} from '../MutationContext';
 import type {DetachedNode} from '../../detachedNode';
 
-import {astArrayMutationHelpers} from 'flow-parser/oxidized';
+import {astArrayMutationHelpers} from 'flow-parser';
 import {getStatementParent} from './utils/getStatementParent';
 import {isValidModuleDeclarationParent} from './utils/isValidModuleDeclarationParent';
 import {moveCommentsToNewNode} from '../comments/comments';

--- a/packages/flow-transform/src/transform/print.js
+++ b/packages/flow-transform/src/transform/print.js
@@ -13,10 +13,10 @@
 import type {MaybeDetachedNode} from '../detachedNode';
 import type {Program} from 'flow-estree';
 
-import {mutateESTreeASTForPrettier} from 'flow-parser/oxidized';
+import {mutateESTreeASTForPrettier} from 'flow-parser';
 import * as prettier from 'prettier';
 import {mutateESTreeASTCommentsForPrettier} from './comments/comments';
-import type {VisitorKeysType} from 'flow-parser/oxidized';
+import type {VisitorKeysType} from 'flow-parser';
 
 export async function print(
   ast: MaybeDetachedNode<Program>,

--- a/packages/flow-transform/src/traverse/NodeEventGenerator.js
+++ b/packages/flow-transform/src/traverse/NodeEventGenerator.js
@@ -14,7 +14,7 @@ import type {ESNode} from 'flow-estree';
 import type {ESQueryOptions, Selector} from './esquery';
 import type {SafeEmitter} from './SafeEmitter';
 
-import {FlowVisitorKeys} from 'flow-parser/oxidized';
+import {FlowVisitorKeys} from 'flow-parser';
 import * as esquery from './esquery';
 
 type ParsedSelector = Readonly<{

--- a/packages/flow-transform/src/traverse/traverse.js
+++ b/packages/flow-transform/src/traverse/traverse.js
@@ -15,7 +15,7 @@ import type {EmitterListener} from './SafeEmitter';
 import {codeFrameColumns} from '@babel/code-frame';
 import {NodeEventGenerator} from './NodeEventGenerator';
 import {SafeEmitter} from './SafeEmitter';
-import {SimpleTraverser} from 'flow-parser/oxidized';
+import {SimpleTraverser} from 'flow-parser';
 
 export type TraversalContextBase = Readonly<{
   /**

--- a/packages/jest.config.js
+++ b/packages/jest.config.js
@@ -45,26 +45,24 @@ module.exports = {
     // the modules themselves
     ...workspaceModuleNameMappers,
 
-    '^flow-parser$': path.resolve(__dirname, 'flow-parser', 'flow_parser.js'),
-
-    '^flow-parser/oxidized$': path.resolve(
+    '^flow-parser$': path.resolve(
       __dirname,
       'flow-parser',
       'oxidized-src',
       'index.js',
     ),
 
-    '^flow-parser/oxidized/(.*)$': path.resolve(
-      __dirname,
-      'flow-parser',
-      'oxidized-src',
-      '$1',
-    ),
-
     '^flow-parser/__test_utils__/(.*)$': path.resolve(
       __dirname,
       'flow-parser',
       '__test_utils__',
+      '$1',
+    ),
+
+    '^flow-parser/(.*)$': path.resolve(
+      __dirname,
+      'flow-parser',
+      'oxidized-src',
       '$1',
     ),
 
@@ -75,11 +73,11 @@ module.exports = {
       'index.mjs',
     ),
 
-    // flow-parser/oxidized
+    // flow-parser
     '.*/FlowParserWASM$': path.resolve(
       __dirname,
       'flow-parser',
-      'oxidized',
+      'dist',
       'FlowParserWASM.js',
     ),
   },

--- a/packages/prettier-plugin-flow-parser/README.md
+++ b/packages/prettier-plugin-flow-parser/README.md
@@ -2,7 +2,7 @@
 
 Forked from `xplat/static_h/tools/hermes-parser/js/prettier-plugin-hermes-parser`.
 A Prettier plugin that consumes the hermes/flow ESTree AST shape — intended to
-pair with the Flow Rust parser stack (`flow-parser/oxidized`,
+pair with the Flow Rust parser stack (`flow-parser`,
 `flow-estree`).
 
 ## Bundle status

--- a/packages/scripts/build.sh
+++ b/packages/scripts/build.sh
@@ -7,6 +7,7 @@
 set -xe -o pipefail
 
 THIS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FLOW_PARSER_SRC_DIR="$THIS_DIR/../flow-parser/oxidized-src"
 
 PACKAGES=(
   flow-estree
@@ -44,7 +45,7 @@ fi
 package_src_dir() {
   local package="$1"
   if [[ "$package" == "flow-parser" ]]; then
-    echo "$THIS_DIR/../$package/oxidized-src"
+    echo "$FLOW_PARSER_SRC_DIR"
   else
     echo "$THIS_DIR/../$package/src"
   fi
@@ -52,11 +53,7 @@ package_src_dir() {
 
 package_dist_dir() {
   local package="$1"
-  if [[ "$package" == "flow-parser" ]]; then
-    echo "$THIS_DIR/../$package/oxidized"
-  else
-    echo "$THIS_DIR/../$package/dist"
-  fi
+  echo "$THIS_DIR/../$package/dist"
 }
 
 # Create fresh dist directory for each package, and copy source files in
@@ -87,7 +84,11 @@ for package in "${PACKAGES[@]}"; do
   done
 
   # Copy just the JS files again
-  rsync -a --include="*/" --include="*.js" --exclude="*" "$SRC_DIR" "$DIST_DIR"
+  if [[ "$package" == "flow-parser" ]]; then
+    rsync -a --include="*/" --include="*.js" --exclude="*" "$SRC_DIR/" "$DIST_DIR/"
+  else
+    rsync -a --include="*/" --include="*.js" --exclude="*" "$SRC_DIR" "$DIST_DIR"
+  fi
 done
 
 # Generate source code that only applies to dist directory
@@ -106,7 +107,7 @@ for package in "${BOOTSTRAP_PACKAGES[@]}"; do
   if [[ "$package" == "flow-parser" ]]; then
     BABEL_IGNORE_ARGS=(
       --ignore
-      "$PACKAGE_DIST_DIR/transform/print/**,$PACKAGE_DIST_DIR/oxidized-src/transform/print/**"
+      "$PACKAGE_DIST_DIR/transform/print/**"
     )
   fi
   yarn babel \
@@ -117,7 +118,7 @@ for package in "${BOOTSTRAP_PACKAGES[@]}"; do
 done
 
 # Re-enable the override so the remaining packages can be parsed with
-# flow-parser/oxidized (they contain Flow `as` cast syntax).
+# flow-parser (they contain Flow `as` cast syntax).
 unset SKIP_HERMES_PARSER_OVERRIDE
 
 for package in "${PACKAGES[@]}"; do
@@ -138,4 +139,6 @@ done
 
 # Validate that the generated flow files are sane
 # We don't bother validating the raw-js files as they are validated by babel first
-yarn eslint "*/dist/**/*.js.flow" "flow-parser/oxidized/**/*.js.flow" --no-ignore
+yarn eslint \
+  "*/dist/**/*.js.flow" \
+  --no-ignore

--- a/packages/scripts/genFlowWasmParser.js
+++ b/packages/scripts/genFlowWasmParser.js
@@ -14,7 +14,7 @@ const path = require('path');
 
 const OUTPUT_FILE = path.resolve(
   __dirname,
-  '../flow-parser/oxidized/FlowParserWASM.js',
+  '../flow-parser/dist/FlowParserWASM.js',
 );
 
 const HEADER = `/**
@@ -51,4 +51,5 @@ module.exports.default = module.exports;
 const wasmParserContents = fs.readFileSync(process.argv[2]).toString();
 const fileContents = HEADER + wasmParserContents + FOOTER;
 
+fs.mkdirSync(path.dirname(OUTPUT_FILE), {recursive: true});
 fs.writeFileSync(OUTPUT_FILE, fileContents);

--- a/packages/scripts/runOxidizedJestTests.sh
+++ b/packages/scripts/runOxidizedJestTests.sh
@@ -37,8 +37,8 @@ for arg in "$@"; do
 done
 
 # Serialize dist/ rebuilds + reads against runContractTests.sh, which also
-# rebuilds the oxidized parser output and then `require()`s
-# `flow-parser/oxidized`. Buck
+# rebuilds the generated parser output and then `require()`s
+# `flow-parser`. Buck
 # schedules `oxidized_jest_test` and `wasm_parser_contract_test` in
 # parallel; without this flock, target A's jest can read a torn
 # `dist/index.js` (un-stripped Flow `import type` lines from the cp -r
@@ -46,7 +46,7 @@ done
 #   `SyntaxError: Cannot use import statement outside a module` or
 #   `TypeError: FlowParserWASMModule is not a function`.
 # Hold the lock through both `yarn build` AND the jest run so a concurrent
-# target can't clobber `dist/` while we're reading from it.
+# target can't clobber generated output while we're reading from it.
 DIST_FLOCK="$PARSER_DIR/.dist.flock"
 exec 9> "$DIST_FLOCK"
 echo "==> waiting for exclusive lock on $DIST_FLOCK"
@@ -61,8 +61,8 @@ cd "$WORKSPACE_DIR"
 yarn install --offline
 
 # Build output for each package (and embed the WASM parser into
-# flow-parser/oxidized/FlowParserWASM.js). The unified jest config maps
-# `*/FlowParserWASM` -> flow-parser/oxidized/FlowParserWASM.js so tests can
+# flow-parser/dist/FlowParserWASM.js). The unified jest config maps
+# `*/FlowParserWASM` -> flow-parser/dist/FlowParserWASM.js so tests can
 # resolve the wasm wrapper from src-level imports.
 yarn build
 

--- a/rust_port/crates/flow_parser_wasm/regen.sh
+++ b/rust_port/crates/flow_parser_wasm/regen.sh
@@ -85,11 +85,11 @@ run_arc_f() {
     arc f "${out}"
 }
 
-# 1. JS deserializer (default) — for flow-parser/oxidized
+# 1. JS deserializer (default) — for flow-parser
 run_codegen "JS deserializer" "${parser_pkg}/FlowParserNodeDeserializers.js"
 run_arc_f "${parser_pkg}/FlowParserNodeDeserializers.js"
 
-# 2. ESTree visitor keys (--estree-visitor-keys) — for flow-parser/oxidized
+# 2. ESTree visitor keys (--estree-visitor-keys) — for flow-parser
 run_codegen "ESTree visitor keys" \
     "${parser_pkg}/generated/ESTreeVisitorKeys.js" \
     --estree-visitor-keys

--- a/rust_port/crates/flow_parser_wasm/src/bin/codegen.rs
+++ b/rust_port/crates/flow_parser_wasm/src/bin/codegen.rs
@@ -27,7 +27,7 @@
 //!
 //! ## ESTree visitor keys (`--estree-visitor-keys`)
 //!
-//! Generates `ESTreeVisitorKeys.js` for `flow-parser/oxidized`:
+//! Generates `ESTreeVisitorKeys.js` for `flow-parser`:
 //!
 //! ```sh
 //! buck run fbcode//flow/rust_port/crates/flow_parser_wasm:codegen -- \
@@ -891,7 +891,7 @@ const DEFAULT_HERMES_ESTREE_TYPES_PATH: &str =
 /// - **TS-only nodes** — upstream Hermes parses TypeScript; these kinds
 ///   exist in our SCHEMA only because the Rust serializer kind list mirrors
 ///   the OCaml binary protocol's full type space. Flow-only consumers will
-///   never see them via the flow-parser/oxidized adapter.
+///   never see them via the flow-parser adapter.
 /// - **Custom-encoded** — `Literal` (the only `custom_emit` kind) is
 ///   modeled upstream as the `Literal` union over BigInt/Boolean/Null/
 ///   Numeric/RegExp/StringLiteral, not as a standalone interface.
@@ -1146,7 +1146,7 @@ const PREDICATE_SPECIAL_NODES: &[&str] = &["Identifier", "JSXIdentifier", "JSXTe
 /// - **TS-only kinds** — upstream Hermes parses TypeScript; these kinds exist
 ///   in our SCHEMA only because the Rust serializer kind list mirrors the
 ///   OCaml binary protocol's full type space. Flow-only consumers will never
-///   see them via the flow-parser/oxidized adapter.
+///   see them via the flow-parser adapter.
 const PREDICATE_EXCLUDED_TYPES: &[&str] = &[
     // Optional-chain refinements collapsed into Call/Member by upstream.
     "OptionalCallExpression",


### PR DESCRIPTION
Summary:
This is the diff that switches over the `flow-parser` packages to be based on the rust port only. Before this diff, it has the structure of

```
- package.json (main pointing to flow_parser.js)
- flow_parser.js
- oxidized/ (rust port parser stuff)
```

Now it's

```
- package.json (main pointing to dist/index.js)
- dist/ (rust port parser stuff)
```

Scripts are updated to make it happen. We also stop building flow_parser.js in OSS CI

Changelog: [parser] `flow-parser` is now backed by the Rust port parser. It will have public API similar to that of `hermes-parser`.

Differential Revision: D109255045
