### PR TITLE
[flow-api-translator] Translate `declare module.exports` to TS `export =`

### DIFF
--- a/packages/flow-api-translator/__tests__/flowDefToTSDef/fixtures/export/module-exports/identifier/type-alias/spec.js
+++ b/packages/flow-api-translator/__tests__/flowDefToTSDef/fixtures/export/module-exports/identifier/type-alias/spec.js
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+declare type Foo = {};
+declare module.exports: Foo;

--- a/packages/flow-api-translator/__tests__/flowDefToTSDef/fixtures/export/module-exports/identifier/type-alias/translate-result.shot
+++ b/packages/flow-api-translator/__tests__/flowDefToTSDef/fixtures/export/module-exports/identifier/type-alias/translate-result.shot
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`flowDefToTSDef export/module-exports/declare 1`] = `
+exports[`flowDefToTSDef export/module-exports/identifier/type-alias 1`] = `
 "/**
  * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
@@ -11,7 +11,8 @@ exports[`flowDefToTSDef export/module-exports/declare 1`] = `
  * @format
  */
 
-declare const $$MODULE_EXPORTS$$: () => void;
+declare type Foo = {};
+declare const $$MODULE_EXPORTS$$: Foo;
 declare type $$MODULE_EXPORTS$$ = typeof $$MODULE_EXPORTS$$;
 export = $$MODULE_EXPORTS$$;
 "

--- a/packages/flow-api-translator/__tests__/flowDefToTSDef/fixtures/export/module-exports/named-exports/spec.js
+++ b/packages/flow-api-translator/__tests__/flowDefToTSDef/fixtures/export/module-exports/named-exports/spec.js
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+export type Foo = string;
+declare module.exports: {bar: number};

--- a/packages/flow-api-translator/__tests__/flowDefToTSDef/fixtures/export/module-exports/named-exports/translate-result.shot
+++ b/packages/flow-api-translator/__tests__/flowDefToTSDef/fixtures/export/module-exports/named-exports/translate-result.shot
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`flowDefToTSDef export/module-exports/named-exports 1`] = `
+[ExpectedTranslationError: 
+> 12 | declare module.exports: {bar: number};
+     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ CommonJS exports cannot be combined with ES module exports.]
+`;

--- a/packages/flow-api-translator/__tests__/flowDefToTSDef/fixtures/export/module-exports/object/spec.js
+++ b/packages/flow-api-translator/__tests__/flowDefToTSDef/fixtures/export/module-exports/object/spec.js
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+declare function foo(): void;
+declare module.exports: {foo: typeof foo};

--- a/packages/flow-api-translator/__tests__/flowDefToTSDef/fixtures/export/module-exports/object/translate-result.shot
+++ b/packages/flow-api-translator/__tests__/flowDefToTSDef/fixtures/export/module-exports/object/translate-result.shot
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`flowDefToTSDef export/module-exports/declare 1`] = `
+exports[`flowDefToTSDef export/module-exports/object 1`] = `
 "/**
  * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
@@ -11,7 +11,8 @@ exports[`flowDefToTSDef export/module-exports/declare 1`] = `
  * @format
  */
 
-declare const $$MODULE_EXPORTS$$: () => void;
+declare function foo(): void;
+declare const $$MODULE_EXPORTS$$: {foo: typeof foo};
 declare type $$MODULE_EXPORTS$$ = typeof $$MODULE_EXPORTS$$;
 export = $$MODULE_EXPORTS$$;
 "

--- a/packages/flow-api-translator/__tests__/flowDefToTSDef/fixtures/export/module-exports/typeof/class/spec.js
+++ b/packages/flow-api-translator/__tests__/flowDefToTSDef/fixtures/export/module-exports/typeof/class/spec.js
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+declare class Foo {}
+declare module.exports: typeof Foo;

--- a/packages/flow-api-translator/__tests__/flowDefToTSDef/fixtures/export/module-exports/typeof/class/translate-result.shot
+++ b/packages/flow-api-translator/__tests__/flowDefToTSDef/fixtures/export/module-exports/typeof/class/translate-result.shot
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`flowDefToTSDef export/module-exports/declare 1`] = `
+exports[`flowDefToTSDef export/module-exports/typeof/class 1`] = `
 "/**
  * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
@@ -11,8 +11,7 @@ exports[`flowDefToTSDef export/module-exports/declare 1`] = `
  * @format
  */
 
-declare const $$MODULE_EXPORTS$$: () => void;
-declare type $$MODULE_EXPORTS$$ = typeof $$MODULE_EXPORTS$$;
-export = $$MODULE_EXPORTS$$;
+declare class Foo {}
+export = Foo;
 "
 `;

