### PR TITLE
Fix version badges rendering unstyled in the docs

### DIFF
--- a/website/components/VersionTags.js
+++ b/website/components/VersionTags.js
@@ -13,8 +13,7 @@ import * as React from 'react';
 
 export function SinceVersion({version}: {version: string}): React.MixedElement {
   return (
-    // $FlowFixMe[incompatible-type] class vs className
-    <span class="version added" title={`Added in ${version}`}>
+    <span className="version added" title={`Added in ${version}`}>
       &ge;{version}
     </span>
   );
@@ -22,8 +21,7 @@ export function SinceVersion({version}: {version: string}): React.MixedElement {
 
 export function UntilVersion({version}: {version: string}): React.MixedElement {
   return (
-    // $FlowFixMe[incompatible-type] class vs className
-    <span class="version removed" title={`Removed after ${version}`}>
+    <span className="version removed" title={`Removed after ${version}`}>
       &le;{version}
     </span>
   );


### PR DESCRIPTION
## Summary
`SinceVersion`/`UntilVersion` in `website/components/VersionTags.js` rendered their `<span>` with the DOM attribute `class` instead of `className`. On React 18 (pinned by the website via `react@^18.3.1`) the unknown `class` prop is dropped, so the `.version` / `.version.added` / `.version.removed` styles (defined in `website/src/css/custom.css`) never applied — the version badges rendered completely unstyled.

These components are used in `website/docs/types/utilities.md` to show "≥0.317"-style version tags on the live docs site, so the issue is user-visible.

## Changes
- Switch `class` → `className` on both spans so the existing CSS applies.
- Remove the two `$FlowFixMe[incompatible-type] class vs className` suppressions — they only existed because Flow had **correctly** flagged the `class` usage, so they're now obsolete (and would otherwise become unused-suppression errors).

## Verification
- Confirmed `.version`, `.version.added`, `.version.removed` exist in `website/src/css/custom.css`.
- Confirmed usage in `website/docs/types/utilities.md`.