### PR TITLE
[flow] Add ES2026 Map methods (#9484)

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -2084,6 +2084,8 @@ declare class Map<K, V> extends $ReadOnlyMap<K, V> {
     entries(): Iterator<[K, V]>;
     forEach<This>(callbackfn: (this : This, value: V, index: K, map: Map<K, V>) => unknown, thisArg: This): void;
     get(key: K): V | void;
+    getOrInsert(key: K, value: V): V;
+    getOrInsertComputed(key: K, callbackfn: (key: K) => V): V;
     has(key: K): boolean;
     /**
      * Returns an iterable of keys in the map
@@ -2176,6 +2178,8 @@ declare class WeakMap<K extends WeaklyReferenceable, V> extends $ReadOnlyWeakMap
     constructor(iterable?: ?Iterable<[+key: K, +value: V]>): void;
     delete(key: K): boolean;
     get(key: K): V | void;
+    getOrInsert(key: K, value: V): V;
+    getOrInsertComputed(key: K, callbackfn: (key: K) => V): V;
     has(key: K): boolean;
     set(key: K, value: V): WeakMap<K, V>;
 }

--- a/tests/async/async.exp
+++ b/tests/async/async.exp
@@ -7,8 +7,8 @@ Cannot return `1` because in type argument `R` [1]: `1` [2] is incompatible with
                   ^ [2]
 
 References:
-   <BUILTINS>/core.js:2285:24
-   2285| declare class Promise<+R = unknown> {
+   <BUILTINS>/core.js:2289:24
+   2289| declare class Promise<+R = unknown> {
                                 ^ [1]
    async.js:9:30
       9| async function f1(): Promise<boolean> {
@@ -25,8 +25,8 @@ Cannot return `await p` because in type argument `R` [1]: `number` [2] is incomp
                   ^^^^^^^
 
 References:
-   <BUILTINS>/core.js:2285:24
-   2285| declare class Promise<+R = unknown> {
+   <BUILTINS>/core.js:2289:24
+   2289| declare class Promise<+R = unknown> {
                                 ^ [1]
    async.js:28:30
      28| async function f4(p: Promise<number>): Promise<boolean> {
@@ -99,8 +99,8 @@ incompatible with `void` [3]. [incompatible-type]
              ^^^^^^^^^^^^^^^ [3]
 
 References:
-   <BUILTINS>/core.js:2285:24
-   2285| declare class Promise<+R = unknown> {
+   <BUILTINS>/core.js:2289:24
+   2289| declare class Promise<+R = unknown> {
                                 ^ [1]
    async2.js:55:13
      55|   : Promise<number> { // error, number != void
@@ -142,8 +142,8 @@ Cannot return undefined because in type argument `R` [1]: `void` [2] is incompat
            ^^^^^^^ [2]
 
 References:
-   <BUILTINS>/core.js:2285:24
-   2285| declare class Promise<+R = unknown> {
+   <BUILTINS>/core.js:2289:24
+   2289| declare class Promise<+R = unknown> {
                                 ^ [1]
    async_return_void.js:1:32
       1| async function foo1(): Promise<string> {
@@ -160,8 +160,8 @@ Cannot return `undefined` because in type argument `R` [1]: `void` [2] is incomp
                   ^^^^^^^^^ [2]
 
 References:
-   <BUILTINS>/core.js:2285:24
-   2285| declare class Promise<+R = unknown> {
+   <BUILTINS>/core.js:2289:24
+   2289| declare class Promise<+R = unknown> {
                                 ^ [1]
    async_return_void.js:5:32
       5| async function foo2(): Promise<string> {
@@ -178,8 +178,8 @@ Cannot return `bar()` because in type argument `R` [1]: `void` [2] is incompatib
                   ^^^^^
 
 References:
-   <BUILTINS>/core.js:2285:24
-   2285| declare class Promise<+R = unknown> {
+   <BUILTINS>/core.js:2289:24
+   2289| declare class Promise<+R = unknown> {
                                 ^ [1]
    async_return_void.js:10:17
      10|   function bar() { }
@@ -229,8 +229,8 @@ References:
    generator.js:21:45
      21| async function *genError1(): AsyncGenerator<number, void, void> {
                                                      ^^^^^^ [2]
-   <BUILTINS>/core.js:2348:59
-   2348|       T extends ReadonlyArray<unknown> ? {[K in keyof T]: Awaited<T[K]>} :
+   <BUILTINS>/core.js:2352:59
+   2352|       T extends ReadonlyArray<unknown> ? {[K in keyof T]: Awaited<T[K]>} :
                                                                    ^^^^^^^^^^^^^ [3]
 
 
@@ -246,8 +246,8 @@ References:
    <BUILTINS>/core.js:2037:27
    2037| interface AsyncGenerator<+Yield,+Return,-Next> {
                                    ^^^^^ [1]
-   <BUILTINS>/core.js:2348:59
-   2348|       T extends ReadonlyArray<unknown> ? {[K in keyof T]: Awaited<T[K]>} :
+   <BUILTINS>/core.js:2352:59
+   2352|       T extends ReadonlyArray<unknown> ? {[K in keyof T]: Awaited<T[K]>} :
                                                                    ^^^^^^^^^^^^^ [2]
    generator.js:21:45
      21| async function *genError1(): AsyncGenerator<number, void, void> {

--- a/tests/async_component_syntax/async_component_syntax.exp
+++ b/tests/async_component_syntax/async_component_syntax.exp
@@ -37,8 +37,8 @@ Cannot return `result` because `Promise<string>` [1] is incompatible with `strin
                   ^^^^^^
 
 References:
-   <BUILTINS>/core.js:2285:15
-   2285| declare class Promise<+R = unknown> {
+   <BUILTINS>/core.js:2289:15
+   2289| declare class Promise<+R = unknown> {
                        ^^^^^^^ [1]
    test.js:45:28
      45| async hook useAsyncHook(): string {
@@ -55,8 +55,8 @@ Cannot return `await Promise.resolve(...)` because `Promise<"hello">` [1] is inc
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:2285:15
-   2285| declare class Promise<+R = unknown> {
+   <BUILTINS>/core.js:2289:15
+   2289| declare class Promise<+R = unknown> {
                        ^^^^^^^ [1]
    test.js:63:43
      63| export async hook useExportedAsyncHook(): string {

--- a/tests/async_component_syntax_disabled/async_component_syntax_disabled.exp
+++ b/tests/async_component_syntax_disabled/async_component_syntax_disabled.exp
@@ -31,8 +31,8 @@ Cannot return `result` because `Promise<string>` [1] is incompatible with `strin
                   ^^^^^^
 
 References:
-   <BUILTINS>/core.js:2285:15
-   2285| declare class Promise<+R = unknown> {
+   <BUILTINS>/core.js:2289:15
+   2289| declare class Promise<+R = unknown> {
                        ^^^^^^^ [1]
    test.js:8:28
       8| async hook useAsyncHook(): string { // ERROR: async hook syntax not enabled

--- a/tests/bigint/bigint.exp
+++ b/tests/bigint/bigint.exp
@@ -30,23 +30,23 @@ Cannot call `BigInt` with `null` bound to `value` because: [incompatible-type]
                 ^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:3122:18
-   3122|   static (value: boolean | string | number | bigint | interface {} | ReadonlyArray<unknown>): bigint;
+   <BUILTINS>/core.js:3126:18
+   3126|   static (value: boolean | string | number | bigint | interface {} | ReadonlyArray<unknown>): bigint;
                           ^^^^^^^ [2]
-   <BUILTINS>/core.js:3122:28
-   3122|   static (value: boolean | string | number | bigint | interface {} | ReadonlyArray<unknown>): bigint;
+   <BUILTINS>/core.js:3126:28
+   3126|   static (value: boolean | string | number | bigint | interface {} | ReadonlyArray<unknown>): bigint;
                                     ^^^^^^ [3]
-   <BUILTINS>/core.js:3122:37
-   3122|   static (value: boolean | string | number | bigint | interface {} | ReadonlyArray<unknown>): bigint;
+   <BUILTINS>/core.js:3126:37
+   3126|   static (value: boolean | string | number | bigint | interface {} | ReadonlyArray<unknown>): bigint;
                                              ^^^^^^ [4]
-   <BUILTINS>/core.js:3122:46
-   3122|   static (value: boolean | string | number | bigint | interface {} | ReadonlyArray<unknown>): bigint;
+   <BUILTINS>/core.js:3126:46
+   3126|   static (value: boolean | string | number | bigint | interface {} | ReadonlyArray<unknown>): bigint;
                                                       ^^^^^^ [5]
-   <BUILTINS>/core.js:3122:55
-   3122|   static (value: boolean | string | number | bigint | interface {} | ReadonlyArray<unknown>): bigint;
+   <BUILTINS>/core.js:3126:55
+   3126|   static (value: boolean | string | number | bigint | interface {} | ReadonlyArray<unknown>): bigint;
                                                                ^^^^^^^^^^^^ [6]
-   <BUILTINS>/core.js:3122:70
-   3122|   static (value: boolean | string | number | bigint | interface {} | ReadonlyArray<unknown>): bigint;
+   <BUILTINS>/core.js:3126:70
+   3126|   static (value: boolean | string | number | bigint | interface {} | ReadonlyArray<unknown>): bigint;
                                                                               ^^^^^^^^^^^^^^^^^^^^^^ [7]
 
 

--- a/tests/closure/closure.exp
+++ b/tests/closure/closure.exp
@@ -250,8 +250,8 @@ Cannot call `withDefaults` because `unknown` [1] is not a polymorphic type. [inc
          ^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:3195:43
-   3195| type Omit<O extends interface {}, Keys> = $Omit<O, Keys>;
+   <BUILTINS>/core.js:3199:43
+   3199| type Omit<O extends interface {}, Keys> = $Omit<O, Keys>;
                                                    ^^^^^^^^^^^^^^ [1]
 
 

--- a/tests/component_type/component_type.exp
+++ b/tests/component_type/component_type.exp
@@ -482,8 +482,8 @@ References:
    <BUILTINS>/react.js:106:19
     106|   type RefSetter<-T> =
                            ^ [1]
-   <BUILTINS>/core.js:2239:19
-   2239| declare class Set<T> extends $ReadOnlySet<T> {
+   <BUILTINS>/core.js:2243:19
+   2243| declare class Set<T> extends $ReadOnlySet<T> {
                            ^ [2]
    everything_implicit_instantiation.js:11:41
      11| C as component(ref: React.RefSetter<Set<number>>, foo: string, bar: number); // error
@@ -880,8 +880,8 @@ References:
    <BUILTINS>/react.js:106:19
     106|   type RefSetter<-T> =
                            ^ [1]
-   <BUILTINS>/core.js:2239:19
-   2239| declare class Set<T> extends $ReadOnlySet<T> {
+   <BUILTINS>/core.js:2243:19
+   2243| declare class Set<T> extends $ReadOnlySet<T> {
                            ^ [2]
    props_implicit_instantiation.js:12:41
      12| C as component(ref: React.RefSetter<Set<number>>, foo: string, bar: number); // error: number ~> string

--- a/tests/constructor_type/constructor_type.exp
+++ b/tests/constructor_type/constructor_type.exp
@@ -171,8 +171,8 @@ a subtype of an interface. [incompatible-type]
                                            ^^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:3161:38
-   3161| type ConstructorParameters<T extends new (...args: ReadonlyArray<empty>) => unknown> =
+   <BUILTINS>/core.js:3165:38
+   3165| type ConstructorParameters<T extends new (...args: ReadonlyArray<empty>) => unknown> =
                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [2]
 
 
@@ -186,8 +186,8 @@ return type is missing in statics of function type [1] but exists in interface t
                                   ^^^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:3165:29
-   3165| type InstanceType<T extends new (...args: ReadonlyArray<empty>) => unknown> =
+   <BUILTINS>/core.js:3169:29
+   3169| type InstanceType<T extends new (...args: ReadonlyArray<empty>) => unknown> =
                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [2]
 
 

--- a/tests/contextual_typing/contextual_typing.exp
+++ b/tests/contextual_typing/contextual_typing.exp
@@ -22,8 +22,8 @@ expression to your expected type. [underconstrained-implicit-instantiation]
                             ^^^
 
 References:
-   <BUILTINS>/core.js:2239:19
-   2239| declare class Set<T> extends $ReadOnlySet<T> {
+   <BUILTINS>/core.js:2243:19
+   2243| declare class Set<T> extends $ReadOnlySet<T> {
                            ^ [1]
    arr_rest.js:9:16
       9| const [...y] = new Set() // still error
@@ -485,8 +485,8 @@ Cannot cast `a` to `Set` because in type argument `T` [1]: `string` [2] is incom
            ^
 
 References:
-   <BUILTINS>/core.js:2239:19
-   2239| declare class Set<T> extends $ReadOnlySet<T> {
+   <BUILTINS>/core.js:2243:19
+   2243| declare class Set<T> extends $ReadOnlySet<T> {
                            ^ [1]
    implicit_instantiation.js:144:29
     144| function test12(foo: ?Array<string>) {
@@ -506,8 +506,8 @@ Cannot cast `b` to `Set` because in type argument `T` [1]: `string` [2] is incom
            ^
 
 References:
-   <BUILTINS>/core.js:2239:19
-   2239| declare class Set<T> extends $ReadOnlySet<T> {
+   <BUILTINS>/core.js:2243:19
+   2243| declare class Set<T> extends $ReadOnlySet<T> {
                            ^ [1]
    implicit_instantiation.js:144:29
     144| function test12(foo: ?Array<string>) {

--- a/tests/core_tests/core_tests.exp
+++ b/tests/core_tests/core_tests.exp
@@ -215,6 +215,126 @@ References:
                          ^^^^^^ [2]
 
 
+Error ----------------------------------------------------------------------------------------------------- map.js:41:19
+
+Cannot call `x.getOrInsert` with `123` bound to `key` because `123` [1] is incompatible with `string` [2].
+[incompatible-type]
+
+   map.js:41:19
+   41|     x.getOrInsert(123, 123); // error, wrong key type
+                         ^^^ [1]
+
+References:
+   map.js:39:19
+   39|   function(x: Map<string, number>) {
+                         ^^^^^^ [2]
+
+
+Error ----------------------------------------------------------------------------------------------------- map.js:42:26
+
+Cannot call `x.getOrInsert` with `'bar'` bound to `value` because `"bar"` [1] is incompatible with `number` [2].
+[incompatible-type]
+
+   map.js:42:26
+   42|     x.getOrInsert('foo', 'bar'); // error, wrong value type
+                                ^^^^^ [1]
+
+References:
+   map.js:39:27
+   39|   function(x: Map<string, number>) {
+                                 ^^^^^^ [2]
+
+
+Error ----------------------------------------------------------------------------------------------------- map.js:48:27
+
+Cannot call `x.getOrInsertComputed` with `123` bound to `key` because `123` [1] is incompatible with `string` [2].
+[incompatible-type]
+
+   map.js:48:27
+   48|     x.getOrInsertComputed(123, () => 123); // error, wrong key type
+                                 ^^^ [1]
+
+References:
+   map.js:39:19
+   39|   function(x: Map<string, number>) {
+                         ^^^^^^ [2]
+
+
+Error ----------------------------------------------------------------------------------------------------- map.js:49:40
+
+Cannot call `x.getOrInsertComputed` with function bound to `callbackfn` because in the return value: `"bar"` [1] is
+incompatible with `number` [2]. [incompatible-type]
+
+   map.js:49:40
+   49|     x.getOrInsertComputed('foo', () => 'bar'); // error, wrong value type
+                                              ^^^^^ [1]
+
+References:
+   map.js:39:27
+   39|   function(x: Map<string, number>) {
+                                 ^^^^^^ [2]
+
+
+Error ----------------------------------------------------------------------------------------------------- map.js:55:19
+
+Cannot call `x.getOrInsert` with `'foo'` bound to `key` because `"foo"` [1] is incompatible with `{foo: string}` [2].
+[incompatible-type]
+
+   map.js:55:19
+   55|     x.getOrInsert('foo', 123); // error, wrong key type
+                         ^^^^^ [1]
+
+References:
+   map.js:53:23
+   53|   function(x: WeakMap<{foo: string}, number>, key: {foo: string}) {
+                             ^^^^^^^^^^^^^ [2]
+
+
+Error ----------------------------------------------------------------------------------------------------- map.js:56:24
+
+Cannot call `x.getOrInsert` with `'bar'` bound to `value` because `"bar"` [1] is incompatible with `number` [2].
+[incompatible-type]
+
+   map.js:56:24
+   56|     x.getOrInsert(key, 'bar'); // error, wrong value type
+                              ^^^^^ [1]
+
+References:
+   map.js:53:38
+   53|   function(x: WeakMap<{foo: string}, number>, key: {foo: string}) {
+                                            ^^^^^^ [2]
+
+
+Error ----------------------------------------------------------------------------------------------------- map.js:62:27
+
+Cannot call `x.getOrInsertComputed` with `'foo'` bound to `key` because `"foo"` [1] is incompatible with
+`{foo: string}` [2]. [incompatible-type]
+
+   map.js:62:27
+   62|     x.getOrInsertComputed('foo', () => 123); // error, wrong key type
+                                 ^^^^^ [1]
+
+References:
+   map.js:53:23
+   53|   function(x: WeakMap<{foo: string}, number>, key: {foo: string}) {
+                             ^^^^^^^^^^^^^ [2]
+
+
+Error ----------------------------------------------------------------------------------------------------- map.js:63:38
+
+Cannot call `x.getOrInsertComputed` with function bound to `callbackfn` because in the return value: `"bar"` [1] is
+incompatible with `number` [2]. [incompatible-type]
+
+   map.js:63:38
+   63|     x.getOrInsertComputed(key, () => 'bar'); // error, wrong value type
+                                            ^^^^^ [1]
+
+References:
+   map.js:53:38
+   53|   function(x: WeakMap<{foo: string}, number>, key: {foo: string}) {
+                                            ^^^^^^ [2]
+
+
 Error ------------------------------------------------------------------------------------------------- weakref.js:17:23
 
 Cannot call `WeakRef` because in type argument `T`: [incompatible-type]
@@ -230,11 +350,11 @@ not shown. To see all branches, re-run Flow with --show-all-branches.
                                ^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:2109:28
-   2109| type WeaklyReferenceable = interface {} | ReadonlyArray<unknown>;
+   <BUILTINS>/core.js:2111:28
+   2111| type WeaklyReferenceable = interface {} | ReadonlyArray<unknown>;
                                     ^^^^^^^^^^^^ [2]
-   <BUILTINS>/core.js:2109:43
-   2109| type WeaklyReferenceable = interface {} | ReadonlyArray<unknown>;
+   <BUILTINS>/core.js:2111:43
+   2111| type WeaklyReferenceable = interface {} | ReadonlyArray<unknown>;
                                                    ^^^^^^^^^^^^^^^^^^^^^^ [3]
 
 
@@ -253,11 +373,11 @@ not shown. To see all branches, re-run Flow with --show-all-branches.
                                ^^^ [1]
 
 References:
-   <BUILTINS>/core.js:2109:28
-   2109| type WeaklyReferenceable = interface {} | ReadonlyArray<unknown>;
+   <BUILTINS>/core.js:2111:28
+   2111| type WeaklyReferenceable = interface {} | ReadonlyArray<unknown>;
                                     ^^^^^^^^^^^^ [2]
-   <BUILTINS>/core.js:2109:43
-   2109| type WeaklyReferenceable = interface {} | ReadonlyArray<unknown>;
+   <BUILTINS>/core.js:2111:43
+   2111| type WeaklyReferenceable = interface {} | ReadonlyArray<unknown>;
                                                    ^^^^^^^^^^^^^^^^^^^^^^ [3]
 
 
@@ -276,11 +396,11 @@ not shown. To see all branches, re-run Flow with --show-all-branches.
                                ^^^^^^^^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:2109:28
-   2109| type WeaklyReferenceable = interface {} | ReadonlyArray<unknown>;
+   <BUILTINS>/core.js:2111:28
+   2111| type WeaklyReferenceable = interface {} | ReadonlyArray<unknown>;
                                     ^^^^^^^^^^^^ [2]
-   <BUILTINS>/core.js:2109:43
-   2109| type WeaklyReferenceable = interface {} | ReadonlyArray<unknown>;
+   <BUILTINS>/core.js:2111:43
+   2111| type WeaklyReferenceable = interface {} | ReadonlyArray<unknown>;
                                                    ^^^^^^^^^^^^^^^^^^^^^^ [3]
 
 
@@ -299,11 +419,11 @@ not shown. To see all branches, re-run Flow with --show-all-branches.
                                 ^ [1]
 
 References:
-   <BUILTINS>/core.js:2109:28
-   2109| type WeaklyReferenceable = interface {} | ReadonlyArray<unknown>;
+   <BUILTINS>/core.js:2111:28
+   2111| type WeaklyReferenceable = interface {} | ReadonlyArray<unknown>;
                                     ^^^^^^^^^^^^ [2]
-   <BUILTINS>/core.js:2109:43
-   2109| type WeaklyReferenceable = interface {} | ReadonlyArray<unknown>;
+   <BUILTINS>/core.js:2111:43
+   2111| type WeaklyReferenceable = interface {} | ReadonlyArray<unknown>;
                                                    ^^^^^^^^^^^^^^^^^^^^^^ [3]
 
 
@@ -322,11 +442,11 @@ not shown. To see all branches, re-run Flow with --show-all-branches.
                                    ^ [1]
 
 References:
-   <BUILTINS>/core.js:2109:28
-   2109| type WeaklyReferenceable = interface {} | ReadonlyArray<unknown>;
+   <BUILTINS>/core.js:2111:28
+   2111| type WeaklyReferenceable = interface {} | ReadonlyArray<unknown>;
                                     ^^^^^^^^^^^^ [2]
-   <BUILTINS>/core.js:2109:43
-   2109| type WeaklyReferenceable = interface {} | ReadonlyArray<unknown>;
+   <BUILTINS>/core.js:2111:43
+   2111| type WeaklyReferenceable = interface {} | ReadonlyArray<unknown>;
                                                    ^^^^^^^^^^^^^^^^^^^^^^ [3]
 
 
@@ -345,11 +465,11 @@ not shown. To see all branches, re-run Flow with --show-all-branches.
                                       ^ [1]
 
 References:
-   <BUILTINS>/core.js:2109:28
-   2109| type WeaklyReferenceable = interface {} | ReadonlyArray<unknown>;
+   <BUILTINS>/core.js:2111:28
+   2111| type WeaklyReferenceable = interface {} | ReadonlyArray<unknown>;
                                     ^^^^^^^^^^^^ [2]
-   <BUILTINS>/core.js:2109:43
-   2109| type WeaklyReferenceable = interface {} | ReadonlyArray<unknown>;
+   <BUILTINS>/core.js:2111:43
+   2111| type WeaklyReferenceable = interface {} | ReadonlyArray<unknown>;
                                                    ^^^^^^^^^^^^^^^^^^^^^^ [3]
 
 
@@ -371,13 +491,13 @@ References:
    weakset.js:24:31
      24| function* numbers(): Iterable<number> {
                                        ^^^^^^ [1]
-   <BUILTINS>/core.js:2109:28
-   2109| type WeaklyReferenceable = interface {} | ReadonlyArray<unknown>;
+   <BUILTINS>/core.js:2111:28
+   2111| type WeaklyReferenceable = interface {} | ReadonlyArray<unknown>;
                                     ^^^^^^^^^^^^ [2]
-   <BUILTINS>/core.js:2109:43
-   2109| type WeaklyReferenceable = interface {} | ReadonlyArray<unknown>;
+   <BUILTINS>/core.js:2111:43
+   2111| type WeaklyReferenceable = interface {} | ReadonlyArray<unknown>;
                                                    ^^^^^^^^^^^^^^^^^^^^^^ [3]
 
 
 
-Found 17 errors
+Found 25 errors

--- a/tests/core_tests/map.js
+++ b/tests/core_tests/map.js
@@ -34,4 +34,32 @@ let tests = [
     x.get('foo') as boolean; // error, string | void
     x.get(123); // error, wrong key type
   },
+
+  // getOrInsert() and getOrInsertComputed()
+  function(x: Map<string, number>) {
+    x.getOrInsert('foo', 123) as number;
+    x.getOrInsert(123, 123); // error, wrong key type
+    x.getOrInsert('foo', 'bar'); // error, wrong value type
+
+    x.getOrInsertComputed('foo', key => {
+      key as string;
+      return 123;
+    }) as number;
+    x.getOrInsertComputed(123, () => 123); // error, wrong key type
+    x.getOrInsertComputed('foo', () => 'bar'); // error, wrong value type
+  },
+
+  // WeakMap getOrInsert() and getOrInsertComputed()
+  function(x: WeakMap<{foo: string}, number>, key: {foo: string}) {
+    x.getOrInsert(key, 123) as number;
+    x.getOrInsert('foo', 123); // error, wrong key type
+    x.getOrInsert(key, 'bar'); // error, wrong value type
+
+    x.getOrInsertComputed(key, callbackKey => {
+      callbackKey as {foo: string};
+      return 123;
+    }) as number;
+    x.getOrInsertComputed('foo', () => 123); // error, wrong key type
+    x.getOrInsertComputed(key, () => 'bar'); // error, wrong value type
+  },
 ];

--- a/tests/enums/enums.exp
+++ b/tests/enums/enums.exp
@@ -48,20 +48,20 @@ Cannot instantiate `EnumValue` because in type argument `TRepresentationType`: [
                           ^^^^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:3232:32
-   3232| type EnumRepresentationTypes = string | number | symbol | boolean | bigint;
+   <BUILTINS>/core.js:3236:32
+   3236| type EnumRepresentationTypes = string | number | symbol | boolean | bigint;
                                         ^^^^^^ [2]
-   <BUILTINS>/core.js:3232:41
-   3232| type EnumRepresentationTypes = string | number | symbol | boolean | bigint;
+   <BUILTINS>/core.js:3236:41
+   3236| type EnumRepresentationTypes = string | number | symbol | boolean | bigint;
                                                  ^^^^^^ [3]
-   <BUILTINS>/core.js:3232:50
-   3232| type EnumRepresentationTypes = string | number | symbol | boolean | bigint;
+   <BUILTINS>/core.js:3236:50
+   3236| type EnumRepresentationTypes = string | number | symbol | boolean | bigint;
                                                           ^^^^^^ [4]
-   <BUILTINS>/core.js:3232:59
-   3232| type EnumRepresentationTypes = string | number | symbol | boolean | bigint;
+   <BUILTINS>/core.js:3236:59
+   3236| type EnumRepresentationTypes = string | number | symbol | boolean | bigint;
                                                                    ^^^^^^^ [5]
-   <BUILTINS>/core.js:3232:69
-   3232| type EnumRepresentationTypes = string | number | symbol | boolean | bigint;
+   <BUILTINS>/core.js:3236:69
+   3236| type EnumRepresentationTypes = string | number | symbol | boolean | bigint;
                                                                              ^^^^^^ [6]
 
 
@@ -143,8 +143,8 @@ Cannot cast `x` to `EnumValue` because in the enum's representation type: `numbe
            ^
 
 References:
-   <BUILTINS>/core.js:3246:16
-   3246| > = $EnumValue<TRepresentationType>;
+   <BUILTINS>/core.js:3250:16
+   3250| > = $EnumValue<TRepresentationType>;
                         ^^^^^^^^^^^^^^^^^^^ [1]
    abstract-enum-value.js:35:18
      35|   x as EnumValue<boolean>; // ERROR
@@ -161,8 +161,8 @@ Cannot cast `x` to `EnumValue` because in the enum's representation type: `strin
            ^
 
 References:
-   <BUILTINS>/core.js:3246:16
-   3246| > = $EnumValue<TRepresentationType>;
+   <BUILTINS>/core.js:3250:16
+   3250| > = $EnumValue<TRepresentationType>;
                         ^^^^^^^^^^^^^^^^^^^ [1]
    abstract-enum-value.js:35:18
      35|   x as EnumValue<boolean>; // ERROR
@@ -234,8 +234,8 @@ Cannot instantiate `Enum` because in type argument `TEnumValue`: `boolean` [1] i
                        ^^^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:3263:31
-   3263| type Enum<+TEnumValue extends EnumValue<> = EnumValue<>> = $Enum<TEnumValue>;
+   <BUILTINS>/core.js:3267:31
+   3267| type Enum<+TEnumValue extends EnumValue<> = EnumValue<>> = $Enum<TEnumValue>;
                                        ^^^^^^^^^^^ [2]
 
 
@@ -266,11 +266,11 @@ Cannot cast `x` to `Enum` because in type argument `TEnumValue` [1] > type argum
            ^
 
 References:
-   <BUILTINS>/core.js:3263:12
-   3263| type Enum<+TEnumValue extends EnumValue<> = EnumValue<>> = $Enum<TEnumValue>;
+   <BUILTINS>/core.js:3267:12
+   3267| type Enum<+TEnumValue extends EnumValue<> = EnumValue<>> = $Enum<TEnumValue>;
                     ^^^^^^^^^^ [1]
-   <BUILTINS>/core.js:3245:4
-   3245|   +TRepresentationType extends EnumRepresentationTypes = EnumRepresentationTypes
+   <BUILTINS>/core.js:3249:4
+   3249|   +TRepresentationType extends EnumRepresentationTypes = EnumRepresentationTypes
             ^^^^^^^^^^^^^^^^^^^ [2]
    abstract-enum.js:15:35
      15|   declare const x: Enum<EnumValue<string>>;
@@ -290,8 +290,8 @@ Cannot cast `x` to `Enum` because in type argument `TEnumValue` [1]: enum [2] is
            ^
 
 References:
-   <BUILTINS>/core.js:3263:12
-   3263| type Enum<+TEnumValue extends EnumValue<> = EnumValue<>> = $Enum<TEnumValue>;
+   <BUILTINS>/core.js:3267:12
+   3267| type Enum<+TEnumValue extends EnumValue<> = EnumValue<>> = $Enum<TEnumValue>;
                     ^^^^^^^^^^ [1]
    abstract-enum.js:15:25
      15|   declare const x: Enum<EnumValue<string>>;
@@ -339,8 +339,8 @@ Cannot call `f` because in type argument `TEnumValue`: `true` [1] is incompatibl
            ^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:3263:31
-   3263| type Enum<+TEnumValue extends EnumValue<> = EnumValue<>> = $Enum<TEnumValue>;
+   <BUILTINS>/core.js:3267:31
+   3267| type Enum<+TEnumValue extends EnumValue<> = EnumValue<>> = $Enum<TEnumValue>;
                                        ^^^^^^^^^^^ [2]
 
 
@@ -2262,8 +2262,8 @@ incompatible with `void` [3]. [incompatible-type]
                                  ^^^^^^^^^^^^^^^ [3]
 
 References:
-   <BUILTINS>/core.js:2285:24
-   2285| declare class Promise<+R = unknown> {
+   <BUILTINS>/core.js:2289:24
+   2289| declare class Promise<+R = unknown> {
                                 ^ [1]
    exhaustive-check-implicit-return.js:208:33
     208| async function v(x: E): Promise<number> { // Error: switch isn't exhaustive
@@ -2405,8 +2405,8 @@ References:
    exhaustive-check.js:3:6
       3| enum E {
               ^ [3]
-   <BUILTINS>/core.js:3007:3
-   3007|   isValid(this: TEnum, input: ?TRepresentationType | TEnumValue): boolean,
+   <BUILTINS>/core.js:3011:3
+   3011|   isValid(this: TEnum, input: ?TRepresentationType | TEnumValue): boolean,
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [4]
 
 
@@ -3027,15 +3027,15 @@ Cannot get `E.nonExistent` because property `nonExistent` is missing in `$EnumPr
            ^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:3004:59
+   <BUILTINS>/core.js:3008:59
                                                                    v
-   3004| type $EnumProto<TEnum, TEnumValue, TRepresentationType> = {
-   3005|   cast(this: TEnum, input: ?TRepresentationType): void | TEnumValue,
-   3006|   getName(this: TEnum, input: TEnumValue): string,
-   3007|   isValid(this: TEnum, input: ?TRepresentationType | TEnumValue): boolean,
-   3008|   members(this: TEnum): Iterator<TEnumValue>,
-   3009|   __proto__: null,
-   3010| }
+   3008| type $EnumProto<TEnum, TEnumValue, TRepresentationType> = {
+   3009|   cast(this: TEnum, input: ?TRepresentationType): void | TEnumValue,
+   3010|   getName(this: TEnum, input: TEnumValue): string,
+   3011|   isValid(this: TEnum, input: ?TRepresentationType | TEnumValue): boolean,
+   3012|   members(this: TEnum): Iterator<TEnumValue>,
+   3013|   __proto__: null,
+   3014| }
          ^ [1]
 
 
@@ -3048,15 +3048,15 @@ Cannot call `E.nonExistent` because property `nonExistent` is missing in `$EnumP
            ^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:3004:59
+   <BUILTINS>/core.js:3008:59
                                                                    v
-   3004| type $EnumProto<TEnum, TEnumValue, TRepresentationType> = {
-   3005|   cast(this: TEnum, input: ?TRepresentationType): void | TEnumValue,
-   3006|   getName(this: TEnum, input: TEnumValue): string,
-   3007|   isValid(this: TEnum, input: ?TRepresentationType | TEnumValue): boolean,
-   3008|   members(this: TEnum): Iterator<TEnumValue>,
-   3009|   __proto__: null,
-   3010| }
+   3008| type $EnumProto<TEnum, TEnumValue, TRepresentationType> = {
+   3009|   cast(this: TEnum, input: ?TRepresentationType): void | TEnumValue,
+   3010|   getName(this: TEnum, input: TEnumValue): string,
+   3011|   isValid(this: TEnum, input: ?TRepresentationType | TEnumValue): boolean,
+   3012|   members(this: TEnum): Iterator<TEnumValue>,
+   3013|   __proto__: null,
+   3014| }
          ^ [1]
 
 
@@ -3083,15 +3083,15 @@ Cannot call `E.A` because property `A` is missing in `$EnumProto` [1]. [prop-mis
            ^
 
 References:
-   <BUILTINS>/core.js:3004:59
+   <BUILTINS>/core.js:3008:59
                                                                    v
-   3004| type $EnumProto<TEnum, TEnumValue, TRepresentationType> = {
-   3005|   cast(this: TEnum, input: ?TRepresentationType): void | TEnumValue,
-   3006|   getName(this: TEnum, input: TEnumValue): string,
-   3007|   isValid(this: TEnum, input: ?TRepresentationType | TEnumValue): boolean,
-   3008|   members(this: TEnum): Iterator<TEnumValue>,
-   3009|   __proto__: null,
-   3010| }
+   3008| type $EnumProto<TEnum, TEnumValue, TRepresentationType> = {
+   3009|   cast(this: TEnum, input: ?TRepresentationType): void | TEnumValue,
+   3010|   getName(this: TEnum, input: TEnumValue): string,
+   3011|   isValid(this: TEnum, input: ?TRepresentationType | TEnumValue): boolean,
+   3012|   members(this: TEnum): Iterator<TEnumValue>,
+   3013|   __proto__: null,
+   3014| }
          ^ [1]
 
 
@@ -3104,15 +3104,15 @@ Cannot call `E.toString` because property `toString` is missing in `$EnumProto` 
            ^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:3004:59
+   <BUILTINS>/core.js:3008:59
                                                                    v
-   3004| type $EnumProto<TEnum, TEnumValue, TRepresentationType> = {
-   3005|   cast(this: TEnum, input: ?TRepresentationType): void | TEnumValue,
-   3006|   getName(this: TEnum, input: TEnumValue): string,
-   3007|   isValid(this: TEnum, input: ?TRepresentationType | TEnumValue): boolean,
-   3008|   members(this: TEnum): Iterator<TEnumValue>,
-   3009|   __proto__: null,
-   3010| }
+   3008| type $EnumProto<TEnum, TEnumValue, TRepresentationType> = {
+   3009|   cast(this: TEnum, input: ?TRepresentationType): void | TEnumValue,
+   3010|   getName(this: TEnum, input: TEnumValue): string,
+   3011|   isValid(this: TEnum, input: ?TRepresentationType | TEnumValue): boolean,
+   3012|   members(this: TEnum): Iterator<TEnumValue>,
+   3013|   __proto__: null,
+   3014| }
          ^ [1]
 
 
@@ -3125,8 +3125,8 @@ Cannot cast `E.getName(...)` to boolean because `string` [1] is incompatible wit
          ^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:3006:44
-   3006|   getName(this: TEnum, input: TEnumValue): string,
+   <BUILTINS>/core.js:3010:44
+   3010|   getName(this: TEnum, input: TEnumValue): string,
                                                     ^^^^^^ [1]
    methods.js:44:19
      44| E.getName(E.B) as boolean; // Error - wrong type

--- a/tests/get_def_enums/get_def_enums.exp
+++ b/tests/get_def_enums/get_def_enums.exp
@@ -28,9 +28,9 @@ library.js:4:3,4:5
 
 main.js:27:13
 Flags:
-[LIB] core.js:3005:3,3005:6
+[LIB] core.js:3009:3,3009:6
 
 main.js:30:13
 Flags:
-[LIB] core.js:3007:3,3007:9
+[LIB] core.js:3011:3,3011:9
 

--- a/tests/lti_friendly_errors/lti_friendly_errors.exp
+++ b/tests/lti_friendly_errors/lti_friendly_errors.exp
@@ -8,11 +8,11 @@ Cannot cast `p` to `Promise` because in type argument `R` [1]: `unknown` [2] is 
          ^
 
 References:
-   <BUILTINS>/core.js:2285:24
-   2285| declare class Promise<+R = unknown> {
+   <BUILTINS>/core.js:2289:24
+   2289| declare class Promise<+R = unknown> {
                                 ^ [1]
-   <BUILTINS>/core.js:2285:28
-   2285| declare class Promise<+R = unknown> {
+   <BUILTINS>/core.js:2289:28
+   2289| declare class Promise<+R = unknown> {
                                     ^^^^^^^ [2]
    reason_of_inferred_targs.js:2:14
       2| p as Promise<string>; // error

--- a/tests/mapped_type_utilities/mapped_type_utilities.exp
+++ b/tests/mapped_type_utilities/mapped_type_utilities.exp
@@ -7,8 +7,8 @@ Cannot call `action` because `unknown` [1] is not a polymorphic type. [incompati
          ^^^^^^
 
 References:
-   <BUILTINS>/core.js:3195:43
-   3195| type Omit<O extends interface {}, Keys> = $Omit<O, Keys>;
+   <BUILTINS>/core.js:3199:43
+   3199| type Omit<O extends interface {}, Keys> = $Omit<O, Keys>;
                                                    ^^^^^^^^^^^^^^ [1]
 
 
@@ -21,8 +21,8 @@ Cannot call `actionNamespace.tools.action` because `unknown` [1] is not a polymo
                                ^^^^^^
 
 References:
-   <BUILTINS>/core.js:3195:43
-   3195| type Omit<O extends interface {}, Keys> = $Omit<O, Keys>;
+   <BUILTINS>/core.js:3199:43
+   3199| type Omit<O extends interface {}, Keys> = $Omit<O, Keys>;
                                                    ^^^^^^^^^^^^^^ [1]
 
 
@@ -231,8 +231,8 @@ https://flow.org/en/docs/faq/#why-cant-i-pass-a-string-to-a-function-that-takes-
          ^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:3195:43
-   3195| type Omit<O extends interface {}, Keys> = $Omit<O, Keys>;
+   <BUILTINS>/core.js:3199:43
+   3199| type Omit<O extends interface {}, Keys> = $Omit<O, Keys>;
                                                    ^^^^^^^^^^^^^^ [1]
    omit_inference.js:1:40
       1| function projectWithoutA<T extends {a: number, b: string}>(): Omit<T, 'a'> {
@@ -251,8 +251,8 @@ Cannot call `actionWithDefaults` because `unknown` [1] is not a polymorphic type
          ^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:3195:43
-   3195| type Omit<O extends interface {}, Keys> = $Omit<O, Keys>;
+   <BUILTINS>/core.js:3199:43
+   3199| type Omit<O extends interface {}, Keys> = $Omit<O, Keys>;
                                                    ^^^^^^^^^^^^^^ [1]
 
 
@@ -273,8 +273,8 @@ Cannot cast `pickedO1.bar` to string because `void` [1] is incompatible with `st
          ^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:3190:75
-   3190| type Pick<O extends interface {}, Keys extends keyof O> = {[key in Keys]: O[key]};
+   <BUILTINS>/core.js:3194:75
+   3194| type Pick<O extends interface {}, Keys extends keyof O> = {[key in Keys]: O[key]};
                                                                                    ^^^^^^ [1]
    pick.js:9:17
       9| pickedO1.bar as string; // ERROR bar is optional

--- a/tests/meta_property/meta_property.exp
+++ b/tests/meta_property/meta_property.exp
@@ -8,13 +8,13 @@ Cannot cast `import.meta` to number literal `1` because `Import$Meta` [1] is inc
          ^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:3115:20
+   <BUILTINS>/core.js:3119:20
                             v
-   3115| type Import$Meta = {
-   3116|   [string]: unknown,
-   3117|   url?: string,
-   3118|   ...
-   3119| };
+   3119| type Import$Meta = {
+   3120|   [string]: unknown,
+   3121|   url?: string,
+   3122|   ...
+   3123| };
          ^ [1]
    import_meta.js:5:16
       5| import.meta as 1; // Error
@@ -31,8 +31,8 @@ Cannot cast `import.meta.XXX` to number literal `1` because `unknown` [1] is inc
          ^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:3116:13
-   3116|   [string]: unknown,
+   <BUILTINS>/core.js:3120:13
+   3120|   [string]: unknown,
                      ^^^^^^^ [1]
    import_meta.js:6:20
       6| import.meta.XXX as 1; // Error

--- a/tests/natural_inference_primitive/natural_inference_primitive.exp
+++ b/tests/natural_inference_primitive/natural_inference_primitive.exp
@@ -2769,8 +2769,8 @@ Cannot call `Set` with array literal bound to `iterable` because: [incompatible-
                             ^^^^^ [1]
 
 References:
-   <BUILTINS>/core.js:2241:29
-   2241|     constructor(iterable?: ?Iterable<T>): void;
+   <BUILTINS>/core.js:2245:29
+   2245|     constructor(iterable?: ?Iterable<T>): void;
                                      ^^^^^^^^^^^ [2]
    <BUILTINS>/core.js:1880:30
    1880| interface $IteratorProtocol<+Yield,+Return=void,-Next=void> {

--- a/tests/new_env/new_env.exp
+++ b/tests/new_env/new_env.exp
@@ -219,12 +219,12 @@ Cannot call `Promise` because function [1] requires another argument. [incompati
                      ^^^^^^^
 
 References:
-   <BUILTINS>/core.js:2286:5
+   <BUILTINS>/core.js:2290:5
              v----------------------
-   2286|     constructor(callback: (
-   2287|       resolve: (result: Promise<R> | R) => void,
-   2288|       reject: (error: any) => void
-   2289|     ) => unknown): void;
+   2290|     constructor(callback: (
+   2291|       resolve: (result: Promise<R> | R) => void,
+   2292|       reject: (error: any) => void
+   2293|     ) => unknown): void;
              ------------------^ [1]
 
 

--- a/tests/new_merge/new_merge.exp
+++ b/tests/new_merge/new_merge.exp
@@ -310,8 +310,8 @@ Cannot cast `f15()` to empty because `Promise<void>` [1] is incompatible with `e
          ^^^^^
 
 References:
-   <BUILTINS>/core.js:2285:15
-   2285| declare class Promise<+R = unknown> {
+   <BUILTINS>/core.js:2289:15
+   2289| declare class Promise<+R = unknown> {
                        ^^^^^^^ [1]
    main.js:60:10
      60| f15() as empty;

--- a/tests/promises/promises.exp
+++ b/tests/promises/promises.exp
@@ -7,8 +7,8 @@ Cannot cast `a` to number because `string` [1] is incompatible with `number` [2]
            ^
 
 References:
-   <BUILTINS>/core.js:2348:59
-   2348|       T extends ReadonlyArray<unknown> ? {[K in keyof T]: Awaited<T[K]>} :
+   <BUILTINS>/core.js:2352:59
+   2352|       T extends ReadonlyArray<unknown> ? {[K in keyof T]: Awaited<T[K]>} :
                                                                    ^^^^^^^^^^^^^ [1]
    all.js:11:8
      11|   a as number;  // Error: string ~> number
@@ -24,8 +24,8 @@ Cannot cast `b` to boolean because `number` [1] is incompatible with `boolean` [
            ^
 
 References:
-   <BUILTINS>/core.js:2348:59
-   2348|       T extends ReadonlyArray<unknown> ? {[K in keyof T]: Awaited<T[K]>} :
+   <BUILTINS>/core.js:2352:59
+   2352|       T extends ReadonlyArray<unknown> ? {[K in keyof T]: Awaited<T[K]>} :
                                                                    ^^^^^^^^^^^^^ [1]
    all.js:12:8
      12|   b as boolean; // Error: number ~> boolean
@@ -41,8 +41,8 @@ Cannot cast `c` to string because `boolean` [1] is incompatible with `string` [2
            ^
 
 References:
-   <BUILTINS>/core.js:2348:59
-   2348|       T extends ReadonlyArray<unknown> ? {[K in keyof T]: Awaited<T[K]>} :
+   <BUILTINS>/core.js:2352:59
+   2352|       T extends ReadonlyArray<unknown> ? {[K in keyof T]: Awaited<T[K]>} :
                                                                    ^^^^^^^^^^^^^ [1]
    all.js:13:8
      13|   c as string;  // Error: boolean ~> string
@@ -58,8 +58,8 @@ Cannot cast `x` to undefined because `boolean` [1] is incompatible with `void` [
              ^
 
 References:
-   <BUILTINS>/core.js:2348:59
-   2348|       T extends ReadonlyArray<unknown> ? {[K in keyof T]: Awaited<T[K]>} :
+   <BUILTINS>/core.js:2352:59
+   2352|       T extends ReadonlyArray<unknown> ? {[K in keyof T]: Awaited<T[K]>} :
                                                                    ^^^^^^^^^^^^^ [1]
    all.js:17:10
      17|     x as void;  // Errors: string ~> void, number ~> void, boolean ~> void
@@ -75,8 +75,8 @@ Cannot cast `x` to undefined because `number` [1] is incompatible with `void` [2
              ^
 
 References:
-   <BUILTINS>/core.js:2348:59
-   2348|       T extends ReadonlyArray<unknown> ? {[K in keyof T]: Awaited<T[K]>} :
+   <BUILTINS>/core.js:2352:59
+   2352|       T extends ReadonlyArray<unknown> ? {[K in keyof T]: Awaited<T[K]>} :
                                                                    ^^^^^^^^^^^^^ [1]
    all.js:17:10
      17|     x as void;  // Errors: string ~> void, number ~> void, boolean ~> void
@@ -92,8 +92,8 @@ Cannot cast `x` to undefined because `string` [1] is incompatible with `void` [2
              ^
 
 References:
-   <BUILTINS>/core.js:2348:59
-   2348|       T extends ReadonlyArray<unknown> ? {[K in keyof T]: Awaited<T[K]>} :
+   <BUILTINS>/core.js:2352:59
+   2352|       T extends ReadonlyArray<unknown> ? {[K in keyof T]: Awaited<T[K]>} :
                                                                    ^^^^^^^^^^^^^ [1]
    all.js:17:10
      17|     x as void;  // Errors: string ~> void, number ~> void, boolean ~> void
@@ -109,12 +109,12 @@ Cannot call `Promise.all` because function [1] requires another argument. [incom
                  ^^^
 
 References:
-   <BUILTINS>/core.js:2347:5
+   <BUILTINS>/core.js:2351:5
              v-------------------------------------------------------------
-   2347|     static all<T extends Iterable<unknown>>(promises: T): Promise<
-   2348|       T extends ReadonlyArray<unknown> ? {[K in keyof T]: Awaited<T[K]>} :
-   2349|       T extends Iterable<infer V> ? Array<Awaited<V>> : any
-   2350|     >;
+   2351|     static all<T extends Iterable<unknown>>(promises: T): Promise<
+   2352|       T extends ReadonlyArray<unknown> ? {[K in keyof T]: Awaited<T[K]>} :
+   2353|       T extends Iterable<infer V> ? Array<Awaited<V>> : any
+   2354|     >;
              ^ [1]
 
 
@@ -142,12 +142,12 @@ Cannot call `Promise.allSettled` because function [1] requires another argument.
                  ^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:2357:5
+   <BUILTINS>/core.js:2361:5
              v--------------------------------------------------------------------
-   2357|     static allSettled<T extends Iterable<unknown>>(promises: T): Promise<
-   2358|       T extends ReadonlyArray<unknown> ? {[K in keyof T]: $SettledPromiseResult<Awaited<T[K]>>} :
-   2359|       T extends Iterable<infer V> ? Array<$SettledPromiseResult<Awaited<V>>> : any
-   2360|     >;
+   2361|     static allSettled<T extends Iterable<unknown>>(promises: T): Promise<
+   2362|       T extends ReadonlyArray<unknown> ? {[K in keyof T]: $SettledPromiseResult<Awaited<T[K]>>} :
+   2363|       T extends Iterable<infer V> ? Array<$SettledPromiseResult<Awaited<V>>> : any
+   2364|     >;
              ^ [1]
 
 
@@ -175,8 +175,8 @@ Cannot cast `first.status` to empty because `"rejected"` [1] is incompatible wit
                ^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:2382:12
-   2382|   +status: 'rejected',
+   <BUILTINS>/core.js:2386:12
+   2386|   +status: 'rejected',
                     ^^^^^^^^^^ [1]
    allSettled.js:31:23
      31|       first.status as empty // Error: 'rejected' case was not covered
@@ -192,8 +192,8 @@ Cannot call `second.value.foo` because property `foo` is missing in `Bar` [1]. [
                                       ^^^
 
 References:
-   <BUILTINS>/core.js:2358:81
-   2358|       T extends ReadonlyArray<unknown> ? {[K in keyof T]: $SettledPromiseResult<Awaited<T[K]>>} :
+   <BUILTINS>/core.js:2362:81
+   2362|       T extends ReadonlyArray<unknown> ? {[K in keyof T]: $SettledPromiseResult<Awaited<T[K]>>} :
                                                                                          ^^^^^^^^^^^^^ [1]
 
 
@@ -206,8 +206,8 @@ Cannot use function type [1] with fewer than 2 type arguments. [missing-type-arg
          ^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:2375:15
-   2375|     static any<T, Elem extends Promise<T> | T>(promises: Iterable<Elem>): Promise<T>;
+   <BUILTINS>/core.js:2379:15
+   2379|     static any<T, Elem extends Promise<T> | T>(promises: Iterable<Elem>): Promise<T>;
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 
@@ -220,8 +220,8 @@ Cannot call `Promise.any` because function [1] requires another argument. [incom
                  ^^^
 
 References:
-   <BUILTINS>/core.js:2375:5
-   2375|     static any<T, Elem extends Promise<T> | T>(promises: Iterable<Elem>): Promise<T>;
+   <BUILTINS>/core.js:2379:5
+   2379|     static any<T, Elem extends Promise<T> | T>(promises: Iterable<Elem>): Promise<T>;
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 
@@ -234,8 +234,8 @@ Cannot use function type [1] with fewer than 2 type arguments. [missing-type-arg
          ^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:2375:15
-   2375|     static any<T, Elem extends Promise<T> | T>(promises: Iterable<Elem>): Promise<T>;
+   <BUILTINS>/core.js:2379:15
+   2379|     static any<T, Elem extends Promise<T> | T>(promises: Iterable<Elem>): Promise<T>;
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 
@@ -250,8 +250,8 @@ subtype of an interface. [incompatible-type]
                                      ^ [1]
 
 References:
-   <BUILTINS>/core.js:2375:58
-   2375|     static any<T, Elem extends Promise<T> | T>(promises: Iterable<Elem>): Promise<T>;
+   <BUILTINS>/core.js:2379:58
+   2379|     static any<T, Elem extends Promise<T> | T>(promises: Iterable<Elem>): Promise<T>;
                                                                   ^^^^^^^^^^^^^^ [2]
 
 
@@ -633,8 +633,8 @@ Cannot cast `Promise.resolve()` to `Promise` because in type argument `R` [1]: `
          ^^^^^^^^^^^^^^^^^ [2]
 
 References:
-   <BUILTINS>/core.js:2285:24
-   2285| declare class Promise<+R = unknown> {
+   <BUILTINS>/core.js:2289:24
+   2289| declare class Promise<+R = unknown> {
                                 ^ [1]
    resolve_void.js:1:30
       1| Promise.resolve() as Promise<number>; // error
@@ -651,8 +651,8 @@ Cannot cast `Promise.resolve(...)` to `Promise` because in type argument `R` [1]
                          ^^^^^^^^^ [2]
 
 References:
-   <BUILTINS>/core.js:2285:24
-   2285| declare class Promise<+R = unknown> {
+   <BUILTINS>/core.js:2289:24
+   2289| declare class Promise<+R = unknown> {
                                 ^ [1]
    resolve_void.js:3:39
       3| Promise.resolve(undefined) as Promise<number>; // error

--- a/tests/provider_havoc/provider_havoc.exp
+++ b/tests/provider_havoc/provider_havoc.exp
@@ -231,8 +231,8 @@ References:
    provider_edge_cases.js:5:30
       5| if (((x: unknown) => 42) === console.log) { // constant-condition error
                                       ^^^^^^^^^^^ [2]
-   <BUILTINS>/core.js:2991:5
-   2991|     log(...data: Array<any>): void,
+   <BUILTINS>/core.js:2995:5
+   2995|     log(...data: Array<any>): void,
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [3]
 
 

--- a/tests/react/react.exp
+++ b/tests/react/react.exp
@@ -1043,8 +1043,8 @@ Cannot create `Resize` element because `unknown` [1] is not a polymorphic type. 
           ^^^^^^
 
 References:
-   <BUILTINS>/core.js:3195:43
-   3195| type Omit<O extends interface {}, Keys> = $Omit<O, Keys>;
+   <BUILTINS>/core.js:3199:43
+   3199| type Omit<O extends interface {}, Keys> = $Omit<O, Keys>;
                                                    ^^^^^^^^^^^^^^ [1]
 
 
@@ -1057,8 +1057,8 @@ Cannot call `takesConfig` because `unknown` [1] is not a polymorphic type. [inco
          ^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:3195:43
-   3195| type Omit<O extends interface {}, Keys> = $Omit<O, Keys>;
+   <BUILTINS>/core.js:3199:43
+   3199| type Omit<O extends interface {}, Keys> = $Omit<O, Keys>;
                                                    ^^^^^^^^^^^^^^ [1]
 
 

--- a/tests/react_16_6/react_16_6.exp
+++ b/tests/react_16_6/react_16_6.exp
@@ -88,8 +88,8 @@ Functions without statics are not compatible with objects.
                                           ^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:2285:24
-   2285| declare class Promise<+R = unknown> {
+   <BUILTINS>/core.js:2289:24
+   2289| declare class Promise<+R = unknown> {
                                 ^ [1]
    lazy.js:6:1
       6| function FunctionComponent(x: Props): React.Node { return null }
@@ -113,8 +113,8 @@ property `default` is missing in statics of `ClassComponent` [2] but exists in o
                                           ^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:2285:24
-   2285| declare class Promise<+R = unknown> {
+   <BUILTINS>/core.js:2289:24
+   2289| declare class Promise<+R = unknown> {
                                 ^ [1]
    lazy.js:7:7
       7| class ClassComponent extends React.Component<Props> {}

--- a/tests/records/records.exp
+++ b/tests/records/records.exp
@@ -274,8 +274,8 @@ Operation `Pick` [1] is not allowed on record `R` [2]. To fix, turn the record t
                              ^ [2]
 
 References:
-   <BUILTINS>/core.js:3190:60
-   3190| type Pick<O extends interface {}, Keys extends keyof O> = {[key in Keys]: O[key]};
+   <BUILTINS>/core.js:3194:60
+   3194| type Pick<O extends interface {}, Keys extends keyof O> = {[key in Keys]: O[key]};
                                                                     ^^^^^^^^^^^^^^^^^^^^^ [1]
 
 
@@ -289,8 +289,8 @@ Operation `Omit` [1] is not allowed on record `R` [2]. To fix, turn the record t
                              ^ [2]
 
 References:
-   <BUILTINS>/core.js:3195:43
-   3195| type Omit<O extends interface {}, Keys> = $Omit<O, Keys>;
+   <BUILTINS>/core.js:3199:43
+   3199| type Omit<O extends interface {}, Keys> = $Omit<O, Keys>;
                                                    ^^^^^^^^^^^^^^ [1]
 
 

--- a/tests/return/return.exp
+++ b/tests/return/return.exp
@@ -40,8 +40,8 @@ incompatible with `void` [3]. [incompatible-type]
                               ^^^^^^^^^^^^^^^ [3]
 
 References:
-   <BUILTINS>/core.js:2285:24
-   2285| declare class Promise<+R = unknown> {
+   <BUILTINS>/core.js:2289:24
+   2289| declare class Promise<+R = unknown> {
                                 ^ [1]
    implicit.js:7:30
       7| async function g2(): Promise<number> {}

--- a/tests/rust_port_async_scope/rust_port_async_scope.exp
+++ b/tests/rust_port_async_scope/rust_port_async_scope.exp
@@ -7,8 +7,8 @@ Cannot return `input + 1` because `Promise<number>` [1] is incompatible with `nu
                   ^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:2285:15
-   2285| declare class Promise<+R = unknown> {
+   <BUILTINS>/core.js:2289:15
+   2289| declare class Promise<+R = unknown> {
                        ^^^^^^^ [1]
    test.js:9:41
       9| async hook useAsyncData(input: number): number {
@@ -24,8 +24,8 @@ Cannot return `"hello"` because `Promise<"hello">` [1] is incompatible with `str
                   ^^^^^^^
 
 References:
-   <BUILTINS>/core.js:2285:15
-   2285| declare class Promise<+R = unknown> {
+   <BUILTINS>/core.js:2289:15
+   2289| declare class Promise<+R = unknown> {
                        ^^^^^^^ [1]
    test.js:13:26
      13| async hook useChained(): string {
@@ -41,8 +41,8 @@ Cannot return `42` because `Promise<42>` [1] is incompatible with `string` [2]. 
                   ^^
 
 References:
-   <BUILTINS>/core.js:2285:15
-   2285| declare class Promise<+R = unknown> {
+   <BUILTINS>/core.js:2289:15
+   2289| declare class Promise<+R = unknown> {
                        ^^^^^^^ [1]
    test.js:18:28
      18| async hook useBadReturn(): string {

--- a/tests/speculative_cast_in_return_hint/speculative_cast_in_return_hint.exp
+++ b/tests/speculative_cast_in_return_hint/speculative_cast_in_return_hint.exp
@@ -8,8 +8,8 @@ missing in `Headers` [2] but exists in `RequiredHeaders` [3]. [incompatible-type
                    ^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:2285:24
-   2285| declare class Promise<+R = unknown> {
+   <BUILTINS>/core.js:2289:24
+   2289| declare class Promise<+R = unknown> {
                                 ^ [1]
    lib.d.ts:14:21
      14|   readonly headers: Headers;

--- a/tests/string_type_utils/string_type_utils.exp
+++ b/tests/string_type_utils/string_type_utils.exp
@@ -311,8 +311,8 @@ Cannot use `StringPrefix` [1] without 1-2 type arguments. [missing-type-arg]
                        ^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:3212:18
-   3212| type StringPrefix<out P extends string, out R extends string = string> = `${P}${R}`;
+   <BUILTINS>/core.js:3216:18
+   3216| type StringPrefix<out P extends string, out R extends string = string> = `${P}${R}`;
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 
@@ -325,8 +325,8 @@ Cannot use `StringPrefix` [1] with fewer than 1 type argument. [missing-type-arg
                              ^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:3212:18
-   3212| type StringPrefix<out P extends string, out R extends string = string> = `${P}${R}`;
+   <BUILTINS>/core.js:3216:18
+   3216| type StringPrefix<out P extends string, out R extends string = string> = `${P}${R}`;
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 
@@ -339,8 +339,8 @@ Cannot use `StringPrefix` [1] with more than 2 type arguments. [extra-type-arg]
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:3212:18
-   3212| type StringPrefix<out P extends string, out R extends string = string> = `${P}${R}`;
+   <BUILTINS>/core.js:3216:18
+   3216| type StringPrefix<out P extends string, out R extends string = string> = `${P}${R}`;
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 
@@ -438,8 +438,8 @@ Cannot instantiate `StringPrefix` because in type argument `R`: `1` [1] is incom
                                                      ^ [1]
 
 References:
-   <BUILTINS>/core.js:3212:55
-   3212| type StringPrefix<out P extends string, out R extends string = string> = `${P}${R}`;
+   <BUILTINS>/core.js:3216:55
+   3216| type StringPrefix<out P extends string, out R extends string = string> = `${P}${R}`;
                                                                ^^^^^^ [2]
 
 
@@ -606,8 +606,8 @@ Cannot use `StringSuffix` [1] without 1-2 type arguments. [missing-type-arg]
                        ^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:3221:18
-   3221| type StringSuffix<out S extends string, out R extends string = string> = `${R}${S}`;
+   <BUILTINS>/core.js:3225:18
+   3225| type StringSuffix<out S extends string, out R extends string = string> = `${R}${S}`;
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 
@@ -620,8 +620,8 @@ Cannot use `StringSuffix` [1] with fewer than 1 type argument. [missing-type-arg
                              ^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:3221:18
-   3221| type StringSuffix<out S extends string, out R extends string = string> = `${R}${S}`;
+   <BUILTINS>/core.js:3225:18
+   3225| type StringSuffix<out S extends string, out R extends string = string> = `${R}${S}`;
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 
@@ -634,8 +634,8 @@ Cannot use `StringSuffix` [1] with more than 2 type arguments. [extra-type-arg]
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:3221:18
-   3221| type StringSuffix<out S extends string, out R extends string = string> = `${R}${S}`;
+   <BUILTINS>/core.js:3225:18
+   3225| type StringSuffix<out S extends string, out R extends string = string> = `${R}${S}`;
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]
 
 
@@ -732,8 +732,8 @@ Cannot instantiate `StringSuffix` because in type argument `R`: `1` [1] is incom
                                                      ^ [1]
 
 References:
-   <BUILTINS>/core.js:3221:55
-   3221| type StringSuffix<out S extends string, out R extends string = string> = `${R}${S}`;
+   <BUILTINS>/core.js:3225:55
+   3225| type StringSuffix<out S extends string, out R extends string = string> = `${R}${S}`;
                                                                ^^^^^^ [2]
 
 

--- a/tests/this_type/this_type.exp
+++ b/tests/this_type/this_type.exp
@@ -926,8 +926,8 @@ Cannot call `i16.set(...).copyWithin` because property `copyWithin` is missing i
                             ^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:2618:58
-   2618|     set(array: Array<T> | $TypedArray, offset?: number): void;
+   <BUILTINS>/core.js:2622:58
+   2622|     set(array: Array<T> | $TypedArray, offset?: number): void;
                                                                   ^^^^ [1]
 
 

--- a/tests/type_at_pos_react/type_at_pos_react.exp
+++ b/tests/type_at_pos_react/type_at_pos_react.exp
@@ -20,7 +20,7 @@ lazy_ref.js:19:9 = Promise<
 
 'ExactReactElement_DEPRECATED' defined at (lib) react.js:58:20
 'Node' defined at (lib) react.js:439:22
-'Promise' defined at (lib) core.js:2285:14
+'Promise' defined at (lib) core.js:2289:14
 'Props' defined at exports-component.js:5:5
 
 lazy_ref.js:19:9,19:9

--- a/tests/type_guards/type_guards.exp
+++ b/tests/type_guards/type_guards.exp
@@ -1570,8 +1570,8 @@ Cannot return `(typeof x) == "number"` because `Promise<boolean>` [1] is incompa
                   ^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:2285:15
-   2285| declare class Promise<+R = unknown> {
+   <BUILTINS>/core.js:2289:15
+   2289| declare class Promise<+R = unknown> {
                        ^^^^^^^ [1]
    invalid.js:28:35
      28| async function async(x: unknown): x is number { // error

--- a/tests/type_of_name/type_of_name.exp
+++ b/tests/type_of_name/type_of_name.exp
@@ -494,13 +494,13 @@ where
 
 Found exact match 'UserSummary' defined at complex_types.js:22:6,22:16 with type `type UserSummary = Pick<User, "name" | "email">` 
 where
-'Pick' is defined at [LIB] core.js:3190:6-9
+'Pick' is defined at [LIB] core.js:3194:6-9
 'User' is defined at complex_types.js:5:6-9 = {age: number, email: string, isAdmin: boolean, name: string}
 'UserSummary' is defined at complex_types.js:22:6-16
 
 Found exact match 'UserWithoutEmail' defined at complex_types.js:25:6,25:21 with type `type UserWithoutEmail = Omit<User, "email">` 
 where
-'Omit' is defined at [LIB] core.js:3195:6-9
+'Omit' is defined at [LIB] core.js:3199:6-9
 'User' is defined at complex_types.js:5:6-9 = {age: number, email: string, isAdmin: boolean, name: string}
 'UserWithoutEmail' is defined at complex_types.js:25:6-21
 
@@ -515,7 +515,7 @@ where
 
 Found exact match 'StatusMap' defined at complex_types.js:32:6,32:14 with type `type StatusMap = Record<"active" | "inactive" | "pending", number>` 
 where
-'Record' is defined at [LIB] core.js:3201:6-11
+'Record' is defined at [LIB] core.js:3205:6-11
 'StatusMap' is defined at complex_types.js:32:6-14
 
 
@@ -533,25 +533,25 @@ Found exact match 'ActiveStatus' defined at complex_types.js:40:6,40:17 with typ
 where
 'ActiveStatus' is defined at complex_types.js:40:6-17
 'AllStatus' is defined at complex_types.js:39:6-14 = "active" | "inactive" | "pending" | "deleted"
-'Exclude' is defined at [LIB] core.js:3169:6-12
+'Exclude' is defined at [LIB] core.js:3173:6-12
 
 Found exact match 'DangerStatus' defined at complex_types.js:41:6,41:17 with type `type DangerStatus = Extract<AllStatus, "inactive" | "deleted">` 
 where
 'AllStatus' is defined at complex_types.js:39:6-14 = "active" | "inactive" | "pending" | "deleted"
 'DangerStatus' is defined at complex_types.js:41:6-17
-'Extract' is defined at [LIB] core.js:3172:6-12
+'Extract' is defined at [LIB] core.js:3176:6-12
 
 
 === ReturnType, Parameters, Class ===
 Found exact match 'SampleReturn' defined at complex_types.js:45:6,45:17 with type `type SampleReturn = ReturnType<SampleFn>` 
 where
-'ReturnType' is defined at [LIB] core.js:3151:6-15
+'ReturnType' is defined at [LIB] core.js:3155:6-15
 'SampleFn' is defined at complex_types.js:44:6-13 = (x: string, y: number) => boolean
 'SampleReturn' is defined at complex_types.js:45:6-17
 
 Found exact match 'SampleParams' defined at complex_types.js:46:6,46:17 with type `type SampleParams = Parameters<SampleFn>` 
 where
-'Parameters' is defined at [LIB] core.js:3156:6-15
+'Parameters' is defined at [LIB] core.js:3160:6-15
 'SampleFn' is defined at complex_types.js:44:6-13 = (x: string, y: number) => boolean
 'SampleParams' is defined at complex_types.js:46:6-17
 
@@ -601,13 +601,13 @@ where
 === Promise Types ===
 Found exact match 'StringPromise' defined at complex_types.js:79:6,79:18 with type `type StringPromise = Promise<string>` 
 where
-'Promise' is defined at [LIB] core.js:2285:15-21
+'Promise' is defined at [LIB] core.js:2289:15-21
 'StringPromise' is defined at complex_types.js:79:6-18
 
 Found exact match 'NestedPromise' defined at complex_types.js:80:6,80:18 with type `type NestedPromise = Promise<Promise<number>>` 
 where
 'NestedPromise' is defined at complex_types.js:80:6-18
-'Promise' is defined at [LIB] core.js:2285:15-21
+'Promise' is defined at [LIB] core.js:2289:15-21
 
 
 === Readonly Collections ===
@@ -618,12 +618,12 @@ where
 Found exact match 'ReadOnlyMap_t' defined at complex_types.js:85:6,85:18 with type `type ReadOnlyMap_t = ReadonlyMap<string, number>` 
 where
 'ReadOnlyMap_t' is defined at complex_types.js:85:6-18
-'ReadonlyMap' is defined at [LIB] core.js:3224:6-16
+'ReadonlyMap' is defined at [LIB] core.js:3228:6-16
 
 Found exact match 'ReadOnlySet_t' defined at complex_types.js:86:6,86:18 with type `type ReadOnlySet_t = ReadonlySet<string>` 
 where
 'ReadOnlySet_t' is defined at complex_types.js:86:6-18
-'ReadonlySet' is defined at [LIB] core.js:3226:6-16
+'ReadonlySet' is defined at [LIB] core.js:3230:6-16
 
 
 === Interfaces ===
@@ -689,7 +689,7 @@ where
 === Conditional Types ===
 Found exact match 'UnwrapPromise' defined at complex_types.js:125:6,125:18 with type `type UnwrapPromise<T> = T extends Promise<infer V> ? V : T` 
 where
-'Promise' is defined at [LIB] core.js:2285:15-21
+'Promise' is defined at [LIB] core.js:2289:15-21
 'UnwrapPromise' is defined at complex_types.js:125:6-18
 'V' is defined at complex_types.js:125:49
 
@@ -716,7 +716,7 @@ where
 Found exact match 'AsyncFn' defined at complex_types.js:145:6,145:12 with type `type AsyncFn<T> = () => Promise<T>` 
 where
 'AsyncFn' is defined at complex_types.js:145:6-12
-'Promise' is defined at [LIB] core.js:2285:15-21
+'Promise' is defined at [LIB] core.js:2289:15-21
 
 
 === Nested/Deep Object Types ===
@@ -786,18 +786,18 @@ where
 Found exact match 'DataAttr' defined at complex_types.js:199:6,199:13 with type `type DataAttr = StringPrefix<"data-">` 
 where
 'DataAttr' is defined at complex_types.js:199:6-13
-'StringPrefix' is defined at [LIB] core.js:3212:6-17
+'StringPrefix' is defined at [LIB] core.js:3216:6-17
 
 Found exact match 'ExclaimStr' defined at complex_types.js:200:6,200:15 with type `type ExclaimStr = StringSuffix<"!">` 
 where
 'ExclaimStr' is defined at complex_types.js:200:6-15
-'StringSuffix' is defined at [LIB] core.js:3221:6-17
+'StringSuffix' is defined at [LIB] core.js:3225:6-17
 
 Found exact match 'CSSVar' defined at complex_types.js:201:6,201:11 with type `type CSSVar = StringPrefix<"var(--"> & StringSuffix<")">` 
 where
 'CSSVar' is defined at complex_types.js:201:6-11
-'StringPrefix' is defined at [LIB] core.js:3212:6-17
-'StringSuffix' is defined at [LIB] core.js:3221:6-17
+'StringPrefix' is defined at [LIB] core.js:3216:6-17
+'StringSuffix' is defined at [LIB] core.js:3225:6-17
 
 
 === Mapped Types over Tuples ===

--- a/tests/type_param_variance2/type_param_variance2.exp
+++ b/tests/type_param_variance2/type_param_variance2.exp
@@ -8,8 +8,8 @@ surprising behaviors. [libdef-override]
                        ^^^^^^^
 
 References:
-   <BUILTINS>/core.js:2285:15
-   2285| declare class Promise<+R = unknown> {
+   <BUILTINS>/core.js:2289:15
+   2289| declare class Promise<+R = unknown> {
                        ^^^^^^^ [1]
 
 

--- a/tests/unused_promise/unused_promise.exp
+++ b/tests/unused_promise/unused_promise.exp
@@ -106,8 +106,8 @@ out-of-bounds array accesses, etc.). If the check is valid, you might want to ma
              ^^^^^^^^^^^^^^^^^^^^^
 
 References:
-   <BUILTINS>/core.js:2319:8
-   2319|     ): Promise<R | U>;
+   <BUILTINS>/core.js:2323:8
+   2323|     ): Promise<R | U>;
                 ^^^^^^^^^^^^^^ [1]
 
 

--- a/website/tests/snapshots/lang/annotation-requirement.exp
+++ b/website/tests/snapshots/lang/annotation-requirement.exp
@@ -125,8 +125,8 @@ expression to your expected type. [underconstrained-implicit-instantiation]
                          ^^^
 
 References:
-   <BUILTINS>/core.js:2239:19
-   2239| declare class Set<T> extends $ReadOnlySet<T> {
+   <BUILTINS>/core.js:2243:19
+   2243| declare class Set<T> extends $ReadOnlySet<T> {
                            ^ [1]
    -:2:13
       2| const set = new Set(); // Error


### PR DESCRIPTION
Summary:

Adds the ES2026 Map methods to the typedefs:

- `Map.prototype.getOrInsert`
- `Map.prototype.getOrInsertComputed`
- `WeakMap.prototype.getOrInsert`
- `WeakMap.prototype.getOrInsertComputed`

These are all baseline 2026 (newly available) and thus work on all modern browsers.

Differential Revision: D115601120