--- a/packages/flow-api-translator/__tests__/flowDefToTSDef/fixtures/export/module-exports/typeof/function/spec.js
+++ b/packages/flow-api-translator/__tests__/flowDefToTSDef/fixtures/export/module-exports/typeof/function/spec.js
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+declare function foo(): void;
+declare module.exports: typeof foo;

--- a/packages/flow-api-translator/__tests__/flowDefToTSDef/fixtures/export/module-exports/typeof/function/translate-result.shot
+++ b/packages/flow-api-translator/__tests__/flowDefToTSDef/fixtures/export/module-exports/typeof/function/translate-result.shot
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`flowDefToTSDef export/module-exports/declare 1`] = `
+exports[`flowDefToTSDef export/module-exports/typeof/function 1`] = `
 "/**
  * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
@@ -11,7 +11,8 @@ exports[`flowDefToTSDef export/module-exports/declare 1`] = `
  * @format
  */
 
-declare const $$MODULE_EXPORTS$$: () => void;
+declare function foo(): void;
+declare const $$MODULE_EXPORTS$$: typeof foo;
 declare type $$MODULE_EXPORTS$$ = typeof $$MODULE_EXPORTS$$;
 export = $$MODULE_EXPORTS$$;
 "

--- a/packages/flow-api-translator/__tests__/flowDefToTSDef/fixtures/export/module-exports/typeof/import/spec.js
+++ b/packages/flow-api-translator/__tests__/flowDefToTSDef/fixtures/export/module-exports/typeof/import/spec.js
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import Foo from './foo';
+declare module.exports: typeof Foo;

--- a/packages/flow-api-translator/__tests__/flowDefToTSDef/fixtures/export/module-exports/typeof/import/translate-result.shot
+++ b/packages/flow-api-translator/__tests__/flowDefToTSDef/fixtures/export/module-exports/typeof/import/translate-result.shot
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`flowDefToTSDef export/module-exports/declare 1`] = `
+exports[`flowDefToTSDef export/module-exports/typeof/import 1`] = `
 "/**
  * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
@@ -11,7 +11,8 @@ exports[`flowDefToTSDef export/module-exports/declare 1`] = `
  * @format
  */
 
-declare const $$MODULE_EXPORTS$$: () => void;
+import Foo from './foo';
+declare const $$MODULE_EXPORTS$$: typeof Foo;
 declare type $$MODULE_EXPORTS$$ = typeof $$MODULE_EXPORTS$$;
 export = $$MODULE_EXPORTS$$;
 "

--- a/packages/flow-api-translator/src/flowDefToTSDef.js
+++ b/packages/flow-api-translator/src/flowDefToTSDef.js
@@ -830,6 +830,83 @@ const getTransforms = (
     }
   };
 
