### PR TITLE
[flow][parser] Support `import defer`, add `phase` to `ImportDeclaration`/`ImportExpression`

### DIFF
--- a/packages/flow-parser/__tests__/ImportDeclaration-test.js
+++ b/packages/flow-parser/__tests__/ImportDeclaration-test.js
@@ -35,6 +35,7 @@ describe('ImportDeclaration', () => {
            {
              "attributes": [],
              "importKind": "value",
+             "phase": null,
              "source": {
                "literalType": "string",
                "raw": "'Foo'",
@@ -123,6 +124,7 @@ describe('ImportDeclaration', () => {
            {
              "attributes": [],
              "importKind": "value",
+             "phase": null,
              "source": {
                "literalType": "string",
                "raw": "'Foo'",
@@ -199,6 +201,7 @@ describe('ImportDeclaration', () => {
            {
              "attributes": [],
              "importKind": "value",
+             "phase": null,
              "source": {
                "literalType": "string",
                "raw": "'Foo'",
@@ -275,6 +278,7 @@ describe('ImportDeclaration', () => {
            {
              "attributes": [],
              "importKind": "value",
+             "phase": null,
              "source": {
                "literalType": "string",
                "raw": "'Foo'",
@@ -379,6 +383,7 @@ describe('ImportDeclaration', () => {
            {
              "attributes": [],
              "importKind": "value",
+             "phase": null,
              "source": {
                "literalType": "string",
                "raw": "'Foo'",
@@ -474,6 +479,7 @@ describe('ImportDeclaration', () => {
            {
              "attributes": [],
              "importKind": "value",
+             "phase": null,
              "source": {
                "literalType": "string",
                "raw": "'Foo'",
@@ -593,6 +599,7 @@ describe('ImportDeclaration', () => {
            {
              "attributes": [],
              "importKind": "type",
+             "phase": null,
              "source": {
                "literalType": "string",
                "raw": "'Foo'",
@@ -672,6 +679,7 @@ describe('ImportDeclaration', () => {
            {
              "attributes": [],
              "importKind": "typeof",
+             "phase": null,
              "source": {
                "literalType": "string",
                "raw": "'Foo'",

--- a/packages/flow-parser/__tests__/ImportExpression-test.js
+++ b/packages/flow-parser/__tests__/ImportExpression-test.js
@@ -29,25 +29,26 @@ describe('ImportExpression', () => {
 
   test('ESTree', () => {
     expect(parseForSnapshot(testCase.code)).toMatchInlineSnapshot(`
-      {
-        "body": [
-          {
-            "directive": null,
-            "expression": {
-              "options": null,
-              "source": {
-                "literalType": "string",
-                "raw": "'foo'",
-                "type": "Literal",
-                "value": "foo",
-              },
-              "type": "ImportExpression",
-            },
-            "type": "ExpressionStatement",
-          },
-        ],
-        "type": "Program",
-      }
+     {
+       "body": [
+         {
+           "directive": null,
+           "expression": {
+             "options": null,
+             "phase": null,
+             "source": {
+               "literalType": "string",
+               "raw": "'foo'",
+               "type": "Literal",
+               "value": "foo",
+             },
+             "type": "ImportExpression",
+           },
+           "type": "ExpressionStatement",
+         },
+       ],
+       "type": "Program",
+     }
     `);
     expectEspreeAlignment(testCase);
   });

--- a/packages/flow-parser/oxidized-src/FlowParserNodeDeserializers.js
+++ b/packages/flow-parser/oxidized-src/FlowParserNodeDeserializers.js
@@ -344,6 +344,7 @@ module.exports = [
       source: this.deserializeNode(),
       importKind: this.deserializeString(),
       attributes: this.deserializeNodeList(),
+      phase: this.deserializeString(),
     };
   },
 
@@ -695,6 +696,7 @@ module.exports = [
       loc: this.addEmptyLoc(),
       source: this.deserializeNode(),
       options: this.deserializeNode(),
+      phase: this.deserializeString(),
     };
   },
 
@@ -3085,6 +3087,10 @@ module.exports = [
     {
       const value = this.deserializeNodeList();
       if (value.length > 0) node['attributes'] = value;
+    }
+    {
+      const value = this.deserializeString();
+      if (value != null) node['phase'] = value;
     }
     return node;
   },

--- a/rust_port/crates/flow_parser/src/ast.rs
+++ b/rust_port/crates/flow_parser/src/ast.rs
@@ -3074,6 +3074,46 @@ pub mod statement {
         ImportValue,
     }
 
+    /// The evaluation phase an import is modified with, as introduced by the
+    /// deferred import evaluation proposal:
+    ///
+    /// ```ignore
+    /// import defer * as ns from "m";
+    /// const ns = await import.defer("m");
+    /// ```
+    ///
+    /// [None] on an unmodified `import` / `import()`.
+    ///
+    /// The source phase (`import source x from "m"`, `import.source("m")`) is
+    /// not parsed yet. Adding it is a `Source` variant here plus the parse and
+    /// validation arms the compiler will point at: nothing about the field,
+    /// the ESTree `phase` property or the WASM wire format needs to change to
+    /// carry it.
+    #[derive(
+        Debug,
+        Clone,
+        Copy,
+        PartialEq,
+        Eq,
+        Hash,
+        PartialOrd,
+        Ord,
+        serde::Serialize,
+        serde::Deserialize
+    )]
+    pub enum ImportPhase {
+        Defer,
+    }
+
+    impl ImportPhase {
+        /// The ESTree `phase` property value for this phase.
+        pub fn as_str(self) -> &'static str {
+            match self {
+                ImportPhase::Defer => "defer",
+            }
+        }
+    }
+
     pub mod import_declaration {
         use super::*;
 
@@ -3179,6 +3219,7 @@ pub mod statement {
     )]
     pub struct ImportDeclaration<M: Dupe, T: Dupe> {
         pub import_kind: ImportKind,
+        pub phase: Option<ImportPhase>,
         pub source: (T, StringLiteral<M>),
         pub default: Option<import_declaration::DefaultIdentifier<M, T>>,
         pub specifiers: Option<import_declaration::Specifier<M, T>>,
@@ -4719,6 +4760,9 @@ pub mod expression {
     pub struct Import<M: Dupe, T: Dupe> {
         pub argument: Expression<M, T>,
         pub options: Option<Expression<M, T>>,
+        /// [Some] for a phase-modified dynamic import (`import.defer(...)`),
+        /// [None] for a plain `import(...)`.
+        pub phase: Option<super::statement::ImportPhase>,
         pub comments: Option<Syntax<M, ()>>,
     }
 

--- a/rust_port/crates/flow_parser/src/ast_visitor.rs
+++ b/rust_port/crates/flow_parser/src/ast_visitor.rs
@@ -13578,6 +13578,7 @@ pub fn import_default<'ast, Loc: Dupe, Type: Dupe, C, E>(
     let ast::expression::Import {
         argument,
         options,
+        phase: _,
         comments,
     } = expr;
     visitor.expression(argument)?;
@@ -13595,12 +13596,14 @@ pub fn map_import_default<'ast, Loc: Dupe, Type: Dupe, C, E>(
     let ast::expression::Import {
         argument,
         options,
+        phase: _,
         comments,
     } = expr;
     let argument_ = visitor.map_expression(argument);
     let options_ = options.as_ref().map(|opts| visitor.map_expression(opts));
     let comments_ = visitor.map_syntax_opt(comments.as_ref());
     ast::expression::Import {
+        phase: expr.phase,
         argument: argument_,
         options: options_,
         comments: comments_,
@@ -13713,6 +13716,7 @@ pub fn import_declaration_default<'ast, Loc: Dupe, Type: Dupe, C, E>(
     let _ = loc;
     let ast::statement::ImportDeclaration {
         import_kind,
+        phase: _,
         source,
         specifiers,
         default,
@@ -13741,6 +13745,7 @@ pub fn map_import_declaration_default<'ast, Loc: Dupe, Type: Dupe, C, E>(
 ) -> ast::statement::ImportDeclaration<Loc, Loc> {
     let ast::statement::ImportDeclaration {
         import_kind,
+        phase,
         source,
         default,
         specifiers,
@@ -13767,6 +13772,7 @@ pub fn map_import_declaration_default<'ast, Loc: Dupe, Type: Dupe, C, E>(
     let comments_ = visitor.map_syntax_opt(comments.as_ref());
     ast::statement::ImportDeclaration {
         import_kind: *import_kind,
+        phase: *phase,
         source: source_,
         default: default_,
         specifiers: specifiers_,

--- a/rust_port/crates/flow_parser/src/comment_attachment.rs
+++ b/rust_port/crates/flow_parser/src/comment_attachment.rs
@@ -373,6 +373,7 @@ impl<'ast> AstVisitor<'ast, Loc, Loc, &'ast Loc, !> for TrailingCommentsRemover 
         expr: &'ast ast::expression::Import<Loc, Loc>,
     ) -> ast::expression::Import<Loc, Loc> {
         ast::expression::Import {
+            phase: expr.phase,
             argument: expr.argument.clone(),
             options: expr.options.clone(),
             comments: self.map_syntax_opt(expr.comments.as_ref()),

--- a/rust_port/crates/flow_parser/src/estree_translator.rs
+++ b/rust_port/crates/flow_parser/src/estree_translator.rs
@@ -1137,6 +1137,10 @@ fn statement(
                 ("importKind", string(import_kind_str)),
             ];
 
+            if let Some(phase) = inner.phase {
+                properties.push(("phase", string(phase.as_str())));
+            }
+
             if let Some((_, attrs)) = &inner.attributes {
                 properties.push((
                     "attributes",
@@ -1891,6 +1895,9 @@ pub fn expression(
             )];
             if let Some(opts) = &inner.options {
                 fields.push(("options", expression(offset_table, config, false, opts)));
+            }
+            if let Some(phase) = inner.phase {
+                fields.push(("phase", string(phase.as_str())));
             }
             node(
                 offset_table,

--- a/rust_port/crates/flow_parser/src/expression_parser.rs
+++ b/rust_port/crates/flow_parser/src/expression_parser.rs
@@ -1088,6 +1088,29 @@ fn import_expr(env: &mut ParserEnv) -> Result<expression::Expression<Loc, Loc>, 
         expect::token(env, TokenKind::TImport)?;
 
         if eat::maybe(env, TokenKind::TPeriod)? {
+            // `import.defer(specifier)` — deferred eval of a dynamic import
+            if matches!(peek::token(env), TokenKind::TIdentifier { raw, .. } if raw == "defer") {
+                eat::token(env)?;
+                return import_call(env, leading, Some(statement::ImportPhase::Defer));
+            }
+            // `import.<phase>(...)` for a phase this parser does not
+            // implement. The call parens are what distinguish a phase from a
+            // mistyped `import.meta`, which still reports as such. Reported
+            // here rather than let through to the meta-property path, which
+            // would emit a MetaProperty and a misleading "expected the
+            // identifier `meta`".
+            let unsupported_phase = match peek::token(env) {
+                TokenKind::TIdentifier { raw, .. } if raw != "meta" => Some(raw.to_string()),
+                _ => None,
+            };
+            if let Some(phase) = unsupported_phase
+                && peek::token_after_current_is_lparen(env)
+            {
+                let phase_loc = peek::loc(env).dupe();
+                eat::token(env)?;
+                env.error_at(phase_loc, ParseError::ImportPhaseUnsupported(phase))?;
+                return import_call(env, leading, None);
+            }
             // import.meta
             let import_ident = Identifier::new(IdentifierInner {
                 loc: start_loc.dupe(),
@@ -1111,29 +1134,40 @@ fn import_expr(env: &mut ParserEnv) -> Result<expression::Expression<Loc, Loc>, 
                 }),
             })
         } else {
-            let leading_arg = peek::comments(env);
-            expect::token(env, TokenKind::TLparen)?;
-            let argument =
-                add_comments(env.with_no_in(false, assignment)?, Some(leading_arg), None);
-            let options = if eat::maybe(env, TokenKind::TComma)? {
-                Some(env.with_no_in(false, assignment)?)
-            } else {
-                None
-            };
-            expect::token(env, TokenKind::TRparen)?;
-            let trailing = eat::trailing_comments(env);
-            Ok(ExpressionInner::Import {
-                loc: LOC_NONE,
-                inner: Arc::new(expression::Import {
-                    argument,
-                    options,
-                    comments: mk_comments_opt(Some(leading.into()), Some(trailing.into())),
-                }),
-            })
+            import_call(env, leading, None)
         }
     })?;
     *inner.loc_mut() = loc;
     Ok(expression::Expression::new(inner))
+}
+
+/// Parses the argument list of a dynamic import, from the opening paren. The
+/// caller has already consumed `import` and, for a phase-modified call, the
+/// `.defer` that follows it.
+fn import_call(
+    env: &mut ParserEnv,
+    leading: Vec<Comment<Loc>>,
+    phase: Option<statement::ImportPhase>,
+) -> Result<ExpressionInner<Loc, Loc>, Rollback> {
+    let leading_arg = peek::comments(env);
+    expect::token(env, TokenKind::TLparen)?;
+    let argument = add_comments(env.with_no_in(false, assignment)?, Some(leading_arg), None);
+    let options = if eat::maybe(env, TokenKind::TComma)? {
+        Some(env.with_no_in(false, assignment)?)
+    } else {
+        None
+    };
+    expect::token(env, TokenKind::TRparen)?;
+    let trailing = eat::trailing_comments(env);
+    Ok(ExpressionInner::Import {
+        loc: LOC_NONE,
+        inner: Arc::new(expression::Import {
+            argument,
+            options,
+            phase,
+            comments: mk_comments_opt(Some(leading.into()), Some(trailing.into())),
+        }),
+    })
 }
 
 pub(super) fn call_cover(

--- a/rust_port/crates/flow_parser/src/flow_ast_mapper_test.rs
+++ b/rust_port/crates/flow_parser/src/flow_ast_mapper_test.rs
@@ -70,6 +70,7 @@ mod tests {
             loc: (),
             inner: Arc::new(statement::ImportDeclaration {
                 import_kind,
+                phase: None,
                 source,
                 default: None,
                 specifiers: Some(import_declaration::Specifier::ImportNamedSpecifiers(

--- a/rust_port/crates/flow_parser/src/parse_error.rs
+++ b/rust_port/crates/flow_parser/src/parse_error.rs
@@ -116,6 +116,8 @@ pub enum ParseError {
     IllegalReturn,
     IllegalUnicodeEscape,
     ImportAttributeMissingComma,
+    ImportDeferPhaseRequiresNamespace,
+    ImportPhaseUnsupported(String),
     ImportSpecifierMissingComma,
     ImportTypeShorthandOnlyInPureImport,
     IndexSignatureInvalidModifier(String),
@@ -513,6 +515,12 @@ impl fmt::Display for ParseError {
             }
             Self::ImportAttributeMissingComma => {
                 write!(f, "Missing comma between import attributes")
+            }
+            Self::ImportDeferPhaseRequiresNamespace => {
+                write!(f, "Only `import defer * as ns from \"module\"` is valid")
+            }
+            Self::ImportPhaseUnsupported(phase) => {
+                write!(f, "The `{}` import phase is not supported.", phase)
             }
             Self::ImportSpecifierMissingComma => {
                 write!(f, "Missing comma between import specifiers")

--- a/rust_port/crates/flow_parser/src/parser_env.rs
+++ b/rust_port/crates/flow_parser/src/parser_env.rs
@@ -1690,7 +1690,18 @@ pub(crate) mod peek {
         lexer_lookahead1_matches(env, |token| matches!(token, TokenKind::TIdentifier { .. }))
     }
 
-    pub(crate) fn import_equals_module_reference_starts_require_call(env: &mut ParserEnv) -> bool {
+    pub(crate) fn token_after_current_is_string(env: &mut ParserEnv) -> bool {
+        lexer_lookahead1_matches(env, |token| matches!(token, TokenKind::TString(..)))
+    }
+
+    pub(crate) fn token_after_current_is_identifier_other_than_from(env: &mut ParserEnv) -> bool {
+        lexer_lookahead1_matches(
+            env,
+            |token| matches!(token, TokenKind::TIdentifier { raw, .. } if raw != "from"),
+        )
+    }
+
+    pub(crate) fn token_after_current_is_lparen(env: &mut ParserEnv) -> bool {
         lexer_lookahead1_matches(env, |token| token == &TokenKind::TLparen)
     }
 

--- a/rust_port/crates/flow_parser/src/polymorphic_ast_mapper.rs
+++ b/rust_port/crates/flow_parser/src/polymorphic_ast_mapper.rs
@@ -1138,6 +1138,7 @@ pub fn import_expr<M: Dupe, T: Dupe, N: Dupe, U: Dupe, E>(
     let ast::expression::Import {
         argument,
         options,
+        phase,
         comments,
     } = expr;
     let argument_ = expression(mapper, argument)?;
@@ -1148,6 +1149,7 @@ pub fn import_expr<M: Dupe, T: Dupe, N: Dupe, U: Dupe, E>(
     let comments_ = syntax_opt(mapper, comments.as_ref())?;
     Ok(ast::expression::Import {
         argument: argument_,
+        phase: *phase,
         options: options_,
         comments: comments_,
     })
@@ -4875,6 +4877,7 @@ pub fn import_declaration<M: Dupe, T: Dupe, N: Dupe, U: Dupe, E>(
 ) -> Result<ast::statement::ImportDeclaration<N, U>, E> {
     let ast::statement::ImportDeclaration {
         import_kind,
+        phase,
         source,
         default,
         specifiers,
@@ -4920,6 +4923,7 @@ pub fn import_declaration<M: Dupe, T: Dupe, N: Dupe, U: Dupe, E>(
     let comments_ = syntax_opt(mapper, comments.as_ref())?;
     Ok(ast::statement::ImportDeclaration {
         import_kind: *import_kind,
+        phase: *phase,
         source: source_,
         default: default_,
         specifiers: specifiers_,

--- a/rust_port/crates/flow_parser/src/statement_parser.rs
+++ b/rust_port/crates/flow_parser/src/statement_parser.rs
@@ -2680,7 +2680,7 @@ fn import_equals_module_reference(
     env: &mut ParserEnv,
 ) -> Result<statement::import_equals_declaration::ModuleReference<Loc, Loc>, Rollback> {
     let is_require_call = matches!(peek::token(env), TokenKind::TIdentifier { raw, .. } if raw == "require")
-        && peek::import_equals_module_reference_starts_require_call(env);
+        && peek::token_after_current_is_lparen(env);
     match peek::token(env) {
         TokenKind::TIdentifier { raw, .. } if raw == "require" && is_require_call => {
             // require("module")
@@ -4697,12 +4697,51 @@ fn import_declaration(env: &mut ParserEnv) -> Result<statement::Statement<Loc, L
         }
     }
 
+    /// Rejects the specifier forms a phase modifier does not accept. The defer
+    /// phase takes only a `NameSpaceImport`, so a named specifier list reaching
+    /// here with the phase is an error. `source`, when it lands, accepts exactly
+    /// the default-binding form and so will want the inverse: rejecting both
+    /// specifier shapes here and accepting the default in
+    /// [check_phase_default].
+    fn check_phase_specifiers(
+        env: &mut ParserEnv,
+        phase: Option<statement::ImportPhase>,
+        specifiers: &Option<statement::import_declaration::Specifier<Loc, Loc>>,
+        specifier_loc: Loc,
+    ) -> Result<(), Rollback> {
+        match (phase, specifiers) {
+            (
+                Some(statement::ImportPhase::Defer),
+                Some(statement::import_declaration::Specifier::ImportNamedSpecifiers(_)),
+            ) => env.error_at(specifier_loc, ParseError::ImportDeferPhaseRequiresNamespace),
+            _ => Ok(()),
+        }
+    }
+
+    /// The default-binding counterpart of [check_phase_specifiers]: no phase
+    /// this parser implements accepts one.
+    fn check_phase_default(
+        env: &mut ParserEnv,
+        phase: Option<statement::ImportPhase>,
+        default_loc: Loc,
+    ) -> Result<(), Rollback> {
+        match phase {
+            None => Ok(()),
+            Some(statement::ImportPhase::Defer) => {
+                env.error_at(default_loc, ParseError::ImportDeferPhaseRequiresNamespace)
+            }
+        }
+    }
+
     fn with_specifiers(
         env: &mut ParserEnv,
         import_kind: statement::ImportKind,
+        phase: Option<statement::ImportPhase>,
         leading: Vec<Comment<Loc>>,
     ) -> Result<StatementInner<Loc, Loc>, Rollback> {
+        let specifier_loc = peek::loc(env).dupe();
         let specifiers = named_or_namespace_specifier(env, import_kind)?;
+        check_phase_specifiers(env, phase, &specifiers, specifier_loc)?;
         let mut source = source(env)?;
         let attributes = import_attributes(env)?;
         let trailing = semicolon_and_trailing(env, &mut source)?;
@@ -4710,6 +4749,7 @@ fn import_declaration(env: &mut ParserEnv) -> Result<statement::Statement<Loc, L
             loc: LOC_NONE,
             inner: Arc::new(statement::ImportDeclaration {
                 import_kind,
+                phase,
                 source,
                 specifiers,
                 default: None,
@@ -4722,6 +4762,7 @@ fn import_declaration(env: &mut ParserEnv) -> Result<statement::Statement<Loc, L
     fn with_default(
         env: &mut ParserEnv,
         import_kind: statement::ImportKind,
+        phase: Option<statement::ImportPhase>,
         leading: Vec<Comment<Loc>>,
     ) -> Result<StatementInner<Loc, Loc>, Rollback> {
         let default_specifier = match import_kind {
@@ -4738,15 +4779,21 @@ fn import_declaration(env: &mut ParserEnv) -> Result<statement::Statement<Loc, L
                 }
             }
         };
-        with_default_identifier(env, import_kind, leading, default_specifier)
+        with_default_identifier(env, import_kind, phase, leading, default_specifier)
     }
 
     fn with_default_identifier(
         env: &mut ParserEnv,
         import_kind: statement::ImportKind,
+        phase: Option<statement::ImportPhase>,
         leading: Vec<Comment<Loc>>,
         default_specifier: statement::import_declaration::DefaultIdentifier<Loc, Loc>,
     ) -> Result<StatementInner<Loc, Loc>, Rollback> {
+        // `import defer x from "m"` — the phase takes a namespace, so the
+        // default binding is the error. It is reported once, here: with
+        // `import defer x, { y } from "m"` the named specifiers are not
+        // separately at fault.
+        check_phase_default(env, phase, default_specifier.identifier.loc.dupe())?;
         let additional_specifiers = match peek::token(env) {
             TokenKind::TComma => {
                 // `import Foo, ...`
@@ -4763,6 +4810,7 @@ fn import_declaration(env: &mut ParserEnv) -> Result<statement::Statement<Loc, L
             loc: LOC_NONE,
             inner: Arc::new(statement::ImportDeclaration {
                 import_kind,
+                phase,
                 source,
                 specifiers: additional_specifiers,
                 default: Some(default_specifier),
@@ -4783,11 +4831,11 @@ fn import_declaration(env: &mut ParserEnv) -> Result<statement::Statement<Loc, L
             match current_token {
                 TokenKind::TMult => {
                     // `import * as ns from "ModuleName";`
-                    with_specifiers(env, statement::ImportKind::ImportValue, leading)
+                    with_specifiers(env, statement::ImportKind::ImportValue, None, leading)
                 }
                 TokenKind::TLcurly => {
                     // `import { ... } from "ModuleName";`
-                    with_specifiers(env, statement::ImportKind::ImportValue, leading)
+                    with_specifiers(env, statement::ImportKind::ImportValue, None, leading)
                 }
                 // `import "ModuleName";`
                 TokenKind::TString(loc, value, raw, octal) => {
@@ -4798,6 +4846,7 @@ fn import_declaration(env: &mut ParserEnv) -> Result<statement::Statement<Loc, L
                         loc: LOC_NONE,
                         inner: Arc::new(statement::ImportDeclaration {
                             import_kind: statement::ImportKind::ImportValue,
+                            phase: None,
                             source,
                             specifiers: None,
                             default: None,
@@ -4822,6 +4871,7 @@ fn import_declaration(env: &mut ParserEnv) -> Result<statement::Statement<Loc, L
                         TokenKind::TComma => with_default_identifier(
                             env,
                             statement::ImportKind::ImportValue,
+                            None,
                             leading,
                             type_default,
                         ),
@@ -4831,6 +4881,7 @@ fn import_declaration(env: &mut ParserEnv) -> Result<statement::Statement<Loc, L
                             with_default_identifier(
                                 env,
                                 statement::ImportKind::ImportValue,
+                                None,
                                 leading,
                                 type_default,
                             )
@@ -4850,10 +4901,10 @@ fn import_declaration(env: &mut ParserEnv) -> Result<statement::Statement<Loc, L
                             }
                         }),
                         TokenKind::TMult => {
-                            with_specifiers(env, statement::ImportKind::ImportType, leading)
+                            with_specifiers(env, statement::ImportKind::ImportType, None, leading)
                         }
                         TokenKind::TLcurly => {
-                            with_specifiers(env, statement::ImportKind::ImportType, leading)
+                            with_specifiers(env, statement::ImportKind::ImportType, None, leading)
                         }
                         _ => {
                             // Check for import type Foo = ...
@@ -4881,6 +4932,7 @@ fn import_declaration(env: &mut ParserEnv) -> Result<statement::Statement<Loc, L
                                 with_default_identifier(
                                     env,
                                     statement::ImportKind::ImportType,
+                                    None,
                                     leading,
                                     default_specifier,
                                 )
@@ -4893,10 +4945,106 @@ fn import_declaration(env: &mut ParserEnv) -> Result<statement::Statement<Loc, L
                     expect::token(env, TokenKind::TTypeof)?;
                     match peek::token(env) {
                         TokenKind::TMult | TokenKind::TLcurly => {
-                            with_specifiers(env, statement::ImportKind::ImportTypeof, leading)
+                            with_specifiers(env, statement::ImportKind::ImportTypeof, None, leading)
                         }
-                        _ => with_default(env, statement::ImportKind::ImportTypeof, leading),
+                        _ => with_default(env, statement::ImportKind::ImportTypeof, None, leading),
                     }
+                }
+                // `import defer * as ns from "ModuleName";` — deferred
+                // evaluation.
+                //
+                // `defer` is contextual, so it is only the phase modifier when
+                // the import's binding follows it. `import defer from "m"`,
+                // `import defer, { x } from "m"` and `import defer =
+                // require("m")` all still bind a local named `defer`.
+                TokenKind::TIdentifier { ref raw, .. } if raw == "defer" => {
+                    let defer_id = main_parser::parse_identifier(env, None)?;
+                    let defer_default = statement::import_declaration::DefaultIdentifier {
+                        identifier: defer_id,
+                        remote_default_name_def_loc: None,
+                    };
+                    let after_defer = peek::token(env).clone();
+                    match after_defer {
+                        // `import defer, { other } from "ModuleName";`
+                        TokenKind::TComma => with_default_identifier(
+                            env,
+                            statement::ImportKind::ImportValue,
+                            None,
+                            leading,
+                            defer_default,
+                        ),
+                        // `import defer = require("ModuleName");`
+                        TokenKind::TAssign => import_equals_declaration_with_id(
+                            env,
+                            statement::ImportKind::ImportValue,
+                            false,
+                            leading,
+                            defer_default.identifier,
+                        )
+                        .map(|inner| {
+                            StatementInner::ImportEqualsDeclaration {
+                                loc: LOC_NONE,
+                                inner,
+                            }
+                        }),
+                        // `import defer from ...`: the `from` is this import's
+                        // clause keyword when a module specifier follows it,
+                        // and a (rejected) default binding under the phase
+                        // otherwise (`import defer from from "ModuleName";`).
+                        TokenKind::TIdentifier { ref raw, .. }
+                            if raw == "from" && peek::token_after_current_is_string(env) =>
+                        {
+                            with_default_identifier(
+                                env,
+                                statement::ImportKind::ImportValue,
+                                None,
+                                leading,
+                                defer_default,
+                            )
+                        }
+                        // Phase modifier. The binding forms it does not accept
+                        // are still parsed, so that `import defer x from "m"`
+                        // reports the phase error rather than a cascade of
+                        // token errors.
+                        _ => {
+                            let phase = Some(statement::ImportPhase::Defer);
+                            match peek::token(env) {
+                                TokenKind::TMult | TokenKind::TLcurly => with_specifiers(
+                                    env,
+                                    statement::ImportKind::ImportValue,
+                                    phase,
+                                    leading,
+                                ),
+                                _ => with_default(
+                                    env,
+                                    statement::ImportKind::ImportValue,
+                                    phase,
+                                    leading,
+                                ),
+                            }
+                        }
+                    }
+                }
+                // `import <phase> x from "ModuleName";` for a phase this
+                // parser does not implement, `source` being the one that
+                // exists today. An identifier followed by another identifier
+                // can only be a phase modifier — `from` excepted, since
+                // `import x from "m"` is the unphased import — so no phase is
+                // named here and any future one taking the default-binding
+                // form is covered; the defer phase is claimed by the arm above
+                // and never reaches this, and `type`/`typeof` are keyword
+                // tokens with arms of their own. Reporting and then parsing the
+                // default import anyway keeps it to one error rather than a
+                // cascade, and leaves an AST that differs from the intended one
+                // only in the phase.
+                TokenKind::TIdentifier { ref raw, .. }
+                    if peek::token_after_current_is_identifier_other_than_from(env) =>
+                {
+                    let phase_loc = peek::loc(env).dupe();
+                    let phase = raw.to_string();
+                    eat::token(env)?;
+                    env.error_at(phase_loc, ParseError::ImportPhaseUnsupported(phase))?;
+                    with_default(env, statement::ImportKind::ImportValue, None, leading)
                 }
                 // import Foo from "ModuleName"; or import Foo = ...
                 // Check for import equals: import Foo = ...
@@ -4924,6 +5072,7 @@ fn import_declaration(env: &mut ParserEnv) -> Result<statement::Statement<Loc, L
                         with_default_identifier(
                             env,
                             statement::ImportKind::ImportValue,
+                            None,
                             leading,
                             default_specifier,
                         )

--- a/rust_port/crates/flow_parser_utils/src/ast_builder.rs
+++ b/rust_port/crates/flow_parser_utils/src/ast_builder.rs
@@ -1358,6 +1358,8 @@ pub mod statements {
             loc,
             inner: Arc::new(statement::ImportDeclaration {
                 import_kind,
+                // Synthesised imports are never phase-modified.
+                phase: None,
                 source,
                 default,
                 specifiers,

--- a/rust_port/crates/flow_parser_utils/src/flow_ast_differ.rs
+++ b/rust_port/crates/flow_parser_utils/src/flow_ast_differ.rs
@@ -1354,6 +1354,7 @@ fn import_declaration(
 ) -> Option<Vec<NodeChange>> {
     let ast::statement::ImportDeclaration {
         import_kind: imprt_knd1,
+        phase: phase1,
         source: src1,
         default: dflt1,
         specifiers: spec1,
@@ -1362,13 +1363,14 @@ fn import_declaration(
     } = import1;
     let ast::statement::ImportDeclaration {
         import_kind: imprt_knd2,
+        phase: phase2,
         source: src2,
         default: dflt2,
         specifiers: spec2,
         comments: comments2,
         ..
     } = import2;
-    if imprt_knd1 != imprt_knd2 || src1 != src2 {
+    if imprt_knd1 != imprt_knd2 || phase1 != phase2 || src1 != src2 {
         None
     } else {
         let dflt_diff = import_default_specifier(dflt1, dflt2);
@@ -6004,13 +6006,20 @@ fn import_expression(
     let expression::Import {
         argument: argument1,
         options: options1,
+        phase: phase1,
         comments: comments1,
     } = import1;
     let expression::Import {
         argument: argument2,
         options: options2,
+        phase: phase2,
         comments: comments2,
     } = import2;
+    if phase1 != phase2 {
+        // No edit within the node can turn `import(x)` into
+        // `import.defer(x)`; the whole node has to be replaced.
+        return None;
+    }
     let parent = ExpressionNodeParent::ExpressionParentOfExpression(expression::Expression::new(
         ExpressionInner::Import {
             loc: loc.dupe(),

--- a/rust_port/crates/flow_parser_utils/src/flow_ast_differ_tests.rs
+++ b/rust_port/crates/flow_parser_utils/src/flow_ast_differ_tests.rs
@@ -748,6 +748,7 @@ fn import_statement(loc: Loc, source: &str) -> Statement<Loc, Loc> {
         loc: loc.dupe(),
         inner: Arc::new(statement::ImportDeclaration {
             import_kind: statement::ImportKind::ImportValue,
+            phase: None,
             source: (
                 loc.dupe(),
                 ast::StringLiteral {
@@ -1112,6 +1113,7 @@ impl<'ast> AstVisitor<'ast, Loc, Loc, &'ast Loc, !> for InsertImportAndAnnotMapp
                 loc: Loc::none(),
                 inner: Arc::new(statement::ImportDeclaration {
                     import_kind: statement::ImportKind::ImportType,
+                    phase: None,
                     source: (
                         Loc::none(),
                         ast::StringLiteral {

--- a/rust_port/crates/flow_parser_utils_output/src/js_layout_generator.rs
+++ b/rust_port/crates/flow_parser_utils_output/src/js_layout_generator.rs
@@ -2065,6 +2065,10 @@ pub fn expression(
                 inner.comments.as_ref(),
                 fuse(vec![
                     atom("import"),
+                    match inner.phase {
+                        Some(ast::statement::ImportPhase::Defer) => atom(".defer"),
+                        None => LayoutNode::empty(),
+                    },
                     wrap_in_parens(
                         false,
                         match &inner.options {
@@ -3329,6 +3333,10 @@ fn import_declaration(
         import.comments.as_ref(),
         with_semicolon(fuse(vec![
             atom("import"),
+            match import.phase {
+                Some(ast::statement::ImportPhase::Defer) => fuse(vec![space(), atom("defer")]),
+                None => LayoutNode::empty(),
+            },
             match import.import_kind {
                 ast::statement::ImportKind::ImportType => fuse(vec![space(), atom("type")]),
                 ast::statement::ImportKind::ImportTypeof => fuse(vec![space(), atom("typeof")]),

--- a/rust_port/crates/flow_parser_utils_output/src/js_layout_generator_test/import_test.rs
+++ b/rust_port/crates/flow_parser_utils_output/src/js_layout_generator_test/import_test.rs
@@ -64,6 +64,29 @@ fn test_basic() {
 }
 
 #[test]
+fn test_defer_phase() {
+    assert_statement_string(false, None, r#"import defer *as a from"a";"#);
+    assert_statement_string(true, None, r#"import defer * as a from "a";"#);
+    assert_statement_string(
+        true,
+        None,
+        r#"import defer * as a from "a" with { type: "json" };"#,
+    );
+    // `defer` as an ordinary binding name still prints without the phase.
+    assert_statement_string(true, None, r#"import defer from "a";"#);
+    assert_statement_string(true, None, r#"import defer, { b } from "a";"#);
+    assert_statement_string(true, None, r#"import defer * as defer from "a";"#);
+    // Dynamic form.
+    assert_statement_string(true, None, r#"import.defer("a");"#);
+    assert_statement_string(
+        true,
+        None,
+        r#"import.defer("a", { with: { type: "json" } });"#,
+    );
+    assert_statement_string(true, None, r#"import("a");"#);
+}
+
+#[test]
 fn test_wrap_specifiers() {
     assert_statement_string(
         true,

--- a/rust_port/crates/flow_parser_wasm/src/bin/codegen.rs
+++ b/rust_port/crates/flow_parser_wasm/src/bin/codegen.rs
@@ -181,6 +181,7 @@ fn deserialize_call(ty: PropType) -> &'static str {
         PropType::OptionalNode => "this.deserializeNode()",
         PropType::TrueBoolean => "this.deserializeBoolean()",
         PropType::NonEmptyNodeList => "this.deserializeNodeList()",
+        PropType::MaybeString => "this.deserializeString()",
         PropType::MaybeNode => "this.deserializeNode()",
         PropType::MaybeBoolean => "this.deserializeBoolean()",
         PropType::CommentList => "this.deserializeComments()",
@@ -202,6 +203,12 @@ fn print_property(indent: &str, prop_name: &str, prop_ty: PropType) {
             println!("{indent}{{");
             println!("{indent}  const value = this.deserializeNodeList();");
             println!("{indent}  if (value.length > 0) node['{prop_name}'] = value;");
+            println!("{indent}}}");
+        }
+        PropType::MaybeString => {
+            println!("{indent}{{");
+            println!("{indent}  const value = this.deserializeString();");
+            println!("{indent}  if (value != null) node['{prop_name}'] = value;");
             println!("{indent}}}");
         }
         PropType::MaybeNode => {
@@ -228,6 +235,7 @@ fn is_conditional_property(prop_ty: PropType) -> bool {
         PropType::OptionalNode
             | PropType::TrueBoolean
             | PropType::NonEmptyNodeList
+            | PropType::MaybeString
             | PropType::MaybeNode
             | PropType::MaybeBoolean
     )

--- a/rust_port/crates/flow_parser_wasm/src/lib.rs
+++ b/rust_port/crates/flow_parser_wasm/src/lib.rs
@@ -625,7 +625,7 @@ mod tests {
                 let len = buf[idx] as usize;
                 (0..len).fold(idx + 1, |cursor, _| skip_node(buf, cursor))
             }
-            PropType::String => skip_string(buf, idx),
+            PropType::String | PropType::MaybeString => skip_string(buf, idx),
             PropType::Boolean | PropType::TrueBoolean => idx + 1,
             PropType::Number => {
                 let aligned = if idx.is_multiple_of(2) { idx } else { idx + 1 };
@@ -750,6 +750,57 @@ mod tests {
             buf[declare_variable_idx + 3],
             encoded_kind(NodeKind::VariableDeclarator),
             "DeclareVariable.declarations should contain VariableDeclarator nodes"
+        );
+    }
+
+    /// The buffer walkers above cannot step over a `Literal`, whose payload is
+    /// `custom` in the schema, so a node containing one — every
+    /// ImportDeclaration — is not addressable by property name. Search the
+    /// string buffer instead: the phase is the only place these fixtures can
+    /// put the word "defer" on the wire.
+    fn string_buffer_contains(
+        buffers: &crate::serializer::SerializerBuffers,
+        needle: &str,
+    ) -> bool {
+        buffers
+            .string_buffer
+            .windows(needle.len())
+            .any(|window| window == needle.as_bytes())
+    }
+
+    #[test]
+    fn import_declaration_serializes_defer_phase() {
+        let phased =
+            parse_and_serialize_with_filename("import defer * as ns from \"m\";", "test.js");
+        assert!(
+            string_buffer_contains(&phased, "defer"),
+            "`import defer * as ns from \"m\"` should serialize phase=\"defer\""
+        );
+
+        let unphased = parse_and_serialize_with_filename("import * as ns from \"m\";", "test.js");
+        assert!(
+            !string_buffer_contains(&unphased, "defer"),
+            "an unmodified import should serialize a null phase"
+        );
+        assert_eq!(
+            phased.program_buffer.len(),
+            unphased.program_buffer.len() + 1,
+            "the phase should cost one extra word over the null sentinel"
+        );
+    }
+
+    #[test]
+    fn import_expression_serializes_defer_phase() {
+        let phased = parse_and_serialize_with_filename("import.defer(\"m\");", "test.js");
+        assert!(
+            string_buffer_contains(&phased, "defer"),
+            "`import.defer(\"m\")` should serialize phase=\"defer\""
+        );
+
+        let unphased = parse_and_serialize_with_filename("import(\"m\");", "test.js");
+        assert!(
+            !string_buffer_contains(&unphased, "defer"),
+            "a plain `import()` should serialize a null phase"
         );
     }
 

--- a/rust_port/crates/flow_parser_wasm/src/node_kinds.rs
+++ b/rust_port/crates/flow_parser_wasm/src/node_kinds.rs
@@ -93,6 +93,10 @@ pub enum PropType {
     TrueBoolean,
     /// Read a node list and omit the JS property when it is empty.
     NonEmptyNodeList,
+    /// Read a string slot and omit the JS property when it is null. Used for
+    /// Babel-shaped nodes whose alignment baseline (the pinned `@babel/parser`)
+    /// predates the property.
+    MaybeString,
     /// Read a presence bit followed by a node slot, assigning even when null.
     MaybeNode,
     /// Read a presence bit followed by a boolean value.
@@ -596,6 +600,7 @@ define_nodes! {
         source: Node,
         importKind: String,
         attributes: NodeList,
+        phase: String,
     } from Statement::ImportDeclaration { loc, inner }
         {=> self.serialize_import_declaration(loc, inner)},
     ImportDefaultSpecifier = 30 {
@@ -823,6 +828,7 @@ define_nodes! {
     ImportExpression = 62 {
         source: Node,
         options: Node,
+        phase: String,
     } from Expression::Import { loc, inner }
         {=> self.serialize_import_expression(loc, inner)},
     MetaProperty = 63 {
@@ -2007,6 +2013,7 @@ define_nodes! {
         source: Node,
         importKind: String,
         attributes: NonEmptyNodeList,
+        phase: MaybeString,
     },
     BabelExportNamedDeclaration = 273 as "ExportNamedDeclaration" {
         declaration: OptionalNode,

--- a/rust_port/crates/flow_parser_wasm/src/serializer.rs
+++ b/rust_port/crates/flow_parser_wasm/src/serializer.rs
@@ -1015,7 +1015,10 @@ impl<'a> Serializer<'a> {
         loc: &Loc,
         inner: &ast::expression::Import<Loc, Loc>,
     ) {
-        if self.is_babel() {
+        // A phase-modified call has no `Import` callee to hang the phase off,
+        // so Babel represents it as an ImportExpression too — only a plain
+        // `import(...)` lowers to `CallExpression(Import, ...)`.
+        if self.is_babel() && inner.phase.is_none() {
             self.write_node_header(NodeKind::BabelCallExpression, loc);
             let import_loc = Loc {
                 source: loc.source.clone(),
@@ -1040,6 +1043,7 @@ impl<'a> Serializer<'a> {
                 Some(options) => self.serialize_expression(options),
                 None => self.write_null_node(),
             }
+            self.write_str_opt(inner.phase.map(|phase| phase.as_str()));
         }
     }
 
@@ -2793,7 +2797,7 @@ impl<'a> Serializer<'a> {
         loc: &Loc,
         decl: &ast::statement::ImportDeclaration<Loc, Loc>,
     ) {
-        // 29: ImportDeclaration — specifiers(NodeList) source(Node) importKind(String) attributes(NodeList)
+        // 29: ImportDeclaration — specifiers(NodeList) source(Node) importKind(String) attributes(NodeList) phase(String)
         self.write_node_header(
             if self.is_babel() {
                 NodeKind::BabelImportDeclaration
@@ -2873,6 +2877,8 @@ impl<'a> Serializer<'a> {
             }
             None => self.buf.push(0),
         }
+        // phase — the null string sentinel for an unmodified import.
+        self.write_str_opt(decl.phase.map(|phase| phase.as_str()));
     }
 
     fn serialize_import_attribute(

--- a/rust_port/crates/flow_services_autocomplete/src/autofix_imports.rs
+++ b/rust_port/crates/flow_services_autocomplete/src/autofix_imports.rs
@@ -252,6 +252,7 @@ fn update_import(
     match &**stmt {
         StatementInner::ImportDeclaration { inner, .. } => {
             let import_kind = inner.import_kind;
+            let phase = inner.phase;
             let source = inner.source.clone();
             let from = source.1.value.to_string();
             let default = inner.default.clone();
@@ -365,6 +366,7 @@ fn update_import(
                         loc: loc.clone(),
                         inner: std::sync::Arc::new(statement::ImportDeclaration {
                             import_kind,
+                            phase,
                             source,
                             default,
                             specifiers: Some(

--- a/rust_port/crates/flow_services_code_action/src/autofix_imports.rs
+++ b/rust_port/crates/flow_services_code_action/src/autofix_imports.rs
@@ -322,6 +322,7 @@ fn update_import(
     match &**stmt {
         StatementInner::ImportDeclaration { loc: _, inner } => {
             let import_kind = inner.import_kind;
+            let phase = inner.phase;
             let source = &inner.source;
             let default = &inner.default;
             let specifiers = &inner.specifiers;
@@ -443,6 +444,7 @@ fn update_import(
                         loc: loc.dupe(),
                         inner: Arc::new(statement::ImportDeclaration {
                             import_kind,
+                            phase,
                             source: source.clone(),
                             default: default.clone(),
                             specifiers: new_specifiers_wrapped,
@@ -1031,6 +1033,9 @@ fn merge_imports(
             if a_inner.import_kind != b_inner.import_kind {
                 panic!("Can't merge imports of different kinds");
             }
+            if a_inner.phase != b_inner.phase {
+                panic!("Can't merge imports of different phases");
+            }
             let default = merge_defaults(&a_inner.default, &b_inner.default);
             let specifiers = merge_specifiers(&a_inner.specifiers, &b_inner.specifiers);
             let comments = merge_comments(&a_inner.comments, &b_inner.comments);
@@ -1038,6 +1043,7 @@ fn merge_imports(
                 loc: LOC_NONE,
                 inner: Arc::new(statement::ImportDeclaration {
                     import_kind: a_inner.import_kind,
+                    phase: a_inner.phase,
                     source: a_inner.source.clone(),
                     default,
                     specifiers,

--- a/rust_port/crates/flow_services_code_action/src/autofix_type_to_value_import.rs
+++ b/rust_port/crates/flow_services_code_action/src/autofix_type_to_value_import.rs
@@ -129,6 +129,9 @@ impl Mapper {
                     source,
                     specifiers,
                     default,
+                    // Only `import type` declarations are rewritten here, and
+                    // those are never phase-modified.
+                    phase: _,
                     attributes: _,
                     comments: _,
                 } = &**decl;
@@ -204,6 +207,7 @@ impl Mapper {
                                     loc: loc.dupe(),
                                     inner: Arc::new(ast::statement::ImportDeclaration {
                                         import_kind: ImportKind::ImportValue,
+                                        phase: None,
                                         default: None,
                                         source: source.clone(),
                                         specifiers: Some(
@@ -261,6 +265,7 @@ impl Mapper {
                                     loc: loc.dupe(),
                                     inner: Arc::new(ast::statement::ImportDeclaration {
                                         import_kind: ImportKind::ImportValue,
+                                        phase: None,
                                         default: None,
                                         source: source.clone(),
                                         specifiers: Some(

--- a/rust_port/crates/flow_services_code_action/src/insert_type_imports.rs
+++ b/rust_port/crates/flow_services_code_action/src/insert_type_imports.rs
@@ -875,6 +875,8 @@ pub mod imports_helper {
                         loc: dummy_loc.dupe(),
                         inner: Arc::new(ast::statement::ImportDeclaration {
                             import_kind: import_declaration.import_kind,
+                            // Synthesised type imports are never phase-modified.
+                            phase: None,
                             source: import_declaration.source,
                             default: import_declaration.default.map(|identifier| {
                                 ast::statement::import_declaration::DefaultIdentifier {
@@ -900,6 +902,7 @@ pub mod imports_helper {
                         loc: dummy_loc.dupe(),
                         inner: Arc::new(ast::statement::ImportDeclaration {
                             import_kind,
+                            phase: None,
                             source,
                             default: None,
                             specifiers,

--- a/rust_port/crates/flow_type_sig/src/type_sig_parse.rs
+++ b/rust_port/crates/flow_type_sig/src/type_sig_parse.rs
@@ -13248,6 +13248,9 @@ fn import_decl<'arena, 'ast>(
         default,
         specifiers,
         import_kind: kind,
+        // Deferred evaluation does not change the shape of the namespace, so
+        // a deferred import is signed exactly like the eager one.
+        phase: _,
         attributes: _,
         comments: _,
     } = decl;

--- a/rust_port/crates/flow_typing_statement/src/statement.rs
+++ b/rust_port/crates/flow_typing_statement/src/statement.rs
@@ -4288,6 +4288,7 @@ fn statement_<'a>(
                     specifiers: specifiers_ast,
                     default: default_ast,
                     import_kind: inner.import_kind,
+                    phase: inner.phase,
                     attributes: None,
                     comments: inner.comments.dupe(),
                 })
@@ -8102,6 +8103,7 @@ fn expression_<'a>(
                                 inner: lit.clone(),
                             }),
                             options: opts_prime,
+                            phase: inner.phase,
                             comments: inner.comments.dupe(),
                         }
                         .into(),
@@ -8130,6 +8132,7 @@ fn expression_<'a>(
                                 },
                             ),
                             options: opts_prime,
+                            phase: inner.phase,
                             comments: inner.comments.dupe(),
                         })
                         .into(),

--- a/src/parser/test/flow/import_defer_phase/basic.js
+++ b/src/parser/test/flow/import_defer_phase/basic.js
@@ -1,0 +1,1 @@
+import defer * as ns from "module";

--- a/src/parser/test/flow/import_defer_phase/basic.tree.json
+++ b/src/parser/test/flow/import_defer_phase/basic.tree.json
@@ -1,0 +1,102 @@
+{
+  "body": [
+    {
+      "importKind": "value",
+      "loc": {
+        "end": {
+          "column": 35,
+          "line": 1
+        },
+        "source": null,
+        "start": {
+          "column": 0,
+          "line": 1
+        }
+      },
+      "phase": "defer",
+      "range": [
+        0,
+        35
+      ],
+      "source": {
+        "loc": {
+          "end": {
+            "column": 34,
+            "line": 1
+          },
+          "source": null,
+          "start": {
+            "column": 26,
+            "line": 1
+          }
+        },
+        "range": [
+          26,
+          34
+        ],
+        "raw": "\"module\"",
+        "type": "Literal",
+        "value": "module"
+      },
+      "specifiers": [
+        {
+          "loc": {
+            "end": {
+              "column": 20,
+              "line": 1
+            },
+            "source": null,
+            "start": {
+              "column": 13,
+              "line": 1
+            }
+          },
+          "local": {
+            "loc": {
+              "end": {
+                "column": 20,
+                "line": 1
+              },
+              "source": null,
+              "start": {
+                "column": 18,
+                "line": 1
+              }
+            },
+            "name": "ns",
+            "optional": false,
+            "range": [
+              18,
+              20
+            ],
+            "type": "Identifier",
+            "typeAnnotation": null
+          },
+          "range": [
+            13,
+            20
+          ],
+          "type": "ImportNamespaceSpecifier"
+        }
+      ],
+      "type": "ImportDeclaration"
+    }
+  ],
+  "comments": [],
+  "loc": {
+    "end": {
+      "column": 35,
+      "line": 1
+    },
+    "source": null,
+    "start": {
+      "column": 0,
+      "line": 1
+    }
+  },
+  "range": [
+    0,
+    35
+  ],
+  "type": "Program"
+}

--- a/src/parser/test/flow/import_defer_phase/binding_named_defer.js
+++ b/src/parser/test/flow/import_defer_phase/binding_named_defer.js
@@ -1,0 +1,1 @@
+import defer * as defer from "module";

--- a/src/parser/test/flow/import_defer_phase/binding_named_defer.tree.json
+++ b/src/parser/test/flow/import_defer_phase/binding_named_defer.tree.json
@@ -1,0 +1,102 @@
+{
+  "body": [
+    {
+      "importKind": "value",
+      "loc": {
+        "end": {
+          "column": 38,
+          "line": 1
+        },
+        "source": null,
+        "start": {
+          "column": 0,
+          "line": 1
+        }
+      },
+      "phase": "defer",
+      "range": [
+        0,
+        38
+      ],
+      "source": {
+        "loc": {
+          "end": {
+            "column": 37,
+            "line": 1
+          },
+          "source": null,
+          "start": {
+            "column": 29,
+            "line": 1
+          }
+        },
+        "range": [
+          29,
+          37
+        ],
+        "raw": "\"module\"",
+        "type": "Literal",
+        "value": "module"
+      },
+      "specifiers": [
+        {
+          "loc": {
+            "end": {
+              "column": 23,
+              "line": 1
+            },
+            "source": null,
+            "start": {
+              "column": 13,
+              "line": 1
+            }
+          },
+          "local": {
+            "loc": {
+              "end": {
+                "column": 23,
+                "line": 1
+              },
+              "source": null,
+              "start": {
+                "column": 18,
+                "line": 1
+              }
+            },
+            "name": "defer",
+            "optional": false,
+            "range": [
+              18,
+              23
+            ],
+            "type": "Identifier",
+            "typeAnnotation": null
+          },
+          "range": [
+            13,
+            23
+          ],
+          "type": "ImportNamespaceSpecifier"
+        }
+      ],
+      "type": "ImportDeclaration"
+    }
+  ],
+  "comments": [],
+  "loc": {
+    "end": {
+      "column": 38,
+      "line": 1
+    },
+    "source": null,
+    "start": {
+      "column": 0,
+      "line": 1
+    }
+  },
+  "range": [
+    0,
+    38
+  ],
+  "type": "Program"
+}

--- a/src/parser/test/flow/import_defer_phase/contextual_binding_named_from.js
+++ b/src/parser/test/flow/import_defer_phase/contextual_binding_named_from.js
@@ -1,0 +1,1 @@
+import defer from from "module";

--- a/src/parser/test/flow/import_defer_phase/contextual_binding_named_from.tree.json
+++ b/src/parser/test/flow/import_defer_phase/contextual_binding_named_from.tree.json
@@ -1,0 +1,118 @@
+{
+  "body": [
+    {
+      "importKind": "value",
+      "loc": {
+        "end": {
+          "column": 32,
+          "line": 1
+        },
+        "source": null,
+        "start": {
+          "column": 0,
+          "line": 1
+        }
+      },
+      "phase": "defer",
+      "range": [
+        0,
+        32
+      ],
+      "source": {
+        "loc": {
+          "end": {
+            "column": 31,
+            "line": 1
+          },
+          "source": null,
+          "start": {
+            "column": 23,
+            "line": 1
+          }
+        },
+        "range": [
+          23,
+          31
+        ],
+        "raw": "\"module\"",
+        "type": "Literal",
+        "value": "module"
+      },
+      "specifiers": [
+        {
+          "loc": {
+            "end": {
+              "column": 17,
+              "line": 1
+            },
+            "source": null,
+            "start": {
+              "column": 13,
+              "line": 1
+            }
+          },
+          "local": {
+            "loc": {
+              "end": {
+                "column": 17,
+                "line": 1
+              },
+              "source": null,
+              "start": {
+                "column": 13,
+                "line": 1
+              }
+            },
+            "name": "from",
+            "optional": false,
+            "range": [
+              13,
+              17
+            ],
+            "type": "Identifier",
+            "typeAnnotation": null
+          },
+          "range": [
+            13,
+            17
+          ],
+          "type": "ImportDefaultSpecifier"
+        }
+      ],
+      "type": "ImportDeclaration"
+    }
+  ],
+  "comments": [],
+  "errors": [
+    {
+      "loc": {
+        "end": {
+          "column": 17,
+          "line": 1
+        },
+        "source": null,
+        "start": {
+          "column": 13,
+          "line": 1
+        }
+      },
+      "message": "Only `import defer * as ns from \"module\"` is valid"
+    }
+  ],
+  "loc": {
+    "end": {
+      "column": 32,
+      "line": 1
+    },
+    "source": null,
+    "start": {
+      "column": 0,
+      "line": 1
+    }
+  },
+  "range": [
+    0,
+    32
+  ],
+  "type": "Program"
+}

--- a/src/parser/test/flow/import_defer_phase/contextual_default_and_named.js
+++ b/src/parser/test/flow/import_defer_phase/contextual_default_and_named.js
@@ -1,0 +1,1 @@
+import defer, { a } from "module";

--- a/src/parser/test/flow/import_defer_phase/contextual_default_and_named.tree.json
+++ b/src/parser/test/flow/import_defer_phase/contextual_default_and_named.tree.json
@@ -1,0 +1,162 @@
+{
+  "body": [
+    {
+      "importKind": "value",
+      "loc": {
+        "end": {
+          "column": 34,
+          "line": 1
+        },
+        "source": null,
+        "start": {
+          "column": 0,
+          "line": 1
+        }
+      },
+      "range": [
+        0,
+        34
+      ],
+      "source": {
+        "loc": {
+          "end": {
+            "column": 33,
+            "line": 1
+          },
+          "source": null,
+          "start": {
+            "column": 25,
+            "line": 1
+          }
+        },
+        "range": [
+          25,
+          33
+        ],
+        "raw": "\"module\"",
+        "type": "Literal",
+        "value": "module"
+      },
+      "specifiers": [
+        {
+          "loc": {
+            "end": {
+              "column": 12,
+              "line": 1
+            },
+            "source": null,
+            "start": {
+              "column": 7,
+              "line": 1
+            }
+          },
+          "local": {
+            "loc": {
+              "end": {
+                "column": 12,
+                "line": 1
+              },
+              "source": null,
+              "start": {
+                "column": 7,
+                "line": 1
+              }
+            },
+            "name": "defer",
+            "optional": false,
+            "range": [
+              7,
+              12
+            ],
+            "type": "Identifier",
+            "typeAnnotation": null
+          },
+          "range": [
+            7,
+            12
+          ],
+          "type": "ImportDefaultSpecifier"
+        },
+        {
+          "importKind": null,
+          "imported": {
+            "loc": {
+              "end": {
+                "column": 17,
+                "line": 1
+              },
+              "source": null,
+              "start": {
+                "column": 16,
+                "line": 1
+              }
+            },
+            "name": "a",
+            "optional": false,
+            "range": [
+              16,
+              17
+            ],
+            "type": "Identifier",
+            "typeAnnotation": null
+          },
+          "loc": {
+            "end": {
+              "column": 17,
+              "line": 1
+            },
+            "source": null,
+            "start": {
+              "column": 16,
+              "line": 1
+            }
+          },
+          "local": {
+            "loc": {
+              "end": {
+                "column": 17,
+                "line": 1
+              },
+              "source": null,
+              "start": {
+                "column": 16,
+                "line": 1
+              }
+            },
+            "name": "a",
+            "optional": false,
+            "range": [
+              16,
+              17
+            ],
+            "type": "Identifier",
+            "typeAnnotation": null
+          },
+          "range": [
+            16,
+            17
+          ],
+          "type": "ImportSpecifier"
+        }
+      ],
+      "type": "ImportDeclaration"
+    }
+  ],
+  "comments": [],
+  "loc": {
+    "end": {
+      "column": 34,
+      "line": 1
+    },
+    "source": null,
+    "start": {
+      "column": 0,
+      "line": 1
+    }
+  },
+  "range": [
+    0,
+    34
+  ],
+  "type": "Program"
+}

--- a/src/parser/test/flow/import_defer_phase/contextual_default_binding.js
+++ b/src/parser/test/flow/import_defer_phase/contextual_default_binding.js
@@ -1,0 +1,1 @@
+import defer from "module";

--- a/src/parser/test/flow/import_defer_phase/contextual_default_binding.tree.json
+++ b/src/parser/test/flow/import_defer_phase/contextual_default_binding.tree.json
@@ -1,0 +1,101 @@
+{
+  "body": [
+    {
+      "importKind": "value",
+      "loc": {
+        "end": {
+          "column": 27,
+          "line": 1
+        },
+        "source": null,
+        "start": {
+          "column": 0,
+          "line": 1
+        }
+      },
+      "range": [
+        0,
+        27
+      ],
+      "source": {
+        "loc": {
+          "end": {
+            "column": 26,
+            "line": 1
+          },
+          "source": null,
+          "start": {
+            "column": 18,
+            "line": 1
+          }
+        },
+        "range": [
+          18,
+          26
+        ],
+        "raw": "\"module\"",
+        "type": "Literal",
+        "value": "module"
+      },
+      "specifiers": [
+        {
+          "loc": {
+            "end": {
+              "column": 12,
+              "line": 1
+            },
+            "source": null,
+            "start": {
+              "column": 7,
+              "line": 1
+            }
+          },
+          "local": {
+            "loc": {
+              "end": {
+                "column": 12,
+                "line": 1
+              },
+              "source": null,
+              "start": {
+                "column": 7,
+                "line": 1
+              }
+            },
+            "name": "defer",
+            "optional": false,
+            "range": [
+              7,
+              12
+            ],
+            "type": "Identifier",
+            "typeAnnotation": null
+          },
+          "range": [
+            7,
+            12
+          ],
+          "type": "ImportDefaultSpecifier"
+        }
+      ],
+      "type": "ImportDeclaration"
+    }
+  ],
+  "comments": [],
+  "loc": {
+    "end": {
+      "column": 27,
+      "line": 1
+    },
+    "source": null,
+    "start": {
+      "column": 0,
+      "line": 1
+    }
+  },
+  "range": [
+    0,
+    27
+  ],
+  "type": "Program"
+}

--- a/src/parser/test/flow/import_defer_phase/contextual_import_equals.js
+++ b/src/parser/test/flow/import_defer_phase/contextual_import_equals.js
@@ -1,0 +1,1 @@
+import defer = require("module");

--- a/src/parser/test/flow/import_defer_phase/contextual_import_equals.tree.json
+++ b/src/parser/test/flow/import_defer_phase/contextual_import_equals.tree.json
@@ -1,0 +1,100 @@
+{
+  "body": [
+    {
+      "id": {
+        "loc": {
+          "end": {
+            "column": 12,
+            "line": 1
+          },
+          "source": null,
+          "start": {
+            "column": 7,
+            "line": 1
+          }
+        },
+        "name": "defer",
+        "optional": false,
+        "range": [
+          7,
+          12
+        ],
+        "type": "Identifier",
+        "typeAnnotation": null
+      },
+      "importKind": "value",
+      "isExport": false,
+      "loc": {
+        "end": {
+          "column": 33,
+          "line": 1
+        },
+        "source": null,
+        "start": {
+          "column": 0,
+          "line": 1
+        }
+      },
+      "moduleReference": {
+        "expression": {
+          "loc": {
+            "end": {
+              "column": 31,
+              "line": 1
+            },
+            "source": null,
+            "start": {
+              "column": 23,
+              "line": 1
+            }
+          },
+          "range": [
+            23,
+            31
+          ],
+          "raw": "\"module\"",
+          "type": "Literal",
+          "value": "module"
+        },
+        "loc": {
+          "end": {
+            "column": 31,
+            "line": 1
+          },
+          "source": null,
+          "start": {
+            "column": 23,
+            "line": 1
+          }
+        },
+        "range": [
+          23,
+          31
+        ],
+        "type": "ExternalModuleReference"
+      },
+      "range": [
+        0,
+        33
+      ],
+      "type": "ImportEqualsDeclaration"
+    }
+  ],
+  "comments": [],
+  "loc": {
+    "end": {
+      "column": 33,
+      "line": 1
+    },
+    "source": null,
+    "start": {
+      "column": 0,
+      "line": 1
+    }
+  },
+  "range": [
+    0,
+    33
+  ],
+  "type": "Program"
+}

--- a/src/parser/test/flow/import_defer_phase/default_and_namespace_invalid.js
+++ b/src/parser/test/flow/import_defer_phase/default_and_namespace_invalid.js
@@ -1,0 +1,1 @@
+import defer x, * as ns from "module";

--- a/src/parser/test/flow/import_defer_phase/default_and_namespace_invalid.tree.json
+++ b/src/parser/test/flow/import_defer_phase/default_and_namespace_invalid.tree.json
@@ -1,0 +1,157 @@
+{
+  "body": [
+    {
+      "importKind": "value",
+      "loc": {
+        "end": {
+          "column": 38,
+          "line": 1
+        },
+        "source": null,
+        "start": {
+          "column": 0,
+          "line": 1
+        }
+      },
+      "phase": "defer",
+      "range": [
+        0,
+        38
+      ],
+      "source": {
+        "loc": {
+          "end": {
+            "column": 37,
+            "line": 1
+          },
+          "source": null,
+          "start": {
+            "column": 29,
+            "line": 1
+          }
+        },
+        "range": [
+          29,
+          37
+        ],
+        "raw": "\"module\"",
+        "type": "Literal",
+        "value": "module"
+      },
+      "specifiers": [
+        {
+          "loc": {
+            "end": {
+              "column": 14,
+              "line": 1
+            },
+            "source": null,
+            "start": {
+              "column": 13,
+              "line": 1
+            }
+          },
+          "local": {
+            "loc": {
+              "end": {
+                "column": 14,
+                "line": 1
+              },
+              "source": null,
+              "start": {
+                "column": 13,
+                "line": 1
+              }
+            },
+            "name": "x",
+            "optional": false,
+            "range": [
+              13,
+              14
+            ],
+            "type": "Identifier",
+            "typeAnnotation": null
+          },
+          "range": [
+            13,
+            14
+          ],
+          "type": "ImportDefaultSpecifier"
+        },
+        {
+          "loc": {
+            "end": {
+              "column": 23,
+              "line": 1
+            },
+            "source": null,
+            "start": {
+              "column": 16,
+              "line": 1
+            }
+          },
+          "local": {
+            "loc": {
+              "end": {
+                "column": 23,
+                "line": 1
+              },
+              "source": null,
+              "start": {
+                "column": 21,
+                "line": 1
+              }
+            },
+            "name": "ns",
+            "optional": false,
+            "range": [
+              21,
+              23
+            ],
+            "type": "Identifier",
+            "typeAnnotation": null
+          },
+          "range": [
+            16,
+            23
+          ],
+          "type": "ImportNamespaceSpecifier"
+        }
+      ],
+      "type": "ImportDeclaration"
+    }
+  ],
+  "comments": [],
+  "errors": [
+    {
+      "loc": {
+        "end": {
+          "column": 14,
+          "line": 1
+        },
+        "source": null,
+        "start": {
+          "column": 13,
+          "line": 1
+        }
+      },
+      "message": "Only `import defer * as ns from \"module\"` is valid"
+    }
+  ],
+  "loc": {
+    "end": {
+      "column": 38,
+      "line": 1
+    },
+    "source": null,
+    "start": {
+      "column": 0,
+      "line": 1
+    }
+  },
+  "range": [
+    0,
+    38
+  ],
+  "type": "Program"
+}

--- a/src/parser/test/flow/import_defer_phase/default_invalid.js
+++ b/src/parser/test/flow/import_defer_phase/default_invalid.js
@@ -1,0 +1,1 @@
+import defer x from "module";

--- a/src/parser/test/flow/import_defer_phase/default_invalid.tree.json
+++ b/src/parser/test/flow/import_defer_phase/default_invalid.tree.json
@@ -1,0 +1,118 @@
+{
+  "body": [
+    {
+      "importKind": "value",
+      "loc": {
+        "end": {
+          "column": 29,
+          "line": 1
+        },
+        "source": null,
+        "start": {
+          "column": 0,
+          "line": 1
+        }
+      },
+      "phase": "defer",
+      "range": [
+        0,
+        29
+      ],
+      "source": {
+        "loc": {
+          "end": {
+            "column": 28,
+            "line": 1
+          },
+          "source": null,
+          "start": {
+            "column": 20,
+            "line": 1
+          }
+        },
+        "range": [
+          20,
+          28
+        ],
+        "raw": "\"module\"",
+        "type": "Literal",
+        "value": "module"
+      },
+      "specifiers": [
+        {
+          "loc": {
+            "end": {
+              "column": 14,
+              "line": 1
+            },
+            "source": null,
+            "start": {
+              "column": 13,
+              "line": 1
+            }
+          },
+          "local": {
+            "loc": {
+              "end": {
+                "column": 14,
+                "line": 1
+              },
+              "source": null,
+              "start": {
+                "column": 13,
+                "line": 1
+              }
+            },
+            "name": "x",
+            "optional": false,
+            "range": [
+              13,
+              14
+            ],
+            "type": "Identifier",
+            "typeAnnotation": null
+          },
+          "range": [
+            13,
+            14
+          ],
+          "type": "ImportDefaultSpecifier"
+        }
+      ],
+      "type": "ImportDeclaration"
+    }
+  ],
+  "comments": [],
+  "errors": [
+    {
+      "loc": {
+        "end": {
+          "column": 14,
+          "line": 1
+        },
+        "source": null,
+        "start": {
+          "column": 13,
+          "line": 1
+        }
+      },
+      "message": "Only `import defer * as ns from \"module\"` is valid"
+    }
+  ],
+  "loc": {
+    "end": {
+      "column": 29,
+      "line": 1
+    },
+    "source": null,
+    "start": {
+      "column": 0,
+      "line": 1
+    }
+  },
+  "range": [
+    0,
+    29
+  ],
+  "type": "Program"
+}

--- a/src/parser/test/flow/import_defer_phase/dynamic.js
+++ b/src/parser/test/flow/import_defer_phase/dynamic.js
@@ -1,0 +1,4 @@
+const x = import.defer("module");
+async function f() {
+  return await import.defer("module", { with: { type: "json" } });
+}

--- a/src/parser/test/flow/import_defer_phase/dynamic.tree.json
+++ b/src/parser/test/flow/import_defer_phase/dynamic.tree.json
@@ -1,0 +1,407 @@
+{
+  "body": [
+    {
+      "declarations": [
+        {
+          "id": {
+            "loc": {
+              "end": {
+                "column": 7,
+                "line": 1
+              },
+              "source": null,
+              "start": {
+                "column": 6,
+                "line": 1
+              }
+            },
+            "name": "x",
+            "optional": false,
+            "range": [
+              6,
+              7
+            ],
+            "type": "Identifier",
+            "typeAnnotation": null
+          },
+          "init": {
+            "loc": {
+              "end": {
+                "column": 32,
+                "line": 1
+              },
+              "source": null,
+              "start": {
+                "column": 10,
+                "line": 1
+              }
+            },
+            "phase": "defer",
+            "range": [
+              10,
+              32
+            ],
+            "source": {
+              "loc": {
+                "end": {
+                  "column": 31,
+                  "line": 1
+                },
+                "source": null,
+                "start": {
+                  "column": 23,
+                  "line": 1
+                }
+              },
+              "range": [
+                23,
+                31
+              ],
+              "raw": "\"module\"",
+              "type": "Literal",
+              "value": "module"
+            },
+            "type": "ImportExpression"
+          },
+          "loc": {
+            "end": {
+              "column": 32,
+              "line": 1
+            },
+            "source": null,
+            "start": {
+              "column": 6,
+              "line": 1
+            }
+          },
+          "range": [
+            6,
+            32
+          ],
+          "type": "VariableDeclarator"
+        }
+      ],
+      "kind": "const",
+      "loc": {
+        "end": {
+          "column": 33,
+          "line": 1
+        },
+        "source": null,
+        "start": {
+          "column": 0,
+          "line": 1
+        }
+      },
+      "range": [
+        0,
+        33
+      ],
+      "type": "VariableDeclaration"
+    },
+    {
+      "async": true,
+      "body": {
+        "body": [
+          {
+            "argument": {
+              "argument": {
+                "loc": {
+                  "end": {
+                    "column": 65,
+                    "line": 3
+                  },
+                  "source": null,
+                  "start": {
+                    "column": 15,
+                    "line": 3
+                  }
+                },
+                "options": {
+                  "loc": {
+                    "end": {
+                      "column": 64,
+                      "line": 3
+                    },
+                    "source": null,
+                    "start": {
+                      "column": 38,
+                      "line": 3
+                    }
+                  },
+                  "properties": [
+                    {
+                      "computed": false,
+                      "key": {
+                        "loc": {
+                          "end": {
+                            "column": 44,
+                            "line": 3
+                          },
+                          "source": null,
+                          "start": {
+                            "column": 40,
+                            "line": 3
+                          }
+                        },
+                        "name": "with",
+                        "optional": false,
+                        "range": [
+                          95,
+                          99
+                        ],
+                        "type": "Identifier",
+                        "typeAnnotation": null
+                      },
+                      "kind": "init",
+                      "loc": {
+                        "end": {
+                          "column": 62,
+                          "line": 3
+                        },
+                        "source": null,
+                        "start": {
+                          "column": 40,
+                          "line": 3
+                        }
+                      },
+                      "method": false,
+                      "range": [
+                        95,
+                        117
+                      ],
+                      "shorthand": false,
+                      "type": "Property",
+                      "value": {
+                        "loc": {
+                          "end": {
+                            "column": 62,
+                            "line": 3
+                          },
+                          "source": null,
+                          "start": {
+                            "column": 46,
+                            "line": 3
+                          }
+                        },
+                        "properties": [
+                          {
+                            "computed": false,
+                            "key": {
+                              "loc": {
+                                "end": {
+                                  "column": 52,
+                                  "line": 3
+                                },
+                                "source": null,
+                                "start": {
+                                  "column": 48,
+                                  "line": 3
+                                }
+                              },
+                              "name": "type",
+                              "optional": false,
+                              "range": [
+                                103,
+                                107
+                              ],
+                              "type": "Identifier",
+                              "typeAnnotation": null
+                            },
+                            "kind": "init",
+                            "loc": {
+                              "end": {
+                                "column": 60,
+                                "line": 3
+                              },
+                              "source": null,
+                              "start": {
+                                "column": 48,
+                                "line": 3
+                              }
+                            },
+                            "method": false,
+                            "range": [
+                              103,
+                              115
+                            ],
+                            "shorthand": false,
+                            "type": "Property",
+                            "value": {
+                              "loc": {
+                                "end": {
+                                  "column": 60,
+                                  "line": 3
+                                },
+                                "source": null,
+                                "start": {
+                                  "column": 54,
+                                  "line": 3
+                                }
+                              },
+                              "range": [
+                                109,
+                                115
+                              ],
+                              "raw": "\"json\"",
+                              "type": "Literal",
+                              "value": "json"
+                            }
+                          }
+                        ],
+                        "range": [
+                          101,
+                          117
+                        ],
+                        "type": "ObjectExpression"
+                      }
+                    }
+                  ],
+                  "range": [
+                    93,
+                    119
+                  ],
+                  "type": "ObjectExpression"
+                },
+                "phase": "defer",
+                "range": [
+                  70,
+                  120
+                ],
+                "source": {
+                  "loc": {
+                    "end": {
+                      "column": 36,
+                      "line": 3
+                    },
+                    "source": null,
+                    "start": {
+                      "column": 28,
+                      "line": 3
+                    }
+                  },
+                  "range": [
+                    83,
+                    91
+                  ],
+                  "raw": "\"module\"",
+                  "type": "Literal",
+                  "value": "module"
+                },
+                "type": "ImportExpression"
+              },
+              "loc": {
+                "end": {
+                  "column": 65,
+                  "line": 3
+                },
+                "source": null,
+                "start": {
+                  "column": 9,
+                  "line": 3
+                }
+              },
+              "range": [
+                64,
+                120
+              ],
+              "type": "AwaitExpression"
+            },
+            "loc": {
+              "end": {
+                "column": 66,
+                "line": 3
+              },
+              "source": null,
+              "start": {
+                "column": 2,
+                "line": 3
+              }
+            },
+            "range": [
+              57,
+              121
+            ],
+            "type": "ReturnStatement"
+          }
+        ],
+        "loc": {
+          "end": {
+            "column": 1,
+            "line": 4
+          },
+          "source": null,
+          "start": {
+            "column": 19,
+            "line": 2
+          }
+        },
+        "range": [
+          53,
+          123
+        ],
+        "type": "BlockStatement"
+      },
+      "expression": false,
+      "generator": false,
+      "id": {
+        "loc": {
+          "end": {
+            "column": 16,
+            "line": 2
+          },
+          "source": null,
+          "start": {
+            "column": 15,
+            "line": 2
+          }
+        },
+        "name": "f",
+        "optional": false,
+        "range": [
+          49,
+          50
+        ],
+        "type": "Identifier",
+        "typeAnnotation": null
+      },
+      "loc": {
+        "end": {
+          "column": 1,
+          "line": 4
+        },
+        "source": null,
+        "start": {
+          "column": 0,
+          "line": 2
+        }
+      },
+      "params": [],
+      "predicate": null,
+      "range": [
+        34,
+        123
+      ],
+      "returnType": null,
+      "type": "FunctionDeclaration",
+      "typeParameters": null
+    }
+  ],
+  "comments": [],
+  "loc": {
+    "end": {
+      "column": 1,
+      "line": 4
+    },
+    "source": null,
+    "start": {
+      "column": 0,
+      "line": 1
+    }
+  },
+  "range": [
+    0,
+    123
+  ],
+  "type": "Program"
+}

--- a/src/parser/test/flow/import_defer_phase/named_invalid.js
+++ b/src/parser/test/flow/import_defer_phase/named_invalid.js
@@ -1,0 +1,1 @@
+import defer { a } from "module";

--- a/src/parser/test/flow/import_defer_phase/named_invalid.tree.json
+++ b/src/parser/test/flow/import_defer_phase/named_invalid.tree.json
@@ -1,0 +1,140 @@
+{
+  "body": [
+    {
+      "importKind": "value",
+      "loc": {
+        "end": {
+          "column": 33,
+          "line": 1
+        },
+        "source": null,
+        "start": {
+          "column": 0,
+          "line": 1
+        }
+      },
+      "phase": "defer",
+      "range": [
+        0,
+        33
+      ],
+      "source": {
+        "loc": {
+          "end": {
+            "column": 32,
+            "line": 1
+          },
+          "source": null,
+          "start": {
+            "column": 24,
+            "line": 1
+          }
+        },
+        "range": [
+          24,
+          32
+        ],
+        "raw": "\"module\"",
+        "type": "Literal",
+        "value": "module"
+      },
+      "specifiers": [
+        {
+          "importKind": null,
+          "imported": {
+            "loc": {
+              "end": {
+                "column": 16,
+                "line": 1
+              },
+              "source": null,
+              "start": {
+                "column": 15,
+                "line": 1
+              }
+            },
+            "name": "a",
+            "optional": false,
+            "range": [
+              15,
+              16
+            ],
+            "type": "Identifier",
+            "typeAnnotation": null
+          },
+          "loc": {
+            "end": {
+              "column": 16,
+              "line": 1
+            },
+            "source": null,
+            "start": {
+              "column": 15,
+              "line": 1
+            }
+          },
+          "local": {
+            "loc": {
+              "end": {
+                "column": 16,
+                "line": 1
+              },
+              "source": null,
+              "start": {
+                "column": 15,
+                "line": 1
+              }
+            },
+            "name": "a",
+            "optional": false,
+            "range": [
+              15,
+              16
+            ],
+            "type": "Identifier",
+            "typeAnnotation": null
+          },
+          "range": [
+            15,
+            16
+          ],
+          "type": "ImportSpecifier"
+        }
+      ],
+      "type": "ImportDeclaration"
+    }
+  ],
+  "comments": [],
+  "errors": [
+    {
+      "loc": {
+        "end": {
+          "column": 14,
+          "line": 1
+        },
+        "source": null,
+        "start": {
+          "column": 13,
+          "line": 1
+        }
+      },
+      "message": "Only `import defer * as ns from \"module\"` is valid"
+    }
+  ],
+  "loc": {
+    "end": {
+      "column": 33,
+      "line": 1
+    },
+    "source": null,
+    "start": {
+      "column": 0,
+      "line": 1
+    }
+  },
+  "range": [
+    0,
+    33
+  ],
+  "type": "Program"
+}

--- a/src/parser/test/flow/import_defer_phase/namespace_on_next_line.js
+++ b/src/parser/test/flow/import_defer_phase/namespace_on_next_line.js
@@ -1,0 +1,2 @@
+import defer
+* as ns from "module";

--- a/src/parser/test/flow/import_defer_phase/namespace_on_next_line.tree.json
+++ b/src/parser/test/flow/import_defer_phase/namespace_on_next_line.tree.json
@@ -1,0 +1,102 @@
+{
+  "body": [
+    {
+      "importKind": "value",
+      "loc": {
+        "end": {
+          "column": 22,
+          "line": 2
+        },
+        "source": null,
+        "start": {
+          "column": 0,
+          "line": 1
+        }
+      },
+      "phase": "defer",
+      "range": [
+        0,
+        35
+      ],
+      "source": {
+        "loc": {
+          "end": {
+            "column": 21,
+            "line": 2
+          },
+          "source": null,
+          "start": {
+            "column": 13,
+            "line": 2
+          }
+        },
+        "range": [
+          26,
+          34
+        ],
+        "raw": "\"module\"",
+        "type": "Literal",
+        "value": "module"
+      },
+      "specifiers": [
+        {
+          "loc": {
+            "end": {
+              "column": 7,
+              "line": 2
+            },
+            "source": null,
+            "start": {
+              "column": 0,
+              "line": 2
+            }
+          },
+          "local": {
+            "loc": {
+              "end": {
+                "column": 7,
+                "line": 2
+              },
+              "source": null,
+              "start": {
+                "column": 5,
+                "line": 2
+              }
+            },
+            "name": "ns",
+            "optional": false,
+            "range": [
+              18,
+              20
+            ],
+            "type": "Identifier",
+            "typeAnnotation": null
+          },
+          "range": [
+            13,
+            20
+          ],
+          "type": "ImportNamespaceSpecifier"
+        }
+      ],
+      "type": "ImportDeclaration"
+    }
+  ],
+  "comments": [],
+  "loc": {
+    "end": {
+      "column": 22,
+      "line": 2
+    },
+    "source": null,
+    "start": {
+      "column": 0,
+      "line": 1
+    }
+  },
+  "range": [
+    0,
+    35
+  ],
+  "type": "Program"
+}

--- a/src/parser/test/flow/import_defer_phase/with_attributes.js
+++ b/src/parser/test/flow/import_defer_phase/with_attributes.js
@@ -1,0 +1,1 @@
+import defer * as ns from "module" with { type: "json" };

--- a/src/parser/test/flow/import_defer_phase/with_attributes.tree.json
+++ b/src/parser/test/flow/import_defer_phase/with_attributes.tree.json
@@ -1,0 +1,163 @@
+{
+  "body": [
+    {
+      "attributes": [
+        {
+          "key": {
+            "loc": {
+              "end": {
+                "column": 46,
+                "line": 1
+              },
+              "source": null,
+              "start": {
+                "column": 42,
+                "line": 1
+              }
+            },
+            "name": "type",
+            "optional": false,
+            "range": [
+              42,
+              46
+            ],
+            "type": "Identifier",
+            "typeAnnotation": null
+          },
+          "loc": {
+            "end": {
+              "column": 54,
+              "line": 1
+            },
+            "source": null,
+            "start": {
+              "column": 42,
+              "line": 1
+            }
+          },
+          "range": [
+            42,
+            54
+          ],
+          "type": "ImportAttribute",
+          "value": {
+            "loc": {
+              "end": {
+                "column": 54,
+                "line": 1
+              },
+              "source": null,
+              "start": {
+                "column": 48,
+                "line": 1
+              }
+            },
+            "range": [
+              48,
+              54
+            ],
+            "raw": "\"json\"",
+            "type": "Literal",
+            "value": "json"
+          }
+        }
+      ],
+      "importKind": "value",
+      "loc": {
+        "end": {
+          "column": 57,
+          "line": 1
+        },
+        "source": null,
+        "start": {
+          "column": 0,
+          "line": 1
+        }
+      },
+      "phase": "defer",
+      "range": [
+        0,
+        57
+      ],
+      "source": {
+        "loc": {
+          "end": {
+            "column": 34,
+            "line": 1
+          },
+          "source": null,
+          "start": {
+            "column": 26,
+            "line": 1
+          }
+        },
+        "range": [
+          26,
+          34
+        ],
+        "raw": "\"module\"",
+        "type": "Literal",
+        "value": "module"
+      },
+      "specifiers": [
+        {
+          "loc": {
+            "end": {
+              "column": 20,
+              "line": 1
+            },
+            "source": null,
+            "start": {
+              "column": 13,
+              "line": 1
+            }
+          },
+          "local": {
+            "loc": {
+              "end": {
+                "column": 20,
+                "line": 1
+              },
+              "source": null,
+              "start": {
+                "column": 18,
+                "line": 1
+              }
+            },
+            "name": "ns",
+            "optional": false,
+            "range": [
+              18,
+              20
+            ],
+            "type": "Identifier",
+            "typeAnnotation": null
+          },
+          "range": [
+            13,
+            20
+          ],
+          "type": "ImportNamespaceSpecifier"
+        }
+      ],
+      "type": "ImportDeclaration"
+    }
+  ],
+  "comments": [],
+  "loc": {
+    "end": {
+      "column": 57,
+      "line": 1
+    },
+    "source": null,
+    "start": {
+      "column": 0,
+      "line": 1
+    }
+  },
+  "range": [
+    0,
+    57
+  ],
+  "type": "Program"
+}

--- a/src/parser/test/flow/import_unsupported_phase/contextual_default_and_named.js
+++ b/src/parser/test/flow/import_unsupported_phase/contextual_default_and_named.js
@@ -1,0 +1,1 @@
+import source, { x } from "./foo";

--- a/src/parser/test/flow/import_unsupported_phase/contextual_default_and_named.tree.json
+++ b/src/parser/test/flow/import_unsupported_phase/contextual_default_and_named.tree.json
@@ -1,0 +1,162 @@
+{
+  "body": [
+    {
+      "importKind": "value",
+      "loc": {
+        "end": {
+          "column": 34,
+          "line": 1
+        },
+        "source": null,
+        "start": {
+          "column": 0,
+          "line": 1
+        }
+      },
+      "range": [
+        0,
+        34
+      ],
+      "source": {
+        "loc": {
+          "end": {
+            "column": 33,
+            "line": 1
+          },
+          "source": null,
+          "start": {
+            "column": 26,
+            "line": 1
+          }
+        },
+        "range": [
+          26,
+          33
+        ],
+        "raw": "\"./foo\"",
+        "type": "Literal",
+        "value": "./foo"
+      },
+      "specifiers": [
+        {
+          "loc": {
+            "end": {
+              "column": 13,
+              "line": 1
+            },
+            "source": null,
+            "start": {
+              "column": 7,
+              "line": 1
+            }
+          },
+          "local": {
+            "loc": {
+              "end": {
+                "column": 13,
+                "line": 1
+              },
+              "source": null,
+              "start": {
+                "column": 7,
+                "line": 1
+              }
+            },
+            "name": "source",
+            "optional": false,
+            "range": [
+              7,
+              13
+            ],
+            "type": "Identifier",
+            "typeAnnotation": null
+          },
+          "range": [
+            7,
+            13
+          ],
+          "type": "ImportDefaultSpecifier"
+        },
+        {
+          "importKind": null,
+          "imported": {
+            "loc": {
+              "end": {
+                "column": 18,
+                "line": 1
+              },
+              "source": null,
+              "start": {
+                "column": 17,
+                "line": 1
+              }
+            },
+            "name": "x",
+            "optional": false,
+            "range": [
+              17,
+              18
+            ],
+            "type": "Identifier",
+            "typeAnnotation": null
+          },
+          "loc": {
+            "end": {
+              "column": 18,
+              "line": 1
+            },
+            "source": null,
+            "start": {
+              "column": 17,
+              "line": 1
+            }
+          },
+          "local": {
+            "loc": {
+              "end": {
+                "column": 18,
+                "line": 1
+              },
+              "source": null,
+              "start": {
+                "column": 17,
+                "line": 1
+              }
+            },
+            "name": "x",
+            "optional": false,
+            "range": [
+              17,
+              18
+            ],
+            "type": "Identifier",
+            "typeAnnotation": null
+          },
+          "range": [
+            17,
+            18
+          ],
+          "type": "ImportSpecifier"
+        }
+      ],
+      "type": "ImportDeclaration"
+    }
+  ],
+  "comments": [],
+  "loc": {
+    "end": {
+      "column": 34,
+      "line": 1
+    },
+    "source": null,
+    "start": {
+      "column": 0,
+      "line": 1
+    }
+  },
+  "range": [
+    0,
+    34
+  ],
+  "type": "Program"
+}

--- a/src/parser/test/flow/import_unsupported_phase/contextual_default_binding.js
+++ b/src/parser/test/flow/import_unsupported_phase/contextual_default_binding.js
@@ -1,0 +1,1 @@
+import source from "./foo";

--- a/src/parser/test/flow/import_unsupported_phase/contextual_default_binding.tree.json
+++ b/src/parser/test/flow/import_unsupported_phase/contextual_default_binding.tree.json
@@ -1,0 +1,101 @@
+{
+  "body": [
+    {
+      "importKind": "value",
+      "loc": {
+        "end": {
+          "column": 27,
+          "line": 1
+        },
+        "source": null,
+        "start": {
+          "column": 0,
+          "line": 1
+        }
+      },
+      "range": [
+        0,
+        27
+      ],
+      "source": {
+        "loc": {
+          "end": {
+            "column": 26,
+            "line": 1
+          },
+          "source": null,
+          "start": {
+            "column": 19,
+            "line": 1
+          }
+        },
+        "range": [
+          19,
+          26
+        ],
+        "raw": "\"./foo\"",
+        "type": "Literal",
+        "value": "./foo"
+      },
+      "specifiers": [
+        {
+          "loc": {
+            "end": {
+              "column": 13,
+              "line": 1
+            },
+            "source": null,
+            "start": {
+              "column": 7,
+              "line": 1
+            }
+          },
+          "local": {
+            "loc": {
+              "end": {
+                "column": 13,
+                "line": 1
+              },
+              "source": null,
+              "start": {
+                "column": 7,
+                "line": 1
+              }
+            },
+            "name": "source",
+            "optional": false,
+            "range": [
+              7,
+              13
+            ],
+            "type": "Identifier",
+            "typeAnnotation": null
+          },
+          "range": [
+            7,
+            13
+          ],
+          "type": "ImportDefaultSpecifier"
+        }
+      ],
+      "type": "ImportDeclaration"
+    }
+  ],
+  "comments": [],
+  "loc": {
+    "end": {
+      "column": 27,
+      "line": 1
+    },
+    "source": null,
+    "start": {
+      "column": 0,
+      "line": 1
+    }
+  },
+  "range": [
+    0,
+    27
+  ],
+  "type": "Program"
+}

--- a/src/parser/test/flow/import_unsupported_phase/contextual_import_equals.js
+++ b/src/parser/test/flow/import_unsupported_phase/contextual_import_equals.js
@@ -1,0 +1,1 @@
+import source = require("./foo");

--- a/src/parser/test/flow/import_unsupported_phase/contextual_import_equals.tree.json
+++ b/src/parser/test/flow/import_unsupported_phase/contextual_import_equals.tree.json
@@ -1,0 +1,100 @@
+{
+  "body": [
+    {
+      "id": {
+        "loc": {
+          "end": {
+            "column": 13,
+            "line": 1
+          },
+          "source": null,
+          "start": {
+            "column": 7,
+            "line": 1
+          }
+        },
+        "name": "source",
+        "optional": false,
+        "range": [
+          7,
+          13
+        ],
+        "type": "Identifier",
+        "typeAnnotation": null
+      },
+      "importKind": "value",
+      "isExport": false,
+      "loc": {
+        "end": {
+          "column": 33,
+          "line": 1
+        },
+        "source": null,
+        "start": {
+          "column": 0,
+          "line": 1
+        }
+      },
+      "moduleReference": {
+        "expression": {
+          "loc": {
+            "end": {
+              "column": 31,
+              "line": 1
+            },
+            "source": null,
+            "start": {
+              "column": 24,
+              "line": 1
+            }
+          },
+          "range": [
+            24,
+            31
+          ],
+          "raw": "\"./foo\"",
+          "type": "Literal",
+          "value": "./foo"
+        },
+        "loc": {
+          "end": {
+            "column": 31,
+            "line": 1
+          },
+          "source": null,
+          "start": {
+            "column": 24,
+            "line": 1
+          }
+        },
+        "range": [
+          24,
+          31
+        ],
+        "type": "ExternalModuleReference"
+      },
+      "range": [
+        0,
+        33
+      ],
+      "type": "ImportEqualsDeclaration"
+    }
+  ],
+  "comments": [],
+  "loc": {
+    "end": {
+      "column": 33,
+      "line": 1
+    },
+    "source": null,
+    "start": {
+      "column": 0,
+      "line": 1
+    }
+  },
+  "range": [
+    0,
+    33
+  ],
+  "type": "Program"
+}

--- a/src/parser/test/flow/import_unsupported_phase/default_binding.js
+++ b/src/parser/test/flow/import_unsupported_phase/default_binding.js
@@ -1,0 +1,1 @@
+import source x from "./foo";

--- a/src/parser/test/flow/import_unsupported_phase/default_binding.tree.json
+++ b/src/parser/test/flow/import_unsupported_phase/default_binding.tree.json
@@ -1,0 +1,117 @@
+{
+  "body": [
+    {
+      "importKind": "value",
+      "loc": {
+        "end": {
+          "column": 29,
+          "line": 1
+        },
+        "source": null,
+        "start": {
+          "column": 0,
+          "line": 1
+        }
+      },
+      "range": [
+        0,
+        29
+      ],
+      "source": {
+        "loc": {
+          "end": {
+            "column": 28,
+            "line": 1
+          },
+          "source": null,
+          "start": {
+            "column": 21,
+            "line": 1
+          }
+        },
+        "range": [
+          21,
+          28
+        ],
+        "raw": "\"./foo\"",
+        "type": "Literal",
+        "value": "./foo"
+      },
+      "specifiers": [
+        {
+          "loc": {
+            "end": {
+              "column": 15,
+              "line": 1
+            },
+            "source": null,
+            "start": {
+              "column": 14,
+              "line": 1
+            }
+          },
+          "local": {
+            "loc": {
+              "end": {
+                "column": 15,
+                "line": 1
+              },
+              "source": null,
+              "start": {
+                "column": 14,
+                "line": 1
+              }
+            },
+            "name": "x",
+            "optional": false,
+            "range": [
+              14,
+              15
+            ],
+            "type": "Identifier",
+            "typeAnnotation": null
+          },
+          "range": [
+            14,
+            15
+          ],
+          "type": "ImportDefaultSpecifier"
+        }
+      ],
+      "type": "ImportDeclaration"
+    }
+  ],
+  "comments": [],
+  "errors": [
+    {
+      "loc": {
+        "end": {
+          "column": 13,
+          "line": 1
+        },
+        "source": null,
+        "start": {
+          "column": 7,
+          "line": 1
+        }
+      },
+      "message": "The `source` import phase is not supported."
+    }
+  ],
+  "loc": {
+    "end": {
+      "column": 29,
+      "line": 1
+    },
+    "source": null,
+    "start": {
+      "column": 0,
+      "line": 1
+    }
+  },
+  "range": [
+    0,
+    29
+  ],
+  "type": "Program"
+}

--- a/src/parser/test/flow/import_unsupported_phase/dynamic.js
+++ b/src/parser/test/flow/import_unsupported_phase/dynamic.js
@@ -1,0 +1,1 @@
+const x = import.source("./foo");

--- a/src/parser/test/flow/import_unsupported_phase/dynamic.tree.json
+++ b/src/parser/test/flow/import_unsupported_phase/dynamic.tree.json
@@ -1,0 +1,135 @@
+{
+  "body": [
+    {
+      "declarations": [
+        {
+          "id": {
+            "loc": {
+              "end": {
+                "column": 7,
+                "line": 1
+              },
+              "source": null,
+              "start": {
+                "column": 6,
+                "line": 1
+              }
+            },
+            "name": "x",
+            "optional": false,
+            "range": [
+              6,
+              7
+            ],
+            "type": "Identifier",
+            "typeAnnotation": null
+          },
+          "init": {
+            "loc": {
+              "end": {
+                "column": 32,
+                "line": 1
+              },
+              "source": null,
+              "start": {
+                "column": 10,
+                "line": 1
+              }
+            },
+            "range": [
+              10,
+              32
+            ],
+            "source": {
+              "loc": {
+                "end": {
+                  "column": 31,
+                  "line": 1
+                },
+                "source": null,
+                "start": {
+                  "column": 24,
+                  "line": 1
+                }
+              },
+              "range": [
+                24,
+                31
+              ],
+              "raw": "\"./foo\"",
+              "type": "Literal",
+              "value": "./foo"
+            },
+            "type": "ImportExpression"
+          },
+          "loc": {
+            "end": {
+              "column": 32,
+              "line": 1
+            },
+            "source": null,
+            "start": {
+              "column": 6,
+              "line": 1
+            }
+          },
+          "range": [
+            6,
+            32
+          ],
+          "type": "VariableDeclarator"
+        }
+      ],
+      "kind": "const",
+      "loc": {
+        "end": {
+          "column": 33,
+          "line": 1
+        },
+        "source": null,
+        "start": {
+          "column": 0,
+          "line": 1
+        }
+      },
+      "range": [
+        0,
+        33
+      ],
+      "type": "VariableDeclaration"
+    }
+  ],
+  "comments": [],
+  "errors": [
+    {
+      "loc": {
+        "end": {
+          "column": 23,
+          "line": 1
+        },
+        "source": null,
+        "start": {
+          "column": 17,
+          "line": 1
+        }
+      },
+      "message": "The `source` import phase is not supported."
+    }
+  ],
+  "loc": {
+    "end": {
+      "column": 33,
+      "line": 1
+    },
+    "source": null,
+    "start": {
+      "column": 0,
+      "line": 1
+    }
+  },
+  "range": [
+    0,
+    33
+  ],
+  "type": "Program"
+}

--- a/src/parser/test/flow/import_unsupported_phase/mistyped_meta.js
+++ b/src/parser/test/flow/import_unsupported_phase/mistyped_meta.js
@@ -1,0 +1,1 @@
+import.metaa;

--- a/src/parser/test/flow/import_unsupported_phase/mistyped_meta.tree.json
+++ b/src/parser/test/flow/import_unsupported_phase/mistyped_meta.tree.json
@@ -1,0 +1,116 @@
+{
+  "body": [
+    {
+      "directive": null,
+      "expression": {
+        "loc": {
+          "end": {
+            "column": 12,
+            "line": 1
+          },
+          "source": null,
+          "start": {
+            "column": 0,
+            "line": 1
+          }
+        },
+        "meta": {
+          "loc": {
+            "end": {
+              "column": 6,
+              "line": 1
+            },
+            "source": null,
+            "start": {
+              "column": 0,
+              "line": 1
+            }
+          },
+          "name": "import",
+          "optional": false,
+          "range": [
+            0,
+            6
+          ],
+          "type": "Identifier",
+          "typeAnnotation": null
+        },
+        "property": {
+          "loc": {
+            "end": {
+              "column": 12,
+              "line": 1
+            },
+            "source": null,
+            "start": {
+              "column": 7,
+              "line": 1
+            }
+          },
+          "name": "meta",
+          "optional": false,
+          "range": [
+            7,
+            12
+          ],
+          "type": "Identifier",
+          "typeAnnotation": null
+        },
+        "range": [
+          0,
+          12
+        ],
+        "type": "MetaProperty"
+      },
+      "loc": {
+        "end": {
+          "column": 13,
+          "line": 1
+        },
+        "source": null,
+        "start": {
+          "column": 0,
+          "line": 1
+        }
+      },
+      "range": [
+        0,
+        13
+      ],
+      "type": "ExpressionStatement"
+    }
+  ],
+  "comments": [],
+  "errors": [
+    {
+      "loc": {
+        "end": {
+          "column": 12,
+          "line": 1
+        },
+        "source": null,
+        "start": {
+          "column": 7,
+          "line": 1
+        }
+      },
+      "message": "Unexpected identifier, expected the identifier `meta`"
+    }
+  ],
+  "loc": {
+    "end": {
+      "column": 13,
+      "line": 1
+    },
+    "source": null,
+    "start": {
+      "column": 0,
+      "line": 1
+    }
+  },
+  "range": [
+    0,
+    13
+  ],
+  "type": "Program"
+}

--- a/src/parser/test/flow/import_unsupported_phase/unknown_phase.js
+++ b/src/parser/test/flow/import_unsupported_phase/unknown_phase.js
@@ -1,0 +1,1 @@
+import bogusphase x from "./foo";

--- a/src/parser/test/flow/import_unsupported_phase/unknown_phase.tree.json
+++ b/src/parser/test/flow/import_unsupported_phase/unknown_phase.tree.json
@@ -1,0 +1,117 @@
+{
+  "body": [
+    {
+      "importKind": "value",
+      "loc": {
+        "end": {
+          "column": 33,
+          "line": 1
+        },
+        "source": null,
+        "start": {
+          "column": 0,
+          "line": 1
+        }
+      },
+      "range": [
+        0,
+        33
+      ],
+      "source": {
+        "loc": {
+          "end": {
+            "column": 32,
+            "line": 1
+          },
+          "source": null,
+          "start": {
+            "column": 25,
+            "line": 1
+          }
+        },
+        "range": [
+          25,
+          32
+        ],
+        "raw": "\"./foo\"",
+        "type": "Literal",
+        "value": "./foo"
+      },
+      "specifiers": [
+        {
+          "loc": {
+            "end": {
+              "column": 19,
+              "line": 1
+            },
+            "source": null,
+            "start": {
+              "column": 18,
+              "line": 1
+            }
+          },
+          "local": {
+            "loc": {
+              "end": {
+                "column": 19,
+                "line": 1
+              },
+              "source": null,
+              "start": {
+                "column": 18,
+                "line": 1
+              }
+            },
+            "name": "x",
+            "optional": false,
+            "range": [
+              18,
+              19
+            ],
+            "type": "Identifier",
+            "typeAnnotation": null
+          },
+          "range": [
+            18,
+            19
+          ],
+          "type": "ImportDefaultSpecifier"
+        }
+      ],
+      "type": "ImportDeclaration"
+    }
+  ],
+  "comments": [],
+  "errors": [
+    {
+      "loc": {
+        "end": {
+          "column": 17,
+          "line": 1
+        },
+        "source": null,
+        "start": {
+          "column": 7,
+          "line": 1
+        }
+      },
+      "message": "The `bogusphase` import phase is not supported."
+    }
+  ],
+  "loc": {
+    "end": {
+      "column": 33,
+      "line": 1
+    },
+    "source": null,
+    "start": {
+      "column": 0,
+      "line": 1
+    }
+  },
+  "range": [
+    0,
+    33
+  ],
+  "type": "Program"
+}

--- a/src/parser/test/flow/import_unsupported_phase/unknown_phase_dynamic.js
+++ b/src/parser/test/flow/import_unsupported_phase/unknown_phase_dynamic.js
@@ -1,0 +1,1 @@
+const x = import.bogusphase("./foo");

--- a/src/parser/test/flow/import_unsupported_phase/unknown_phase_dynamic.tree.json
+++ b/src/parser/test/flow/import_unsupported_phase/unknown_phase_dynamic.tree.json
@@ -1,0 +1,135 @@
+{
+  "body": [
+    {
+      "declarations": [
+        {
+          "id": {
+            "loc": {
+              "end": {
+                "column": 7,
+                "line": 1
+              },
+              "source": null,
+              "start": {
+                "column": 6,
+                "line": 1
+              }
+            },
+            "name": "x",
+            "optional": false,
+            "range": [
+              6,
+              7
+            ],
+            "type": "Identifier",
+            "typeAnnotation": null
+          },
+          "init": {
+            "loc": {
+              "end": {
+                "column": 36,
+                "line": 1
+              },
+              "source": null,
+              "start": {
+                "column": 10,
+                "line": 1
+              }
+            },
+            "range": [
+              10,
+              36
+            ],
+            "source": {
+              "loc": {
+                "end": {
+                  "column": 35,
+                  "line": 1
+                },
+                "source": null,
+                "start": {
+                  "column": 28,
+                  "line": 1
+                }
+              },
+              "range": [
+                28,
+                35
+              ],
+              "raw": "\"./foo\"",
+              "type": "Literal",
+              "value": "./foo"
+            },
+            "type": "ImportExpression"
+          },
+          "loc": {
+            "end": {
+              "column": 36,
+              "line": 1
+            },
+            "source": null,
+            "start": {
+              "column": 6,
+              "line": 1
+            }
+          },
+          "range": [
+            6,
+            36
+          ],
+          "type": "VariableDeclarator"
+        }
+      ],
+      "kind": "const",
+      "loc": {
+        "end": {
+          "column": 37,
+          "line": 1
+        },
+        "source": null,
+        "start": {
+          "column": 0,
+          "line": 1
+        }
+      },
+      "range": [
+        0,
+        37
+      ],
+      "type": "VariableDeclaration"
+    }
+  ],
+  "comments": [],
+  "errors": [
+    {
+      "loc": {
+        "end": {
+          "column": 27,
+          "line": 1
+        },
+        "source": null,
+        "start": {
+          "column": 17,
+          "line": 1
+        }
+      },
+      "message": "The `bogusphase` import phase is not supported."
+    }
+  ],
+  "loc": {
+    "end": {
+      "column": 37,
+      "line": 1
+    },
+    "source": null,
+    "start": {
+      "column": 0,
+      "line": 1
+    }
+  },
+  "range": [
+    0,
+    37
+  ],
+  "type": "Program"
+}


### PR DESCRIPTION
Summary:
[Deferred import evaluation](https://github.com/tc39/proposal-defer-import-eval) is a TC39 stage 3 proposal - spec complete, seeking implementations.

It looks like this:
```
import defer * as ns from './foo';
```

Where `defer` is a contextual keyword. (Or the dynamic equivalent, `const ns = await import.defer('./foo')`)

`./foo` and its dependencies are loaded and linked, but not evaluated until a property of `ns` is first accessed. This gives the startup-cost benefits of a lazy `require()` while keeping a top-level, static-analysis and bundler-friendly `import`.

Matching Babel, `phase` is `"defer"` on a phase-modified import and absent/null otherwise, on both `ImportDeclaration` and `ImportExpression`.

### Edge cases
`defer` stays a contextual keyword: `import defer from "m"`, `import defer, { x } from "m"` and `import defer = require("m")` all still bind a local named `defer`. Binding forms the phase does not accept are parsed and then reported as `ImportDeferPhaseRequiresNamespace` at the offending binding rather than cascading token errors.

### Later extension
The phase is carried as `Option<ImportPhase>` rather than a boolean, suitable for extension to other phases (like
[`source`](https://github.com/tc39/proposal-source-phase-imports)).

Phases this parser does not implement are rejected clearly: an identifier followed by an identifier other than `from` can only be a phase modifier, and `import.<name>(` can only be a phase call, so both report a single `ImportPhaseUnsupported` carrying the name and then parse as the unphased import they shadow. A mistyped `import.metaa` still reports as a meta-property rather than a phase, since it has no call parens.

### Type checking
Deferred evaluation does not change the shape of the namespace object, so a deferred import is checked exactly like the eager `import * as ns` it shadows, and `import.defer(m)` like `import(m)`. Both are correctly checked with no changes needed.

Changelog: [parser] Parse [deferred imports](https://github.com/tc39/proposal-defer-import-eval): `import defer * as ns from "m"` and `import.defer("m")` now set the ESTree `phase` property to `"defer"`.

Test plan:
12 fixtures under `src/parser/test/flow/import_defer_phase/` cover the phase, the three contextual `defer`-as-a-binding forms, `from` as the binding, attributes, a line terminator before the namespace, the dynamic form, and the three rejected binding forms with their recorded errors. 8 under `import_unsupported_phase/` cover both unsupported-phase shapes, a `bogusphase` case to pin that nothing keys off `source` specifically, the mistyped `import.metaa`, and the phase names used as ordinary bindings. Plus round-trip printer cases in `js_layout_generator_test/import_test.rs` and serializer cases in `flow_parser_wasm/src/lib.rs`.

```
cargo test --workspace --no-fail-fast
```
```
passed: 2450 failed: 0 ignored: 7
```

`RUST_MIN_STACK` is needed for `esprima_tests` - it overflows an 8MB thread stack in a debug build on `main` too, so unrelated to this.

No existing `.tree.json` changed, which is the check that the contextual keyword did not move any pre-existing parse. The only ESTree surface change is `phase` itself: nine inline snapshots under `packages/flow-parser/__tests__/` gain `"phase": null`.

The WASM parser was built from this tree with Emscripten 4.0.23 and both JS suites run against it, so the wire format and the generated deserializer are exercised rather than just the Rust translator - `runWasmFixtures.js` covers both new fixture directories end to end:

```
yarn jest flow-parser                     # 56/56 suites, 413/413 tests
node --test __tests__/runWasmFixtures.js  # 1873 pass, 0 fail
```

Reproducing that WASM build needs two fixes to `buildFlowParserWasm.sh` that are unrelated to this diff, so they are not included here: the `EXPORTED_RUNTIME_METHODS` list is missing the heap views the JS glue reads (`HEAP8`, and `HEAPU8`/`HEAPU32`/`HEAPF64` for the deserializer), and on Emscripten 4 and later `-sSINGLE_FILE=1` embeds the module as a raw binary string rather than a base64 data URI, which `build.sh` then mangles by running Babel over `dist/`.

Against a current `@babel/parser` with `deferredImportEvaluation` enabled, babel-mode output for `import.defer("m")` is identical, and for `import defer * as ns from "m"` the only difference is the pre-existing `attributes` omission that also shows on an unphased import. Error positions for the rejected binding forms match Babel's `DeferImportRequiresNamespace` too. `BabelImportDeclaration` omits `phase` when null via a new `MaybeString` schema type, because `expectBabelAlignment` compares against the `@babel/parser` pinned at 7.7.4 in `flow-parser/node_modules`, which predates the property - the same reason `attributes` is already `NonEmptyNodeList` there.

Type checking was exercised against a `flow_cli` built from this tree: `import defer * as ns from "./m"` types `ns.x` as the export's declared type and `import.defer("./m")` as `Promise<typeof ns>`, with no further changes.