+  /*
+  Flow can export a bare type, eg
+  ```
+  declare export default TypeName;
+  declare module.exports: TypeName;
+  ```
+  but TS can only export values, so declare a temporary variable to hold the
+  type and reference that in the export declaration:
+  ```
+  declare const SPECIFIER: TypeName;
+  declare type SPECIFIER = typeof SPECIFIER;
+  ```
+  */
+  const declareTypeAsVariable = (
+    specifier: string,
+    type: FlowESTree.TypeAnnotationType,
+  ): [TSESTree.VariableDeclaration, TSESTree.TSTypeAliasDeclaration] => [
+    {
+      type: 'VariableDeclaration',
+      loc: DUMMY_LOC,
+      declarations: [
+        {
+          type: 'VariableDeclarator',
+          loc: DUMMY_LOC,
+          id: {
+            type: 'Identifier',
+            loc: DUMMY_LOC,
+            name: specifier,
+            typeAnnotation: {
+              type: 'TSTypeAnnotation',
+              loc: DUMMY_LOC,
+              typeAnnotation: transformTypeAnnotationType(type),
+            },
+          },
+          init: null,
+        },
+      ],
+      declare: true,
+      kind: 'const',
+    },
+    {
+      type: 'TSTypeAliasDeclaration',
+      declare: true,
+      id: {
+        type: 'Identifier',
+        decorators: [],
+        name: specifier,
+        optional: false,
+        loc: DUMMY_LOC,
+      },
+      typeAnnotation: {
+        type: 'TSTypeQuery',
+        exprName: {
+          type: 'Identifier',
+          decorators: [],
+          name: specifier,
+          optional: false,
+          loc: DUMMY_LOC,
+        },
+        loc: DUMMY_LOC,
+      },
+      loc: DUMMY_LOC,
+    },
+  ];
+
+  // Whether `name` is bound at the top level by a class declaration, which is
+  // the one case where `typeof name` can be re-exported as `name` itself and
+  // keep both its value and its type meaning.
+  const isDeclaredClass = (name: string): boolean => {
+    const exportedVar = topScope.set.get(name);
+    return (
+      exportedVar != null &&
+      exportedVar.defs.length === 1 &&
+      exportedVar.defs[0].type === 'ClassName'
+    );
+  };
+
   const wellKnownSymbols = new Set([
     'iterator',
     'asyncIterator',
@@ -1332,97 +1409,30 @@ const getTransforms = (
           case 'TypeofTypeAnnotation': {
             if (
               declaration.type === 'TypeofTypeAnnotation' &&
-              declaration.argument.type === 'Identifier'
+              declaration.argument.type === 'Identifier' &&
+              isDeclaredClass(declaration.argument.name)
             ) {
-              const name = declaration.argument.name;
-              const exportedVar = topScope.set.get(name);
-              if (exportedVar != null && exportedVar.defs.length === 1) {
-                const def = exportedVar.defs[0];
-
-                switch (def.type) {
-                  case 'ClassName': {
-                    return {
-                      type: 'ExportDefaultDeclaration',
-                      declaration: {
-                        type: 'Identifier',
-                        decorators: [],
-                        name,
-                        optional: false,
-                        loc: DUMMY_LOC,
-                      },
-                      exportKind: 'value',
-                      loc: DUMMY_LOC,
-                    };
-                  }
-                }
-              }
+              return {
+                type: 'ExportDefaultDeclaration',
+                declaration: {
+                  type: 'Identifier',
+                  decorators: [],
+                  name: declaration.argument.name,
+                  optional: false,
+                  loc: DUMMY_LOC,
+                },
+                exportKind: 'value',
+                loc: DUMMY_LOC,
+              };
             }
 
             // intentional fallthrough to the "default" handling
           }
 
           default: {
-            /*
-            flow allows syntax like
-            ```
-            declare export default TypeName;
-            ```
-            but TS does not, so we have to declare a temporary variable to
-            reference in the export declaration:
-            ```
-            declare const $$EXPORT_DEFAULT_DECLARATION$$: TypeName;
-            export default $$EXPORT_DEFAULT_DECLARATION$$;
-            ```
-            */
             const SPECIFIER = '$$EXPORT_DEFAULT_DECLARATION$$';
             return [
-              {
-                type: 'VariableDeclaration',
-                loc: DUMMY_LOC,
-                declarations: [
-                  {
-                    type: 'VariableDeclarator',
-                    loc: DUMMY_LOC,
-                    id: {
-                      type: 'Identifier',
-                      loc: DUMMY_LOC,
-                      name: SPECIFIER,
-                      typeAnnotation: {
-                        type: 'TSTypeAnnotation',
-                        loc: DUMMY_LOC,
-                        typeAnnotation:
-                          transformTypeAnnotationType(declaration),
-                      },
-                    },
-                    init: null,
-                  },
-                ],
-                declare: true,
-                kind: 'const',
-              },
-              {
-                type: 'TSTypeAliasDeclaration',
-                declare: true,
-                id: {
-                  type: 'Identifier',
-                  decorators: [],
-                  name: SPECIFIER,
-                  optional: false,
-                  loc: DUMMY_LOC,
-                },
-                typeAnnotation: {
-                  type: 'TSTypeQuery',
-                  exprName: {
-                    type: 'Identifier',
-                    decorators: [],
-                    name: SPECIFIER,
-                    optional: false,
-                    loc: DUMMY_LOC,
-                  },
-                  loc: DUMMY_LOC,
-                },
-                loc: DUMMY_LOC,
-              },
+              ...declareTypeAsVariable(SPECIFIER, declaration),
               {
                 type: 'ExportDefaultDeclaration',
                 loc: DUMMY_LOC,
@@ -1974,8 +1984,65 @@ const getTransforms = (
     },
     DeclareModuleExports(
       node: FlowESTree.DeclareModuleExports,
-    ): TSESTree.TypeNode {
-      throw translationError(node, 'CommonJS exports are not supported.');
+    ):
+      | TSESTree.TSExportAssignment
+      | [
+          TSESTree.VariableDeclaration,
+          TSESTree.TSTypeAliasDeclaration,
+          TSESTree.TSExportAssignment,
+        ] {
+      // TS forbids `export = ` in a module that has any other export, so a
+      // module combining the two has no faithful translation.
+      if (
+        node.parent.type === 'Program' &&
+        node.parent.body.some(
+          statement =>
+            statement.type === 'DeclareExportAllDeclaration' ||
+            statement.type === 'DeclareExportDeclaration' ||
+            statement.type === 'ExportAllDeclaration' ||
+            statement.type === 'ExportDefaultDeclaration' ||
+            statement.type === 'ExportNamedDeclaration',
+        )
+      ) {
+        throw translationError(
+          node,
+          'CommonJS exports cannot be combined with ES module exports.',
+        );
+      }
+
+      // `declare module.exports: T` is TS's `export = <value>`, which - like
+      // `export default` - can only name a value.
+      const type = node.typeAnnotation.typeAnnotation;
+
+      if (
+        type.type === 'TypeofTypeAnnotation' &&
+        type.argument.type === 'Identifier' &&
+        isDeclaredClass(type.argument.name)
+      ) {
+        return {
+          type: 'TSExportAssignment',
+          loc: DUMMY_LOC,
+          expression: {
+            type: 'Identifier',
+            loc: DUMMY_LOC,
+            name: type.argument.name,
+          },
+        };
+      }
+
+      const SPECIFIER = '$$MODULE_EXPORTS$$';
+      return [
+        ...declareTypeAsVariable(SPECIFIER, type),
+        {
+          type: 'TSExportAssignment',
+          loc: DUMMY_LOC,
+          expression: {
+            type: 'Identifier',
+            loc: DUMMY_LOC,
+            name: SPECIFIER,
+          },
+        },
+      ];
     },
     ExistsTypeAnnotation(
       node: FlowESTree.ExistsTypeAnnotation,


### PR DESCRIPTION
`flowDefToTSDef` throws `CommonJS exports are not supported.` for any module using CommonJS exports. Metro still has a few stubborn ones (entry points that register Babel, CLIs, lazy re-exports), and currently we have to hand-maintain `.d.ts` files for those modules - it'd be very handy for the translator to take over.

It turns out Flow -> Flow declarations handles CommonJS fine, the gap is just Flow decl -> TS decl.

TypeScript's analogue of `declare module.exports`.is [`export = <value>`](https://www.typescriptlang.org/docs/handbook/modules/reference.html#export--and-import--require) (must be the module's only export). Like `export default` it can only name a value, not a bare type. That's the problem `declare export default` already solves by binding the type to a synthetic `$$EXPORT_DEFAULT_DECLARATION$$`, so this reuses much of the same code with a refactor to lift it to a reusable position.

With this change:

```js
declare class Foo {}
declare module.exports: typeof Foo;
```
translates to
```ts
declare class Foo {}
export = Foo;
```
and
```js
declare type Foo = {};
declare module.exports: Foo;
```
translates to
```ts
declare type Foo = {};
declare const $$MODULE_EXPORTS$$: Foo;
declare type $$MODULE_EXPORTS$$ = typeof $$MODULE_EXPORTS$$;
export = $$MODULE_EXPORTS$$;
```

The variable-binding block and the `typeof <class>` scope lookup are factored out of the `declare export default` handler as `declareTypeAsVariable` and `isDeclaredClass`. `export default` output is unchanged.

`TSExportAssignment` is already handled in the other direction by `TSDefToFlowDef`, so this closes the round trip.

One case still has no faithful translation: TS forbids `export = ` in a module with any other export, so `declare module.exports` alongside named exports now throws rather than emitting a `.d.ts` that fails to compile with TS2309. Expressing that needs `declare namespace` merging, which I've left alone.

Changelog:
[Feature] api-translator: Support translating `declare module.exports` from Flow to TypeScript

Test plan:

New fixtures under `export/module-exports` cover the class fast path, the synthetic binding (function type, type alias, object type, `typeof` of an imported value and of a declared function), and the named-exports error. The pre-existing `export/module-exports/declare` fixture flips from the "not supported" error to a translation.

```
$ yarn test flowDefToTSDef
...
    ✓ export/module-exports/declare (1 ms)
    ✓ export/module-exports/identifier/type-alias
    ✓ export/module-exports/named-exports (1 ms)
    ✓ export/module-exports/object (1 ms)
    ✓ export/module-exports/typeof/class
    ✓ export/module-exports/typeof/function (1 ms)
    ✓ export/module-exports/typeof/import
...
Test Suites: 1 passed, 1 total
Tests:       201 passed, 201 total
Snapshots:   200 passed, 200 total
```

All of `flow-api-translator`, to confirm the `export default` refactor is inert:

```
$ yarn test flow-api-translator
PASS flow-api-translator/__tests__/flowImportTo-test.js
PASS flow-api-translator/__tests__/flowToFlowDef-test.js
PASS flow-api-translator/__tests__/flowToJS/flowToJS-test.js
PASS flow-api-translator/__tests__/TSDefToFlowDef/TSDefToFlowDef-test.js
PASS flow-api-translator/__tests__/flowDefToTSDef/flowDefToTSDef-test.js
Test Suites: 5 passed, 5 total
Tests:       389 passed, 389 total
```

`yarn test` across the whole workspace has 48 suites failing in `flow-parser` and `babel-plugin-syntax-flow-parser` on a clean checkout, identically with and without this change - they need the built WASM artifacts;